### PR TITLE
Update reference card preview behavior

### DIFF
--- a/.changeset/open-reference-cards-tab.md
+++ b/.changeset/open-reference-cards-tab.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: open reference field preview cards in new tab

--- a/packages/root-cms/CHANGELOG.md
+++ b/packages/root-cms/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @blinkk/root-cms
 
+## 1.4.6
+
+### Patch Changes
+
+- feat: open reference field preview cards in new tab
+
 ## 1.4.5
 
 ### Patch Changes

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blinkk/root-cms",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "author": "s@blinkk.com",
   "license": "MIT",
   "engines": {

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.css
@@ -25,6 +25,8 @@
   padding: 8px;
   border: 1px solid var(--color-border);
   overflow: hidden;
+  text-decoration: none;
+  color: inherit;
 }
 
 .ReferenceField__DocCard__image {

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
@@ -144,7 +144,11 @@ ReferenceField.DocCard = (props: {doc: any}) => {
     rootCollection.preview?.defaultImage;
 
   return (
-    <div className="ReferenceField__DocCard">
+    <a
+      className="ReferenceField__DocCard"
+      href={`/cms/content/${docId}`}
+      target="_blank"
+    >
       <div className="ReferenceField__DocCard__image">
         <Image
           src={previewImage?.src}
@@ -163,6 +167,6 @@ ReferenceField.DocCard = (props: {doc: any}) => {
           {previewTitle || '[UNTITLED]'}
         </div>
       </div>
-    </div>
+    </a>
   );
 };


### PR DESCRIPTION
## Summary
- open reference preview cards in a new tab
- document change in changelog

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*