### PR TITLE
fix: remove empty space below collection name

### DIFF
--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -102,9 +102,11 @@ export function CollectionPage(props: CollectionPageProps) {
                 <div className="CollectionPage__side__collection__name">
                   {collection.name || collection.id}
                 </div>
-                <div className="CollectionPage__side__collection__desc">
-                  {collection.description || ''}
-                </div>
+                {collection.description && (
+                  <div className="CollectionPage__side__collection__desc">
+                    {collection.description}
+                  </div>
+                )}
               </a>
             ))}
             {matchedCollections.length === 0 && (

--- a/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
+++ b/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
@@ -69,9 +69,11 @@ ProjectPage.CollectionList = () => {
           <div className="ProjectPage__collectionList__collection__name">
             {collection.name || collection.id}
           </div>
-          <div className="ProjectPage__collectionList__collection__desc">
-            {collection.description || ''}
-          </div>
+          {collection.description && (
+            <div className="ProjectPage__collectionList__collection__desc">
+              {collection.description}
+            </div>
+          )}
         </a>
       ))}
       {collections.length === 0 && (


### PR DESCRIPTION
- empty space appears when collection description is left blank