### PR TITLE
feat: add date field to doc editor

### DIFF
--- a/.changeset/grumpy-jobs-march.md
+++ b/.changeset/grumpy-jobs-march.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add date field to doc editor

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -506,6 +506,15 @@
   font-size: 12px;
 }
 
+.DocEditor__DateField input {
+  display: block;
+  width: 100%;
+  border: 1px solid #dedede;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 12px;
+}
+
 .DocEditor__DateTimeField__timezone {
   font-size: 10px;
   font-weight: 400;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -69,6 +69,7 @@ import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Viewers} from '../Viewers/Viewers.js';
 import {BooleanField} from './fields/BooleanField.js';
 import {DateTimeField} from './fields/DateTimeField.js';
+import {DateField} from './fields/DateField.js';
 import {FieldProps} from './fields/FieldProps.js';
 import {FileField} from './fields/FileField.js';
 import {ImageField} from './fields/ImageField.js';
@@ -339,6 +340,8 @@ DocEditor.Field = (props: FieldProps) => {
           <DocEditor.ArrayField {...props} />
         ) : field.type === 'boolean' ? (
           <BooleanField {...props} />
+        ) : field.type === 'date' ? (
+          <DateField {...props} />
         ) : field.type === 'datetime' ? (
           <DateTimeField {...props} />
         ) : field.type === 'file' ? (

--- a/packages/root-cms/ui/components/DocEditor/fields/DateField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/DateField.tsx
@@ -1,0 +1,42 @@
+import {useEffect, useState} from 'preact/hooks';
+import * as schema from '../../../../core/schema.js';
+import {FieldProps} from './FieldProps.js';
+
+export function DateField(props: FieldProps) {
+  const field = props.field as schema.DateField;
+  const [value, setValue] = useState(field.default || '');
+
+  function onChange(newValue: string) {
+    if (newValue) {
+      // Value is stored in DB as YYYY-MM-DD string
+      props.draft.updateKey(props.deepKey, newValue);
+      setValue(newValue);
+    } else {
+      setValue('');
+      props.draft.removeKey(props.deepKey);
+    }
+    if (props.onChange) {
+      props.onChange(newValue);
+    }
+  }
+
+  useEffect(() => {
+    const unsubscribe = props.draft.subscribe(props.deepKey, (newVal: string) => {
+      setValue(newVal || '');
+    });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <div className="DocEditor__DateField">
+      <input
+        type="date"
+        value={value}
+        onChange={(e: Event) => {
+          const target = e.currentTarget as HTMLInputElement;
+          onChange(target.value);
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `DateField` component for DocEditor
- render `DateField` when schema field type is `date`
- style the new input in DocEditor CSS

## Testing
- `pnpm test` *(fails: unable to download dependencies)*
- `pnpm lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ad4f8423883238a373c00f9b409a5