### PR TITLE
fix: prevent unauthorized users from accessing cms ui

### DIFF
--- a/.changeset/chilled-lizards-hide.md
+++ b/.changeset/chilled-lizards-hide.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: prevent unauthorized users from accessing cms ui

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -567,7 +567,9 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       // Render the CMS SPA.
       server.use('/cms', async (req: Request, res: Response) => {
         try {
-          // If user is not logged in and authorized, redirect to the login page.
+          // Enforce login for all CMS paths. The `req.user` would only be
+          // populated if the firebase auth token is valid and the user has
+          // access via the Root CMS sharebox.
           if (!req.user) {
             redirectToLogin(req, res);
             return;


### PR DESCRIPTION
Note: This bug fixes a case sensitive issue with unauthorized users being able to see the CMS UI by accessing /CMS (all caps). The user would not have been able to see any of the actual content which is guarded by firestore's security rules.

With this fix, there are additional checks to ensure the user is logged in and verified to have access (via the site's ACL) before being rendered the CMS UI.