### PR TITLE
Update Node engines to >=18

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "module": "index.js",
   "engines": {
-    "node": "18"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "root dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Root.js is a developer-focused CMS that writes directly to Firestore.",
   "packageManager": "pnpm@8.9.0",
   "main": "index.js",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "turbo run build --filter=\"@blinkk/*\"",
     "changeset": "changeset",

--- a/packages/create-root/package.json
+++ b/packages/create-root/package.json
@@ -5,7 +5,7 @@
   "author": "s@blinkk.com",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-root/package.json
+++ b/packages/eslint-config-root/package.json
@@ -9,7 +9,7 @@
     "eslintconfig"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/rds/package.json
+++ b/packages/rds/package.json
@@ -5,7 +5,7 @@
   "author": "s@blinkk.com",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -4,7 +4,7 @@
   "author": "s@blinkk.com",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- update all package Node engine requirements to `>=18.0.0`

## Testing
- `pnpm test` *(fails: ConnectTimeoutError while fetching pnpm)*