### PR TITLE
chore: migrate root eslint config to flat format

### DIFF
--- a/.changeset/updating-eslint-to-v9.md
+++ b/.changeset/updating-eslint-to-v9.md
@@ -1,0 +1,5 @@
+---
+"@blinkk/eslint-config-root": major
+---
+
+chore: update for ESLint v9 compatibility

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["@blinkk/root"],
-  "parserOptions": {
-    "sourceType": "module"
-  }
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+const {FlatCompat} = require('@eslint/eslintrc');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+module.exports = compat.config({
+  extends: ['@blinkk/root'],
+  parserOptions: {
+    sourceType: 'module',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@blinkk/eslint-config-root": "workspace:*",
     "@changesets/cli": "^2.26.2",
-    "eslint": "^8.51.0",
+    "eslint": "^9.0.0",
     "prettier": "^3.0.3",
     "turbo": "^1.10.15",
     "typescript": "^5.2.2"

--- a/packages/eslint-config-root/README.md
+++ b/packages/eslint-config-root/README.md
@@ -9,14 +9,18 @@ yarn add eslint prettier typescript
 yarn add -D @blinkk/eslint-config-root
 ```
 
-Add eslint config file `.eslintrc.json`:
+Add eslint config file `eslint.config.js`:
 
-```json
-{
-  "extends": [
-    "@blinkk/root"
-  ]
-}
+```js
+const {FlatCompat} = require('@eslint/eslintrc');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+module.exports = compat.config({
+  extends: ['@blinkk/root'],
+});
 ```
 
 Add `.eslintignore`:
@@ -37,3 +41,4 @@ Add scripts to `package.json`:
   }
 }
 ```
+

--- a/packages/eslint-config-root/index.js
+++ b/packages/eslint-config-root/index.js
@@ -1,6 +1,6 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:node/recommended', 'prettier'],
-  plugins: ['node', 'prettier', 'import'],
+  extends: ['eslint:recommended', 'plugin:n/recommended', 'prettier'],
+  plugins: ['n', 'prettier', 'import'],
   rules: {
     'prettier/prettier': 'error',
     'block-scoped-var': 'error',
@@ -40,11 +40,11 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/camelcase': 'off',
-        'node/no-missing-import': 'off',
-        'node/no-empty-function': 'off',
-        'node/no-unsupported-features/es-syntax': 'off',
-        'node/no-missing-require': 'off',
-        'node/shebang': 'off',
+        'n/no-missing-import': 'off',
+        'n/no-empty-function': 'off',
+        'n/no-unsupported-features/es-syntax': 'off',
+        'n/no-missing-require': 'off',
+        'n/shebang': 'off',
         'no-dupe-class-members': 'off',
         'require-atomic-updates': 'off',
         'import/order': [

--- a/packages/eslint-config-root/package.json
+++ b/packages/eslint-config-root/package.json
@@ -24,16 +24,16 @@
     "@typescript-eslint/parser": "^6.8.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^5.0.1"
   },
   "devDependencies": {
-    "eslint": "^8.51.0",
+    "eslint": "^9.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "eslint": ">= 8",
+    "eslint": ">= 9",
     "prettier": ">= 2",
     "typescript": ">= 4"
   }

--- a/packages/root-cms/core/tsup.config.ts
+++ b/packages/root-cms/core/tsup.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-import */
+/* eslint-disable n/no-unpublished-import */
 
 import {defineConfig} from 'tsup';
 

--- a/packages/root-password-protect/tsup.config.ts
+++ b/packages/root-password-protect/tsup.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-import */
+/* eslint-disable n/no-unpublished-import */
 
 import {defineConfig} from 'tsup';
 

--- a/packages/root/tsup.config.ts
+++ b/packages/root/tsup.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-import */
+/* eslint-disable n/no-unpublished-import */
 
 import {defineConfig} from 'tsup';
 


### PR DESCRIPTION
## Summary
- replace `.eslintrc.json` with `eslint.config.js`
- document new configuration in config package README

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*