### PR TITLE
feat: add support for non-default firestore databases

### DIFF
--- a/.changeset/cold-rivers-flash.md
+++ b/.changeset/cold-rivers-flash.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add support for non-default firestore databases

--- a/packages/root-cms/cli/init-firebase.ts
+++ b/packages/root-cms/cli/init-firebase.ts
@@ -1,5 +1,5 @@
 import {loadRootConfig} from '@blinkk/root/node';
-import {Firestore, getFirestore} from 'firebase-admin/firestore';
+import {Firestore} from 'firebase-admin/firestore';
 import {getCmsPlugin} from '../core/client.js';
 import {applySecurityRules} from '../core/security.js';
 

--- a/packages/root-cms/cli/init-firebase.ts
+++ b/packages/root-cms/cli/init-firebase.ts
@@ -27,8 +27,7 @@ export async function initFirebase(options: InitFirebaseOptions) {
   await applySecurityRules(gcpProjectId);
 
   if (options.admin) {
-    const app = cmsPlugin.getFirebaseApp();
-    const db = getFirestore(app);
+    const db = cmsPlugin.getFirestore();
     const rootProjectId = cmsPluginOptions.id || 'default';
     await addAdmin(db, rootProjectId, options.admin);
   }

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -140,7 +140,7 @@ export class RootCMSClient {
     const cmsPluginOptions = this.cmsPlugin.getConfig();
     this.projectId = cmsPluginOptions.id || 'default';
     this.app = this.cmsPlugin.getFirebaseApp();
-    this.db = getFirestore(this.app);
+    this.db = this.cmsPlugin.getFirestore();
   }
 
   /**

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -141,6 +141,12 @@ function getFirebaseApp(gcpProjectId: string): App {
 }
 
 export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
+  if (!options.firebaseConfig) {
+    throw new Error(
+      'missing firebaseConfig. create a new app in the firebase admin console and copy the firebase config object to root.config.ts'
+    );
+  }
+
   const firebaseConfig = options.firebaseConfig || {};
   const app = getFirebaseApp(firebaseConfig.projectId);
   const auth = getAuth(app);

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -18,6 +18,7 @@ import {
   initializeApp,
 } from 'firebase-admin/app';
 import {getAuth, DecodedIdToken} from 'firebase-admin/auth';
+import {Firestore, getFirestore} from 'firebase-admin/firestore';
 import * as jsonwebtoken from 'jsonwebtoken';
 import sirv from 'sirv';
 import {generateTypes} from '../cli/generate-types.js';
@@ -53,11 +54,12 @@ export type CMSPluginOptions = {
    * going to "Project Settings".
    */
   firebaseConfig: {
-    [key: string]: string;
+    [key: string]: string | undefined;
     apiKey: string;
     authDomain: string;
     projectId: string;
     storageBucket: string;
+    databaseId?: string;
   };
 
   /**
@@ -112,6 +114,7 @@ export type CMSPlugin = Plugin & {
   name: 'root-cms';
   getConfig: () => CMSPluginOptions;
   getFirebaseApp: () => App;
+  getFirestore: () => Firestore;
 };
 
 function isExpired(decodedIdToken: DecodedIdToken) {
@@ -138,7 +141,7 @@ function getFirebaseApp(gcpProjectId: string): App {
 }
 
 export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
-  const firebaseConfig = options.firebaseConfig;
+  const firebaseConfig = options.firebaseConfig || {};
   const app = getFirebaseApp(firebaseConfig.projectId);
   const auth = getAuth(app);
 
@@ -323,6 +326,14 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
      */
     getFirebaseApp: () => {
       return app;
+    },
+
+    /**
+     * Returns the Firestore instance used by the plugin.
+     */
+    getFirestore: () => {
+      const databaseId = firebaseConfig.databaseId || '(default)';
+      return getFirestore(app, databaseId);
     },
 
     /**

--- a/packages/root-cms/core/runtime.ts
+++ b/packages/root-cms/core/runtime.ts
@@ -1,12 +1,7 @@
 /** @deprecated Use client.ts instead. */
 
 import {RootConfig} from '@blinkk/root';
-import {
-  FieldValue,
-  Query,
-  Timestamp,
-  getFirestore,
-} from 'firebase-admin/firestore';
+import {FieldValue, Query, Timestamp} from 'firebase-admin/firestore';
 import {
   LoadTranslationsOptions,
   LocaleTranslations,
@@ -34,8 +29,7 @@ export async function getDoc<T>(
   const projectId = cmsPluginOptions.id || 'default';
   const mode = options.mode;
   const modeCollection = mode === 'draft' ? 'Drafts' : 'Published';
-  const app = cmsPlugin.getFirebaseApp();
-  const db = getFirestore(app);
+  const db = cmsPlugin.getFirestore();
   // Slugs with slashes are encoded as `--` in the DB.
   slug = slug.replaceAll('/', '--');
   const dbPath = `Projects/${projectId}/Collections/${collectionId}/${modeCollection}/${slug}`;
@@ -70,8 +64,7 @@ export async function listDocs<T>(
   const projectId = cmsPluginOptions.id || 'default';
   const mode = options.mode;
   const modeCollection = mode === 'draft' ? 'Drafts' : 'Published';
-  const app = cmsPlugin.getFirebaseApp();
-  const db = getFirestore(app);
+  const db = cmsPlugin.getFirestore();
   const dbPath = `Projects/${projectId}/Collections/${collectionId}/${modeCollection}`;
   let query: Query = db.collection(dbPath);
   if (options.limit) {
@@ -112,8 +105,7 @@ export async function numDocs(
   const projectId = cmsPluginOptions.id || 'default';
   const mode = options.mode;
   const modeCollection = mode === 'draft' ? 'Drafts' : 'Published';
-  const app = cmsPlugin.getFirebaseApp();
-  const db = getFirestore(app);
+  const db = cmsPlugin.getFirestore();
   const dbPath = `Projects/${projectId}/Collections/${collectionId}/${modeCollection}`;
   let query: Query = db.collection(dbPath);
   if (options.query) {
@@ -132,8 +124,7 @@ export async function publishScheduledDocs(rootConfig: RootConfig) {
   const cmsPlugin = getCmsPlugin(rootConfig);
   const cmsPluginOptions = cmsPlugin.getConfig();
   const projectId = cmsPluginOptions.id || 'default';
-  const app = cmsPlugin.getFirebaseApp();
-  const db = getFirestore(app);
+  const db = cmsPlugin.getFirestore();
 
   const projectCollectionsPath = `Projects/${projectId}/Collections`;
   const now = Math.ceil(new Date().getTime());
@@ -248,8 +239,7 @@ export async function loadTranslations(
   const cmsPlugin = getCmsPlugin(rootConfig);
   const cmsPluginOptions = cmsPlugin.getConfig();
   const projectId = cmsPluginOptions.id || 'default';
-  const app = cmsPlugin.getFirebaseApp();
-  const db = getFirestore(app);
+  const db = cmsPlugin.getFirestore();
 
   const dbPath = `Projects/${projectId}/Translations`;
   let query: Query = db.collection(dbPath);

--- a/packages/root-cms/core/versions.ts
+++ b/packages/root-cms/core/versions.ts
@@ -20,12 +20,7 @@
 
 import path from 'node:path';
 import {RootConfig} from '@blinkk/root';
-import {
-  Firestore,
-  Query,
-  Timestamp,
-  getFirestore,
-} from 'firebase-admin/firestore';
+import {Firestore, Query, Timestamp} from 'firebase-admin/firestore';
 import glob from 'tiny-glob';
 import {getCmsPlugin} from './client.js';
 
@@ -56,8 +51,7 @@ export class VersionsService {
     const cmsPluginOptions = cmsPlugin.getConfig();
     const projectId = cmsPluginOptions.id || 'default';
     this.projectId = projectId;
-    const app = cmsPlugin.getFirebaseApp();
-    this.db = getFirestore(app);
+    this.db = cmsPlugin.getFirestore();
   }
 
   /**

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -138,15 +138,20 @@ function loginRedirect() {
 }
 
 const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
+const databaseId = window.__ROOT_CTX.firebaseConfig.databaseId || '(default)';
 // const db = getFirestore(app);
 // NOTE(stevenle): the firestore web channel rpc sometimes has issues in
 // collections with a large number of docs. Forcing long polling and disabling
 // fetch streams seems to work for some people. This may cause performance
 // issues however.
-const db = initializeFirestore(app, {
-  experimentalForceLongPolling: true,
-  useFetchStreams: false,
-} as any);
+const db = initializeFirestore(
+  app,
+  {
+    experimentalForceLongPolling: true,
+    useFetchStreams: false,
+  } as any,
+  databaseId
+);
 const auth = getAuth(app);
 const storage = getStorage(app);
 auth.onAuthStateChanged((user) => {


### PR DESCRIPTION
Context: Root CMS requires firestore to be in "native" mode. Some older GCP projects will have the default database in "datastore" mode, which cannot be easily migrated. Those projects can create a "new database" in native mode and they can set which database to use by updating the root.config.ts file:

```typescript
firebaseConfig: {
  ...
  databaseId: 'my-native-firestore-database-id',
}
```