### PR TITLE
feat: add hotkey support to array items in doc editor

### DIFF
--- a/.changeset/funny-apples-hide.md
+++ b/.changeset/funny-apples-hide.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add hotkey support to array items in doc editor

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -275,6 +275,14 @@
   border: 2px solid lightblue;
 }
 
+.DocEditor__ArrayField__item__header:focus:not(:focus-visible) .DocEditor__ArrayField__item__header__preview {
+  text-decoration: underline;
+}
+
+.DocEditor__ArrayField__item__header:focus-visible {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
 .DocEditor__ArrayField__add {
   margin-top: 16px;
 }

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -507,6 +507,8 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
 interface ArrayFieldValue {
   [key: string]: any;
   _array: string[];
+  /** Tracks the last-moved array item. */
+  _moved?: string;
   _new?: string[];
 }
 
@@ -681,6 +683,7 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       return {
         ...data,
         _array: order,
+        _moved: order[action.index - 1],
       };
     }
     case 'moveDown': {
@@ -696,6 +699,7 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       return {
         ...data,
         _array: order,
+        _moved: order[action.index + 1],
       };
     }
     case 'removeAt': {
@@ -743,6 +747,13 @@ DocEditor.ArrayField = (props: FieldProps) => {
     return unsubscribe;
   }, []);
 
+  // Focus the field that was just moved (for hotkey support).
+  useEffect(() => {
+    if (value._moved) {
+      focusFieldHeader(props.deepKey, order.indexOf(value._moved));
+    }
+  }, [value]);
+
   const add = () => {
     dispatch({type: 'add', draft: draft, deepKey: props.deepKey});
   };
@@ -783,22 +794,31 @@ DocEditor.ArrayField = (props: FieldProps) => {
     });
   };
 
+  /** Focus the field header (the clickable "summary" part). */
+  const focusFieldHeader = (deepKey: string, index: number) => {
+    document.getElementById(`summary-for-${deepKey}.${order[index]}`)?.focus();
+  };
+
   const moveUp = (index: number) => {
-    dispatch({
-      type: 'moveUp',
-      draft: draft,
-      deepKey: props.deepKey,
-      index: index,
-    });
+    if (index > 0) {
+      dispatch({
+        type: 'moveUp',
+        draft: draft,
+        deepKey: props.deepKey,
+        index: index,
+      });
+    }
   };
 
   const moveDown = (index: number) => {
-    dispatch({
-      type: 'moveDown',
-      draft: draft,
-      deepKey: props.deepKey,
-      index: index,
-    });
+    if (index < order.length - 1) {
+      dispatch({
+        type: 'moveDown',
+        draft: draft,
+        deepKey: props.deepKey,
+        index: index,
+      });
+    }
   };
 
   const editJsonModal = useEditJsonModal();
@@ -828,6 +848,26 @@ DocEditor.ArrayField = (props: FieldProps) => {
     );
   }
 
+  /** Handler for using the arrow keys when the array item's header is focused.  */
+  function handleKeyDown(e: KeyboardEvent, arrayKey: string) {
+    if (!e.target) {
+      return;
+    }
+    // Move the items up and down using the up/down arrow keys.
+    // Collapse and expand the item using the left/right arrow keys.
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveUp(order.indexOf(arrayKey));
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveDown(order.indexOf(arrayKey));
+    } else if (e.key === 'ArrowLeft') {
+      (e.target as HTMLElement).closest('details')!.open = false;
+    } else if (e.key === 'ArrowRight') {
+      (e.target as HTMLElement).closest('details')!.open = true;
+    }
+  }
+
   return (
     <div className="DocEditor__ArrayField">
       <div className="DocEditor__ArrayField__items">
@@ -840,7 +880,12 @@ DocEditor.ArrayField = (props: FieldProps) => {
             key={key}
             open={newlyAdded.includes(key) || itemInDeeplink(key)}
           >
-            <summary className="DocEditor__ArrayField__item__header">
+            <summary
+              id={`summary-for-${props.deepKey}.${order[i]}`}
+              className="DocEditor__ArrayField__item__header"
+              onKeyDown={(e: KeyboardEvent) => handleKeyDown(e, key)}
+              tabIndex={0}
+            >
               <div className="DocEditor__ArrayField__item__header__icon">
                 <IconTriangleFilled size={6} />
               </div>


### PR DESCRIPTION
screencast:
https://github.com/user-attachments/assets/026412b9-6ef3-4a21-abd1-367a99f3ac0a

- the focus ring is only visible once you use the hotkeys
- otherwise, the only ui change is the last-moved field gets underlined (this helps disambiguate between two fields with the same preview)

