### PR TITLE
feat: add data source publishing to releases

### DIFF
--- a/.changeset/ninety-bulldogs-dream.md
+++ b/.changeset/ninety-bulldogs-dream.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add data source publishing to releases

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -680,14 +680,15 @@ export class RootCMSClient {
         scheduledAt: FieldValue.delete(),
         scheduledBy: FieldValue.delete(),
       });
+      await this.publishDataSources(release.dataSourceIds || [], {
+        publishedBy,
+        batch,
+        commitBatch: false,
+      });
       await this.publishDocs(release.docIds || [], {
         publishedBy,
         batch,
         releaseId: release.id,
-      });
-      await this.publishDataSources(release.dataSourceIds || [], {
-        publishedBy,
-        batch,
       });
     }
   }
@@ -970,7 +971,7 @@ export class RootCMSClient {
 
   async publishDataSources(
     dataSourceIds: string[],
-    options?: {publishedBy: string; batch?: WriteBatch}
+    options?: {publishedBy: string; batch?: WriteBatch, commitBatch?: boolean}
   ) {
     const publishedBy = options?.publishedBy || 'root-cms-client';
     const batch = options?.batch || this.db.batch();
@@ -1005,7 +1006,7 @@ export class RootCMSClient {
         publishedBy,
       });
     }
-    if (!options?.batch) {
+    if (!options?.batch || options?.commitBatch) {
       await batch.commit();
     }
   }

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -989,7 +989,7 @@ export class RootCMSClient {
         `Projects/${this.projectId}/DataSources/${id}/published`
       );
       const dataRes = await this.getFromDataSource(id, {mode: 'draft'});
-      const updatedDataSource: DataSource = {
+      const updatedDataSource = {
         ...dataSource,
         publishedAt: FieldValue.serverTimestamp(),
         publishedBy,

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -680,11 +680,14 @@ export class RootCMSClient {
         scheduledAt: FieldValue.delete(),
         scheduledBy: FieldValue.delete(),
       });
-      await this.publishDataSources(release.dataSourceIds || [], {
-        publishedBy,
-        batch,
-        commitBatch: false,
-      });
+      const dataSourceIds = release.dataSourceIds || [];
+      if (dataSourceIds.length > 0) {
+        await this.publishDataSources(dataSourceIds, {
+          publishedBy,
+          batch,
+          commitBatch: false,
+        });
+      }
       await this.publishDocs(release.docIds || [], {
         publishedBy,
         batch,

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -141,6 +141,7 @@ export interface Release {
   id: string;
   description?: string;
   docIds?: string[];
+  dataSourceIds?: string[];
   createdAt?: Timestamp;
   createdBy?: string;
   scheduledAt?: Timestamp;
@@ -684,6 +685,10 @@ export class RootCMSClient {
         batch,
         releaseId: release.id,
       });
+      await this.publishDataSources(release.dataSourceIds || [], {
+        publishedBy,
+        batch,
+      });
     }
   }
 
@@ -961,6 +966,48 @@ export class RootCMSClient {
 
     console.log(`published data ${dataSourceId}`);
     console.log(`published by: ${publishedBy}`);
+  }
+
+  async publishDataSources(
+    dataSourceIds: string[],
+    options?: {publishedBy: string; batch?: WriteBatch}
+  ) {
+    const publishedBy = options?.publishedBy || 'root-cms-client';
+    const batch = options?.batch || this.db.batch();
+    for (const id of dataSourceIds) {
+      const dataSource = await this.getDataSource(id);
+      if (!dataSource) {
+        throw new Error(`data source not found: ${id}`);
+      }
+      const dataSourceDocRef = this.db.doc(
+        `Projects/${this.projectId}/DataSources/${id}`
+      );
+      const dataDocRefDraft = this.db.doc(
+        `Projects/${this.projectId}/DataSources/${id}/draft`
+      );
+      const dataDocRefPublished = this.db.doc(
+        `Projects/${this.projectId}/DataSources/${id}/published`
+      );
+      const dataRes = await this.getFromDataSource(id, {mode: 'draft'});
+      const updatedDataSource: DataSource = {
+        ...dataSource,
+        publishedAt: FieldValue.serverTimestamp(),
+        publishedBy,
+      };
+      batch.set(dataDocRefPublished, {
+        dataSource: updatedDataSource,
+        data: dataRes?.data || null,
+        ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
+      });
+      batch.update(dataDocRefDraft, {dataSource: updatedDataSource});
+      batch.update(dataSourceDocRef, {
+        publishedAt: FieldValue.serverTimestamp(),
+        publishedBy,
+      });
+    }
+    if (!options?.batch) {
+      await batch.commit();
+    }
   }
 
   private async fetchData(dataSource: DataSource) {

--- a/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.css
+++ b/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.css
@@ -1,0 +1,27 @@
+.DataSourceSelectModal__list {
+  border-top: 1px solid var(--color-border);
+}
+
+.DataSourceSelectModal__item {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.DataSourceSelectModal__item__info {
+  flex: 1;
+}
+
+.DataSourceSelectModal__item__id {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.DataSourceSelectModal__item__description {
+  font-size: 12px;
+}
+
+.DataSourceSelectModal__item__action {
+  flex-shrink: 0;
+}

--- a/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.tsx
+++ b/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.tsx
@@ -1,0 +1,110 @@
+import {Button, Loader} from '@mantine/core';
+import {ContextModalProps, useModals} from '@mantine/modals';
+import {useEffect, useState} from 'preact/hooks';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {DataSource, listDataSources} from '../../utils/data-source.js';
+import './DataSourceSelectModal.css';
+
+const MODAL_ID = 'DataSourceSelectModal';
+
+export interface DataSourceSelectModalProps {
+  [key: string]: unknown;
+  onChange?: (id: string, selected: boolean) => void | Promise<void>;
+  selectedDataSourceIds?: string[];
+}
+
+export function useDataSourceSelectModal() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  return {
+    open: (props: DataSourceSelectModalProps) => {
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        innerProps: props,
+        size: '600px',
+        overflow: 'inside',
+      });
+    },
+    close: () => {
+      modals.closeModal(MODAL_ID);
+    },
+  };
+}
+
+export function DataSourceSelectModal(
+  modalProps: ContextModalProps<DataSourceSelectModalProps>
+) {
+  const {innerProps: props} = modalProps;
+  const [loading, setLoading] = useState(true);
+  const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const selectedIds = props.selectedDataSourceIds || [];
+
+  useEffect(() => {
+    async function init() {
+      const res = await listDataSources();
+      setDataSources(res);
+      setLoading(false);
+    }
+    init();
+  }, []);
+
+  function onSelect(id: string) {
+    if (props.onChange) {
+      props.onChange(id, true);
+    }
+  }
+
+  function onUnselect(id: string) {
+    if (props.onChange) {
+      props.onChange(id, false);
+    }
+  }
+
+  return (
+    <div className="DataSourceSelectModal">
+      {loading ? (
+        <div className="DataSourceSelectModal__loading">
+          <Loader color="gray" size="xl" />
+        </div>
+      ) : dataSources.length === 0 ? (
+        <div className="DataSourceSelectModal__empty">No data sources.</div>
+      ) : (
+        <div className="DataSourceSelectModal__list">
+          {dataSources.map((ds) => (
+            <div key={ds.id} className="DataSourceSelectModal__item">
+              <div className="DataSourceSelectModal__item__info">
+                <div className="DataSourceSelectModal__item__id">{ds.id}</div>
+                <div className="DataSourceSelectModal__item__description">
+                  {ds.description || ''}
+                </div>
+              </div>
+              <div className="DataSourceSelectModal__item__action">
+                {selectedIds.includes(ds.id) ? (
+                  <Button
+                    variant="light"
+                    color="blue"
+                    size="xs"
+                    onClick={() => onUnselect(ds.id)}
+                  >
+                    Unselect
+                  </Button>
+                ) : (
+                  <Button
+                    variant="filled"
+                    color="blue"
+                    size="xs"
+                    onClick={() => onSelect(ds.id)}
+                  >
+                    Select
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+DataSourceSelectModal.id = MODAL_ID;

--- a/packages/root-cms/ui/components/ReleaseForm/ReleaseForm.css
+++ b/packages/root-cms/ui/components/ReleaseForm/ReleaseForm.css
@@ -71,3 +71,23 @@
   gap: 2px;
   padding-top: 8px;
 }
+
+.ReleaseForm__DataSourceIds {
+  margin: 20px 0;
+}
+
+.ReleaseForm__DataSourceIds__item {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+  padding: 4px 0;
+}
+
+.ReleaseForm__DataSourceIds__item:first-child {
+  border-top: 1px solid var(--color-border);
+}
+
+.ReleaseForm__DataSourceIds__item__id {
+  font-size: 14px;
+  font-family: monospace;
+}

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
@@ -79,3 +79,24 @@
   padding: 4px 8px;
   text-decoration: none;
 }
+
+.ReleasePage__DataSourcesList {
+  margin-top: 40px;
+  max-width: 800px;
+}
+
+.ReleasePage__DataSourcesList__header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.ReleasePage__DataSourcesList__items {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ReleasePage__DataSourcesList__item {
+  border-top: 1px solid var(--color-border);
+  padding: 4px 8px;
+}

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
@@ -92,6 +92,14 @@ export function ReleasePage(props: {id: string}) {
                 key={`docs-list-${updated}`}
               />
             )}
+            {release &&
+              release.dataSourceIds &&
+              release.dataSourceIds.length > 0 && (
+                <ReleasePage.DataSourcesList
+                  release={release}
+                  key={`data-sources-${updated}`}
+                />
+              )}
           </>
         )}
       </div>
@@ -117,10 +125,12 @@ ReleasePage.PublishStatus = (props: {
 
   function onPublishClicked() {
     const docIds = release.docIds || [];
-    if (docIds.length === 0) {
+    const dataSourceIds = release.dataSourceIds || [];
+    const total = docIds.length + dataSourceIds.length;
+    if (total === 0) {
       showNotification({
         title: 'Cannot publish release',
-        message: 'Error: no docs in the release to publish.',
+        message: 'Error: nothing in the release to publish.',
         color: 'red',
         autoClose: false,
       });
@@ -132,8 +142,8 @@ ReleasePage.PublishStatus = (props: {
       title: `Publish release: ${release.id}`,
       children: (
         <Text size="body-sm" weight="semi-bold">
-          Are you sure you want to publish this release? The {docIds.length}{' '}
-          docs in the release will go live immediately.
+          Are you sure you want to publish this release? The {total} items in
+          the release will go live immediately.
         </Text>
       ),
       labels: {confirm: 'Publish', cancel: 'Cancel'},
@@ -152,10 +162,12 @@ ReleasePage.PublishStatus = (props: {
     await notifyErrors(async () => {
       const notificationId = `publish-release-${release.id}`;
       const numDocs = release.docIds?.length || 0;
+      const numDataSources = release.dataSourceIds?.length || 0;
+      const total = numDocs + numDataSources;
       showNotification({
         id: notificationId,
         title: 'Publishing release',
-        message: `Publishing ${numDocs} docs...`,
+        message: `Publishing ${total} items...`,
         loading: true,
         autoClose: false,
       });
@@ -164,7 +176,7 @@ ReleasePage.PublishStatus = (props: {
       updateNotification({
         id: notificationId,
         title: 'Published release!',
-        message: `Successfully published ${numDocs} docs!`,
+        message: `Successfully published ${total} items!`,
         loading: false,
         autoClose: 5000,
       });
@@ -283,6 +295,34 @@ ReleasePage.DocsList = (props: {release: Release}) => {
             <a href={`/cms/content/${docId}`}>
               <DocPreviewCard docId={docId} statusBadges />
             </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+ReleasePage.DataSourcesList = (props: {release: Release}) => {
+  const release = props.release;
+  const ids = release.dataSourceIds || [];
+  return (
+    <div className="ReleasePage__DataSourcesList">
+      <div className="ReleasePage__DataSourcesList__header">
+        <Heading size="h2">Data Sources</Heading>
+        <Button
+          component="a"
+          variant="default"
+          size="xs"
+          compact
+          href={`/cms/releases/${release.id}/edit`}
+        >
+          Edit
+        </Button>
+      </div>
+      <div className="ReleasePage__DataSourcesList__items">
+        {ids.map((id) => (
+          <div key={id} className="ReleasePage__DataSourcesList__item">
+            <a href={`/cms/data/${id}`}>{id}</a>
           </div>
         ))}
       </div>

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -11,6 +11,7 @@ import {Collection} from '../core/schema.js';
 import {CopyDocModal} from './components/CopyDocModal/CopyDocModal.js';
 import {DocPickerModal} from './components/DocPickerModal/DocPickerModal.js';
 import {DocSelectModal} from './components/DocSelectModal/DocSelectModal.js';
+import {DataSourceSelectModal} from './components/DataSourceSelectModal/DataSourceSelectModal.js';
 import {EditJsonModal} from './components/EditJsonModal/EditJsonModal.js';
 import {EditTranslationsModal} from './components/EditTranslationsModal/EditTranslationsModal.js';
 import {ExportSheetModal} from './components/ExportSheetModal/ExportSheetModal.js';
@@ -100,6 +101,7 @@ function App() {
               [CopyDocModal.id]: CopyDocModal,
               [DocPickerModal.id]: DocPickerModal,
               [DocSelectModal.id]: DocSelectModal,
+              [DataSourceSelectModal.id]: DataSourceSelectModal,
               [EditJsonModal.id]: EditJsonModal,
               [EditTranslationsModal.id]: EditTranslationsModal,
               [ExportSheetModal.id]: ExportSheetModal,

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -1,5 +1,6 @@
 import {
   Timestamp,
+  WriteBatch,
   collection,
   doc,
   getDoc,
@@ -255,7 +256,7 @@ export async function publishDataSource(id: string) {
 
 export async function cmsPublishDataSources(
   ids: string[],
-  options?: {batch?: WriteBatch}
+  options?: {batch?: WriteBatch; commitBatch?: boolean}
 ) {
   if (ids.length === 0) {
     return;
@@ -288,7 +289,7 @@ export async function cmsPublishDataSources(
       'Data',
       'published'
     );
-    const updatedDataSource: DataSource = {
+    const updatedDataSource = {
       ...dataSource,
       publishedAt: serverTimestamp(),
       publishedBy: window.firebase.user.email!,
@@ -305,7 +306,7 @@ export async function cmsPublishDataSources(
     });
     logAction('datasource.publish', {metadata: {datasourceId: id}});
   }
-  if (!options?.batch) {
+  if (!options?.batch || options?.commitBatch) {
     await batch.commit();
   }
 }

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -253,6 +253,63 @@ export async function publishDataSource(id: string) {
   logAction('datasource.publish', {metadata: {datasourceId: id}});
 }
 
+export async function cmsPublishDataSources(
+  ids: string[],
+  options?: {batch?: WriteBatch}
+) {
+  if (ids.length === 0) {
+    return;
+  }
+  const db = window.firebase.db;
+  const projectId = window.__ROOT_CTX.rootConfig.projectId;
+  const batch = options?.batch || writeBatch(db);
+  for (const id of ids) {
+    const dataSource = await getDataSource(id);
+    if (!dataSource) {
+      throw new Error(`data source not found: ${id}`);
+    }
+    const dataRes = await getFromDataSource(id, {mode: 'draft'});
+    const dataSourceDocRef = doc(db, 'Projects', projectId, 'DataSources', id);
+    const dataDocRefDraft = doc(
+      db,
+      'Projects',
+      projectId,
+      'DataSources',
+      id,
+      'Data',
+      'draft'
+    );
+    const dataDocRefPublished = doc(
+      db,
+      'Projects',
+      projectId,
+      'DataSources',
+      id,
+      'Data',
+      'published'
+    );
+    const updatedDataSource: DataSource = {
+      ...dataSource,
+      publishedAt: serverTimestamp(),
+      publishedBy: window.firebase.user.email!,
+    };
+    batch.set(dataDocRefPublished, {
+      dataSource: updatedDataSource,
+      data: dataRes?.data || null,
+      ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
+    });
+    batch.update(dataDocRefDraft, {dataSource: updatedDataSource});
+    batch.update(dataSourceDocRef, {
+      publishedAt: serverTimestamp(),
+      publishedBy: window.firebase.user.email!,
+    });
+    logAction('datasource.publish', {metadata: {datasourceId: id}});
+  }
+  if (!options?.batch) {
+    await batch.commit();
+  }
+}
+
 export async function deleteDataSource(id: string) {
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   const db = window.firebase.db;

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -120,10 +120,10 @@ export async function publishRelease(id: string) {
     scheduledAt: deleteField(),
     scheduledBy: deleteField(),
   });
-  await cmsPublishDocs(docIds, {batch, releaseId: id});
   if (dataSourceIds.length > 0) {
-    await cmsPublishDataSources(dataSourceIds, {batch});
+    await cmsPublishDataSources(dataSourceIds, {batch, commitBatch: false});
   }
+  await cmsPublishDocs(docIds, {batch, releaseId: id});
   console.log(`published release: ${id}`);
   logAction('release.publish', {
     metadata: {releaseId: id, docIds, dataSourceIds},


### PR DESCRIPTION
## Summary
- allow specifying dataSourceIds in release API
- publish data sources when publishing releases
- expose new DataSourceSelectModal and wire into ReleaseForm
- list data sources in ReleasePage

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684267b1d3148323a5753fc250d14910