### PR TITLE
Fix CMS scroll state reuse

### DIFF
--- a/packages/root-cms/ui/utils/doc-ui-state.ts
+++ b/packages/root-cms/ui/utils/doc-ui-state.ts
@@ -44,6 +44,7 @@ function restoreUiState() {
     } catch {
       /* ignore */
     }
+    sessionStorage.removeItem(OPEN_KEY);
   }
   // Restore scroll position.
   const side = document.querySelector(
@@ -52,6 +53,7 @@ function restoreUiState() {
   const scroll = sessionStorage.getItem(SCROLL_KEY);
   if (side && scroll) {
     side.scrollTop = parseInt(scroll, 10);
+    sessionStorage.removeItem(SCROLL_KEY);
   }
 }
 


### PR DESCRIPTION
## Summary
- clear saved UI state after restoring scroll position

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6869b47d164083229c1072f7f8204332