### PR TITLE
feat: add "inline" option to object drawers

### DIFF
--- a/.changeset/flat-gifts-battle.md
+++ b/.changeset/flat-gifts-battle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add "inline" option to object drawers

--- a/docs/blocks/ImageBlock/ImageBlock.schema.ts
+++ b/docs/blocks/ImageBlock/ImageBlock.schema.ts
@@ -29,5 +29,23 @@ export default schema.define({
       help: 'Optional caption that displays below the image.',
       translate: true,
     }),
+    schema.object({
+      id: 'advanced',
+      label: 'Advanced',
+      help: 'These fields are optional.',
+      fields: [
+        schema.string({
+          id: 'maxWidth',
+          label: 'Max Width',
+          help: 'e.g. 300px',
+        }),
+        schema.boolean({
+          id: 'bordered',
+          label: 'Bordered?',
+        }),
+      ],
+      variant: 'drawer',
+      drawerOptions: {collapsed: true, inline: true},
+    }),
   ],
 });

--- a/docs/root-cms.d.ts
+++ b/docs/root-cms.d.ts
@@ -107,6 +107,13 @@ export interface ImageBlockFields {
   image?: RootCMSImage;
   /** Caption. Optional caption that displays below the image. */
   caption?: string;
+  /** Advanced. These fields are optional. */
+  advanced?: {
+    /** Max Width. e.g. 300px */
+    maxWidth?: string;
+    /** Bordered? */
+    bordered?: boolean;
+  };
 }
 
 /** Generated from `/collections/BlogPosts.schema.ts`. */

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -128,7 +128,13 @@ export type ObjectField = CommonFieldProps & {
   variant?: 'drawer';
   /** Options for the "drawer" variant. */
   drawerOptions?: {
+    /** Whether the drawer should initialize to the "collapsed" state. */
     collapsed?: boolean;
+    /**
+     * Whether to render the drawer "inline" (this removes borders from the
+     * toggle button).
+     */
+    inline?: boolean;
   };
 };
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -105,6 +105,19 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.DocEditor__ObjectFieldDrawer--inline .mantine-Accordion-control {
+  border-top: none;
+  border-bottom: none;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .mantine-Accordion-icon {
+  margin-right: 8px;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .mantine-Accordion-content {
+  padding-left: 24px;
+}
+
 .DocEditor__ObjectFieldDrawer .mantine-Accordion-contentInner {
   border: none;
   padding: 12px 16px;
@@ -197,7 +210,7 @@
 }
 
 .DocEditor__ArrayField__item[open] .DocEditor__ArrayField__item__body {
-  padding: 8px;
+  padding: 12px;
   border: 2px solid lightblue;
 }
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -315,9 +315,16 @@ DocEditor.ObjectField = (props: FieldProps) => {
 DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
   const field = props.field as schema.ObjectField;
   const collapsed = field.drawerOptions?.collapsed || false;
+  const inline = field.drawerOptions?.inline || false;
+  const iconPosition = inline ? 'left' : 'right';
   return (
-    <div className="DocEditor__ObjectFieldDrawer">
-      <Accordion iconPosition="right" initialItem={collapsed ? -1 : 0}>
+    <div
+      className={joinClassNames(
+        'DocEditor__ObjectFieldDrawer',
+        inline && 'DocEditor__ObjectFieldDrawer--inline'
+      )}
+    >
+      <Accordion iconPosition={iconPosition} initialItem={collapsed ? -1 : 0}>
         <Accordion.Item
           label={
             <DocEditor.FieldHeader


### PR DESCRIPTION
The "inline" drawer option to object fields allows users to create "expandable" fields that are hidden away, useful for adding "advanced" features without cluttering the UI.

<img width="546" alt="Screenshot 2024-06-06 at 9 07 57 AM" src="https://github.com/blinkk/rootjs/assets/387282/66f606dc-3161-48da-990a-0e4432faf942">

<img width="538" alt="Screenshot 2024-06-06 at 9 08 06 AM" src="https://github.com/blinkk/rootjs/assets/387282/b5dfbf95-114a-434a-b15c-b56f00767794">


fixes #287 