### PR TITLE
feat: read and list docs in a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Start the dev server:
 ```shell
 pnpm run dev
 ```
+
+And then visit: http://localhost:3000/cms/

--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -7,6 +7,8 @@ import {WIP} from './pages/WIP';
 import {WorkspaceProvider} from './hooks/useWorkspace';
 import {UserProvider} from './hooks/useUser';
 import {ProjectPage} from './pages/ProjectPage';
+import {CollectionPage} from './pages/CollectionPage';
+import {DocumentPage} from './pages/DocumentPage';
 
 function App() {
   return (
@@ -21,11 +23,11 @@ function App() {
                   <Route path="/cms/:projectId" element={<ProjectPage />} />
                   <Route
                     path="/cms/:projectId/content/:collectionId"
-                    element={<WIP />}
+                    element={<CollectionPage />}
                   />
                   <Route
                     path="/cms/:projectId/content/:collectionId/:slug"
-                    element={<WIP />}
+                    element={<DocumentPage />}
                   />
                 </Routes>
               </BrowserRouter>

--- a/packages/webui/src/components/AppHeader.tsx
+++ b/packages/webui/src/components/AppHeader.tsx
@@ -1,5 +1,5 @@
 import firebase from 'firebase/compat/app';
-import {Avatar, Header, Text} from '@mantine/core';
+import {Avatar, Header, Menu, Text, UnstyledButton} from '@mantine/core';
 import {useUser} from '../hooks/useUser';
 import styles from './AppHeader.module.sass';
 
@@ -13,16 +13,32 @@ function getInitials(user: firebase.User): string {
   return user.email![0].toUpperCase();
 }
 
+function UserAvatar(props: {user: firebase.User}) {
+  const user = props.user;
+  const initials = getInitials(user);
+  return (
+    <Avatar color="cyan" size="md" radius="xl" title={user.email || ''}>
+      {initials}
+    </Avatar>
+  );
+}
+
 export function AppHeader() {
   const user = useUser();
-  const initials = getInitials(user);
   return (
     <Header height={70} p="md">
       <div className={styles.AppHeader_Contents}>
         <Text weight={700}>Blinkk CMS</Text>
-        <Avatar color="cyan" size="md" radius="xl" title={user.email || ''}>
-          {initials}
-        </Avatar>
+        <Menu
+          control={
+            <UnstyledButton>
+              <UserAvatar user={user} />
+            </UnstyledButton>
+          }
+          gutter={10}
+        >
+          <Menu.Item onClick={() => alert('coming soon')}>Sign Out</Menu.Item>
+        </Menu>
       </div>
     </Header>
   );

--- a/packages/webui/src/hooks/useCollection.tsx
+++ b/packages/webui/src/hooks/useCollection.tsx
@@ -1,0 +1,24 @@
+import {useNotifications} from '@mantine/notifications';
+import {useParams} from 'react-router-dom';
+import {Collection} from '../lib/Collection';
+import {useProject} from './useProject';
+
+export function useCollection(collectionId?: string): Collection {
+  const notifications = useNotifications();
+  const project = useProject();
+  if (!collectionId) {
+    collectionId = useParams().collectionId;
+  }
+  const collectionConfig = project.collections.find(c => c.id === collectionId);
+  if (!collectionConfig) {
+    notifications.showNotification({
+      title: 'Collection Not Found',
+      message: `${collectionId} does not exist`,
+      color: 'red',
+      autoClose: false,
+    });
+    throw new Error(`collection not found: ${collectionId}`);
+  }
+  const collection = new Collection(project, collectionConfig);
+  return collection;
+}

--- a/packages/webui/src/hooks/useDoc.tsx
+++ b/packages/webui/src/hooks/useDoc.tsx
@@ -1,0 +1,33 @@
+import {useNotifications} from '@mantine/notifications';
+import {useParams} from 'react-router-dom';
+import {Collection} from '../lib/Collection';
+import {Doc} from '../lib/Doc';
+import {useProject} from './useProject';
+
+export function useDoc(docId?: string): Doc {
+  const notifications = useNotifications();
+  const project = useProject();
+  let collectionId: string;
+  let slug: string;
+  if (docId) {
+    [collectionId, slug] = docId.split('/');
+  } else {
+    const params = useParams();
+    collectionId = params.collectionId || '';
+    slug = params.slug || '';
+    docId = `${collectionId}/${slug}`;
+  }
+  const collectionConfig = project.collections.find(c => c.id === collectionId);
+  if (!collectionConfig) {
+    notifications.showNotification({
+      title: 'Collection Not Found',
+      message: `${collectionId} does not exist`,
+      color: 'red',
+      autoClose: false,
+    });
+    throw new Error(`collection not found: ${collectionId}`);
+  }
+  const collection = new Collection(project, collectionConfig);
+  const doc = new Doc(collection, slug);
+  return doc;
+}

--- a/packages/webui/src/hooks/useProject.tsx
+++ b/packages/webui/src/hooks/useProject.tsx
@@ -1,20 +1,24 @@
 import {useNotifications} from '@mantine/notifications';
 import {useParams} from 'react-router-dom';
-import {Project, useWorkspace} from './useWorkspace';
+import {Project} from '../lib/Project';
+import {useWorkspace} from './useWorkspace';
 
-export function useProject(): Project {
+export function useProject(projectId?: string): Project {
   const notifications = useNotifications();
   const workspace = useWorkspace();
-  const {projectId} = useParams();
-  const project = workspace.projects.find(p => p.id === projectId);
-  if (!project) {
+  if (!projectId) {
+    projectId = useParams().projectId;
+  }
+  const projectConfig = workspace.projects.find(p => p.id === projectId);
+  if (!projectConfig) {
     notifications.showNotification({
-      title: `Project Not Found`,
+      title: 'Project Not Found',
       message: `${projectId} does not exist`,
       color: 'red',
       autoClose: false,
     });
     throw new Error(`project not found: ${projectId}`);
   }
+  const project = new Project(workspace, projectConfig);
   return project;
 }

--- a/packages/webui/src/hooks/useUser.tsx
+++ b/packages/webui/src/hooks/useUser.tsx
@@ -6,7 +6,6 @@ import {UserSignInPage} from '../pages/UserSignInPage';
 import {LoadingPage} from '../pages/LoadingPage';
 
 type User = firebase.User;
-type Auth = firebase.auth.Auth;
 
 export const UserContext = createContext<User | null>(null);
 
@@ -14,16 +13,13 @@ export function UserProvider({children}: {children: JSX.Element}) {
   const [isSignedIn, setIsSignedIn] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const [auth, setAuth] = useState<Auth | null>(null);
   const workspace = useWorkspace();
 
   useEffect(() => {
     if (!workspace) {
       return;
     }
-    const app = firebase.initializeApp(workspace.firebase);
-    const auth = app.auth();
-    setAuth(auth);
+    const auth = workspace.firebase.auth();
     const unregisterAuthObserver = auth.onAuthStateChanged(user => {
       setIsSignedIn(!!user);
       if (user) {
@@ -38,7 +34,7 @@ export function UserProvider({children}: {children: JSX.Element}) {
     return <LoadingPage />;
   }
   if (!isSignedIn) {
-    return <UserSignInPage auth={auth} />;
+    return <UserSignInPage />;
   }
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
 }

--- a/packages/webui/src/hooks/useWorkspace.tsx
+++ b/packages/webui/src/hooks/useWorkspace.tsx
@@ -1,25 +1,7 @@
 import {createContext, useContext, useState} from 'react';
+import {Workspace, WorkspaceConfig} from '../lib/Workspace';
 import {LoadingPage} from '../pages/LoadingPage';
 import {useJsonRpc} from './useJsonRpc';
-
-export interface Collection {
-  id: string;
-}
-
-export interface Project {
-  id: string;
-  name?: string;
-  description?: string;
-  collections: Collection[];
-}
-
-export interface Workspace {
-  projects: Project[];
-  firebase: {
-    apiKey: string;
-    authDomain: string;
-  };
-}
 
 export const WorkspaceContext = createContext<Workspace | null>(null);
 
@@ -30,8 +12,8 @@ export function WorkspaceProvider({children}: {children: JSX.Element}) {
   const [loading, setLoading] = useState(true);
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
 
-  useJsonRpc<Workspace>('workspace.json', workspace => {
-    console.log(workspace);
+  useJsonRpc<WorkspaceConfig>('workspace.json', workspaceConfig => {
+    const workspace = new Workspace(workspaceConfig);
     setWorkspace(workspace);
     setLoading(false);
   });

--- a/packages/webui/src/lib/Collection.ts
+++ b/packages/webui/src/lib/Collection.ts
@@ -1,0 +1,39 @@
+import {Project} from './Project';
+import {Workspace} from './Workspace';
+
+export interface CollectionConfig {
+  id: string;
+  description?: string;
+}
+
+export class Collection {
+  workspace: Workspace;
+  project: Project;
+  config: CollectionConfig;
+  id: string;
+  description?: string;
+
+  constructor(project: Project, config: CollectionConfig) {
+    this.workspace = project.workspace;
+    this.project = project;
+    this.config = config;
+    this.id = config.id;
+    this.description = config.description;
+  }
+
+  async listDocs(): Promise<any[]> {
+    const db = this.workspace.db();
+    const docsRef = db.collection(
+      `Projects/${this.project.id}/Collections/${this.id}/Docs`
+    );
+    const snapshot = await docsRef.orderBy('draft.modifiedAt', 'desc').get();
+    return snapshot.docs.map(doc => ({...doc.data(), slug: doc.id}));
+  }
+
+  async getRoles(): Promise<Record<string, string>> {
+    const db = this.workspace.db();
+    const docRef = db.doc(`Projects/${this.project.id}/Collections/${this.id}`);
+    const snapshot = await docRef.get();
+    return snapshot?.data()?.roles || {};
+  }
+}

--- a/packages/webui/src/lib/Doc.ts
+++ b/packages/webui/src/lib/Doc.ts
@@ -1,0 +1,29 @@
+import {Collection} from './Collection';
+import {Project} from './Project';
+import {Workspace} from './Workspace';
+
+export class Doc {
+  readonly workspace: Workspace;
+  readonly project: Project;
+  readonly collection: Collection;
+  readonly slug: string;
+  readonly id: string;
+
+  constructor(collection: Collection, slug: string) {
+    this.workspace = collection.project.workspace;
+    this.project = collection.project;
+    this.collection = collection;
+    this.slug = slug;
+    this.id = `${collection.id}/${slug}`;
+  }
+
+  async getContent(options?: {mode?: 'draft' | 'published'}): Promise<any> {
+    const mode = options?.mode || 'draft';
+    const db = this.workspace.db();
+    const docRef = db.doc(
+      `Projects/${this.project.id}/Collections/${this.collection.id}/Docs/${this.slug}/Content/${mode}`
+    );
+    const snapshot = await docRef.get();
+    return snapshot.data() || {};
+  }
+}

--- a/packages/webui/src/lib/Project.ts
+++ b/packages/webui/src/lib/Project.ts
@@ -1,0 +1,29 @@
+import {CollectionConfig} from './Collection';
+import {Workspace} from './Workspace';
+
+export interface ProjectConfig {
+  id: string;
+  name?: string;
+  description?: string;
+  collections: CollectionConfig[];
+}
+
+export class Project {
+  readonly workspace: Workspace;
+  readonly config: ProjectConfig;
+  readonly id: string;
+  readonly description?: string;
+  readonly collections: CollectionConfig[];
+
+  constructor(workspace: Workspace, config: ProjectConfig) {
+    this.workspace = workspace;
+    this.config = config;
+    this.id = config.id;
+    this.description = config.description;
+    this.collections = config.collections;
+  }
+
+  async getRoles(): Promise<Record<string, string>> {
+    return {};
+  }
+}

--- a/packages/webui/src/lib/Workspace.ts
+++ b/packages/webui/src/lib/Workspace.ts
@@ -1,0 +1,40 @@
+import firebase from 'firebase/compat/app';
+import {ProjectConfig} from './Project';
+import 'firebase/compat/firestore';
+
+export interface WorkspaceConfig {
+  projects: ProjectConfig[];
+  firebase: {
+    apiKey: string;
+    authDomain: string;
+  };
+}
+
+export class Workspace {
+  config: WorkspaceConfig;
+  projects: ProjectConfig[];
+  firebase: firebase.app.App;
+
+  constructor(config: WorkspaceConfig) {
+    this.config = config;
+    console.log(config);
+    this.projects = config.projects;
+    if (!this.config.firebase) {
+      throw new Error('firebase config not found');
+    }
+    if (firebase.apps.length > 0) {
+      // On dev with hmr, use the existing firebase app if it's initialized.
+      this.firebase = firebase.app();
+    } else {
+      const firebaseProject = this.config.firebase.authDomain.split('.')[0];
+      this.firebase = firebase.initializeApp({
+        projectId: firebaseProject,
+        ...this.config.firebase,
+      });
+    }
+  }
+
+  db(): firebase.firestore.Firestore {
+    return this.firebase.firestore();
+  }
+}

--- a/packages/webui/src/pages/CollectionPage.tsx
+++ b/packages/webui/src/pages/CollectionPage.tsx
@@ -1,0 +1,77 @@
+import {Breadcrumbs, Title, Text, Group} from '@mantine/core';
+import {useEffect, useState} from 'react';
+import {Link} from 'react-router-dom';
+import {AppShell} from '../components/AppShell';
+import {useCollection} from '../hooks/useCollection';
+
+export function CollectionPage() {
+  const collection = useCollection();
+  const project = collection.project;
+  const [docs, setDocs] = useState<any[]>([]);
+  const [roles, setRoles] = useState<any[]>([]);
+
+  const listDocs = async () => {
+    if (!project) {
+      return;
+    }
+    console.log(`listing docs in ${collection.id}`);
+    const docs = await collection.listDocs();
+    setDocs(docs);
+  };
+
+  const getRoles = async () => {
+    if (!project) {
+      return;
+    }
+    const rolesMap = await collection.getRoles();
+    const roles: any[] = [];
+    for (const email in rolesMap) {
+      roles.push({email: email, role: rolesMap[email]});
+    }
+    setRoles(roles);
+  };
+
+  useEffect(() => {
+    getRoles();
+    listDocs();
+  }, [project.id]);
+
+  const breadcrumbs = [
+    {title: project.id, href: `/cms/${project.id}`},
+    {title: collection.id, href: `/cms/${project.id}/content/${collection.id}`},
+  ].map((item, index) => (
+    <Link to={item.href} key={index}>
+      {item.title}
+    </Link>
+  ));
+  return (
+    <AppShell>
+      <Breadcrumbs>{breadcrumbs}</Breadcrumbs>
+      <Group direction="column" sx={{marginTop: 20}} spacing={10}>
+        <Title>{collection.id}</Title>
+        {collection.description && <Text>{collection.description}</Text>}
+
+        <Title order={2}>Roles</Title>
+        <Group direction="column" spacing={10}>
+          {roles.map(role => (
+            <div key={role.email}>
+              {role.email}: {role.role}
+            </div>
+          ))}
+        </Group>
+
+        <Title order={2}>Docs</Title>
+        <Group direction="column" spacing={10}>
+          {docs.map(doc => (
+            <Link
+              to={`/cms/${project.id}/content/${collection.id}/${doc.slug}`}
+              key={doc.slug}
+            >
+              {doc.draft.meta.title} ({doc.slug})
+            </Link>
+          ))}
+        </Group>
+      </Group>
+    </AppShell>
+  );
+}

--- a/packages/webui/src/pages/DocumentPage.tsx
+++ b/packages/webui/src/pages/DocumentPage.tsx
@@ -1,0 +1,59 @@
+import {Breadcrumbs, Group, JsonInput, Title} from '@mantine/core';
+import {useEffect, useState} from 'react';
+import {Link} from 'react-router-dom';
+import {AppShell} from '../components/AppShell';
+import {useDoc} from '../hooks/useDoc';
+
+export function DocumentPage() {
+  const doc = useDoc();
+  const project = doc.project;
+  const collection = doc.collection;
+  const [content, setContent] = useState<any>({});
+
+  const breadcrumbs = [
+    {title: project.id, href: `/cms/${project.id}`},
+    {title: collection.id, href: `/cms/${project.id}/content/${collection.id}`},
+    {
+      title: doc.slug,
+      href: `/cms/${project.id}/content/${collection.id}/${doc.slug}`,
+    },
+  ].map((item, index) => (
+    <Link to={item.href} key={index}>
+      {item.title}
+    </Link>
+  ));
+
+  const fetchDocContent = async () => {
+    if (!doc) {
+      return;
+    }
+    console.log('fetching content');
+    const content = await doc.getContent();
+    console.log(content);
+    setContent(content);
+  };
+
+  useEffect(() => {
+    fetchDocContent();
+  }, []);
+
+  return (
+    <AppShell>
+      <Breadcrumbs>{breadcrumbs}</Breadcrumbs>
+      <Group direction="column" sx={{marginTop: 20}} spacing={10}>
+        <Title>{doc.id}</Title>
+
+        <Title order={2}>Content</Title>
+        <JsonInput
+          label="Draft Data"
+          validationError="Invalid json"
+          formatOnBlur
+          autosize
+          minRows={4}
+          value={JSON.stringify(content, null, 2)}
+          style={{width: '100%'}}
+        />
+      </Group>
+    </AppShell>
+  );
+}

--- a/packages/webui/src/pages/ProjectPage.module.sass
+++ b/packages/webui/src/pages/ProjectPage.module.sass
@@ -1,7 +1,7 @@
-.ProjectPage
-  padding: 60px 40px
-  max-width: 1200px
-  margin: 0 auto
+// .ProjectPage
+//   padding: 60px 40px
+//   max-width: 1200px
+//   margin: 0 auto
 
 .ProjectPage_ProjectName
   font-size: 40px

--- a/packages/webui/src/pages/UserSignInPage.tsx
+++ b/packages/webui/src/pages/UserSignInPage.tsx
@@ -2,6 +2,8 @@ import firebase from 'firebase/compat/app';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
 import {Title} from '@mantine/core';
 import styles from './UserSignInPage.module.sass';
+import {useWorkspace} from '../hooks/useWorkspace';
+import 'firebase/compat/auth';
 
 // Configure Firebase UI.
 // https://github.com/firebase/firebaseui-web-react
@@ -16,24 +18,19 @@ const FIREBASE_UI_CONFIG = {
   },
 };
 
-interface UserSignInPageProps {
-  auth: firebase.auth.Auth | null;
-}
-
-export function UserSignInPage(props: UserSignInPageProps) {
-  if (!props.auth) {
+export function UserSignInPage() {
+  const workspace = useWorkspace();
+  if (!workspace) {
     return <></>;
   }
+  const auth = workspace.firebase.auth();
   return (
     <div className={styles.UserSignInPage}>
       <div className={styles.UserSignInPage_Logo}></div>
       <Title className={styles.UserSignInPage_Title} order={1}>
         Log in to CMS
       </Title>
-      <StyledFirebaseAuth
-        uiConfig={FIREBASE_UI_CONFIG}
-        firebaseAuth={props.auth}
-      />
+      <StyledFirebaseAuth uiConfig={FIREBASE_UI_CONFIG} firebaseAuth={auth} />
     </div>
   );
 }

--- a/packages/webui/vite.config.ts
+++ b/packages/webui/vite.config.ts
@@ -3,14 +3,16 @@ import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: '/cms/',
-  server: {
-    proxy: {
-      '/cms/api': 'http://localhost:4000',
-      '/cms/preview': 'http://localhost:4000',
+export default defineConfig(({mode}) => {
+  return {
+    base: mode === 'production' ? '/cms/' : '/',
+    server: {
+      proxy: {
+        '/cms/api': 'http://localhost:4000',
+        '/cms/preview': 'http://localhost:4000',
+      },
     },
-  },
-  plugins: [react()],
-  clearScreen: false,
+    plugins: [react()],
+    clearScreen: false,
+  };
 });


### PR DESCRIPTION
Basic functionality for reading and listing documents in a collection directly from Firestore. At the moment I'm testing by using the Firebase admin UI to model the data, and it seems to be working well. The code feels fast and snappy, and I'm already feeling like adding in cursors for collaborative editing will be super quick and easy.

Hooks are available to grab core objects from any component: `useWorkspace()` `useProject()` `useCollection()` `useDoc()`. The firebase app object is available on the workspace, and the firestore db object can be grabbed directly using `workspace.db()`.

Screenshots:

![Screen Shot 2022-03-30 at 9 50 18 AM](https://user-images.githubusercontent.com/387282/160889315-91da9111-10e4-4bff-b4d6-0328c06a5249.jpg)

![Screen Shot 2022-03-30 at 9 53 36 AM](https://user-images.githubusercontent.com/387282/160889558-7f5d742e-8fe6-4c3d-981f-c249523fb970.jpg)

![Screen Shot 2022-03-30 at 9 49 59 AM](https://user-images.githubusercontent.com/387282/160889590-60bc3aec-cf5c-4c8a-961d-0f4f05a269c5.jpg)


