### PR TITLE
feat(root): merge nested StringParamsProvider

### DIFF
--- a/.changeset/plucky-birds-obey.md
+++ b/.changeset/plucky-birds-obey.md
@@ -1,0 +1,5 @@
+---
+"@blinkk/root": patch
+---
+
+fix: merge params from nested StringParamsProvider

--- a/packages/root/src/core/hooks/useStringParams.ts
+++ b/packages/root/src/core/hooks/useStringParams.ts
@@ -1,4 +1,4 @@
-import {createContext} from 'preact';
+import {ComponentChildren, FunctionalComponent, createContext} from 'preact';
 import {useContext} from 'preact/hooks';
 
 export type StringParamsContext = Record<string, string>;
@@ -7,7 +7,22 @@ export const STRING_PARAMS_CONTEXT = createContext<StringParamsContext | null>(
   null
 );
 
-export const StringParamsProvider = STRING_PARAMS_CONTEXT.Provider;
+export interface StringParamsProviderProps {
+  value?: StringParamsContext;
+  children?: ComponentChildren;
+}
+
+export const StringParamsProvider: FunctionalComponent<
+  StringParamsProviderProps
+> = ({value = {}, children}) => {
+  const parent = useContext(STRING_PARAMS_CONTEXT) || {};
+  const merged = {...parent, ...value};
+  return (
+    <STRING_PARAMS_CONTEXT.Provider value={merged}>
+      {children}
+    </STRING_PARAMS_CONTEXT.Provider>
+  );
+};
 
 /**
  * A hook that returns a map of string params, configured via the

--- a/packages/root/src/core/hooks/useStringParams.tsx
+++ b/packages/root/src/core/hooks/useStringParams.tsx
@@ -12,14 +12,13 @@ export interface StringParamsProviderProps {
   children?: ComponentChildren;
 }
 
-export const StringParamsProvider: FunctionalComponent<
-  StringParamsProviderProps
-> = ({value = {}, children}) => {
+export const StringParamsProvider: FunctionalComponent<StringParamsProviderProps> = (props) => {
+  // Allow for nested param values from parent content providers.
   const parent = useContext(STRING_PARAMS_CONTEXT) || {};
-  const merged = {...parent, ...value};
+  const merged = {...parent, ...props.value};
   return (
     <STRING_PARAMS_CONTEXT.Provider value={merged}>
-      {children}
+      {props.children}
     </STRING_PARAMS_CONTEXT.Provider>
   );
 };

--- a/packages/root/test/fixtures/string-params/root.config.ts
+++ b/packages/root/test/fixtures/string-params/root.config.ts
@@ -1,0 +1,3 @@
+export default {
+  prettyHtml: true,
+};

--- a/packages/root/test/fixtures/string-params/routes/index.tsx
+++ b/packages/root/test/fixtures/string-params/routes/index.tsx
@@ -1,0 +1,12 @@
+import {StringParamsProvider, useTranslations} from '../../../../dist/core';
+
+export default function Page() {
+  const t = useTranslations();
+  return (
+    <StringParamsProvider value={{foo: 'foovalue'}}>
+      <StringParamsProvider value={{bar: 'barvalue'}}>
+        <p>{t('{foo} / {bar}')}</p>
+      </StringParamsProvider>
+    </StringParamsProvider>
+  );
+}

--- a/packages/root/test/string-params.test.ts
+++ b/packages/root/test/string-params.test.ts
@@ -1,0 +1,36 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {beforeEach, afterEach, expect, test, assert} from 'vitest';
+import {fileExists} from '../src/utils/fsutils.js';
+import {Fixture, loadFixture} from './testutils.js';
+
+let fixture: Fixture;
+
+beforeEach(async () => {
+  fixture = await loadFixture('./fixtures/string-params');
+});
+
+afterEach(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+test('merge nested StringParamsProvider values', async () => {
+  await fixture.build();
+  const indexPath = path.join(fixture.distDir, 'html/index.html');
+  assert.isTrue(await fileExists(indexPath));
+  const html = await fs.readFile(indexPath, 'utf-8');
+  expect(html).toMatchInlineSnapshot(`
+    "<!doctype html>
+    <html>
+    <head>
+    <meta charset=\"utf-8\">
+    </head>
+    <body>
+    <p>foovalue / barvalue</p>
+    </body>
+    </html>
+    "
+  `);
+});


### PR DESCRIPTION
## Summary
- merge params from nested `StringParamsProvider`
- test nested provider interaction
- add changeset for `@blinkk/root`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*