### PR TITLE
fix: add id to serialized collection data

### DIFF
--- a/.changeset/khaki-otters-ring.md
+++ b/.changeset/khaki-otters-ring.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: add id to serialized collection data #514

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -147,7 +147,8 @@ export async function renderApp(
  */
 function serializeCollection(collection: Collection): Partial<Collection> {
   return {
-    name: collection.name,
+    id: collection.id,
+    name: collection.name ?? collection.id,
     description: collection.description,
     domain: collection.domain,
     url: collection.url,
@@ -249,10 +250,18 @@ export function getCollections(): Record<string, Collection> {
   const schemas = getProjectSchemas();
   Object.entries(schemas).forEach(([fileId, schema]) => {
     if (fileId.startsWith('/collections/')) {
-      collections[schema.name] = schema as Collection;
+      const collectionId = parseCollectionId(fileId);
+      collections[collectionId] = {...schema, id: collectionId} as Collection;
     }
   });
   return collections;
+}
+
+/**
+ * Converts a fileId path like "/collections/Foo.schema.ts" and returns "Foo".
+ */
+function parseCollectionId(fileId: string) {
+  return path.basename(fileId).split('.')[0];
 }
 
 function generateNonce() {

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -256,6 +256,11 @@ export const define = defineSchema;
 
 export type Collection = Schema & {
   /**
+   * The ID of the collection. This comes from the schema filename, e.g
+   * `<id>.schema.ts`.
+   */
+  id: string;
+  /**
    * Domain where the collection serves from. Used for multi-domain sites,
    * defaults to the "domain" value `from root.config.ts`.
    */

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -102,7 +102,7 @@ function useDocData(): CMSDoc {
 
 export function DocEditor(props: DocEditorProps) {
   // Load the full collection schema.
-  const collection = useCollectionSchema(props.collection.name);
+  const collection = useCollectionSchema(props.collection.id);
   const draft = props.draft;
   const {controller, saveState, data} = draft;
   const ref = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
The "id" is the identifier used to store in the DB. The collection "name" is a user-friendly label that's rendered in the CMS UI.