### PR TITLE
Fix missing keys for mapped elements

### DIFF
--- a/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
@@ -250,8 +250,8 @@ DataSourcePage.DataTable = (props: {headers?: string[]; rows?: string[][]}) => {
           </thead>
         )}
         <tbody>
-          {rows.map((row) => (
-            <tr>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
               {row.map((cell, i) => (
                 <td key={i}>{cell}</td>
               ))}

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
@@ -279,7 +279,7 @@ ReleasePage.DocsList = (props: {release: Release}) => {
       </div>
       <div className="ReleasePage__DocsList__cards">
         {docIds.map((docId) => (
-          <div className="ReleasePage__DocsList__card">
+          <div key={docId} className="ReleasePage__DocsList__card">
             <a href={`/cms/content/${docId}`}>
               <DocPreviewCard docId={docId} statusBadges />
             </a>

--- a/packages/root-cms/ui/pages/TranslationsArbPage/TranslationsArbPage.tsx
+++ b/packages/root-cms/ui/pages/TranslationsArbPage/TranslationsArbPage.tsx
@@ -181,7 +181,7 @@ TranslationsArbPage.Preview = (props: {arb: Arb}) => {
       </thead>
       <tbody>
         {values.map((item) => (
-          <tr class="TranslationsArbPage__Preview__Table__row">
+          <tr key={item.source} class="TranslationsArbPage__Preview__Table__row">
             <td>{item.source}</td>
             <td>
               {item.meta?.context}


### PR DESCRIPTION
## Summary
- add row key when rendering DataSourcePage table
- give ReleasePage doc list items unique keys
- key ARB preview rows by source value

## Testing
- `pnpm test` *(fails: ConnectTimeoutError when fetching pnpm)*