### PR TITLE
feat: add cms field deeplinking

### DIFF
--- a/.changeset/quick-mice-sit.md
+++ b/.changeset/quick-mice-sit.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add cms field deeplinking

--- a/docs/templates/Divider/Divider.schema.ts
+++ b/docs/templates/Divider/Divider.schema.ts
@@ -22,6 +22,8 @@ export default schema.define({
       label: 'Spacer',
       help: 'Optional. Vertical spacing above and below the divider.',
       fields: Spacer.fields,
+      variant: 'drawer',
+      drawerOptions: {collapsed: true, inline: true},
     }),
   ],
 });

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -51,8 +51,9 @@
 
 .DocEditor__field.deeplink-target {
   padding: 16px;
-  margin: -16px;
-  background: #FFF9DB;
+  background: linear-gradient(rgb(255, 248, 197), rgb(255, 248, 197));
+  border: 1px solid rgba(212, 167, 44, 0.4);
+  border-radius: 4px;
 }
 
 .DocEditor__FieldHeader__label {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -49,9 +49,33 @@
   opacity: 0.5;
 }
 
+.DocEditor__field.deeplink-target {
+  padding: 16px;
+  margin: -16px;
+  background: #FFF9DB;
+}
+
 .DocEditor__FieldHeader__label {
   font-size: 12px;
   font-weight: 600;
+  display: flex;
+  gap: 8px;
+}
+
+.DocEditor__FieldHeader__label__deeplink {
+  color: #CED4DA;
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.DocEditor__FieldHeader__label:hover .DocEditor__FieldHeader__label__deeplink {
+  opacity: 1;
+}
+
+.DocEditor__FieldHeader__label__deeplink:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .DocEditor__FieldHeader__help {
@@ -120,7 +144,7 @@
 
 .DocEditor__ObjectFieldDrawer .mantine-Accordion-contentInner {
   border: none;
-  padding: 12px 16px;
+  padding: 16px;
 }
 
 .DocEditor__ArrayField__items {
@@ -210,7 +234,7 @@
 }
 
 .DocEditor__ArrayField__item[open] .DocEditor__ArrayField__item__body {
-  padding: 12px;
+  padding: 16px;
   border: 2px solid lightblue;
 }
 

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.css
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.css
@@ -1,5 +1,6 @@
 .RichTextEditor {
   border: 1px solid #ced4da;
+  background: #fff;
   padding: 4px 10px;
 }
 

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -45,7 +45,7 @@
 }
 
 .DocumentPage__side__editor {
-  padding: 16px 12px 160px;
+  padding: 16px 12px 400px;
 }
 
 .DocumentPage__main {


### PR DESCRIPTION
When user hovers over a field label, it should present a `#` symbol which can be used for deeplinking. When the CMS editor loads, it will automatically "open" all parent drawers for the deeplink and scroll to it, highlighting it in yellow.

screens:

<img width="1918" alt="Screenshot 2024-06-06 at 2 46 54 PM" src="https://github.com/blinkk/rootjs/assets/387282/6e74e9ac-9d3b-40a0-b8c9-8779abc981a3">

fixes #351 