### PR TITLE
feat: base.scss styles for rds

### DIFF
--- a/packages/rds/src/styles/base.scss
+++ b/packages/rds/src/styles/base.scss
@@ -1,13 +1,13 @@
 /**
- * Default CSS styles. This file is similar to a "reset" stylesheet and
- * represents base styles for consistency across all RDS components.
+ * Base CSS styles. This file is similar to a "reset" stylesheet and represents
+ * base styles for consistency across all RDS components.
  *
  * This stylesheet can be imported in two different ways:
  *
  * 1) Import within `BaseLayout.tsx`:
  *
  * ```
- * import '@blinkk/rds/styles/default.scss';
+ * import '@blinkk/rds/styles/base.scss';
  * ```
  *
  * Note: Cannot configure the styles using this method. See (2) if you need to
@@ -16,13 +16,13 @@
  * 2) Import within a SCSS file, e.g. `global.scss`:
  *
  * ```
- * @use '@blinkk/rds/styles/default.scss';
+ * @use '@blinkk/rds/styles/base.scss';
  * ```
  *
  * To change any configurations, use the `@use ... with` syntax, e.g.:
  *
  * ```
- * @use '@blinkk/rds/styles/default.scss' with (
+ * @use '@blinkk/rds/styles/base.scss' with (
  *   $enable-prefers-reduced-motion-overrides: false;
  * );
  * ```

--- a/packages/rds/src/styles/base.scss
+++ b/packages/rds/src/styles/base.scss
@@ -32,7 +32,7 @@ $enable-smooth-scroll: true !default;
 $enable-prefers-reduced-motion-overrides: true !default;
 
 // Styles are wrapped in a cascade layer called `rds.base`, which allows them to
-// be easily overrided at the project level. Any styles that are not wrapped in
+// be easily overriden at the project level. Any styles that are not wrapped in
 // a cascade layer will naturally supercede these styles, but if your project
 // also uses cascade layers, make sure to define the cascade order by doing
 // something like:
@@ -45,7 +45,7 @@ $enable-prefers-reduced-motion-overrides: true !default;
 // }
 // ```
 @layer rds.base {
-  //  Use a more intuitive box-sizing strategy.
+  // Use a more intuitive box-sizing strategy.
   *,
   *::before,
   *::after {

--- a/packages/rds/src/styles/default.scss
+++ b/packages/rds/src/styles/default.scss
@@ -1,0 +1,99 @@
+/**
+ * Default CSS styles. This file is similar to a "reset" stylesheet and
+ * represents base styles for consistency across all RDS components.
+ *
+ * This stylesheet can be imported in two different ways:
+ *
+ * 1) Import within `BaseLayout.tsx`:
+ *
+ * ```
+ * import '@blinkk/rds/styles/default.scss';
+ * ```
+ *
+ * Note: Cannot configure the styles using this method. See (2) if you need to
+ * configure the CSS output.
+ *
+ * 2) Import within a SCSS file, e.g. `global.scss`:
+ *
+ * ```
+ * @use '@blinkk/rds/styles/default.scss';
+ * ```
+ *
+ * To change any configurations, use the `@use ... with` syntax, e.g.:
+ *
+ * ```
+ * @use '@blinkk/rds/styles/default.scss' with (
+ *   $disable-prefers-reduced-motion: true;
+ * );
+ * ```
+ */
+
+$disable-smooth-scroll: false !default;
+$disable-prefers-reduced-motion: false !default;
+
+@layer rds.base {
+  //  Use a more intuitive box-sizing strategy.
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  // Reset margins.
+  body {
+    margin: 0;
+  }
+
+  // The default `display: inline` property of img and video causes extra
+  // vertical space within a parent container. `display: block` is generally
+  // more intuitive. Also set a max-width and auto height based on the
+  // width and height attributes of the element.
+  img,
+  svg,
+  video {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  // Inherit font for form elements.
+  input,
+  button,
+  textarea,
+  select {
+    font: inherit;
+  }
+
+  // Set smooth scrolling by default. The `:focus-within` helps with cmd+f
+  // functionality.
+  // https://css-tricks.com/fixing-smooth-scrolling-with-find-on-page/
+  @if not($disable-smooth-scroll) {
+    html:focus-within {
+      scroll-behavior: smooth;
+    }
+    html {
+      --scroll-padding-top: var(--header-height, 0px);
+      scroll-padding-top: var(--scroll-padding-top);
+    }
+  }
+}
+
+// Disable animations when user prefers reduced motion.
+// NOTE: this style needs to occur outside of the cascade layer in order for the
+// selectivity to take precedence over all other CSS on the page.
+@if not($disable-prefers-reduced-motion) {
+  @media (prefers-reduced-motion: reduce) {
+    html:focus-within {
+     scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+}

--- a/packages/rds/src/styles/default.scss
+++ b/packages/rds/src/styles/default.scss
@@ -31,6 +31,19 @@
 $disable-smooth-scroll: false !default;
 $disable-prefers-reduced-motion: false !default;
 
+// Styles are wrapped in a cascade layer called `rds.base`, which allows them to
+// be easily overrided at the project level. Any styles that are not wrapped in
+// a cascade layer will naturally supercede these styles, but if your project
+// also uses cascade layers, make sure to define the cascade order by doing
+// something like:
+//
+// ```
+// /* CSS Cascade layer order (least selective first). */
+// @layer rds.base yourprojectlayer;
+// @layer yourprojectlayer {
+//   /* project specific styles. */
+// }
+// ```
 @layer rds.base {
   //  Use a more intuitive box-sizing strategy.
   *,
@@ -39,8 +52,11 @@ $disable-prefers-reduced-motion: false !default;
     box-sizing: border-box;
   }
 
-  // Reset margins.
   body {
+    // Prevent iOS text scaling when switching from portrait to landscape.
+    // https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/
+    -webkit-text-size-adjust: 100%;
+    // Reset margins.
     margin: 0;
   }
 
@@ -64,16 +80,31 @@ $disable-prefers-reduced-motion: false !default;
     font: inherit;
   }
 
-  // Set smooth scrolling by default. The `:focus-within` helps with cmd+f
-  // functionality.
+  // Enable smooth-scrolling. The `:focus-within` helps with cmd+f.
   // https://css-tricks.com/fixing-smooth-scrolling-with-find-on-page/
+  //
+  // CSS variable configuration options:
+  //
+  // --scroll-padding-top: This value is used to account for any fixed header
+  //   heights, so that the fixed header doesn't overlap the target element.
+  //   Defaults to var(--header-height).
+  // --scroll-margin-top: This value adds a little bit of extra breathing room
+  //   to the target element so that it isn't completely flushed with the top.
+  //   Defaults to 2ex (2 times the calculated height of the letter 'x').
   @if not($disable-smooth-scroll) {
-    html:focus-within {
-      scroll-behavior: smooth;
-    }
-    html {
-      --scroll-padding-top: var(--header-height, 0px);
-      scroll-padding-top: var(--scroll-padding-top);
+    @media (prefers-reduced-motion: no-preference) {
+      html:focus-within {
+        scroll-behavior: smooth;
+      }
+      // Offset the smooth by the height of the fixed header, if any.
+      html {
+        scroll-padding-top: var(--scroll-padding-top, var(--header-height, 0px));
+      }
+      // Add extra breathing room when scrolling to a target element.
+      // https://piccalil.li/quick-tip/add-scroll-margin-to-all-elements-which-can-be-targeted/
+      [id] {
+        scroll-margin-top: var(--scroll-margin-top, 2ex);
+      }
     }
   }
 }
@@ -83,17 +114,12 @@ $disable-prefers-reduced-motion: false !default;
 // selectivity to take precedence over all other CSS on the page.
 @if not($disable-prefers-reduced-motion) {
   @media (prefers-reduced-motion: reduce) {
-    html:focus-within {
-     scroll-behavior: auto;
-    }
-
     *,
     *::before,
     *::after {
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
-      scroll-behavior: auto !important;
     }
   }
 }

--- a/packages/rds/src/styles/default.scss
+++ b/packages/rds/src/styles/default.scss
@@ -23,13 +23,13 @@
  *
  * ```
  * @use '@blinkk/rds/styles/default.scss' with (
- *   $disable-prefers-reduced-motion: true;
+ *   $enable-prefers-reduced-motion-overrides: false;
  * );
  * ```
  */
 
-$disable-smooth-scroll: false !default;
-$disable-prefers-reduced-motion: false !default;
+$enable-smooth-scroll: true !default;
+$enable-prefers-reduced-motion-overrides: true !default;
 
 // Styles are wrapped in a cascade layer called `rds.base`, which allows them to
 // be easily overrided at the project level. Any styles that are not wrapped in
@@ -80,8 +80,7 @@ $disable-prefers-reduced-motion: false !default;
     font: inherit;
   }
 
-  // Enable smooth-scrolling. The `:focus-within` helps with cmd+f.
-  // https://css-tricks.com/fixing-smooth-scrolling-with-find-on-page/
+  // Enable smooth-scrolling.
   //
   // CSS variable configuration options:
   //
@@ -91,8 +90,10 @@ $disable-prefers-reduced-motion: false !default;
   // --scroll-margin-top: This value adds a little bit of extra breathing room
   //   to the target element so that it isn't completely flushed with the top.
   //   Defaults to 2ex (2 times the calculated height of the letter 'x').
-  @if not($disable-smooth-scroll) {
+  @if $enable-smooth-scroll {
     @media (prefers-reduced-motion: no-preference) {
+      // The `:focus-within` selector helps with cmd+f.
+      // https://css-tricks.com/fixing-smooth-scrolling-with-find-on-page/
       html:focus-within {
         scroll-behavior: smooth;
       }
@@ -112,7 +113,7 @@ $disable-prefers-reduced-motion: false !default;
 // Disable animations when user prefers reduced motion.
 // NOTE: this style needs to occur outside of the cascade layer in order for the
 // selectivity to take precedence over all other CSS on the page.
-@if not($disable-prefers-reduced-motion) {
+@if $enable-prefers-reduced-motion-overrides {
   @media (prefers-reduced-motion: reduce) {
     *,
     *::before,


### PR DESCRIPTION
Build plan doc with previous discussion/comments:
https://docs.google.com/document/d/1tA5A04pH7asOHjdQZo_1t2g55fOlfNZWvL5p5eVdfHw/edit

The base.scss file is meant to act similarly to a "reset stylesheet" to provide consistency across all components. For the most part, only styles that are useful for ALL projects should be included in this sheet. Advanced options (like smooth-scroll and prefers-reduced-motion animation timing resets) can be disabled via SCSS configuration variables.