### PR TITLE
feat: Add pre/post string transformations for useTranslations

### DIFF
--- a/packages/root/src/core/components/TransformationProvider.tsx
+++ b/packages/root/src/core/components/TransformationProvider.tsx
@@ -1,0 +1,135 @@
+import {FunctionComponent, ReactNode} from 'preact';
+import {TransformationContext} from '../hooks/useTransformationContext.js';
+import {PreTranslationFunc, PostTranslationFunc} from '../types.js';
+
+/**
+ * Props for the `TransformationProvider` component.
+ */
+export interface TransformationProviderProps {
+  /**
+   * An optional function to be called before a string is translated.
+   * This function receives the original string and the current locale.
+   * It can be used to modify the string before it's looked up in
+   * translation files, for example, to normalize text or provide
+   * locale-specific string variations.
+   * If not provided, the original string is used directly.
+   */
+  preTranslation?: PreTranslationFunc;
+  /**
+   * An optional function to be called after a string has been translated
+   * and any parameters have been substituted. This function receives the
+   * translated string, the parameters used, and the current locale.
+   * It can be used for final adjustments, like formatting or ensuring
+   * specific wordings based on the translated content.
+   * If not provided, the translated string is used as-is.
+   */
+  postTranslation?: PostTranslationFunc;
+  /**
+   * The child components that will have access to the transformation functions
+   * provided by this provider.
+   */
+  children: ReactNode;
+}
+
+/**
+ * A component that provides string transformation functions (`preTranslation` and
+ * `postTranslation`) to its descendant components via the `TransformationContext`.
+ *
+ * This allows for custom manipulation of strings at two stages of the
+ * internationalization (i18n) process:
+ * 1. **Before translation (`preTranslation`)**: Modify a string before it's
+ *    looked up in the translation messages. This is useful for normalization,
+ *    or for handling locale-specific source strings (e.g., using "colour"
+ *    for `en-GB` and "color" for `en-US` before looking up the actual
+ *    translation).
+ * 2. **After translation (`postTranslation`)**: Modify a string after it has
+ *    been translated and parameters have been inserted. This is useful for
+ *    locale-specific formatting of the translated content, such as ensuring
+ *    non-breaking spaces in product names or handling complex parameter
+ *    formatting.
+ *
+ * If `preTranslation` or `postTranslation` props are not provided, identity
+ * functions (which return the input string unchanged) are used by default.
+ *
+ * @example
+ * ```tsx
+ * import {TransformationProvider} from './TransformationProvider';
+ * import {useTranslations} from '../hooks/useTranslations';
+ *
+ * // Example of preTranslation: Using a different source string for a specific locale
+ * const preTranslateExample = (str: string, locale: string): string => {
+ *   if (locale === 'en-GB' && str === 'vacation') {
+ *     return 'holiday'; // For British English, "holiday" is preferred over "vacation"
+ *   }
+ *   return str;
+ * };
+ *
+ * // Example of postTranslation: Ensuring product names use non-breaking spaces
+ * const postTranslateExample = (
+ *   translatedStr: string,
+ *   params: Record<string, string | number> | undefined,
+ *   locale: string
+ * ): string => {
+ *   if (params?.productName && typeof params.productName === 'string') {
+ *     const nbspProductName = params.productName.replace(/ /g, '&nbsp;');
+ *     return translatedStr.replace(params.productName, nbspProductName);
+ *   }
+ *   // Example: Reformat custom footnote syntax like "foo[footnote:bar]" to "foo<sup>bar</sup>"
+ *   return translatedStr.replace(
+ *     /\[footnote:([^\]]+)\]/g,
+ *     '<sup>$1</sup>'
+ *   );
+ * };
+ *
+ * const App = () => (
+ *   <TransformationProvider
+ *     preTranslation={preTranslateExample}
+ *     postTranslation={postTranslateExample}
+ *   >
+ *     <PageContent />
+ *   </TransformationProvider>
+ * );
+ *
+ * const PageContent = () => {
+ *   const t = useTranslations();
+ *
+ *   // Assuming 'en-GB' locale and "vacation" translates to "Vacation" by default,
+ *   // but "holiday" translates to "Holiday".
+ *   // preTranslateExample changes "vacation" to "holiday" before lookup.
+ *   console.log(t('vacation')); // Outputs "Holiday"
+ *
+ *   // Example of postTranslation with product name
+ *   console.log(t('Buy {productName} now!', {productName: 'Super Cool Gadget'}));
+ *   // Outputs "Buy Super&nbsp;Cool&nbsp;Gadget now!"
+ *
+ *   // Example of postTranslation with footnote
+ *   console.log(t('See details[footnote:1]'));
+ *   // Outputs "See details<sup>1</sup>"
+ *
+ *   return (
+ *     <div>
+ *       <p>{t('Welcome to our store!')}</p>
+ *       <p>{t('Check out the new {productName}!', {productName: 'Awesome Phone'})}</p>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export const TransformationProvider: FunctionComponent<
+  TransformationProviderProps
+> = (props) => {
+  const {
+    preTranslation: preTranslationFromProps,
+    postTranslation: postTranslationFromProps,
+    children,
+  } = props;
+
+  const preTranslation = preTranslationFromProps ?? ((str) => str);
+  const postTranslation = postTranslationFromProps ?? ((str) => str);
+
+  return (
+    <TransformationContext.Provider value={{preTranslation, postTranslation}}>
+      {children}
+    </TransformationContext.Provider>
+  );
+};

--- a/packages/root/src/core/hooks/useTransformationContext.ts
+++ b/packages/root/src/core/hooks/useTransformationContext.ts
@@ -1,0 +1,57 @@
+import {createContext} from 'preact';
+import {useContext} from 'preact/hooks';
+import {PreTranslationFunc, PostTranslationFunc} from '../types';
+
+/**
+ * Defines the shape of the context value for string transformations.
+ */
+export interface TransformationContextValue {
+  /**
+   * A function called before a string is passed to the translation mechanism.
+   * Useful for normalizing strings or making locale-specific adjustments
+   * before translation lookup.
+   * @param str The original string.
+   * @param locale The current locale.
+   * @returns The processed string.
+   */
+  preTranslation: PreTranslationFunc;
+  /**
+   * A function called after a string has been translated and parameters
+   * have been substituted. Useful for final adjustments to the translated
+   * string, such as formatting or injecting non-breaking spaces.
+   * @param translatedStr The translated string with parameters substituted.
+   * @param params The parameters used for substitution.
+   * @param locale The current locale.
+   * @returns The processed string.
+   */
+  postTranslation: PostTranslationFunc;
+}
+
+/**
+ * React Context for providing and consuming string transformation functions.
+ * This context allows components deeper in the tree to access `preTranslation`
+ * and `postTranslation` functions provided by an ancestor `TransformationProvider`.
+ */
+export const TransformationContext =
+  createContext<TransformationContextValue | null>(null);
+
+/**
+ * Custom hook to access the string transformation functions from
+ * `TransformationContext`.
+ *
+ * If the hook is used outside a `TransformationProvider`, it returns default
+ * identity functions for both `preTranslation` and `postTranslation`, meaning
+ * strings will pass through unchanged.
+ *
+ * @returns An object containing `preTranslation` and `postTranslation` functions.
+ */
+export const useTransformationContext = (): TransformationContextValue => {
+  const contextValue = useContext(TransformationContext);
+  if (contextValue === null) {
+    return {
+      preTranslation: (str) => str,
+      postTranslation: (str) => str,
+    };
+  }
+  return contextValue;
+};

--- a/packages/root/src/core/hooks/useTranslations.ts
+++ b/packages/root/src/core/hooks/useTranslations.ts
@@ -1,17 +1,68 @@
 import {I18nContext, useI18nContext} from './useI18nContext.js';
 import {useStringParams} from './useStringParams.js';
+import {useTransformationContext} from './useTransformationContext.js';
 
 /**
- * A hook that returns a function that can be used to translate a string, and
- * optionally replace any parameterized values that are surrounded in curly
- * braces.
+ * A hook that returns a function for translating strings and performing
+ * parameter substitution.
  *
- * Usage:
+ * The translation process can be customized by providing `preTranslation` and
+ * `postTranslation` functions through the `TransformationContext`.
  *
- * ```ts
+ * - `preTranslation`: Applied to the string *before* it's looked up in the
+ *   translation files. Useful for string normalization or transformations
+ *   based on the original string and locale.
+ * - `postTranslation`: Applied to the string *after* translation and parameter
+ *   substitution. Useful for adjustments based on the translated string,
+ *   parameters, and locale.
+ *
+ * If no `TransformationContext` is found, or if transformation functions are
+ * not provided, the original string is used as-is for these steps.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage:
  * const t = useTranslations();
- * t('Hello {name}', {name: 'Bob'});
- * // => 'Bounjour Bob'
+ * t('Hello {name}', {name: 'Bob'}); // => 'Bonjour Bob' (if 'fr' locale)
+ *
+ * // With TransformationProvider for custom transformations:
+ * import {TransformationProvider} from '../components/TransformationProvider';
+ *
+ * const App = () => (
+ *   <TransformationProvider
+ *     preTranslation={(str, locale) => {
+ *       if (locale === 'en-US' && str === 'color') return 'colour';
+ *       return str;
+ *     }}
+ *     postTranslation={(translatedStr, params, locale) => {
+ *       // Example: Ensure product names are non-breaking
+ *       if (params?.productName) {
+ *         return translatedStr.replace(
+ *           String(params.productName),
+ *           String(params.productName).replace(/ /g, '&nbsp;')
+ *         );
+ *       }
+ *       return translatedStr;
+ *     }}
+ *   >
+ *     <MyComponent />
+ *   </TransformationProvider>
+ * );
+ *
+ * const MyComponent = () => {
+ *   const t = useTranslations();
+ *   // Assuming 'en-US' locale and 'color' is in translations as 'Color':
+ *   // preTranslation changes 'color' to 'colour'.
+ *   // 'colour' is looked up, let's say it's 'Colour'.
+ *   // postTranslation might further adjust it.
+ *   console.log(t('color')); // Might output 'Colour'
+ *
+ *   // Example with postTranslation for non-breaking spaces:
+ *   console.log(t('Buy {productName} now!', {productName: 'Super Gadget'}));
+ *   // Might output 'Buy Super&nbsp;Gadget now!'
+ *   return <p>{t('Welcome')}</p>;
+ * }
+ * ```
  */
 export function useTranslations() {
   // Ignore I18nContext not found error when used with client-side rehydration.
@@ -23,14 +74,19 @@ export function useTranslations() {
   }
   const translations = i18nContext?.translations || {};
   const stringParams = useStringParams();
+  const {preTranslation, postTranslation} = useTransformationContext();
+  const locale = i18nContext?.locale || 'en';
+
   const t = (str: string, params?: Record<string, string | number>) => {
-    const key = normalizeString(str);
+    const transformedStr = preTranslation(str, locale);
+    const key = normalizeString(transformedStr);
     let translation = translations[key] ?? key ?? '';
     const allParams = {...stringParams, ...params};
     for (const paramName of Object.keys(allParams)) {
       const paramValue = String(allParams[paramName] ?? '');
       translation = translation.replaceAll(`{${paramName}}`, paramValue);
     }
+    translation = postTranslation(translation, params, locale);
     return translation;
   };
   return t;

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -237,3 +237,26 @@ export interface SitemapItem {
    */
   alts: Record<string, {hrefLang: string; urlPath: string}>;
 }
+
+/**
+ * A function that is called before a string is translated.
+ *
+ * @param str The string to be translated.
+ * @param locale The locale of the string.
+ * @returns The processed string.
+ */
+export type PreTranslationFunc = (str: string, locale: string) => string;
+
+/**
+ * A function that is called after a string is translated.
+ *
+ * @param translatedStr The translated string.
+ * @param params The parameters used for translation.
+ * @param locale The locale of the string.
+ * @returns The processed string.
+ */
+export type PostTranslationFunc = (
+  translatedStr: string,
+  params: Record<string, string | number> | undefined,
+  locale: string
+) => string;

--- a/packages/root/test/translations.test.ts
+++ b/packages/root/test/translations.test.ts
@@ -1,0 +1,412 @@
+import {render} from '@testing-library/preact';
+import {FunctionComponent, h} from 'preact';
+import {expect, test, describe, vi} from 'vitest';
+import {useTranslations} from '../src/core/hooks/useTranslations';
+import {
+  TransformationProvider,
+  TransformationProviderProps,
+} from '../src/core/components/TransformationProvider';
+import {I18nContext} from '../src/core/hooks/useI18nContext';
+import {PreTranslationFunc, PostTranslationFunc} from '../src/core/types';
+
+// Helper component to test useTranslations hook
+const TestComponent: FunctionComponent<{
+  stringToTranslate: string;
+  params?: Record<string, string | number>;
+  providerProps?: Partial<TransformationProviderProps>;
+  i18nContextValue?: any;
+}> = ({stringToTranslate, params, providerProps, i18nContextValue}) => {
+  const t = useTranslations();
+  const content = t(stringToTranslate, params);
+
+  if (providerProps) {
+    return (
+      <I18nContext.Provider value={i18nContextValue || mockI18nContextValue}>
+        <TransformationProvider {...providerProps}>
+          <div data-testid="translation">{content}</div>
+        </TransformationProvider>
+      </I18nContext.Provider>
+    );
+  }
+
+  return (
+    <I18nContext.Provider value={i18nContextValue || mockI18nContextValue}>
+      <div data-testid="translation">{content}</div>
+    </I18nContext.Provider>
+  );
+};
+
+const mockI18nContextValue = {
+  locale: 'en',
+  translations: {
+    Hello: 'Bonjour',
+    'Hello {name}': 'Bonjour {name}',
+    'Hello_pre': 'Bonjour_pre',
+    'Hello_pre {name}': 'Bonjour_pre {name}',
+    'Test String': 'Chaîne de test',
+    'Test String_pre': 'Chaîne de test_pre',
+    'colour': 'Colour from translation',
+    'multiline': 'multi\nline\ntranslation',
+    'multiline_pre': 'multi\nline\ntranslation_pre',
+  },
+  locales: ['en', 'fr'],
+};
+
+describe('useTranslations', () => {
+  test('returns original string if no translation exists', () => {
+    const {getByTestId} = render(
+      <TestComponent stringToTranslate="Unknown String" />
+    );
+    expect(getByTestId('translation').textContent).toBe('Unknown String');
+  });
+
+  test('returns translated string if translation exists', () => {
+    const {getByTestId} = render(
+      <TestComponent stringToTranslate="Hello" />
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour');
+  });
+
+  test('handles parameter substitution without transformations', () => {
+    const {getByTestId} = render(
+      <TestComponent
+        stringToTranslate="Hello {name}"
+        params={{name: 'Vitest'}}
+      />
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour Vitest');
+  });
+
+  test('handles multiline strings', () => {
+    const {getByTestId} = render(
+      <TestComponent stringToTranslate="multiline" />
+    );
+    expect(getByTestId('translation').textContent).toBe(
+      'multi\nline\ntranslation'
+    );
+  });
+});
+
+describe('useTranslations with TransformationProvider (preTranslation)', () => {
+  test('preTranslation modifies string before lookup', () => {
+    const preTranslation: PreTranslationFunc = (str, locale) => {
+      expect(locale).toBe('en');
+      return `${str}_pre`;
+    };
+    const {getByTestId} = render(
+      // Intentionally NOT passing i18nContextValue to TestComponent
+      // so it uses the mockI18nContextValue defined in the file.
+      <TransformationProvider preTranslation={preTranslation}>
+        <TestComponent stringToTranslate="Hello" />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour_pre');
+  });
+
+  test('preTranslation handles params correctly', () => {
+    const preTranslation: PreTranslationFunc = (str, locale) => {
+      expect(locale).toBe('en');
+      return `${str}_pre`;
+    };
+    const {getByTestId} = render(
+      <TransformationProvider preTranslation={preTranslation}>
+        <TestComponent
+          stringToTranslate="Hello {name}"
+          params={{name: 'Vitest'}}
+        />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour_pre Vitest');
+  });
+
+  test('preTranslation works with different locale', () => {
+    const preTranslation: PreTranslationFunc = (str, locale) => {
+      expect(locale).toBe('fr');
+      return `${str}_pre_fr`; // Assuming specific fr pre-translation logic
+    };
+    const i18nContextValueFr = {
+      ...mockI18nContextValue,
+      locale: 'fr',
+      translations: {
+        ...mockI18nContextValue.translations,
+        Hello_pre_fr: 'Salut_pre_fr', // French pre-translated string
+      },
+    };
+    const {getByTestId} = render(
+      <I18nContext.Provider value={i18nContextValueFr}>
+        <TransformationProvider preTranslation={preTranslation}>
+          <TestComponent stringToTranslate="Hello" />
+        </TransformationProvider>
+      </I18nContext.Provider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Salut_pre_fr');
+  });
+
+  test('preTranslation uses original string if not in translations', () => {
+    const preTranslation: PreTranslationFunc = (str) => `${str}_pre_unknown`;
+     const {getByTestId} = render(
+      <TransformationProvider preTranslation={preTranslation}>
+        <TestComponent stringToTranslate="Unknown String" />
+      </TransformationProvider>
+    );
+    // preTranslation runs, but "Unknown String_pre_unknown" is not in translations
+    expect(getByTestId('translation').textContent).toBe('Unknown String_pre_unknown');
+  });
+});
+
+describe('useTranslations with TransformationProvider (postTranslation)', () => {
+  test('postTranslation modifies string after lookup and param substitution', () => {
+    const postTranslation: PostTranslationFunc = (
+      translatedStr,
+      params,
+      locale
+    ) => {
+      expect(locale).toBe('en');
+      expect(params).toEqual({name: 'Vitest'});
+      return `${translatedStr}_post`;
+    };
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent
+          stringToTranslate="Hello {name}"
+          params={{name: 'Vitest'}}
+        />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour Vitest_post');
+  });
+
+  test('postTranslation handles string without params', () => {
+    const postTranslation: PostTranslationFunc = (
+      translatedStr,
+      params,
+      locale
+    ) => {
+      expect(locale).toBe('en');
+      expect(params).toBeUndefined();
+      return `${translatedStr}_post_no_params`;
+    };
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent stringToTranslate="Hello" />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').textContent).toBe(
+      'Bonjour_post_no_params'
+    );
+  });
+
+  test('postTranslation for reformatting params (footnote)', () => {
+    const postTranslation: PostTranslationFunc = (translatedStr) => {
+      return translatedStr.replace(/\[footnote:([^\]]+)\]/g, '<sup>$1</sup>');
+    };
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent
+          stringToTranslate="See details[footnote:1]"
+          i18nContextValue={{
+            ...mockI18nContextValue,
+            translations: {
+              'See details[footnote:1]': 'Voir détails[footnote:1]',
+            },
+          }}
+        />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').innerHTML).toBe(
+      'Voir détails<sup>1</sup>'
+    );
+  });
+
+  test('postTranslation for injecting &nbsp;', () => {
+    const postTranslation: PostTranslationFunc = (translatedStr, params) => {
+      if (params?.textToNbsp) {
+        return translatedStr.replace(
+          String(params.textToNbsp),
+          String(params.textToNbsp).replace(/ /g, '&nbsp;')
+        );
+      }
+      return translatedStr;
+    };
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent
+          stringToTranslate="Text: {textToNbsp}"
+          params={{textToNbsp: 'Root CMS'}}
+          i18nContextValue={{
+            ...mockI18nContextValue,
+            translations: {
+              'Text: {textToNbsp}': 'Texte: {textToNbsp}',
+            },
+          }}
+        />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').innerHTML).toBe(
+      'Texte: Root&nbsp;CMS'
+    );
+  });
+
+  test('postTranslation works with different locale', () => {
+    const postTranslation: PostTranslationFunc = (
+      translatedStr,
+      params,
+      locale
+    ) => {
+      expect(locale).toBe('fr');
+      return `${translatedStr}_post_fr`;
+    };
+    const i18nContextValueFr = {
+      ...mockI18nContextValue,
+      locale: 'fr',
+      translations: {
+        ...mockI18nContextValue.translations,
+        Hello: 'Salut', // French translation
+      },
+    };
+    const {getByTestId} = render(
+      <I18nContext.Provider value={i18nContextValueFr}>
+        <TransformationProvider postTranslation={postTranslation}>
+          <TestComponent stringToTranslate="Hello" />
+        </TransformationProvider>
+      </I18nContext.Provider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Salut_post_fr');
+  });
+
+  test('postTranslation uses original string if not in translations', () => {
+    const postTranslation: PostTranslationFunc = (str) => `${str}_post_unknown`;
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent stringToTranslate="Unknown String" />
+      </TransformationProvider>
+    );
+    // postTranslation runs on the original string as it's not in translations
+    expect(getByTestId('translation').textContent).toBe('Unknown String_post_unknown');
+  });
+});
+
+describe('useTranslations with TransformationProvider (pre and postTranslation)', () => {
+  test('pre and postTranslation both applied', () => {
+    const preTranslation: PreTranslationFunc = (str, locale) => {
+      expect(locale).toBe('en');
+      return `${str}_pre`;
+    };
+    const postTranslation: PostTranslationFunc = (
+      translatedStr,
+      params,
+      locale
+    ) => {
+      expect(locale).toBe('en');
+      expect(params).toEqual({name: 'Vitest'});
+      return `${translatedStr}_post`;
+    };
+
+    const {getByTestId} = render(
+      <TransformationProvider
+        preTranslation={preTranslation}
+        postTranslation={postTranslation}
+      >
+        <TestComponent
+          stringToTranslate="Hello {name}"
+          params={{name: 'Vitest'}}
+        />
+      </TransformationProvider>
+    );
+    // "Hello {name}" -> "Hello {name}_pre" (preTranslation)
+    // "Hello {name}_pre" is looked up -> "Bonjour_pre {name}"
+    // "Bonjour_pre Vitest" (param substitution)
+    // "Bonjour_pre Vitest" -> "Bonjour_pre Vitest_post" (postTranslation)
+    expect(getByTestId('translation').textContent).toBe(
+      'Bonjour_pre Vitest_post'
+    );
+  });
+
+  test('pre and postTranslation with different locales', () => {
+    const preTranslation: PreTranslationFunc = (str, locale) => {
+      expect(locale).toBe('fr');
+      return `${str}_pre_fr`;
+    };
+    const postTranslation: PostTranslationFunc = (
+      translatedStr,
+      params,
+      locale
+    ) => {
+      expect(locale).toBe('fr');
+      return `${translatedStr}_post_fr`;
+    };
+
+    const i18nContextValueFr = {
+      locale: 'fr',
+      translations: {
+        'Hello_pre_fr': 'Salut_pre_fr',
+      },
+      locales: ['en', 'fr'],
+    };
+
+    const {getByTestId} = render(
+      <I18nContext.Provider value={i18nContextValueFr}>
+        <TransformationProvider
+          preTranslation={preTranslation}
+          postTranslation={postTranslation}
+        >
+          <TestComponent stringToTranslate="Hello" />
+        </TransformationProvider>
+      </I18nContext.Provider>
+    );
+    // "Hello" -> "Hello_pre_fr" (preTranslation with 'fr' locale)
+    // "Hello_pre_fr" is looked up -> "Salut_pre_fr"
+    // "Salut_pre_fr" -> "Salut_pre_fr_post_fr" (postTranslation with 'fr' locale)
+    expect(getByTestId('translation').textContent).toBe(
+      'Salut_pre_fr_post_fr'
+    );
+  });
+
+  test('default identity functions if no provider', () => {
+    const {getByTestId} = render(
+      // No TransformationProvider, so default identity functions should be used
+      <TestComponent
+        stringToTranslate="Hello {name}"
+        params={{name: 'Vitest'}}
+      />
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour Vitest');
+  });
+
+  test('default identity functions if provider has no props', () => {
+    const {getByTestId} = render(
+      <TransformationProvider>
+        <TestComponent
+          stringToTranslate="Hello {name}"
+          params={{name: 'Vitest'}}
+        />
+      </TransformationProvider>
+    );
+    expect(getByTestId('translation').textContent).toBe('Bonjour Vitest');
+  });
+
+  test('only preTranslation provided', () => {
+    const preTranslation: PreTranslationFunc = (str) => `${str}_pre_only`;
+    const {getByTestId} = render(
+      <TransformationProvider preTranslation={preTranslation}>
+        <TestComponent stringToTranslate="Hello" />
+      </TransformationProvider>
+    );
+    // "Hello" -> "Hello_pre_only"
+    // "Hello_pre_only" not in translations, so it's returned as is
+    // Default postTranslation is identity
+    expect(getByTestId('translation').textContent).toBe('Hello_pre_only');
+  });
+
+  test('only postTranslation provided', () => {
+    const postTranslation: PostTranslationFunc = (str) => `${str}_post_only`;
+    const {getByTestId} = render(
+      <TransformationProvider postTranslation={postTranslation}>
+        <TestComponent stringToTranslate="Hello" />
+      </TransformationProvider>
+    );
+    // "Hello" -> "Bonjour" (translation)
+    // "Bonjour" -> "Bonjour_post_only" (postTranslation)
+    expect(getByTestId('translation').textContent).toBe('Bonjour_post_only');
+  });
+});


### PR DESCRIPTION
This commit introduces a mechanism to transform strings before and after they are processed by the `useTranslations()` hook. This allows for greater flexibility in handling translations, such as overriding strings for specific locales or reformatting parameters.

Key changes:

- **Transformation Function Types**: Defined `PreTranslationFunc` and `PostTranslationFunc` types in `packages/root/src/core/types.ts`.
- **TransformationContext**: Created `TransformationContext` and a `useTransformationContext` hook (`packages/root/src/core/hooks/useTransformationContext.ts`) to provide transformation functions. It defaults to identity functions if no provider is used.
- **`useTranslations` Update**: Modified the `useTranslations` hook (`packages/root/src/core/hooks/useTranslations.ts`) to consume `TransformationContext`. It now applies `preTranslation` before translation lookup and `postTranslation` after parameter substitution. The current locale is passed to both transformation functions.
- **`TransformationProvider`**: Added a `TransformationProvider` component (`packages/root/src/core/components/TransformationProvider.tsx`) that allows you to supply your custom `preTranslation` and `postTranslation` functions.
- **Documentation**: Updated TSDoc for all new and modified components/hooks, including examples for pre- and post-transformation use cases (e.g., locale-specific overrides, parameter reformatting, `&nbsp;` injection).
- **Unit Tests**: Added a comprehensive suite of unit tests in `packages/root/test/translations.test.ts` to cover various scenarios, including transformations, locale handling, and default behavior.

This addresses the need for middleware-like string transformations within the localization process, enabling developers to:
- Override source strings for different locales (e.g., EN vs. ROW).
- Reformat parameters (e.g., `foo[footnote:bar]` to `foo{footnote:bar}` or `foo<sup>bar</sup>`).
- Inject HTML entities like `&nbsp;` for product names.