### PR TITLE
chore: hide empty deprecated fields

### DIFF
--- a/.changeset/sixty-cups-itch.md
+++ b/.changeset/sixty-cups-itch.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+hide empty deprecated fields

--- a/.changeset/sixty-cups-itch.md
+++ b/.changeset/sixty-cups-itch.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-hide empty deprecated fields
+chore: suppress deprecated fields that are empty

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -80,6 +80,7 @@ import {RichTextField} from './fields/RichTextField.js';
 import {SelectField} from './fields/SelectField.js';
 import {StringField} from './fields/StringField.js';
 import {NumberField} from './fields/NumberField.js';
+import {testFieldEmpty} from '../../utils/test-field-empty.js';
 
 interface DocEditorProps {
   docId: string;
@@ -308,6 +309,10 @@ DocEditor.Field = (props: FieldProps) => {
       scrollToDeeplink(ref.current!);
     }
   }, [targeted]);
+
+  if (field.deprecated && testFieldEmpty(field, value)) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/root-cms/ui/utils/test-field-empty.ts
+++ b/packages/root-cms/ui/utils/test-field-empty.ts
@@ -1,0 +1,83 @@
+import * as schema from '../../core/schema.js';
+import {validateRichTextData} from '../components/RichTextEditor/RichTextEditor.js';
+import {isObject} from './objects.js';
+
+/**
+ * Returns whether a field's value should be considered empty.
+ *
+ * Handles nested objects and arrays, along with primitive fields.
+ * This helper is primarily used to hide deprecated fields when they
+ * contain no meaningful data.
+ */
+export function testFieldEmpty(field: schema.Field, value: any): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  switch (field.type) {
+    case 'string':
+    case 'select':
+    case 'date':
+    case 'datetime':
+      return value === '';
+    case 'multiselect':
+      return !Array.isArray(value) || value.length === 0;
+    case 'number':
+    case 'boolean':
+      return value === undefined || value === null;
+    case 'image':
+    case 'file':
+      return !value || !value.src;
+    case 'reference':
+      return !value || !value.id;
+    case 'richtext':
+      return !validateRichTextData(value);
+    case 'object':
+      if (!isObject(value) || Object.keys(value).length === 0) {
+        return true;
+      }
+      for (const child of field.fields || []) {
+        if (!child.id) {
+          continue;
+        }
+        if (!testFieldEmpty(child, value[child.id])) {
+          return false;
+        }
+      }
+      return true;
+    case 'array':
+      if (
+        !isObject(value) ||
+        !Array.isArray(value._array) ||
+        value._array.length === 0
+      ) {
+        return true;
+      }
+      for (const key of value._array) {
+        if (!testFieldEmpty(field.of, value[key])) {
+          return false;
+        }
+      }
+      return false;
+    case 'oneof': {
+      if (!isObject(value) || !value._type) {
+        return true;
+      }
+      const sub = (field.types || []).find((t) => t.name === value._type);
+      if (!sub) {
+        return true;
+      }
+      for (const child of sub.fields || []) {
+        if (!child.id) {
+          continue;
+        }
+        if (!testFieldEmpty(child, value[child.id])) {
+          return false;
+        }
+      }
+      return true;
+    }
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
## Summary
- document `testFieldEmpty`
- hide deprecated field if it's empty without temp variable

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685491f253588322afc7a25539d2e0e9