### PR TITLE
chore: stick translations fields to top

### DIFF
--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.css
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.css
@@ -30,6 +30,7 @@
 .EditTranslationsModal__table td:first-child {
   width: 350px;
   padding-left: 10px;
+  vertical-align: top;
 }
 
 .EditTranslationsModal__table tbody td {
@@ -42,6 +43,8 @@
   background-color: #f8f9fa;
   border: 1px solid #dee2e6;
   padding: 10px;
+  position: sticky;
+  top: 0;
   border-radius: 4px;
   height: 100%;
   white-space: pre-wrap;


### PR DESCRIPTION
this is a small change to make it easier to see the source string when working with large numbers of long translation strings