### PR TITLE
Remove extra semicolons in example configs

### DIFF
--- a/examples/basepath/root.config.ts
+++ b/examples/basepath/root.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import {URL} from 'node:url';
 import {defineConfig} from '@blinkk/root';
 
-const rootDir = new URL('.', import.meta.url).pathname;;
+const rootDir = new URL('.', import.meta.url).pathname;
 
 export default defineConfig({
   base: '/foo/',

--- a/examples/starter/root.config.ts
+++ b/examples/starter/root.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import {URL} from 'node:url';
 import {defineConfig} from '@blinkk/root';
 
-const rootDir = new URL('.', import.meta.url).pathname;;
+const rootDir = new URL('.', import.meta.url).pathname;
 
 export default defineConfig({
   vite: {


### PR DESCRIPTION
## Summary
- fix `rootDir` declarations in example configs

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*