### PR TITLE
feat: add TranslationsManager from `v2` branch

### DIFF
--- a/.changeset/afraid-meals-smash.md
+++ b/.changeset/afraid-meals-smash.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add TranslationsManager from `v2` branch (#541)

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out/
 *.log
 .env
 .turbo/
+*.code-workspace

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -9,6 +9,7 @@ import {
   WriteBatch,
 } from 'firebase-admin/firestore';
 import {CMSPlugin} from './plugin.js';
+import {TranslationsManager} from './translations-manager.js';
 
 export interface Doc<Fields = any> {
   /** The id of the doc, e.g. "Pages/foo-bar". */
@@ -600,6 +601,30 @@ export class RootCMSClient {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Returns a `TranslationsManager` object for managing translations.
+   *
+   * To get translations:
+   * ```
+   * await tm.loadTranslations({
+   *   ids: ['Global/strings', 'Pages/index'],
+   *   locales: ['es'],
+   * });
+   * ```
+   *
+   * NOTE: The `TranslationsManager` is a v2 feature that will eventually
+   * replace the v1 translations system.
+   */
+  getTranslationsManager(): TranslationsManager {
+    const cmsPluginOptions = this.cmsPlugin.getConfig();
+    if (cmsPluginOptions.experiments?.v2TranslationsManager) {
+      throw new Error(
+        '`v2TranslationsManager` is not enabled. update root.config.ts and add: `{experiments: {v2TranslationsManager: true}}`'
+      );
+    }
+    return new TranslationsManager(this);
   }
 
   /**

--- a/packages/root-cms/core/core.ts
+++ b/packages/root-cms/core/core.ts
@@ -1,3 +1,4 @@
 export * from './client.js';
 export * from './runtime.js';
 export * as schema from './schema.js';
+export * from './translations-manager.js';

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -162,7 +162,15 @@ export type CMSPluginOptions = {
    * Experimental config options. Note: these are subject to change at any time.
    */
   experiments?: {
+    /**
+     * Enables the Root CMS AI page.
+     */
     ai?: boolean | CMSAIConfig;
+
+    /**
+     * Enables the v2 `TranslationsManager`.
+     */
+    v2TranslationsManager?: boolean;
   };
 
   /**

--- a/packages/root-cms/core/translations-manager.ts
+++ b/packages/root-cms/core/translations-manager.ts
@@ -1,0 +1,480 @@
+import {
+  FieldValue,
+  Query,
+  Timestamp,
+  WriteBatch,
+} from 'firebase-admin/firestore';
+import {hashStr} from '../shared/strings.js';
+import type {RootCMSClient} from './client.js';
+
+const TRANSLATIONS_DB_PATH_FORMAT =
+  '/Projects/{project}/TranslationsManager/{mode}/Translations';
+
+const TRANSLATIONS_LOCALE_DOC_DB_PATH_FORMAT = `${TRANSLATIONS_DB_PATH_FORMAT}/{id}:{locale}`;
+
+export type Locale = string;
+export type SourceString = string;
+export type TranslatedString = string;
+export type TranslationsDocMode = 'draft' | 'published';
+
+/**
+ * The TranslationsLocaleDoc is the internal doc type stored in the DB. For a
+ * translations doc, the translations for each locale is stored in a separate
+ * doc represented by this type.
+ *
+ * This type is not meant to be used by external callers since this is primarily
+ * an internal implementation detail.
+ */
+interface TranslationsLocaleDoc {
+  /**
+   * Translations id. In most cases, this is the same as the doc id, e.g.
+   * `Pages/foo--bar`.
+   */
+  id: string;
+  locale: string;
+  tags: string[];
+  strings: TranslationsLocaleDocHashMap;
+  sys: {
+    modifiedAt: Timestamp;
+    modifiedBy: string;
+    publishedAt?: Timestamp;
+    publishedBy?: string;
+    linkedSheet?: {
+      spreadsheetId: string;
+      gid: number;
+      linkedAt: Timestamp;
+      linkedBy: string;
+    };
+  };
+}
+
+export interface TranslationsLocaleDocHashMap {
+  /**
+   * A hash map of a source string's hash fingerprint to the source string and
+   * translated string.
+   */
+  [hash: string]: TranslationsLocaleDocEntry;
+}
+
+export interface TranslationsLocaleDocEntry {
+  source: SourceString;
+  translation: TranslatedString;
+  // TODO(stevenle): in the future we should add an ability for content editors
+  // to provide additional translations notes for translators.
+  // context: string;
+}
+
+interface TranslationsDbPathOptions {
+  project: string;
+  mode: TranslationsDocMode;
+}
+
+type TranslationsLocaleDocDbPathOptions = TranslationsDbPathOptions & {
+  id: string;
+  locale: string;
+};
+
+/**
+ * A translations map containing translations for multiple locales.
+ *
+ * Example:
+ * ```
+ * {
+ *   "one": {"es": "uno", "fr": "un"},
+ *   "two": {"es": "dos", "fr": "deux"}
+ * }
+ * ```
+ */
+export interface MultiLocaleTranslationsMap {
+  [source: SourceString]: {
+    [locale: Locale]: TranslatedString;
+  };
+}
+
+/**
+ * A translations map containing translations for a single locale.
+ *
+ * Example:
+ * ```
+ * {
+ *   "one": "uno",
+ *   "two": "dos"
+ * }
+ * ```
+ */
+export interface SingleLocaleTranslationsMap {
+  [source: SourceString]: TranslatedString;
+}
+
+export class TranslationsManager {
+  cmsClient: RootCMSClient;
+
+  constructor(cmsClient: RootCMSClient) {
+    this.cmsClient = cmsClient;
+  }
+
+  /**
+   * Saves draft translations for a translations doc id.
+   *
+   * Example:
+   * ```
+   * const strings = {
+   *   'one': {es: 'uno', fr: 'un'},
+   *   'two': {es: 'dos', fr: 'deux'},
+   * };
+   * await tm.saveTranslations('Pages/index', strings);
+   * ```
+   */
+  async saveTranslations(
+    id: string,
+    strings: MultiLocaleTranslationsMap,
+    options?: {tags?: string[]; modifiedBy?: string}
+  ) {
+    const mode = 'draft';
+    const localesSet: Set<Locale> = new Set();
+    Object.values(strings).forEach((entry) => {
+      Object.keys(entry).forEach((locale) => {
+        if (locale !== 'source') {
+          localesSet.add(locale);
+        }
+      });
+    });
+
+    const batch = this.cmsClient.db.batch();
+    const locales = Array.from(localesSet);
+    locales.forEach((locale) => {
+      const updates: Record<string, any> = {
+        id: id,
+        locale: locale,
+        sys: {
+          modifiedAt: Timestamp.now(),
+          modifiedBy: options?.modifiedBy || 'root-cms-client',
+        },
+        strings: {},
+      };
+      if (options?.tags && options.tags.length > 0) {
+        updates.tags = FieldValue.arrayUnion(...options.tags);
+      }
+      let numUpdates = 0;
+      const hashMap = this.toLocaleDocHashMap(strings, locale);
+      Object.entries(hashMap).forEach(([hash, translations]) => {
+        Object.entries(translations).forEach(([locale, translation]) => {
+          if (translation) {
+            updates.strings[hash] ??= {};
+            updates.strings[hash][locale] = translation;
+            numUpdates += 1;
+          }
+        });
+      });
+      if (numUpdates > 0) {
+        const localeDocPath = buildTranslationsLocaleDocDbPath({
+          project: this.cmsClient.projectId,
+          mode: mode,
+          id: id,
+          locale: locale,
+        });
+        const localeDocRef = this.cmsClient.db.doc(localeDocPath);
+        batch.set(localeDocRef, updates, {merge: true});
+      }
+    });
+    await batch.commit();
+  }
+
+  /**
+   * Publishes a translations doc.
+   */
+  async publishTranslations(
+    id: string,
+    options?: {batch?: WriteBatch; publishedBy?: string}
+  ) {
+    const db = this.cmsClient.db;
+    const project = this.cmsClient.projectId;
+    const draftPath = buildTranslationsDbPath({project, mode: 'draft'});
+    const query = db.collection(draftPath).where('id', '==', id);
+    const res = await query.get();
+    if (res.size === 0) {
+      console.warn(`no translations to publish for ${id}`);
+      return;
+    }
+
+    const batch = options?.batch || db.batch();
+    res.docs.forEach((doc) => {
+      const translationsLocaleDoc = doc.data() as TranslationsLocaleDoc;
+      const sys = {
+        ...translationsLocaleDoc.sys,
+        publishedAt: Timestamp.now(),
+        publishedBy: options?.publishedBy || 'root-cms-client',
+      };
+      batch.update(doc.ref, {sys});
+      const publishedDocPath = buildTranslationsLocaleDocDbPath({
+        project,
+        mode: 'published',
+        id: translationsLocaleDoc.id,
+        locale: translationsLocaleDoc.locale,
+      });
+      const publishedDocRef = db.doc(publishedDocPath);
+      batch.set(publishedDocRef, {...translationsLocaleDoc, sys});
+    });
+
+    // If a batch was provided, assume that the caller is responsible for
+    // calling `batch.commit()`.
+    const shouldCommitBatch = !options?.batch;
+    if (shouldCommitBatch) {
+      await batch.commit();
+    }
+  }
+
+  /**
+   * Fetches translations from one or more translations docs in the translations
+   * manager.
+   *
+   * Example:
+   * ```
+   * await tm.loadTranslations();
+   * // =>
+   * // {
+   * //   "one": {"es": "uno", "fr": "un"},
+   * //   "two": {"es": "dos", "fr": "deux"}
+   * // }
+   * ```
+   *
+   * To load a specific set of translations docs by id:
+   * ```
+   * const translationsToLoad = ['Global/strings', 'Global/header', 'Global/footer', 'Pages/index'];
+   * await tm.loadTranslations({ids: translationsToLoad});
+   * // =>
+   * // {
+   * //   "one": {"es": "uno", "fr": "un"},
+   * //   "two": {"es": "dos", "fr": "deux"}
+   * // }
+   * ```
+   *
+   * To load a subset of locales (more performant):
+   * ```
+   * await tm.loadTranslations({locales: ['es']});
+   * // =>
+   * // {
+   * //   "one": {"es": "uno"},
+   * //   "two": {"es": "dos"}
+   * // }
+   * ```
+   */
+  async loadTranslations(options?: {
+    ids?: string[];
+    tags?: string[];
+    locales?: Locale[];
+    mode?: TranslationsDocMode;
+  }) {
+    const mode = options?.mode || 'published';
+    const dbPath = buildTranslationsDbPath({
+      project: this.cmsClient.projectId,
+      mode: mode,
+    });
+
+    let query = this.cmsClient.db.collection(dbPath) as Query;
+    if (options?.ids && options.ids.length > 0) {
+      query = query.where('id', 'in', options.ids);
+    }
+    if (options?.tags && options.tags.length > 0) {
+      query = query.where('tags', 'array-contains', options.tags);
+    }
+    if (options?.locales && options.locales.length > 0) {
+      query = query.where('locale', 'in', options.locales);
+    }
+
+    const results = await query.get();
+    const strings: MultiLocaleTranslationsMap = {};
+    results.forEach((result) => {
+      const localeDoc = result.data() as TranslationsLocaleDoc;
+      Object.values(localeDoc.strings || {}).forEach((item) => {
+        strings[item.source] ??= {source: item.source};
+        strings[item.source][localeDoc.locale] = item.translation;
+      });
+    });
+    return strings;
+  }
+
+  /**
+   * Fetches translations for a given locale, with optional fallbacks.
+   * The return value is a map of source string to translated string.
+   *
+   * Example:
+   * ```
+   * await translationsDoc.loadTranslationsForLocale('es');
+   * // =>
+   * // {
+   * //   "one": "uno",
+   * //   "two": "dos",
+   * // }
+   * ```
+   */
+  async loadTranslationsForLocale(
+    locale: Locale,
+    options?: {mode?: TranslationsDocMode; fallbackLocales?: Locale[]}
+  ): Promise<SingleLocaleTranslationsMap> {
+    const localeSet: Set<Locale> = new Set([
+      locale,
+      ...(options?.fallbackLocales || []),
+    ]);
+    const fallbackLocales = Array.from(localeSet);
+    const multiLocaleStrings = await this.loadTranslations({
+      mode: options?.mode,
+      locales: fallbackLocales,
+    });
+    return this.toSingleLocaleMap(multiLocaleStrings, fallbackLocales);
+  }
+
+  /**
+   * Converts a multi-locale translations map to a flat single-locale map,
+   * with optional support for fallback locales.
+   *
+   * ```
+   * const multiLocaleStrings = {
+   *   'one': {es: 'uno', fr: 'un'},
+   *   'two': {es: 'dos', fr: 'deux'}
+   * };
+   * translationsDoc.toSingleLocaleMap(multiLocaleStrings, ['es']);
+   * // =>
+   * // {
+   * //   "one": "uno",
+   * //   "two": "dos",
+   * // }
+   * ```
+   */
+  private toSingleLocaleMap(
+    multiLocaleStrings: MultiLocaleTranslationsMap,
+    fallbackLocales: Locale[]
+  ): SingleLocaleTranslationsMap {
+    const singleLocaleStrings: SingleLocaleTranslationsMap = {};
+    Object.entries(multiLocaleStrings).forEach(([source, translations]) => {
+      let translation = source;
+      for (const locale of fallbackLocales) {
+        if (translations[locale]) {
+          translation = translations[locale];
+          break;
+        }
+      }
+      singleLocaleStrings[source] = translation;
+    });
+    return singleLocaleStrings;
+  }
+
+  /**
+   * Converts a multi-locale translations map to a single-locale hashed version,
+   * used for storage in in the DB.
+   *
+   * ```
+   * const multiLocaleStrings = {
+   *   'one': {es: 'uno', fr: 'un'},
+   *   'two': {es: 'dos', fr: 'deux'}
+   * };
+   * translationsDoc.toLocaleDocHashMap(multiLocaleStrings, 'es');
+   * // =>
+   * // {
+   * //   "<hash1>": {"source": "one", "translation": "uno"},
+   * //   "<hash2>": {"source": "two", "translation": "dos"},
+   * // }
+   * ```
+   *
+   * One reason for using hashes is because the DB has limits on the number of
+   * chars that can be used as the "key" in a object map.
+   */
+  private toLocaleDocHashMap(
+    multiLocaleStrings: MultiLocaleTranslationsMap,
+    locale: Locale
+  ): TranslationsLocaleDocHashMap {
+    const hashMap: TranslationsLocaleDocHashMap = {};
+    Object.entries(multiLocaleStrings).forEach(([source, translations]) => {
+      const translation = translations[locale];
+      if (translation) {
+        const hash = hashStr(source);
+        hashMap[hash] = {source, translation};
+      }
+    });
+    return hashMap;
+  }
+
+  /**
+   * Import translations from the v1 system to the TranslationsManager.
+   */
+  async importTranslationsFromV1() {
+    const projectId = this.cmsClient.projectId;
+    const db = this.cmsClient.db;
+    const dbPath = `Projects/${projectId}/Translations`;
+    const query = db.collection(dbPath);
+    const querySnapshot = await query.get();
+    if (querySnapshot.size === 0) {
+      return;
+    }
+
+    console.log(
+      '[root cms] importing v1 Translations to v2 TranslationsManager'
+    );
+
+    const translationsDocs: Record<string, any> = {};
+    querySnapshot.forEach((doc) => {
+      const translation = doc.data();
+      const source = this.cmsClient.normalizeString(translation.source);
+      delete translation.source;
+      const tags = (translation.tags || []) as string[];
+      delete translation.tags;
+      for (const tag of tags) {
+        if (tag.includes('/')) {
+          const translationsId = tag;
+          translationsDocs[translationsId] ??= {
+            id: translationsId,
+            tags: tags,
+            strings: {},
+          };
+          translationsDocs[translationsId].strings[source] = translation;
+        }
+      }
+    });
+
+    if (Object.keys(translationsDocs).length === 0) {
+      console.log('[root cms] no v1 translations to save');
+      return;
+    }
+
+    // Move the doc's "l10nSheet" to the translations doc's "linkedSheet".
+    for (const docId in translationsDocs) {
+      const [collection, slug] = docId.split('/');
+      if (collection && slug) {
+        const doc: any = await this.cmsClient.getDoc(collection, slug, {
+          mode: 'draft',
+        });
+        const linkedSheet = doc?.sys?.l10nSheet;
+        if (linkedSheet) {
+          translationsDocs[docId].sys.linkedSheet = linkedSheet;
+        }
+      }
+    }
+
+    Object.entries(translationsDocs).forEach(([translationsId, data]) => {
+      const len = Object.keys(data.strings).length;
+      console.log(`[root cms] saving ${len} string(s) to ${translationsId}...`);
+      this.saveTranslations(translationsId, data.strings, {
+        tags: data.tags || [translationsId],
+      });
+    });
+  }
+}
+
+export function buildTranslationsDbPath(options: TranslationsDbPathOptions) {
+  return TRANSLATIONS_DB_PATH_FORMAT.replace(
+    '{project}',
+    options.project
+  ).replace('{mode}', options.mode);
+}
+
+export function buildTranslationsLocaleDocDbPath(
+  options: TranslationsLocaleDocDbPathOptions
+) {
+  return TRANSLATIONS_LOCALE_DOC_DB_PATH_FORMAT.replace(
+    '{project}',
+    options.project
+  )
+    .replace('{mode}', options.mode)
+    .replace('{id}', options.id.replaceAll('/', '--'))
+    .replace('{locale}', options.locale);
+}

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -72,6 +72,7 @@
     "csv-parse": "5.5.2",
     "csv-stringify": "6.4.4",
     "dts-dom": "3.7.0",
+    "farmhash-modern": "1.1.0",
     "jsonwebtoken": "9.0.2",
     "kleur": "4.1.5",
     "sirv": "2.0.3",

--- a/packages/root-cms/shared/strings.ts
+++ b/packages/root-cms/shared/strings.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared utility functions for handling strings.
+ */
+
+import * as farmhash from 'farmhash-modern';
+
+/**
+ * Cleans a source string for use in translations. Performs the following:
+ * - Removes any leading/trailing whitespace
+ * - Removes spaces at the end of any line (including &nbsp;)
+ */
+export function normalizeStr(str: string): string {
+  const lines = str
+    .trim()
+    .split('\n')
+    .map((line) => removeTrailingWhitespace(line));
+  return lines.join('\n');
+}
+
+function removeTrailingWhitespace(str: string) {
+  return str.trimEnd().replace(/&nbsp;$/, '');
+}
+
+/**
+ * Returns a hash fingerprint for a string.
+ *
+ * Note that this hash function is meant to be fast and for collision avoidance
+ * for use in a hash map, but is not intended for cryptographic purposes. For
+ * these reasons farmhash is used here.
+ *
+ * @see https://www.npmjs.com/package/farmhash-modern
+ */
+export function hashStr(str: string): string {
+  return String(farmhash.fingerprint32(normalizeStr(str)));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       dts-dom:
         specifier: 3.7.0
         version: 3.7.0
+      farmhash-modern:
+        specifier: 1.1.0
+        version: 1.1.0
       jsonwebtoken:
         specifier: 9.0.2
         version: 9.0.2
@@ -2597,15 +2600,15 @@ packages:
       '@types/gapi.client.discovery-v1': 0.0.4
     dev: true
 
-  /@maxim_mazurok/gapi.client.drive-v3@0.0.20250401:
-    resolution: {integrity: sha512-yAdKB89VS1mHLoUSxptE4X77dqu1w7goZpN26PMladlkgycOG81sIUZNzomObEOeQdtnJ+8FG4Ae4YJbYFidTg==}
+  /@maxim_mazurok/gapi.client.drive-v3@0.0.20250513:
+    resolution: {integrity: sha512-ek5uSGoh6FwJpH9btFxufierppnBmmtlLfLyOfzTUfe3VLtahUJct8PHLE83mgyfraPkN+3WdxKTWysKUMIpAA==}
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
     dev: true
 
-  /@maxim_mazurok/gapi.client.sheets-v4@0.0.20250401:
-    resolution: {integrity: sha512-LmUNEkO7m4bLPBOfH5J66BLxYkpISWitwpYCfk75RZFcZ0kKAIotZhQ5uf5scmB5ntBIIUvU2lQSA1BArwtaaA==}
+  /@maxim_mazurok/gapi.client.sheets-v4@0.0.20250509:
+    resolution: {integrity: sha512-4BzFb79MybDVbI/NFxHPvXe2wogAg0k0ejTXHBVlQSfKBgTDlKt0NXNeaNrCjJOaPcCqMGPFBsUNKVUyXRx72w==}
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
@@ -3457,13 +3460,13 @@ packages:
   /@types/gapi.client.drive-v3@0.0.4:
     resolution: {integrity: sha512-jE37dJ0EzAdY0aJPFOp20xmec/aO0P4HtUIA9k07RMPyedFDOcuMlSac1r0PklwQdgXF7BHaMoObNHNAnwSQUQ==}
     dependencies:
-      '@maxim_mazurok/gapi.client.drive-v3': 0.0.20250401
+      '@maxim_mazurok/gapi.client.drive-v3': 0.0.20250513
     dev: true
 
   /@types/gapi.client.sheets-v4@0.0.4:
     resolution: {integrity: sha512-6kTJ7aDMAElfdQV1XzVJmZWjgbibpa84DMuKuaN8Cwqci/dkglPyHXKvsGrRugmuYvgFYr35AQqwz6j3q8R0dw==}
     dependencies:
-      '@maxim_mazurok/gapi.client.sheets-v4': 0.0.20250401
+      '@maxim_mazurok/gapi.client.sheets-v4': 0.0.20250509
     dev: true
 
   /@types/gapi.client@1.0.8:
@@ -3941,6 +3944,9 @@ packages:
 
   /ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.17.1
 
@@ -6413,6 +6419,11 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
     dev: true
+
+  /farmhash-modern@1.1.0:
+    resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /farmhash@3.3.1:
     resolution: {integrity: sha512-XUizHanzlr/v7suBr/o85HSakOoWh6HKXZjFYl5C2+Gj0f0rkw+XTUZzrd9odDsgI9G5tRUcF4wSbKaX04T0DQ==}


### PR DESCRIPTION
This is the first (of many) `v2` features that are imported into `v1` releases behind experiment flags, which allows developers to test and migrate content before the `v2` version is released.