### PR TITLE
Add version tagging on publish

### DIFF
--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -345,7 +345,7 @@ export class RootCMSClient {
    */
   async publishDocs(
     docIds: string[],
-    options?: {publishedBy: string; batch?: WriteBatch}
+    options?: {publishedBy: string; batch?: WriteBatch; releaseId?: string}
   ) {
     const projectCollectionsPath = `Projects/${this.projectId}/Collections`;
     const publishedBy = options?.publishedBy || 'root-cms-client';
@@ -384,6 +384,10 @@ export class RootCMSClient {
     // // https://firebase.google.com/docs/firestore/manage-data/transactions
     let batchCount = 0;
     const batch = options?.batch || this.db.batch();
+    const versionTags = ['published'];
+    if (options?.releaseId) {
+      versionTags.push(`release:${options.releaseId}`);
+    }
     const publishedDocs: any[] = [];
     for (const doc of docs) {
       const {id, collection, slug, sys, fields} = doc;
@@ -416,6 +420,29 @@ export class RootCMSClient {
           publishedBy: publishedBy,
         },
       });
+      batchCount += 1;
+
+      // Save a version snapshot of the published doc.
+      const versionRef = this.db.doc(
+        `${projectCollectionsPath}/${collection}/Drafts/${slug}/Versions/${Date.now()}`
+      );
+      const versionData: any = {
+        id,
+        collection,
+        slug,
+        fields: fields || {},
+        sys: {
+          ...sys,
+          firstPublishedAt: firstPublishedAt,
+          firstPublishedBy: firstPublishedBy,
+          publishedAt: FieldValue.serverTimestamp(),
+          publishedBy: publishedBy,
+        },
+      };
+      if (versionTags.length) {
+        versionData.tags = versionTags;
+      }
+      batch.set(versionRef, versionData);
       batchCount += 1;
 
       // Remove scheduled doc, if any.
@@ -495,6 +522,7 @@ export class RootCMSClient {
     // https://firebase.google.com/docs/firestore/manage-data/transactions
     let batchCount = 0;
     const batch = this.db.batch();
+    const versionTags = ['published'];
     const publishedDocs: any[] = [];
     for (const doc of docs) {
       const {id, collection, slug, data} = doc;
@@ -528,6 +556,27 @@ export class RootCMSClient {
           publishedBy: scheduledBy || '',
         },
       });
+      batchCount += 1;
+
+      // Save a version snapshot of the published doc.
+      const versionRef = this.db.doc(
+        `${projectCollectionsPath}/${collection}/Drafts/${slug}/Versions/${Date.now()}`
+      );
+      const versionData: any = {
+        id,
+        collection,
+        slug,
+        fields: data.fields || {},
+        sys: {
+          ...sys,
+          firstPublishedAt: firstPublishedAt,
+          firstPublishedBy: firstPublishedBy,
+          publishedAt: FieldValue.serverTimestamp(),
+          publishedBy: scheduledBy || '',
+        },
+        tags: versionTags,
+      };
+      batch.set(versionRef, versionData);
       batchCount += 1;
 
       // Remove published doc.
@@ -583,7 +632,11 @@ export class RootCMSClient {
         scheduledAt: FieldValue.delete(),
         scheduledBy: FieldValue.delete(),
       });
-      await this.publishDocs(release.docIds || [], {publishedBy, batch});
+      await this.publishDocs(release.docIds || [], {
+        publishedBy,
+        batch,
+        releaseId: release.id,
+      });
     }
   }
 

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -117,7 +117,7 @@ export async function publishRelease(id: string) {
     scheduledAt: deleteField(),
     scheduledBy: deleteField(),
   });
-  await cmsPublishDocs(docIds, {batch});
+  await cmsPublishDocs(docIds, {batch, releaseId: id});
   console.log(`published release: ${id}`);
   logAction('release.publish', {metadata: {releaseId: id, docIds: docIds}});
 }


### PR DESCRIPTION
## Summary
- save a version snapshot whenever docs are published
- tag published versions and label releases
- allow querying versions by tag

## Testing
- `pnpm test` *(fails: connect EHOSTUNREACH)*
- `pnpm lint` *(fails: connect EHOSTUNREACH)*