### PR TITLE
chore: add warning when multiple routes generate the same path

### DIFF
--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -393,6 +393,14 @@ export class Renderer {
     });
   }
 
+  /**
+   * Constructs and returns the project's sitemap.
+   *
+   * The sitemap is used to:
+   * - determine all paths to build in SSG mode
+   * - display links on the dev server's 404 page
+   * - construct alternates for localized URL paths
+   */
   async getSitemap(): Promise<Sitemap> {
     const sitemap: Sitemap = {};
     const sitemapItemAlts: Record<
@@ -429,6 +437,11 @@ export class Renderer {
           hrefLang: hrefLang,
           alts: sitemapItemAlts[defaultUrlPath],
         };
+        if (sitemap[routePath.urlPath]) {
+          console.warn(
+            `multiple routes generate the same path: ${routePath.urlPath}. ensure each route generates a unique path.`
+          );
+        }
         sitemap[routePath.urlPath] = sitemapItem;
       });
     });


### PR DESCRIPTION
I ran into a consistency issue with a project where the `index.tsx` and `[[...page]].tsx` both generated files for the same route, so it became inconsistent across builds.

In Amagaki, this was a build failure. Not sure we should make this a bonafide failure so for now I've made it emit a warning (that will at least assist with debugging).