### PR TITLE
Add autolock on edit

### DIFF
--- a/.changeset/quiet-snakes-leave.md
+++ b/.changeset/quiet-snakes-leave.md
@@ -2,4 +2,4 @@
 "@blinkk/root-cms": patch
 ---
 
-feat: add autolock option to automatically lock publishing when a doc is edited
+feat: add autolock option to automatically lock publishing when a doc is edited (#540)

--- a/.changeset/quiet-snakes-leave.md
+++ b/.changeset/quiet-snakes-leave.md
@@ -1,0 +1,5 @@
+---
+"@blinkk/root-cms": patch
+---
+
+feat: add autolock option to automatically lock publishing when a doc is edited

--- a/.changeset/quiet-snakes-leave.md
+++ b/.changeset/quiet-snakes-leave.md
@@ -2,4 +2,4 @@
 "@blinkk/root-cms": patch
 ---
 
-feat: add autolock option to automatically lock publishing when a doc is edited (#540)
+feat: add autolock on edit (#540)

--- a/docs/collections/Pages.schema.ts
+++ b/docs/collections/Pages.schema.ts
@@ -18,6 +18,8 @@ export default schema.collection({
       src: 'https://lh3.googleusercontent.com/c2ECbvhJtxf3xbPIjaXCSpmvAsJkkhzJwG98T9RPvWy4s30jZKClom8pvWTnupRYOnyI3qGhNXPOwqoN6sqljkDO62LIKRtR988',
     },
   },
+  autolock: true,
+  autolockReason: 'Requires approval before publishing.',
 
   fields: [
     schema.object({

--- a/docs/collections/Pages.schema.ts
+++ b/docs/collections/Pages.schema.ts
@@ -19,7 +19,6 @@ export default schema.collection({
     },
   },
   autolock: true,
-  autolockReason: 'Requires approval before publishing.',
 
   fields: [
     schema.object({

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -155,6 +155,8 @@ function serializeCollection(collection: Collection): Partial<Collection> {
     previewUrl: collection.previewUrl,
     preview: collection.preview,
     slugRegex: collection.slugRegex,
+    autolock: collection.autolock,
+    autolockReason: collection.autolockReason,
   };
 }
 

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -293,6 +293,12 @@ export type Collection = Schema & {
    * string so it can be serialized to the CMS UI.
    */
   slugRegex?: string;
+  /**
+   * Automatically add a publishing lock whenever the doc is edited.
+   */
+  autolock?: boolean;
+  /** Reason for the automatic publishing lock. */
+  autolockReason?: string;
 };
 
 export function defineCollection(

--- a/packages/root-cms/ui/hooks/useDraft.ts
+++ b/packages/root-cms/ui/hooks/useDraft.ts
@@ -181,7 +181,6 @@ export class DraftController extends EventListener {
    * Updates a group of keys. The keys can be a nested, e.g. "meta.title".
    */
   async updateKeys(updates: Record<string, any>) {
-    // console.log('updateKeys()', updates);
     for (const key in updates) {
       this.pendingUpdates.set(key, updates[key]);
     }
@@ -255,8 +254,6 @@ export class DraftController extends EventListener {
         reason: this.autolockReason,
       };
     }
-
-    // console.log('flush()', updates);
 
     // Immediately clear the pending updates so that there's no race condition
     // with any new updates the user makes while the changes are being saved to


### PR DESCRIPTION
## Summary
- add `autolock` and `autolockReason` options for collections
- autolock docs when editing in CMS
- include autolock setting in serialized collection info
- demo autolock in `Pages` collection
- add changeset

Fixes #349