### PR TITLE
feat: improve local hmr experience

### DIFF
--- a/.changeset/heavy-zebras-breathe.md
+++ b/.changeset/heavy-zebras-breathe.md
@@ -1,0 +1,6 @@
+---
+'@blinkk/root-cms': patch
+'@blinkk/root': patch
+---
+
+feat: improve local hmr experience

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -43,6 +43,7 @@ import {
   UseDraftHook,
 } from '../../hooks/useDraft.js';
 import {joinClassNames} from '../../utils/classes.js';
+import {preserveUiState} from '../../utils/doc-ui-state.js';
 import {
   CMSDoc,
   testIsScheduled,
@@ -53,6 +54,7 @@ import {getDefaultFieldValue} from '../../utils/fields.js';
 import {flattenNestedKeys} from '../../utils/objects.js';
 import {autokey} from '../../utils/rand.js';
 import {getPlaceholderKeys, strFormat} from '../../utils/str-format.js';
+import {testFieldEmpty} from '../../utils/test-field-empty.js';
 import {formatDateTime} from '../../utils/time.js';
 import {
   useVirtualClipboard,
@@ -67,7 +69,6 @@ import {useEditJsonModal} from '../EditJsonModal/EditJsonModal.js';
 import {useEditTranslationsModal} from '../EditTranslationsModal/EditTranslationsModal.js';
 import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
-import './DocEditor.css';
 import {Viewers} from '../Viewers/Viewers.js';
 import {BooleanField} from './fields/BooleanField.js';
 import {DateTimeField} from './fields/DateTimeField.js';
@@ -75,12 +76,13 @@ import {FieldProps} from './fields/FieldProps.js';
 import {FileField} from './fields/FileField.js';
 import {ImageField} from './fields/ImageField.js';
 import {MultiSelectField} from './fields/MultiSelectField.js';
+import {NumberField} from './fields/NumberField.js';
 import {ReferenceField} from './fields/ReferenceField.js';
 import {RichTextField} from './fields/RichTextField.js';
 import {SelectField} from './fields/SelectField.js';
 import {StringField} from './fields/StringField.js';
-import {NumberField} from './fields/NumberField.js';
-import {testFieldEmpty} from '../../utils/test-field-empty.js';
+
+import './DocEditor.css';
 
 interface DocEditorProps {
   docId: string;
@@ -143,6 +145,10 @@ export function DocEditor(props: DocEditorProps) {
     if (deeplink) {
       setDeeplink(deeplink);
     }
+    const callback = preserveUiState();
+    return () => {
+      callback();
+    };
   }, [loading]);
 
   return (

--- a/packages/root-cms/ui/utils/doc-ui-state.ts
+++ b/packages/root-cms/ui/utils/doc-ui-state.ts
@@ -1,0 +1,83 @@
+const SCROLL_KEY = 'root::cms::scroll';
+const OPEN_KEY = 'root::cms::open';
+
+/*
+ * Save the scroll position and open field editors prior to reloading the page.
+ */
+function saveUiState() {
+  const side = document.querySelector(
+    '.DocumentPage__side'
+  ) as HTMLElement | null;
+  if (side) {
+    sessionStorage.setItem(SCROLL_KEY, String(side.scrollTop));
+  }
+  const openSummaries = Array.from(
+    document.querySelectorAll(
+      '.DocEditor__ObjectFieldDrawer__drawer[open], .DocEditor__ArrayField__item[open] summary'
+    )
+  )
+    .map((el) => el.id)
+    .filter(Boolean);
+  if (openSummaries.length > 0) {
+    sessionStorage.setItem(OPEN_KEY, JSON.stringify(openSummaries));
+  }
+}
+
+/*
+ * Restore the scroll position and open field editors when page is loaded.
+ */
+function restoreUiState() {
+  // Restore open editors.
+  const open = sessionStorage.getItem(OPEN_KEY);
+  if (open) {
+    try {
+      const ids = JSON.parse(open) as string[];
+      ids.forEach((id) => {
+        const summary = document.getElementById(id);
+        if (summary) {
+          const details = summary.closest('details');
+          if (details) {
+            details.open = true;
+          }
+        }
+      });
+    } catch {
+      /* ignore */
+    }
+  }
+  // Restore scroll position.
+  const side = document.querySelector(
+    '.DocumentPage__side'
+  ) as HTMLElement | null;
+  const scroll = sessionStorage.getItem(SCROLL_KEY);
+  if (side && scroll) {
+    side.scrollTop = parseInt(scroll, 10);
+  }
+}
+
+/** Returns whether the UI state should be saved and restored. */
+function testPreserveUiState() {
+  // Currently, this is mainly used for development. Specifically, when the page is HMR'ed, we
+  // want to preserve the scroll position and open editors.
+  return window.location.hostname === 'localhost';
+}
+
+/** Preserves the UI state across page reloads. */
+export function preserveUiState(): () => void {
+  // Do nothing if the UI state should not be preserved.
+  if (!testPreserveUiState()) {
+    return () => {};
+  }
+  // Restore the UI state once the data is loaded.
+  restoreUiState();
+  const beforeUnloadHandler = () => {
+    // Save the scroll position and open field editors prior to reloading the page.
+    saveUiState();
+  };
+  // Before the page is unloaded, save the ui state.
+  window.addEventListener('beforeunload', beforeUnloadHandler);
+  // Return a callback that removes the event listener.
+  return () => {
+    window.removeEventListener('beforeunload', beforeUnloadHandler);
+  };
+}

--- a/packages/root/src/node/vite.ts
+++ b/packages/root/src/node/vite.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import {createServer, ViteDevServer} from 'vite';
 import {RootConfig} from '../core/config.js';
 import {getVitePlugins} from '../core/plugin.js';
@@ -21,6 +23,23 @@ export async function createViteServer(
   const rootDir = rootConfig.rootDir;
   const viteConfig = rootConfig.vite || {};
 
+  /** Ignore paths from .gitignore when hot reloading. */
+  const gitignorePath = path.join(rootDir, '.gitignore');
+  let ignored: Array<string | RegExp> = ['**/dist/**'];
+  if (fs.existsSync(gitignorePath)) {
+    try {
+      const contents = fs.readFileSync(gitignorePath, 'utf8');
+      const patterns = contents
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l && !l.startsWith('#'))
+        .map((p) => (p.endsWith('/') ? `${p}**` : p));
+      ignored = [...ignored, ...patterns];
+    } catch {
+      /** ignore errors reading gitignore */
+    }
+  }
+
   let hmrOptions = viteConfig.server?.hmr;
   if (options?.hmr === false) {
     hmrOptions = false;
@@ -42,6 +61,10 @@ export async function createViteServer(
       ...(viteConfig.server || {}),
       middlewareMode: true,
       hmr: hmrOptions,
+      watch: {
+        ...(viteConfig.server?.watch || {}),
+        ignored,
+      },
     },
     appType: 'custom',
     optimizeDeps: {


### PR DESCRIPTION
## Summary
- ignore `dist` output and gitignored files in Vite watcher
- remember scroll position and open field state in CMS UI when hot reloading
- switch new comments to block style and remove stray blank line

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*


------
https://chatgpt.com/codex/tasks/task_e_684dea6105408322b93fc91625fbdf0e