### PR TITLE
feat: pass rootConfig as context to getStaticPaths

### DIFF
--- a/.changeset/wicked-kiwis-marry.md
+++ b/.changeset/wicked-kiwis-marry.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: pass rootConfig as context to getStaticPaths

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -87,7 +87,7 @@ export class RootCMSClient {
 
   constructor(rootConfig: RootConfig) {
     this.rootConfig = rootConfig;
-    this.cmsPlugin = getCmsPlugin(rootConfig);
+    this.cmsPlugin = getCmsPlugin(this.rootConfig);
 
     const cmsPluginOptions = this.cmsPlugin.getConfig();
     this.projectId = cmsPluginOptions.id || 'default';

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -47,7 +47,9 @@ export type GetStaticProps<T = unknown> = (ctx: {
  * paths that exist for a given route. This should be used alongside a
  * parameterized route, e.g. `/routes/blog/[slug].tsx`.
  */
-export type GetStaticPaths<T = RouteParams> = () => Promise<{
+export type GetStaticPaths<T = RouteParams> = (ctx: {
+  rootConfig: RootConfig;
+}) => Promise<{
   paths: Array<{params: T}>;
 }>;
 
@@ -117,7 +119,7 @@ export type NextFunction = ExpressNextFunction;
  * A context variable passed to a route's `handle()` method within the req
  * object.
  */
-export interface HandlerContext<T = any> {
+export interface HandlerContext<Props = any> {
   /**
    * The resolved route.
    */
@@ -139,7 +141,7 @@ export interface HandlerContext<T = any> {
    */
   getPreferredLocale: (availableLocales: string[]) => string;
   /** Renders the default exported component from the route. */
-  render: HandlerRenderFn;
+  render: HandlerRenderFn<Props>;
   /** Renders a 404 page. */
   render404: () => Promise<void>;
 }
@@ -210,7 +212,7 @@ export interface HandlerRenderOptions {
   translations?: Record<string, string>;
 }
 
-export type HandlerRenderFn = (
-  props: any,
+export type HandlerRenderFn<Props = any> = (
+  props: Props,
   options?: HandlerRenderOptions
 ) => Promise<void>;


### PR DESCRIPTION
This is a fix for SSG-built sites running on Root CMS, which requires the rootConfig to be passed to the RootCMSClient.

```typescript
export async function getStaticPaths(ctx) {
  const client = new RootCMSClient(ctx.rootConfig);
  const docs = await client.listDocs(...);
  return {paths: ...};
}
```