### PR TITLE
feat: add default value caching for object fields

### DIFF
--- a/.changeset/tiny-dancers-shake.md
+++ b/.changeset/tiny-dancers-shake.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: add default value caching for object fields

--- a/examples/blog/collections/BlogPosts.schema.ts
+++ b/examples/blog/collections/BlogPosts.schema.ts
@@ -25,6 +25,7 @@ export default schema.collection({
           id: 'title',
           label: 'Title',
           translate: true,
+          default: 'Lorem ipsum',
         }),
         schema.string({
           id: 'description',

--- a/examples/blog/templates/TemplateHero/TemplateHero.schema.ts
+++ b/examples/blog/templates/TemplateHero/TemplateHero.schema.ts
@@ -20,6 +20,7 @@ export default schema.define({
       id: 'title',
       label: 'Title',
       translate: true,
+      default: 'Hello world',
     }),
     schema.image({
       id: 'image',

--- a/packages/root-cms/cli/commands/generate-types.ts
+++ b/packages/root-cms/cli/commands/generate-types.ts
@@ -152,8 +152,8 @@ function fieldType(field: Field): dom.Type {
     return oneofType;
   }
   if (field.type === 'reference') {
-    const richtextType = dom.create.namedTypeReference('RootCMSReference');
-    return richtextType;
+    const referenceType = dom.create.namedTypeReference('RootCMSReference');
+    return referenceType;
   }
   if (field.type === 'richtext') {
     const richtextType = dom.create.namedTypeReference('RootCMSRichText');

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -672,7 +672,6 @@ DocEditor.OneOfField = (props: FieldProps) => {
     newValue._type = newType;
 
     await props.draft.updateKey(props.deepKey, newValue);
-    // await props.draft.flush();
     setType(newType);
   }
 

--- a/packages/root-cms/ui/components/NewDocModal/NewDocModal.tsx
+++ b/packages/root-cms/ui/components/NewDocModal/NewDocModal.tsx
@@ -1,8 +1,8 @@
 import {Button, Modal, useMantineTheme} from '@mantine/core';
 import {useState} from 'preact/hooks';
 import {route} from 'preact-router';
-import {Collection} from '../../../core/schema.js';
 import {cmsCreateDoc} from '../../utils/doc.js';
+import {getDefaultFieldValue} from '../../utils/fields.js';
 import {SlugInput} from '../SlugInput/SlugInput.js';
 import './NewDocModal.css';
 
@@ -38,23 +38,6 @@ function normalizeSlug(slug: string): string {
     .replaceAll('/', '--');
 }
 
-/**
- * Returns the default field values for a collection. This is used to initialize
- * the doc when it is first created.
- */
-function getDefaultFields(collection: Collection) {
-  const fields: Record<string, unknown> = {};
-  collection.fields.forEach((field) => {
-    if (!field.id) {
-      return;
-    }
-    if (field.default) {
-      fields[field.id] = field.default;
-    }
-  });
-  return fields;
-}
-
 export function NewDocModal(props: NewDocModalProps) {
   const collectionId = props.collection;
   const [slug, setSlug] = useState('');
@@ -87,8 +70,8 @@ export function NewDocModal(props: NewDocModalProps) {
 
     const docId = `${collectionId}/${cleanSlug}`;
     try {
-      const fields = getDefaultFields(rootCollection!);
-      await cmsCreateDoc(docId, {fields});
+      const defaultValue = getDefaultFieldValue(rootCollection);
+      await cmsCreateDoc(docId, {fields: defaultValue});
     } catch (err) {
       setSlugError(String(err));
       setLoading(false);

--- a/packages/root-cms/ui/hooks/useDraft.ts
+++ b/packages/root-cms/ui/hooks/useDraft.ts
@@ -158,7 +158,7 @@ export class DraftController extends EventListener {
    * Updates a single key. The key can be a nested key, e.g. "meta.title".
    */
   async updateKey(key: string, newValue: any) {
-    this.updateKeys({[key]: newValue});
+    await this.updateKeys({[key]: newValue});
   }
 
   /**

--- a/packages/root-cms/ui/utils/array-map.ts
+++ b/packages/root-cms/ui/utils/array-map.ts
@@ -1,0 +1,29 @@
+export interface ArrayMap {
+  [key: string]: any;
+  _array: string[];
+}
+
+/**
+ * Converts an array of objects to a map, where the keys are random and the
+ * array order is preserved through the `_array` field.
+ */
+export function toArrayMap(arr: any[]): ArrayMap {
+  const arrayMap: ArrayMap = {_array: []};
+  arr.forEach((item) => {
+    const key = arrayKey();
+    arrayMap._array.push(key);
+    arrayMap[key] = item;
+  });
+  return arrayMap;
+}
+
+export function arrayKey() {
+  const result = [];
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charsLength = chars.length;
+  for (let i = 0; i < 6; i++) {
+    result.push(chars.charAt(Math.floor(Math.random() * charsLength)));
+  }
+  return result.join('');
+}

--- a/packages/root-cms/ui/utils/fields.ts
+++ b/packages/root-cms/ui/utils/fields.ts
@@ -1,0 +1,28 @@
+import {Collection, ObjectField, Schema} from '../../core/schema.js';
+import {toArrayMap} from './array-map.js';
+
+/**
+ * Returns the default field values for a collection or object field. Used for
+ * initializing a new doc or when adding a new array item.
+ */
+export function getDefaultFieldValue(field: Collection | ObjectField | Schema) {
+  const defaultValue: Record<string, unknown> = {};
+  field.fields.forEach((child) => {
+    if (!child.id) {
+      return;
+    }
+    if (
+      child.type === 'array' &&
+      child.default &&
+      Array.isArray(child.default)
+    ) {
+      // Convert to an "array map" for storage in the db.
+      defaultValue[child.id] = toArrayMap(child.default);
+    } else if (child.default) {
+      defaultValue[child.id] = child.default;
+    } else if (child.type === 'object') {
+      defaultValue[child.id] = getDefaultFieldValue(child);
+    }
+  });
+  return defaultValue;
+}


### PR DESCRIPTION
With this change, selecting a new type in the `oneOf` field will initially default to a default value. When a user switches back to a previous type, the previous value for that type will be automatically re-inserted.