### PR TITLE
feat: add rds package with <Text> and <Heading>

### DIFF
--- a/.changeset/bright-geese-drum.md
+++ b/.changeset/bright-geese-drum.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/rds': minor
+---
+
+feat: add rds package with <Text> and <Heading>

--- a/packages/rds/package.json
+++ b/packages/rds/package.json
@@ -32,7 +32,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@blinkk/root": "*",
+    "@blinkk/root": "1.0.0-beta.17",
     "preact": "*"
   }
 }

--- a/packages/rds/package.json
+++ b/packages/rds/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@blinkk/rds",
+  "description": "Root.js Design System",
+  "version": "1.0.0-beta.0",
+  "author": "s@blinkk.com",
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blinkk/rootjs.git",
+    "directory": "packages/rds"
+  },
+  "files": [
+    "dist/**/*"
+  ],
+  "type": "module",
+  "exports": {
+    "./**/*": {
+      "types": "./dist/**/*.d.ts",
+      "import": "./dist/**/*.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc && copyfiles -u 1 src/**/*.scss dist/"
+  },
+  "devDependencies": {
+    "@blinkk/root": "workspace:*",
+    "copyfiles": "^2.4.1",
+    "preact": "*",
+    "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "@blinkk/root": "*",
+    "preact": "*"
+  }
+}

--- a/packages/rds/src/components/Heading/Heading.tsx
+++ b/packages/rds/src/components/Heading/Heading.tsx
@@ -1,13 +1,32 @@
 import {ComponentChildren} from 'preact';
 
-import {Text, FontWeight} from '../Text/Text.js';
+import {Text, FontWeight, TextSize} from '../Text/Text.js';
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 export type HeadingComponent = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
+/**
+ * The heading size values are generated from a variable called `$text-sizes` in
+ * `tokens.scss`.
+ *
+ * Example:
+ *
+ * ```
+ * // tokens.scss
+ * $text-sizes: (
+ *   'title-lg': (
+ *     'font-size': 32px,
+ *     'line-height': 1.3,
+ *     'font-weight': 700,
+ *   ),
+ * )
+ * ```
+ */
+export type HeadingSize = TextSize;
+
 export type HeadingProps = preact.JSX.HTMLAttributes & {
   level?: HeadingLevel;
-  size?: string;
+  size?: HeadingSize;
   weight?: FontWeight;
   children?: ComponentChildren;
 };

--- a/packages/rds/src/components/Heading/Heading.tsx
+++ b/packages/rds/src/components/Heading/Heading.tsx
@@ -1,0 +1,27 @@
+import {ComponentChildren} from 'preact';
+
+import {Text, FontWeight} from '../Text/Text.js';
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+export type HeadingComponent = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export type HeadingProps = preact.JSX.HTMLAttributes & {
+  level?: HeadingLevel;
+  size?: string;
+  weight?: FontWeight;
+  children?: ComponentChildren;
+};
+
+/**
+ * The `<Heading>` component wraps the `<Text>` component and outputs the
+ * appropriate `<h1>`, `<h2>`, etc. tag depending on the `level` prop value.
+ */
+export function Heading(props: HeadingProps) {
+  const {level, size, weight, ...attrs} = props;
+  const tagName = `h${level || 1}` as HeadingComponent;
+  return (
+    <Text {...attrs} as={tagName} size={size} weight={weight}>
+      {props.children}
+    </Text>
+  );
+}

--- a/packages/rds/src/components/Text/Text.module.scss
+++ b/packages/rds/src/components/Text/Text.module.scss
@@ -1,0 +1,14 @@
+@use 'type';
+@use 'tokens';
+
+@each $text-size, $config in type.$text-sizes {
+  .size\:#{$text-size} {
+    @include type.text($config);
+  }
+}
+
+@each $font-weight-name, $font-weight-value in type.$font-weights {
+  .weight\:#{$font-weight-name} {
+    font-weight: $font-weight-value;
+  }
+}

--- a/packages/rds/src/components/Text/Text.tsx
+++ b/packages/rds/src/components/Text/Text.tsx
@@ -1,0 +1,68 @@
+import {ComponentChildren} from 'preact';
+
+import {joinClassNames} from '../../utils/classes.js';
+
+import styles from './Text.module.scss';
+
+export type FontWeight =
+  | 'thin'
+  | 'extra-light'
+  | 'light'
+  | 'normal'
+  | 'regular'
+  | 'semi-bold'
+  | 'bold'
+  | 'extra-bold'
+  | 'black';
+
+export type TextProps = preact.JSX.HTMLAttributes & {
+  /** HTML tagName to use. */
+  as?: preact.JSX.ElementType;
+  size?: string;
+  weight?: FontWeight;
+  children?: ComponentChildren;
+};
+
+/**
+ * The `<Text>` component applies typography styles to an element.
+ *
+ * The text sizes can be configured by defining a `tokens.scss` file with a
+ * configuration map called `$text-sizes`. For example:
+ *
+ * ```
+ * // tokens.scss
+ * $text-sizes: (
+ *   'body-lg': (
+ *     'font-size': 1rem,
+ *     'line-height': 1.5
+ *   ),
+ * );
+ * ```
+ *
+ * After configuring `$text-sizes` in `tokens.scss`, the size should be usable
+ * within the component, e.g.:
+ *
+ * ```
+ * <Text size="body-lg">Lorem ipsum.</Text>
+ * ```
+ */
+export function Text(props: TextProps) {
+  const {as: tagName, size: sizeProp, weight, children, ...attrs} = props;
+  const Component = tagName || 'div';
+  const size = sizeProp || 'body';
+  if (import.meta.env.DEV && !styles[`size:${size}`]) {
+    throw new Error(`<Text> size="${size}" is not configured`);
+  }
+  return (
+    <Component
+      {...attrs}
+      className={joinClassNames(
+        props.className,
+        styles[`size:${size}`],
+        weight && styles[`weight:${weight}`]
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/packages/rds/src/components/Text/Text.tsx
+++ b/packages/rds/src/components/Text/Text.tsx
@@ -15,10 +15,32 @@ export type FontWeight =
   | 'extra-bold'
   | 'black';
 
+/**
+ * The text size values are generated from a variable called `$text-sizes` in
+ * `tokens.scss`.
+ *
+ * Example:
+ *
+ * ```
+ * // tokens.scss
+ * $text-sizes: (
+ *   'body': (
+ *     'font-size': 16px,
+ *     'line-height': 1.5,
+ *   ),
+ *   'body-lg': (
+ *     'font-size': 18px,
+ *     'line-height': 1.5,
+ *   ),
+ * )
+ * ```
+ */
+export type TextSize = string;
+
 export type TextProps = preact.JSX.HTMLAttributes & {
   /** HTML tagName to use. */
   as?: preact.JSX.ElementType;
-  size?: string;
+  size?: TextSize;
   weight?: FontWeight;
   children?: ComponentChildren;
 };

--- a/packages/rds/src/styles/type.scss
+++ b/packages/rds/src/styles/type.scss
@@ -1,0 +1,71 @@
+// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping
+$font-weight-thin: 100;
+$font-weight-extra-light: 200;
+$font-weight-light: 300;
+$font-weight-normal: 400;
+$font-weight-regular: $font-weight-normal;
+$font-weight-medium: 500;
+$font-weight-semi-bold: 600;
+$font-weight-bold: 700;
+$font-weight-extra-bold: 800;
+$font-weight-black: 900;
+$font-weights: (
+  'thin': $font-weight-thin,
+  'extra-light': $font-weight-extra-light,
+  'light': $font-weight-light,
+  'normal': $font-weight-normal,
+  'regular': $font-weight-regular,
+  'medium': $font-weight-medium,
+  'semi-bold': $font-weight-semi-bold,
+  'bold': $font-weight-bold,
+  'extra-bold': $font-weight-extra-bold,
+  'black': $font-weight-black,
+);
+
+@if variable-exists(tokens.$text-sizes) {
+  $text-sizes: tokens.$text-sizes;
+} @else {
+  $text-sizes: (
+    'body': (
+      'font-size': 16px,
+      'line-height': 1.5,
+    ),
+  );
+}
+
+/**
+ * The `text()` mixin accepts a config map and outputs the appropriate style
+ * property.
+ *
+ * Example usage:
+ * ```
+ * .my-text {
+ *   @include type.text((
+ *     'font-size': 1rem,
+ *     'line-height': 1.5,
+ *   ));
+ * }
+ * ```
+ *
+ * A more typical usage for the `text()` mixin is in conjunction with a
+ * `$text-sizes` tokens map, e.g.:
+ * ```
+ * // tokens.scss
+ * $text-sizes: (
+ *   'body-lg': (
+ *     'font-size': 18px,
+ *     'line-height': 1.5,
+ *   ),
+ * );
+ *
+ * // my-component.scss
+ * @include type.text(map.get(tokens.$text-sizes, 'body-lg'));
+ * ```
+ */
+@mixin text($config) {
+  font-family: map.get($config, 'font-family');
+  font-size: map.get($config, 'font-size');
+  line-height: map.get($config, 'line-height');
+  font-weight: map.get($config, 'font-weight');
+  letter-spacing: map.get($config, 'letter-spacing');
+}

--- a/packages/rds/src/utils/classes.ts
+++ b/packages/rds/src/utils/classes.ts
@@ -1,0 +1,10 @@
+type MaybeString = string | false | null | undefined;
+
+/**
+ * Utility class for joining class names together. Ignores falsy values. When
+ * there are no classNames, returns `undefined` so that the class attribute would be
+ * ignored.
+ */
+export function joinClassNames(...classNames: MaybeString[]) {
+  return classNames.filter((c) => !!c).join(' ') || undefined;
+}

--- a/packages/rds/tsconfig.json
+++ b/packages/rds/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "isolatedModules": true,
+    "module": "esnext",
+    "moduleResolution": "node16",
+    "target": "esnext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "pretty": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "types": ["@blinkk/root/client"],
+  },
+  "include": ["./src/**/*.scss", "./src/**/*.ts", "./src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,18 @@ importers:
       '@types/node': 18.13.0
       tsup: 6.6.3
 
+  packages/rds:
+    specifiers:
+      '@blinkk/root': workspace:*
+      copyfiles: ^2.4.1
+      preact: '*'
+      typescript: ^5.0.4
+    devDependencies:
+      '@blinkk/root': link:../root
+      copyfiles: 2.4.1
+      preact: 10.11.0
+      typescript: 5.0.4
+
   packages/root:
     specifiers:
       '@types/compression': ^1.7.2
@@ -3397,6 +3409,19 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /copyfiles/2.4.1:
+    resolution: {integrity: sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+      minimatch: 3.1.2
+      mkdirp: 1.0.4
+      noms: 0.0.0
+      through2: 2.0.5
+      untildify: 4.0.0
+      yargs: 16.2.0
+    dev: true
+
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -5381,6 +5406,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /isarray/0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+    dev: true
+
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
     dev: true
@@ -5933,8 +5962,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
-    optional: true
 
   /modify-values/1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
@@ -6031,6 +6058,13 @@ packages:
       supports-color: 5.5.0
       touch: 3.1.0
       undefsafe: 2.0.5
+    dev: true
+
+  /noms/0.0.0:
+    resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 1.0.34
     dev: true
 
   /nopt/1.0.10:
@@ -6683,6 +6717,15 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /readable-stream/1.0.34:
+    resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+    dev: true
+
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
@@ -7216,6 +7259,10 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /string_decoder/0.10.31:
+    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
+    dev: true
+
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -7380,6 +7427,13 @@ packages:
 
   /through/2.3.8:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
+    dev: true
+
+  /through2/2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
+    dependencies:
+      readable-stream: 2.3.7
+      xtend: 4.0.2
     dev: true
 
   /through2/4.0.2:
@@ -7775,6 +7829,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript/5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+    dev: true
+
   /uc.micro/1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
     dev: false
@@ -7846,6 +7906,11 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
     dev: false
+
+  /untildify/4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -8307,6 +8372,11 @@ packages:
   /xpath/0.0.32:
     resolution: {integrity: sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==}
     engines: {node: '>=0.6.0'}
+    dev: true
+
+  /xtend/4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
     dev: true
 
   /y18n/4.0.3:


### PR DESCRIPTION
## Background

These two foundational typography components will be the first two components for the Root.js Design System (RDS) and will demonstrate how a project will generally depend on the RDS package and use it within their projects.

## Objective

The `<Text>` component is a server-rendered component that applies typography styles to an element. The `<Heading>` component is a lightweight wrapper around the <Text> component that specifically outputs `<h1>`, `<h2>`, etc. semantic tags.

The typography styles should be configurable through design tokens using a SCSS map to store configuration values, which may include type sizes (font-size, line-height, letter-spacing), weights (font-weight), transforms (uppercase), family (font-family), and responsive styles based on breakpoints.

These typography components should also be able to transform markdown to safe HTML and apply default styles for any child elements (e.g. `<ul>` and `<ol>` lists).

From a build standpoint, the RDS package will need to be distributed as a "source" package that will eventually be bundled and transformed through the project's root bundler. This is so that the components can read from the project's design tokens config directly and generate the necessary style variations.

## Build plan doc

https://docs.google.com/document/d/103O6aGvQ19Wflb8yfMTsukKlcHwc3vkHZkKDlJydwkw/edit#