### PR TITLE
feat: add firebase auth

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+// https://console.firebase.google.com/project/<project>/settings/general/web
+FIREBASE_API_KEY=""
+FIREBASE_AUTH_DOMAIN=""

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ dist/
 node_modules/
 .next/
 .DS_Store
+.env.local
 *.log

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ This project uses [PNPM](https://pnpm.io/). Install it using `npm install -g pnp
 
 Project setup:
 
-```
+```shell
 git clone git@github.com:blinkk/cms.git
 cd cms
 pnpm install
+```
+
+Copy `.env.local.example` to `.env.local` and populate it with an API key from firebase.
+
+Start the dev server:
+
+```shell
+pnpm run dev
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,10 +37,12 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
+    "dotenv": "^16.0.0",
     "esbuild": "^0.14.27",
     "esbuild-register": "^3.3.2",
     "fastify": "^3.27.4",
     "fastify-plugin": "^3.0.1",
+    "glob": "^7.2.0",
     "glob-promise": "^4.2.2",
     "typescript": "^4.6.2"
   }

--- a/packages/core/src/commands/dev.ts
+++ b/packages/core/src/commands/dev.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
 import {cwd, env} from 'process';
 import {Server} from '../server';
+import {loadEnv} from '../utils/loadEnv';
 import Workspace from '../workspace/Workspace';
 
 export async function dev(dirPath?: string) {
-  // TODO(stevenle): load dotenv files.
   let workspaceDir = dirPath || env.CMS_WORKSPACE;
   if (workspaceDir) {
     if (!workspaceDir.startsWith('/')) {
@@ -14,6 +14,7 @@ export async function dev(dirPath?: string) {
   } else {
     workspaceDir = cwd();
   }
+  loadEnv(workspaceDir, {mode: 'development'});
   const workspace = await Workspace.init(workspaceDir);
   const server = new Server({
     workspace: workspace,

--- a/packages/core/src/utils/loadEnv.ts
+++ b/packages/core/src/utils/loadEnv.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+type Env = {[key: string]: string};
+interface EnvFile {
+  path: string;
+  contents: string;
+}
+let cachedEnv: Env | undefined = undefined;
+const cachedLoadedEnvFiles: EnvFile[] = [];
+
+export function loadEnv(
+  dirPath: string,
+  options: {mode: 'development' | 'production'}
+) {
+  if (cachedEnv) {
+    return {env: cachedEnv, loadedEnvFiles: cachedLoadedEnvFiles};
+  }
+
+  const dotenvFiles = [
+    `.env.${options.mode}.local`,
+    '.env.local',
+    `.env.${options.mode}`,
+    '.env',
+  ];
+
+  for (const envFile of dotenvFiles) {
+    const dotEnvPath = path.join(dirPath, envFile);
+    try {
+      const stats = fs.statSync(dotEnvPath);
+      if (!stats.isFile()) {
+        continue;
+      }
+
+      const contents = fs.readFileSync(dotEnvPath, 'utf8');
+      cachedLoadedEnvFiles.push({
+        path: envFile,
+        contents,
+      });
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        console.error(`failed to load env from ${envFile}`, err);
+      }
+    }
+  }
+  cachedEnv = processEnv(dirPath, cachedLoadedEnvFiles);
+  return {env: cachedEnv, loadedEnvFiles: cachedLoadedEnvFiles};
+}
+
+function processEnv(dirPath: string, envFiles: EnvFile[]): Env {
+  if (process.env.__CMS_PROCESSED_ENV || envFiles.length === 0) {
+    return process.env as Env;
+  }
+  process.env.__CMS_PROCESSED_ENV = 'true';
+
+  const origEnv = Object.assign({}, process.env);
+  const parsed: dotenv.DotenvParseOutput = {};
+
+  for (const envFile of envFiles) {
+    try {
+      const result: dotenv.DotenvConfigOutput = {};
+      result.parsed = dotenv.parse(envFile.contents);
+      // If $VAR expansion is eventually needed, uncomment the following line
+      // and `pnpm install dotenv-expand`.
+      // result = dotenvExpand(result);
+
+      if (result.parsed) {
+        console.info(`loaded ${path.join(dirPath || '', envFile.path)}`);
+      }
+
+      for (const key of Object.keys(result.parsed || {})) {
+        if (
+          typeof parsed[key] === 'undefined' &&
+          typeof origEnv[key] === 'undefined'
+        ) {
+          parsed[key] = result.parsed?.[key];
+        }
+      }
+    } catch (err) {
+      console.error(
+        `failed to load env from ${path.join(dirPath || '', envFile.path)}`,
+        err
+      );
+    }
+  }
+
+  return Object.assign(process.env, parsed);
+}

--- a/packages/core/src/workspace/Workspace.ts
+++ b/packages/core/src/workspace/Workspace.ts
@@ -7,6 +7,12 @@ import * as path from 'path';
 
 export interface WorkspaceSerialized {
   projects: ProjectSerialized[];
+  firebase: FirebaseConfig;
+}
+
+interface FirebaseConfig {
+  apiKey: string;
+  authDomain: string;
 }
 
 async function loadConfig(workspaceDir: string): Promise<WorkspaceConfig> {
@@ -83,9 +89,21 @@ export class Workspace {
     return this.projects.find(p => p.id === projectId) || null;
   }
 
+  getFirebaseConfig(): FirebaseConfig {
+    const apiKey = process.env.FIREBASE_API_KEY;
+    const authDomain = process.env.FIREBASE_AUTH_DOMAIN;
+    if (!apiKey || !authDomain) {
+      throw new Error(
+        'missing firebase credentials, please set environment variables: FIREBASE_API_KEY and FIREBASE_AUTH_DOMAIN'
+      );
+    }
+    return {apiKey, authDomain};
+  }
+
   serialize(): WorkspaceSerialized {
     return {
       projects: this.projects.map(p => p.serialize()),
+      firebase: this.getFirebaseConfig(),
     };
   }
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -13,8 +13,10 @@
     "@mantine/modals": "^4.0.5",
     "@mantine/notifications": "^4.0.5",
     "@primer/octicons-react": "^17.0.0",
+    "firebase": "^9.6.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-firebaseui": "^6.0.0",
     "react-router-dom": "^6.2.2",
     "sass": "^1.49.9"
   },

--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -5,6 +5,7 @@ import {ProjectSelectPage} from './pages/ProjectSelectPage';
 import {NotificationsProvider} from '@mantine/notifications';
 import {WIP} from './pages/WIP';
 import {WorkspaceProvider} from './hooks/useWorkspace';
+import {UserProvider} from './hooks/useUser';
 
 function App() {
   return (
@@ -12,20 +13,22 @@ function App() {
       <ModalsProvider labels={{confirm: 'Confirm', cancel: 'Cancel'}}>
         <NotificationsProvider>
           <WorkspaceProvider>
-            <BrowserRouter>
-              <Routes>
-                <Route path="/cms/" element={<ProjectSelectPage />} />
-                <Route path="/cms/:project" element={<WIP />} />
-                <Route
-                  path="/cms/:project/content/:collection"
-                  element={<WIP />}
-                />
-                <Route
-                  path="/cms/:project/content/:collection/:slug"
-                  element={<WIP />}
-                />
-              </Routes>
-            </BrowserRouter>
+            <UserProvider>
+              <BrowserRouter>
+                <Routes>
+                  <Route path="/cms/" element={<ProjectSelectPage />} />
+                  <Route path="/cms/:project" element={<WIP />} />
+                  <Route
+                    path="/cms/:project/content/:collection"
+                    element={<WIP />}
+                  />
+                  <Route
+                    path="/cms/:project/content/:collection/:slug"
+                    element={<WIP />}
+                  />
+                </Routes>
+              </BrowserRouter>
+            </UserProvider>
           </WorkspaceProvider>
         </NotificationsProvider>
       </ModalsProvider>

--- a/packages/webui/src/hooks/useUser.tsx
+++ b/packages/webui/src/hooks/useUser.tsx
@@ -1,0 +1,48 @@
+import {useWorkspace} from './useWorkspace';
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+import {createContext, useContext, useEffect, useState} from 'react';
+import {UserSignInPage} from '../pages/UserSignInPage';
+import {LoadingPage} from '../pages/LoadingPage';
+
+type User = firebase.User;
+type Auth = firebase.auth.Auth;
+
+export const UserContext = createContext<User | null>(null);
+
+export function UserProvider({children}: {children: JSX.Element}) {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [auth, setAuth] = useState<Auth | null>(null);
+  const workspace = useWorkspace();
+
+  useEffect(() => {
+    if (!workspace) {
+      return;
+    }
+    const app = firebase.initializeApp(workspace.firebase);
+    const auth = app.auth();
+    setAuth(auth);
+    const unregisterAuthObserver = auth.onAuthStateChanged(user => {
+      setIsSignedIn(!!user);
+      if (user) {
+        setUser(user);
+      }
+      setLoading(false);
+    });
+    return () => unregisterAuthObserver();
+  }, [workspace]);
+
+  if (loading) {
+    return <LoadingPage />;
+  }
+  if (!isSignedIn) {
+    return <UserSignInPage auth={auth} />;
+  }
+  return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+  return useContext(UserContext)!;
+}

--- a/packages/webui/src/hooks/useWorkspace.tsx
+++ b/packages/webui/src/hooks/useWorkspace.tsx
@@ -1,5 +1,5 @@
-import {Loader} from '@mantine/core';
 import {createContext, useContext, useState} from 'react';
+import {LoadingPage} from '../pages/LoadingPage';
 import {useJsonRpc} from './useJsonRpc';
 
 interface Collection {
@@ -15,24 +15,29 @@ interface Project {
 
 export interface Workspace {
   projects: Project[];
+  firebase: {
+    apiKey: string;
+    authDomain: string;
+  };
 }
 
-export const WorkspaceContext = createContext<Workspace>({projects: []});
+export const WorkspaceContext = createContext<Workspace | null>(null);
 
 /**
  * WorkspaceProvider is a context provider that fetches the CMS workspace.
  */
 export function WorkspaceProvider({children}: {children: JSX.Element}) {
-  const [loading, setLoading] = useState(false);
-  const [workspace, setWorkspace] = useState<Workspace>({projects: []});
+  const [loading, setLoading] = useState(true);
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
 
   useJsonRpc<Workspace>('workspace.json', workspace => {
+    console.log(workspace);
     setWorkspace(workspace);
     setLoading(false);
   });
 
   if (loading) {
-    return <Loader />;
+    return <LoadingPage />;
   }
   return (
     <WorkspaceContext.Provider value={workspace}>
@@ -63,5 +68,5 @@ export function WorkspaceProvider({children}: {children: JSX.Element}) {
  * ```
  */
 export function useWorkspace() {
-  return useContext(WorkspaceContext);
+  return useContext(WorkspaceContext)!;
 }

--- a/packages/webui/src/index.css
+++ b/packages/webui/src/index.css
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+html {
+  box-sizing: border-box;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
+}

--- a/packages/webui/src/pages/LoadingPage.module.sass
+++ b/packages/webui/src/pages/LoadingPage.module.sass
@@ -1,0 +1,5 @@
+.LoadingPage
+  min-height: 100vh
+  display: flex
+  justify-content: center
+  align-items: center

--- a/packages/webui/src/pages/LoadingPage.tsx
+++ b/packages/webui/src/pages/LoadingPage.tsx
@@ -1,0 +1,10 @@
+import {Loader} from '@mantine/core';
+import styles from './LoadingPage.module.sass';
+
+export function LoadingPage() {
+  return (
+    <div className={styles.LoadingPage}>
+      <Loader color="lime" variant="dots" />
+    </div>
+  );
+}

--- a/packages/webui/src/pages/UserSignInPage.module.sass
+++ b/packages/webui/src/pages/UserSignInPage.module.sass
@@ -1,0 +1,20 @@
+.UserSignInPage
+  padding: 100px 20px
+  text-align: center
+  min-height: 100vh
+  display: flex
+  flex-direction: column
+  justify-content: center
+  align-items: center
+
+.UserSignInPage_Logo
+  width: 64px
+  height: 64px
+  border-radius: 50%
+  background-color: #efefef
+  margin: 0 auto 20px
+
+.UserSignInPage_Title
+  font-size: 64px
+  line-height: 1.2
+  margin-bottom: 40px

--- a/packages/webui/src/pages/UserSignInPage.tsx
+++ b/packages/webui/src/pages/UserSignInPage.tsx
@@ -1,0 +1,39 @@
+import firebase from 'firebase/compat/app';
+import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
+import {Title} from '@mantine/core';
+import styles from './UserSignInPage.module.sass';
+
+// Configure Firebase UI.
+// https://github.com/firebase/firebaseui-web-react
+const FIREBASE_UI_CONFIG = {
+  // Popup signin flow rather than redirect flow.
+  signInFlow: 'popup',
+  // signInOptions: [GoogleAuthProvider.PROVIDER_ID],
+  signInOptions: [firebase.auth.GoogleAuthProvider.PROVIDER_ID],
+  callbacks: {
+    // Avoid redirects after sign-in.
+    signInSuccessWithAuthResult: () => false,
+  },
+};
+
+interface UserSignInPageProps {
+  auth: firebase.auth.Auth | null;
+}
+
+export function UserSignInPage(props: UserSignInPageProps) {
+  if (!props.auth) {
+    return <></>;
+  }
+  return (
+    <div className={styles.UserSignInPage}>
+      <div className={styles.UserSignInPage_Logo}></div>
+      <Title className={styles.UserSignInPage_Title} order={1}>
+        Log in to CMS
+      </Title>
+      <StyledFirebaseAuth
+        uiConfig={FIREBASE_UI_CONFIG}
+        firebaseAuth={props.auth}
+      />
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,21 +54,25 @@ importers:
     specifiers:
       '@types/node': ^17.0.21
       commander: ^9.0.0
+      dotenv: ^16.0.0
       esbuild: ^0.14.27
       esbuild-register: ^3.3.2
       fastify: ^3.27.4
       fastify-plugin: ^3.0.1
+      glob: ^7.2.0
       glob-promise: ^4.2.2
       nodemon: ^2.0.15
       tsup: ^5.12.1
       typescript: ^4.6.2
     dependencies:
       commander: 9.0.0
+      dotenv: 16.0.0
       esbuild: 0.14.27
       esbuild-register: 3.3.2_esbuild@0.14.27
       fastify: 3.27.4
       fastify-plugin: 3.0.1
-      glob-promise: 4.2.2
+      glob: 7.2.0
+      glob-promise: 4.2.2_glob@7.2.0
       typescript: 4.6.2
     devDependencies:
       '@types/node': 17.0.21
@@ -85,8 +89,10 @@ importers:
       '@types/react': ^17.0.33
       '@types/react-dom': ^17.0.10
       '@vitejs/plugin-react': ^1.0.7
+      firebase: ^9.6.9
       react: ^17.0.2
       react-dom: ^17.0.2
+      react-firebaseui: ^6.0.0
       react-router-dom: ^6.2.2
       sass: ^1.49.9
       typescript: ^4.5.4
@@ -97,8 +103,10 @@ importers:
       '@mantine/modals': 4.0.5_11d94122b291e5086273da49f89fdef7
       '@mantine/notifications': 4.0.5_11d94122b291e5086273da49f89fdef7
       '@primer/octicons-react': 17.0.0_react@17.0.2
+      firebase: 9.6.9
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      react-firebaseui: 6.0.0_firebase@9.6.9+react@17.0.2
       react-router-dom: 6.2.2_react-dom@17.0.2+react@17.0.2
       sass: 1.49.9
     devDependencies:
@@ -504,6 +512,472 @@ packages:
       ajv: 6.12.6
     dev: false
 
+  /@firebase/analytics-compat/0.1.7_c8a60333997e76cbef3dda80e0a2394a:
+    resolution: {integrity: sha512-bVnv+xM2YwAouWjeo+HCN0GWu6i0sLzM2AcpmfsQuC97SNRFqIpRUYmjaeTdDALt3k1fIUzYMcZZE4xuC2qK/A==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/analytics': 0.7.6_@firebase+app@0.7.19
+      '@firebase/analytics-types': 0.7.0
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+    dev: false
+
+  /@firebase/analytics-types/0.7.0:
+    resolution: {integrity: sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==}
+    dev: false
+
+  /@firebase/analytics/0.7.6_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-hfN+cnWuRY5QfbeBeZOOD9xC/ePavPaAPh3Bc1u0yZLMgF3No3ME6K2dVHKWK1K0BIPzLsliojYYRYnWMF6TZw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/installations': 0.5.6_@firebase+app@0.7.19
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/app-check-compat/0.2.4_c8a60333997e76cbef3dda80e0a2394a:
+    resolution: {integrity: sha512-CnbjhzIdpL7671wwcWMgYDBfCxuMjjg8OITlTtP2vN8h6uBFuPosRpc2GZ/h32IA3fzwyeFplFjy/y8Gyhh6Dw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-check': 0.5.4_@firebase+app@0.7.19
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+    dev: false
+
+  /@firebase/app-check-interop-types/0.1.0:
+    resolution: {integrity: sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==}
+    dev: false
+
+  /@firebase/app-check/0.5.4_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-UX6IcuapbLb8Q4zYaUq5UKbpXURY4lrK41Is2c56Q/h7i4zRiMYLKEETJZIfVATE2vKsbjxSxn02xS9g/VPftw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/app-compat/0.1.20:
+    resolution: {integrity: sha512-s+MQQv5acNZ2Mx/TNyr+B0XaqATq14hkAL9247exIvV0RBwP28THuadPVw99kjrwkHilQtBMFJmmCm1S5ZoktQ==}
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/app-types/0.7.0:
+    resolution: {integrity: sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==}
+    dev: false
+
+  /@firebase/app/0.7.19:
+    resolution: {integrity: sha512-Xs8s3OF4Tn7Ls833TOTAUSMDq/pDs1fDsLRprR1+B4wyxyWCYBisgDMnPx25z9wKJESOWoZTDjyBVHrn6sG92w==}
+    dependencies:
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/auth-compat/0.2.10_cdfe7719f379a3fdf450aeb4d04c93da:
+    resolution: {integrity: sha512-FYsU18N3nZq/l7gfnmH8tYOPDWSU3pPJa/JAmflfcwcDJnYLAiHRHZb0KmLV5baRMD8QdMdER5bGbzWgtOmczQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/auth': 0.19.10_@firebase+app@0.7.19
+      '@firebase/auth-types': 0.11.0_8d05954f5748666b17f36dcdd243eda6
+      '@firebase/component': 0.5.11
+      '@firebase/util': 1.5.0
+      node-fetch: 2.6.7
+      selenium-webdriver: 4.1.1
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@firebase/auth-interop-types/0.1.6_8d05954f5748666b17f36dcdd243eda6:
+    resolution: {integrity: sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+    dependencies:
+      '@firebase/app-types': 0.7.0
+      '@firebase/util': 1.5.0
+    dev: false
+
+  /@firebase/auth-types/0.11.0_8d05954f5748666b17f36dcdd243eda6:
+    resolution: {integrity: sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+    dependencies:
+      '@firebase/app-types': 0.7.0
+      '@firebase/util': 1.5.0
+    dev: false
+
+  /@firebase/auth/0.19.10_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-FqKHohxZriJM4S8hY0RbNwGVb+Y5INsWkWsqOaWQ9pM0hEolYruE10gKqrOHO9kauXhKbdUUGPgKHJJ9+r8eVg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      node-fetch: 2.6.7
+      selenium-webdriver: 4.0.0-rc-1
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@firebase/component/0.5.11:
+    resolution: {integrity: sha512-amtUrJxfJhJdjR3JzXqkHIoghJJ34o8OiSDj3gq96uKL4BRkSpmPaxi0+1r8DcDQ6bQxh3kDSoge8bRCDQCvsw==}
+    dependencies:
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/database-compat/0.1.6_2668787785cafa51f0d66ef4e88354f7:
+    resolution: {integrity: sha512-fDAJWI5ZdXPlS84NC87Et7pE6mJxF5uUoePCaQFpU56wrYVk58COomcSXtFrdX9U5/1FHjR3TaDWV5pJakv83g==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/database': 0.12.6_@firebase+app-types@0.7.0
+      '@firebase/database-types': 0.9.5
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+    dev: false
+
+  /@firebase/database-types/0.9.5:
+    resolution: {integrity: sha512-0p9BDmoZCbW5c//tl7IUn8hOIM4M6wCnLmVdbVUvD30V4hZT36phdhajf36pcMgE9suMsz4xtvWlngEy9FeHwA==}
+    dependencies:
+      '@firebase/app-types': 0.7.0
+      '@firebase/util': 1.5.0
+    dev: false
+
+  /@firebase/database/0.12.6_@firebase+app-types@0.7.0:
+    resolution: {integrity: sha512-vokGkgpk+4bvy1d/s0lsPP9GmC1nrAtctQwEEDH5ZO4WCYPj16Y6rKILsOjrWwJ+Ih21ORnekxSzfpKyd1KHEg==}
+    dependencies:
+      '@firebase/auth-interop-types': 0.1.6_8d05954f5748666b17f36dcdd243eda6
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      faye-websocket: 0.11.4
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+    dev: false
+
+  /@firebase/firestore-compat/0.1.15_cdfe7719f379a3fdf450aeb4d04c93da:
+    resolution: {integrity: sha512-bk0f2JbdgJc0P0eHnQBrqRF7xgMiSh6qyYqDTUh08/5kwdJed1SlmvF/3BSDhQHABcji99YhgR3E1ms6uoZwdg==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/firestore': 3.4.6_@firebase+app@0.7.19
+      '@firebase/firestore-types': 2.5.0_8d05954f5748666b17f36dcdd243eda6
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - encoding
+    dev: false
+
+  /@firebase/firestore-types/2.5.0_8d05954f5748666b17f36dcdd243eda6:
+    resolution: {integrity: sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+    dependencies:
+      '@firebase/app-types': 0.7.0
+      '@firebase/util': 1.5.0
+    dev: false
+
+  /@firebase/firestore/3.4.6_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-HVyrg1LAVePvut+qf856mCSdZbVL9dhnK1skZ6LY2KquS71RW0v7/iu+/Wn00kPHbZSmHGvYzHD6JOf+kjjbuQ==}
+    engines: {node: '>=10.10.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      '@firebase/webchannel-wrapper': 0.6.1
+      '@grpc/grpc-js': 1.5.9
+      '@grpc/proto-loader': 0.6.9
+      node-fetch: 2.6.7
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@firebase/functions-compat/0.1.10_cdfe7719f379a3fdf450aeb4d04c93da:
+    resolution: {integrity: sha512-Iqq1335rnhed+6WcOGUr+C8PzBAUwGnrQCKmo0YkyiLrO7UwRhIEeS/su4cthp4KNTsT5bdZWzEh9I4ZJ00bjw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/functions': 0.7.9_5c860adfc5c562292497b8beda4959cd
+      '@firebase/functions-types': 0.5.0
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - encoding
+    dev: false
+
+  /@firebase/functions-types/0.5.0:
+    resolution: {integrity: sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==}
+    dev: false
+
+  /@firebase/functions/0.7.9_5c860adfc5c562292497b8beda4959cd:
+    resolution: {integrity: sha512-C8FpECq2tSOXnWT+npw/qDihxWvs6vT0NdsOEV0artNKphf0tzUleo8NgklyqSmwnAy0v35YGTNdVvxCWt5N8A==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/app-check-interop-types': 0.1.0
+      '@firebase/auth-interop-types': 0.1.6_8d05954f5748666b17f36dcdd243eda6
+      '@firebase/component': 0.5.11
+      '@firebase/messaging-interop-types': 0.1.0
+      '@firebase/util': 1.5.0
+      node-fetch: 2.6.7
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+      - encoding
+    dev: false
+
+  /@firebase/installations/0.5.6_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-e/sDDungY/haSw9H+DmknZkf6M8Q3O9CLUHoVldqX96lvOpT8le6YndJOgK6fTHiRs0ro3amg+4ef2mn40NqzQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/logger/0.3.2:
+    resolution: {integrity: sha512-lzLrcJp9QBWpo40OcOM9B8QEtBw2Fk1zOZQdvv+rWS6gKmhQBCEMc4SMABQfWdjsylBcDfniD1Q+fUX1dcBTXA==}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/messaging-compat/0.1.10_c8a60333997e76cbef3dda80e0a2394a:
+    resolution: {integrity: sha512-RtdXnn8MWPvWm/1BKR0g0U763RcAALzqPl8zEIkjFBq9wBS7rWqbj9zZ+c4rFUVks4vleLqLv9v6M0O/FsieMg==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/messaging': 0.9.10_@firebase+app@0.7.19
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+    dev: false
+
+  /@firebase/messaging-interop-types/0.1.0:
+    resolution: {integrity: sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==}
+    dev: false
+
+  /@firebase/messaging/0.9.10_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-Q59obc+hhqDxz5oJh012lI7kCKxcnNV7nMB74Hc7LGT7/oZ3abPl1rmnC0KKdaAHm37/riJgEgDW0HrUTc5REA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/installations': 0.5.6_@firebase+app@0.7.19
+      '@firebase/messaging-interop-types': 0.1.0
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/performance-compat/0.1.6_c8a60333997e76cbef3dda80e0a2394a:
+    resolution: {integrity: sha512-DHGw/u4iGZGeEj95CQooA3oOBcPBUw4+JuMSnk7qmY6iYBsYmkcUPVCFsgYNcAVtHBdU64DJX9RZbjkMmNX0uQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/performance': 0.5.6_@firebase+app@0.7.19
+      '@firebase/performance-types': 0.1.0
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+    dev: false
+
+  /@firebase/performance-types/0.1.0:
+    resolution: {integrity: sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==}
+    dev: false
+
+  /@firebase/performance/0.5.6_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-QfVq2Pa5PSoYLgwVyEFApb1i0mKISDzBRDC76VHx5wOSi28c31coYK0qrHjVkHlG51nnyEtBIWqXC2fFaOzr5Q==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/installations': 0.5.6_@firebase+app@0.7.19
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/polyfill/0.3.36:
+    resolution: {integrity: sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==}
+    dependencies:
+      core-js: 3.6.5
+      promise-polyfill: 8.1.3
+      whatwg-fetch: 2.0.4
+    dev: false
+
+  /@firebase/remote-config-compat/0.1.6_c8a60333997e76cbef3dda80e0a2394a:
+    resolution: {integrity: sha512-OEGADnpKIoVQF1blOTxzFBrP6LzEXR+IA7vyLwh7lL+qXpDJGvmg0Eoxb4yxZw4cQCZBGO6fcilBZkDmTDEp/w==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/logger': 0.3.2
+      '@firebase/remote-config': 0.3.5_@firebase+app@0.7.19
+      '@firebase/remote-config-types': 0.2.0
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+    dev: false
+
+  /@firebase/remote-config-types/0.2.0:
+    resolution: {integrity: sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==}
+    dev: false
+
+  /@firebase/remote-config/0.3.5_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-sxV8dpgQNWVPWDAVX7KtLCbkBJyox1L+RlGn/Djpj47YgeNuLOqjRZeEoydL9RO3EdzKG6EcHeqOhdpMBgeiNA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/installations': 0.5.6_@firebase+app@0.7.19
+      '@firebase/logger': 0.3.2
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/storage-compat/0.1.11_cdfe7719f379a3fdf450aeb4d04c93da:
+    resolution: {integrity: sha512-dD0OaFKgNqtNvirOB6omXw2RJEDGnfJtus2K93cgIqkUxso0NawTA/7LyD3nMccb2L11BMh57GcdyKHL0AWoJQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+    dependencies:
+      '@firebase/app-compat': 0.1.20
+      '@firebase/component': 0.5.11
+      '@firebase/storage': 0.9.3_@firebase+app@0.7.19
+      '@firebase/storage-types': 0.6.0_8d05954f5748666b17f36dcdd243eda6
+      '@firebase/util': 1.5.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - encoding
+    dev: false
+
+  /@firebase/storage-types/0.6.0_8d05954f5748666b17f36dcdd243eda6:
+    resolution: {integrity: sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+    dependencies:
+      '@firebase/app-types': 0.7.0
+      '@firebase/util': 1.5.0
+    dev: false
+
+  /@firebase/storage/0.9.3_@firebase+app@0.7.19:
+    resolution: {integrity: sha512-bi1sxMGduTl/cidtIqVyPyIAHEjMrQ5cMry2s4LfJMwaztUdSjgeSZRKLo5Nqy5/CC5fPhNIU3ueLhDm9z7dsA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+    dependencies:
+      '@firebase/app': 0.7.19
+      '@firebase/component': 0.5.11
+      '@firebase/util': 1.5.0
+      node-fetch: 2.6.7
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@firebase/util/1.5.0:
+    resolution: {integrity: sha512-4w4OY3YJVHV/4UBZ8OcXb8BD8I83P5n2y+FW0dHhn9OLXdYDg8bvCTA08P0nszpZqBhwutKQ4OS7c530SGjeLg==}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
+  /@firebase/webchannel-wrapper/0.6.1:
+    resolution: {integrity: sha512-9FqhNjKQWpQ3fGnSOCovHOm+yhhiorKEqYLAfd525jWavunDJcx8rOW6i6ozAh+FbwcYMkL7b+3j4UR/30MpoQ==}
+    dev: false
+
+  /@grpc/grpc-js/1.5.9:
+    resolution: {integrity: sha512-un+cXqErq5P4p3+WgYVNVh7FB51MSnaoRef7QWDcMXKR6FX2R6Z/bltcJMxNNdTUMC85lkOQcpnAAetFziPSng==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+    dependencies:
+      '@grpc/proto-loader': 0.6.9
+      '@types/node': 17.0.21
+    dev: false
+
+  /@grpc/proto-loader/0.6.9:
+    resolution: {integrity: sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      '@types/long': 4.0.1
+      lodash.camelcase: 4.3.0
+      long: 4.0.0
+      protobufjs: 6.11.2
+      yargs: 16.2.0
+    dev: false
+
   /@humanwhocodes/config-array/0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
@@ -745,6 +1219,49 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@protobufjs/aspromise/1.1.2:
+    resolution: {integrity: sha1-m4sMxmPWaafY9vXQiToU00jzD78=}
+    dev: false
+
+  /@protobufjs/base64/1.1.2:
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    dev: false
+
+  /@protobufjs/codegen/2.0.4:
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    dev: false
+
+  /@protobufjs/eventemitter/1.1.0:
+    resolution: {integrity: sha1-NVy8mLr61ZePntCV85diHx0Ga3A=}
+    dev: false
+
+  /@protobufjs/fetch/1.1.0:
+    resolution: {integrity: sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=}
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+    dev: false
+
+  /@protobufjs/float/1.0.2:
+    resolution: {integrity: sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=}
+    dev: false
+
+  /@protobufjs/inquire/1.1.0:
+    resolution: {integrity: sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=}
+    dev: false
+
+  /@protobufjs/path/1.1.2:
+    resolution: {integrity: sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=}
+    dev: false
+
+  /@protobufjs/pool/1.1.0:
+    resolution: {integrity: sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=}
+    dev: false
+
+  /@protobufjs/utf8/1.1.0:
+    resolution: {integrity: sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=}
+    dev: false
+
   /@radix-ui/number/0.1.0:
     resolution: {integrity: sha512-rpf6QiOWLHAkM4FEMYu9i+5Jr8cKT893+R4mPpcdsy4LD7omr9JfdOqj/h/xPA5+EcVrpMMlU6rrRYpUB5UI8g==}
     dependencies:
@@ -889,6 +1406,10 @@ packages:
   /@types/json5/0.0.29:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
     dev: true
+
+  /@types/long/4.0.1:
+    resolution: {integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==}
+    dev: false
 
   /@types/minimatch/3.0.5:
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
@@ -1113,7 +1634,6 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -1126,7 +1646,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /any-promise/1.3.0:
     resolution: {integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=}
@@ -1228,7 +1747,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -1253,7 +1771,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -1359,6 +1876,14 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /cliui/7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: false
+
   /clone-response/1.0.2:
     resolution: {integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=}
     dependencies:
@@ -1380,14 +1905,12 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1401,7 +1924,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-    dev: true
 
   /configstore/5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
@@ -1429,6 +1951,15 @@ packages:
     resolution: {integrity: sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==}
     requiresBuild: true
     dev: true
+
+  /core-js/3.6.5:
+    resolution: {integrity: sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==}
+    requiresBuild: true
+    dev: false
+
+  /core-util-is/1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: false
 
   /cosmiconfig/6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
@@ -1528,6 +2059,10 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /dialog-polyfill/0.4.10:
+    resolution: {integrity: sha512-j5yGMkP8T00UFgyO+78OxiN5vC5dzRQF3BEio+LhNvDbyfxWBsi3sfPArDm54VloaJwy2hm3erEiDWqHRC8rzw==}
+    dev: false
+
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -1563,6 +2098,11 @@ packages:
       is-obj: 2.0.0
     dev: true
 
+  /dotenv/16.0.0:
+    resolution: {integrity: sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==}
+    engines: {node: '>=12'}
+    dev: false
+
   /duplexer3/0.1.4:
     resolution: {integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=}
     dev: true
@@ -1573,7 +2113,6 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -1823,7 +2362,6 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-goat/2.1.1:
     resolution: {integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==}
@@ -2256,6 +2794,13 @@ packages:
     dependencies:
       reusify: 1.0.4
 
+  /faye-websocket/0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+    dependencies:
+      websocket-driver: 0.7.4
+    dev: false
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2290,6 +2835,51 @@ packages:
       locate-path: 2.0.0
     dev: true
 
+  /firebase/9.6.9:
+    resolution: {integrity: sha512-S9OmI+vMLNE8dr8ISyAdF88t8JxSMvbSULFq2Eox0q4P3MUN5N0/68NDIhibXTp6hdLI6/hs7b50SAplTCx9NA==}
+    dependencies:
+      '@firebase/analytics': 0.7.6_@firebase+app@0.7.19
+      '@firebase/analytics-compat': 0.1.7_c8a60333997e76cbef3dda80e0a2394a
+      '@firebase/app': 0.7.19
+      '@firebase/app-check': 0.5.4_@firebase+app@0.7.19
+      '@firebase/app-check-compat': 0.2.4_c8a60333997e76cbef3dda80e0a2394a
+      '@firebase/app-compat': 0.1.20
+      '@firebase/app-types': 0.7.0
+      '@firebase/auth': 0.19.10_@firebase+app@0.7.19
+      '@firebase/auth-compat': 0.2.10_cdfe7719f379a3fdf450aeb4d04c93da
+      '@firebase/database': 0.12.6_@firebase+app-types@0.7.0
+      '@firebase/database-compat': 0.1.6_2668787785cafa51f0d66ef4e88354f7
+      '@firebase/firestore': 3.4.6_@firebase+app@0.7.19
+      '@firebase/firestore-compat': 0.1.15_cdfe7719f379a3fdf450aeb4d04c93da
+      '@firebase/functions': 0.7.9_5c860adfc5c562292497b8beda4959cd
+      '@firebase/functions-compat': 0.1.10_cdfe7719f379a3fdf450aeb4d04c93da
+      '@firebase/installations': 0.5.6_@firebase+app@0.7.19
+      '@firebase/messaging': 0.9.10_@firebase+app@0.7.19
+      '@firebase/messaging-compat': 0.1.10_c8a60333997e76cbef3dda80e0a2394a
+      '@firebase/performance': 0.5.6_@firebase+app@0.7.19
+      '@firebase/performance-compat': 0.1.6_c8a60333997e76cbef3dda80e0a2394a
+      '@firebase/polyfill': 0.3.36
+      '@firebase/remote-config': 0.3.5_@firebase+app@0.7.19
+      '@firebase/remote-config-compat': 0.1.6_c8a60333997e76cbef3dda80e0a2394a
+      '@firebase/storage': 0.9.3_@firebase+app@0.7.19
+      '@firebase/storage-compat': 0.1.11_cdfe7719f379a3fdf450aeb4d04c93da
+      '@firebase/util': 1.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /firebaseui/6.0.1_firebase@9.6.9:
+    resolution: {integrity: sha512-SMNCFt/xns3mnvd0hImEDu7di5fqRU3MVyIaXpVEfg6v0bH6f3m+YybivU7KElRUT/47DHMn++D8MrZYYnoN5g==}
+    peerDependencies:
+      firebase: ^9.1.3
+    dependencies:
+      dialog-polyfill: 0.4.10
+      firebase: 9.6.9
+      material-design-lite: 1.3.0
+    dev: false
+
   /flat-cache/3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2313,7 +2903,6 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
-    dev: true
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2333,6 +2922,11 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
     dev: true
+
+  /get-caller-file/2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: false
 
   /get-intrinsic/1.1.1:
     resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
@@ -2382,13 +2976,14 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob-promise/4.2.2:
+  /glob-promise/4.2.2_glob@7.2.0:
     resolution: {integrity: sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==}
     engines: {node: '>=12'}
     peerDependencies:
       glob: ^7.1.6
     dependencies:
       '@types/glob': 7.2.0
+      glob: 7.2.0
     dev: false
 
   /glob/7.1.6:
@@ -2422,7 +3017,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /global-dirs/3.0.0:
     resolution: {integrity: sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==}
@@ -2532,6 +3126,10 @@ packages:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
     dev: true
 
+  /http-parser-js/0.5.6:
+    resolution: {integrity: sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==}
+    dev: false
+
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -2545,6 +3143,10 @@ packages:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
     dev: true
+
+  /immediate/3.0.6:
+    resolution: {integrity: sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=}
+    dev: false
 
   /immutable/4.0.0:
     resolution: {integrity: sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==}
@@ -2572,11 +3174,9 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini/1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -2655,7 +3255,6 @@ packages:
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2747,6 +3346,10 @@ packages:
     resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==}
     dev: true
 
+  /isarray/1.0.0:
+    resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
+    dev: false
+
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
     dev: true
@@ -2818,6 +3421,15 @@ packages:
       object.assign: 4.1.2
     dev: true
 
+  /jszip/3.7.1:
+    resolution: {integrity: sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==}
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.7
+      set-immediate-shim: 1.0.1
+    dev: false
+
   /keyv/3.1.0:
     resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
     dependencies:
@@ -2848,6 +3460,12 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /lie/3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+    dependencies:
+      immediate: 3.0.6
+    dev: false
 
   /light-my-request/4.8.0:
     resolution: {integrity: sha512-C2XESrTRsZnI59NSQigOsS6IuTxpj8OhSBvZS9fhgBMsamBsAuWN1s4hj/nCi8EeZcyAA6xbROhsZy7wKdfckg==}
@@ -2889,9 +3507,17 @@ packages:
       path-exists: 3.0.0
     dev: true
 
+  /lodash.camelcase/4.3.0:
+    resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
+    dev: false
+
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
+
+  /long/4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+    dev: false
 
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2921,6 +3547,11 @@ packages:
     dependencies:
       semver: 6.3.0
     dev: true
+
+  /material-design-lite/1.3.0:
+    resolution: {integrity: sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=}
+    engines: {node: '>=0.12.0'}
+    dev: false
 
   /memorystream/0.3.1:
     resolution: {integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=}
@@ -2958,7 +3589,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
@@ -3033,6 +3663,18 @@ packages:
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
 
   /node-releases/2.0.2:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==}
@@ -3165,7 +3807,6 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -3220,6 +3861,10 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /pako/1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: false
+
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3252,7 +3897,6 @@ packages:
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-key/2.0.1:
     resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=}
@@ -3372,8 +4016,16 @@ packages:
     hasBin: true
     dev: true
 
+  /process-nextick-args/2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    dev: false
+
   /process-warning/1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+    dev: false
+
+  /promise-polyfill/8.1.3:
+    resolution: {integrity: sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==}
     dev: false
 
   /prop-types/15.8.1:
@@ -3382,6 +4034,26 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  /protobufjs/6.11.2:
+    resolution: {integrity: sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.1
+      '@types/node': 17.0.21
+      long: 4.0.0
+    dev: false
 
   /proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3443,6 +4115,17 @@ packages:
 
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
+    dev: false
+
+  /react-firebaseui/6.0.0_firebase@9.6.9+react@17.0.2:
+    resolution: {integrity: sha512-VzLMiW7DBZCsW/qpP9nky/pPlAoIjDxA2Qyc+QAPf+RjelIkvPPiCBXR2aAz+Upy+ujrx6pYDXj547DW5uC4ww==}
+    peerDependencies:
+      firebase: ^9.1.3
+      react: '>=15 <=17'
+    dependencies:
+      firebase: 9.6.9
+      firebaseui: 6.0.1_firebase@9.6.9
+      react: 17.0.2
     dev: false
 
   /react-is/16.13.1:
@@ -3531,6 +4214,18 @@ packages:
       path-type: 3.0.0
     dev: true
 
+  /readable-stream/2.3.7:
+    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: false
+
   /readdirp/3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3566,6 +4261,11 @@ packages:
     dependencies:
       rc: 1.2.8
     dev: true
+
+  /require-directory/2.1.1:
+    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3620,7 +4320,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
-    dev: true
 
   /rollup/2.70.1:
     resolution: {integrity: sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==}
@@ -3666,6 +4365,31 @@ packages:
     resolution: {integrity: sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==}
     dev: false
 
+  /selenium-webdriver/4.0.0-rc-1:
+    resolution: {integrity: sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==}
+    engines: {node: '>= 10.15.0'}
+    dependencies:
+      jszip: 3.7.1
+      rimraf: 3.0.2
+      tmp: 0.2.1
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /selenium-webdriver/4.1.1:
+    resolution: {integrity: sha512-Fr9e9LC6zvD6/j7NO8M1M/NVxFX67abHcxDJoP5w2KN/Xb1SyYLjMVPGgD14U2TOiKe4XKHf42OmFw9g2JgCBQ==}
+    engines: {node: '>= 10.15.0'}
+    dependencies:
+      jszip: 3.7.1
+      tmp: 0.2.1
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /semver-diff/3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
@@ -3696,6 +4420,11 @@ packages:
 
   /set-cookie-parser/2.4.8:
     resolution: {integrity: sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==}
+    dev: false
+
+  /set-immediate-shim/1.0.1:
+    resolution: {integrity: sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /shebang-command/1.2.0:
@@ -3796,7 +4525,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string.prototype.matchall/4.0.6:
     resolution: {integrity: sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==}
@@ -3834,12 +4562,17 @@ packages:
       define-properties: 1.1.3
     dev: true
 
+  /string_decoder/1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: false
+
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-bom/3.0.0:
     resolution: {integrity: sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=}
@@ -3933,6 +4666,13 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /tmp/0.2.1:
+    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
+    engines: {node: '>=8.17.0'}
+    dependencies:
+      rimraf: 3.0.2
+    dev: false
+
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
     engines: {node: '>=4'}
@@ -3955,6 +4695,10 @@ packages:
       nopt: 1.0.10
     dev: true
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    dev: false
+
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3976,6 +4720,10 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib/2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: false
 
   /tsup/5.12.1_typescript@4.6.2:
     resolution: {integrity: sha512-vI7E4T6+6n5guQ9UKUOkQmzd1n4V9abGK71lbnzJMLJspbkNby5zlwWvgvHafLdYCb1WXpjFuqqmNLjBA0Wz3g==}
@@ -4135,6 +4883,10 @@ packages:
       react: 17.0.2
     dev: false
 
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    dev: false
+
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
@@ -4175,6 +4927,35 @@ packages:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    dev: false
+
+  /websocket-driver/0.7.4:
+    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+    engines: {node: '>=0.8.0'}
+    dependencies:
+      http-parser-js: 0.5.6
+      safe-buffer: 5.1.2
+      websocket-extensions: 0.1.4
+    dev: false
+
+  /websocket-extensions/0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /whatwg-fetch/2.0.4:
+    resolution: {integrity: sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==}
+    dev: false
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive/1.0.2:
@@ -4221,11 +5002,9 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
-    dev: true
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
@@ -4236,10 +5015,28 @@ packages:
       typedarray-to-buffer: 3.1.5
     dev: true
 
+  /ws/8.5.0:
+    resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /xdg-basedir/4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
     dev: true
+
+  /y18n/5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -4247,3 +5044,21 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  /yargs-parser/20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /yargs/16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+    dev: false


### PR DESCRIPTION
This PR adds client-side firebase login as well as a mechanism for the CMS to load the firebase API keys. Although I believe API keys are fine to use and store in a project repo, for the CMS I'm opting to read the keys from a .env file. This design may change in the future, where we might prefer to have the API keys be defined within the workspace/project config files. For now I think .env is a good middleground, since .env.local can be .gitignored in case there are any security concerns.

The server and webui will show an error if the API keys are missing and will provide a hint of what URL to visit to grab those keys. Our onboarding docs and startup scripts will need to make sure to include this as a step in the setup flow for a new project.