### PR TITLE
feat: add option to disable alt text

### DIFF
--- a/.changeset/dry-news-whisper.md
+++ b/.changeset/dry-news-whisper.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add option to disable alt text (#579)

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -96,6 +96,8 @@ export type ImageField = CommonFieldProps & {
    * Cache-control header to set on the GCS object.
    */
   cacheControl?: string;
+  /** Set to `false` to disable the alt text input. */
+  alt?: boolean;
 };
 
 export function image(field: Omit<ImageField, 'type'>): ImageField {
@@ -115,6 +117,8 @@ export type FileField = CommonFieldProps & {
    * Cache-control header to set on the GCS object.
    */
   cacheControl?: string;
+  /** Set to `false` to disable the alt text input. */
+  alt?: boolean;
 };
 
 export function file(field: Omit<FileField, 'type'>): FileField {

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -16,6 +16,7 @@ export function FileField(props: FieldProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const ref = useRef<HTMLDivElement>(null);
 
+  const showAlt = field.alt !== false;
   let accept: string | undefined = undefined;
   if (field.exts) {
     accept = field.exts.join(',');
@@ -164,18 +165,19 @@ export function FileField(props: FieldProps) {
               disabled={true}
             />
           </div>
-          {testShouldHaveAltText(file.src) && (
-            <TextInput
-              className="DocEditor__FileField__file__alt"
-              size="xs"
-              radius={0}
-              value={file.alt || ''}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                setAltText(e.currentTarget.value);
-              }}
-              label="Alt text"
-            />
-          )}
+          {showAlt &&
+            testShouldHaveAltText(file.src) && (
+              <TextInput
+                className="DocEditor__FileField__file__alt"
+                size="xs"
+                radius={0}
+                value={file.alt || ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setAltText(e.currentTarget.value);
+                }}
+                label="Alt text"
+              />
+            )}
         </>
       ) : (
         <div className="DocEditor__FileField__noFile">No file</div>

--- a/packages/root-cms/ui/components/DocEditor/fields/ImageField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ImageField.tsx
@@ -137,6 +137,7 @@ export function ImageField(props: FieldProps) {
     };
   }, []);
 
+  const showAlt = field.alt !== false;
   return (
     <div
       className={joinClassNames(
@@ -175,16 +176,18 @@ export function ImageField(props: FieldProps) {
             value={img.gciUrl || img.src}
             disabled={true}
           />
-          <TextInput
-            className="DocEditor__ImageField__imagePreview__image__alt"
-            size="xs"
-            radius={0}
-            value={img.alt}
-            label="Alt text"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              setAltText(e.currentTarget.value);
-            }}
-          />
+          {showAlt && (
+            <TextInput
+              className="DocEditor__ImageField__imagePreview__image__alt"
+              size="xs"
+              radius={0}
+              value={img.alt}
+              label="Alt text"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setAltText(e.currentTarget.value);
+              }}
+            />
+          )}
         </div>
       ) : (
         <div className="DocEditor__ImageField__noImage">No image</div>

--- a/packages/root-cms/ui/utils/extract.ts
+++ b/packages/root-cms/ui/utils/extract.ts
@@ -67,7 +67,7 @@ export function extractField(
       addString(fieldValue);
     }
   } else if (field.type === 'image') {
-    if (field.translate && fieldValue && fieldValue.alt) {
+    if (field.translate && fieldValue && fieldValue.alt && field.alt !== false) {
       addString(fieldValue.alt);
     }
   } else if (field.type === 'multiselect') {


### PR DESCRIPTION
## Summary
- add `alt?: boolean` to ImageField and FileField
- render alt input only when `alt !== false`
- skip translation extraction when alt text is disabled

## Testing
- `pnpm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685043ddd7548323bc599698d27ad7fa