### PR TITLE
chore: make select fields searchable

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1169,6 +1169,7 @@ DocEditor.OneOfField = (props: FieldProps) => {
           onChange={(e: string) => onTypeChange(e || '')}
           size="xs"
           radius={0}
+          searchable
           // Due to issues with preact/compat, use a div for the dropdown el.
           dropdownComponent="div"
         />

--- a/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
@@ -42,6 +42,7 @@ export function SelectField(props: FieldProps) {
         onChange={(e: string) => onChange(e || '')}
         size="xs"
         radius={0}
+        searchable
         // Due to issues with preact/compat, use a div for the dropdown el.
         dropdownComponent="div"
       />


### PR DESCRIPTION
this helps with long lists of values; the user can hit the first letter of the template to jump to it