### PR TITLE
fix: inject locale into route params

### DIFF
--- a/.changeset/tame-spiders-sneeze.md
+++ b/.changeset/tame-spiders-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: inject locale into route params

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -58,6 +58,9 @@ export class Renderer {
       next();
       return;
     }
+    if (route.locale) {
+      routeParams.locale = route.locale;
+    }
 
     const render404 = async () => {
       // Calling next() will allow the dev server or prod server handle the 404
@@ -211,6 +214,9 @@ export class Renderer {
     options: {routeParams: Record<string, string>}
   ): Promise<{html?: string; notFound?: boolean}> {
     const routeParams = options.routeParams;
+    if (route.locale) {
+      routeParams.locale = route.locale;
+    }
     const Component = route.module.default;
     if (!Component) {
       throw new Error(

--- a/packages/root/test/fixtures/i18n-url-format/routes/foo/[slug].tsx
+++ b/packages/root/test/fixtures/i18n-url-format/routes/foo/[slug].tsx
@@ -1,0 +1,27 @@
+import {GetStaticPaths, GetStaticProps} from '../../../../../dist/core';
+
+interface PageProps {
+  localeFromParams: string;
+}
+
+export default function Page(props: PageProps) {
+  return (
+    <>
+      <p>Locale from params: {props.localeFromParams}</p>
+    </>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [{params: {slug: 'bar'}}],
+  };
+};
+
+export const getStaticProps: GetStaticProps<PageProps> = async (ctx) => {
+  return {
+    props: {
+      localeFromParams: ctx.params.locale || 'default',
+    },
+  };
+};

--- a/packages/root/test/i18n-url-format.test.ts
+++ b/packages/root/test/i18n-url-format.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 
 test('build i18n-url-format project', async () => {
   await fixture.build();
+
   const index = path.join(fixture.distDir, 'html/index.html');
   assert.isTrue(await fileExists(index));
   const html = await fs.readFile(index, 'utf-8');
@@ -49,6 +50,38 @@ test('build i18n-url-format project', async () => {
     <body>
     <h1>Bonjour le monde !</h1>
     <p>Current locale: fr</p>
+    </body>
+    </html>
+    "
+  `);
+
+  const fooDefault = path.join(fixture.distDir, 'html/foo/bar/index.html');
+  assert.isTrue(await fileExists(fooDefault));
+  const fooDefaultHtml = await fs.readFile(fooDefault, 'utf-8');
+  expect(fooDefaultHtml).toMatchInlineSnapshot(`
+    "<!doctype html>
+    <html>
+    <head>
+    <meta charset=\\"utf-8\\">
+    </head>
+    <body>
+    <p>Locale from params: en</p>
+    </body>
+    </html>
+    "
+  `);
+
+  const fooFr = path.join(fixture.distDir, 'html/intl/fr/foo/bar/index.html');
+  assert.isTrue(await fileExists(fooFr));
+  const fooFrHtml = await fs.readFile(fooFr, 'utf-8');
+  expect(fooFrHtml).toMatchInlineSnapshot(`
+    "<!doctype html>
+    <html>
+    <head>
+    <meta charset=\\"utf-8\\">
+    </head>
+    <body>
+    <p>Locale from params: fr</p>
     </body>
     </html>
     "


### PR DESCRIPTION
This PR is related to #107. 

This will allow routes that only have a subset of locales to be able to return `{notFound: true}` within `getStaticProps()` if the route should not exist for a given locale.