### PR TITLE
feat: add router.matchAll for multiple matches

### DIFF
--- a/.changeset/smart-apes-smoke.md
+++ b/.changeset/smart-apes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add router.matchAll for multiple matches

--- a/packages/root/src/render/route-trie.test.ts
+++ b/packages/root/src/render/route-trie.test.ts
@@ -124,3 +124,15 @@ test('walk all routes', async () => {
     expected.sort((a, b) => a[0].localeCompare(b[0]))
   );
 });
+
+test('match all matching routes', () => {
+  routeTrie.add('/[[...slug]]', 'a');
+  routeTrie.add('/foo/[id]', 'b');
+  routeTrie.add('/foo/bar', 'c');
+
+  assert.deepEqual(routeTrie.matchAll('/foo/bar'), [
+    ['c', {}],
+    ['b', {id: 'bar'}],
+    ['a', {slug: 'foo/bar'}],
+  ]);
+});

--- a/packages/root/src/render/router.ts
+++ b/packages/root/src/render/router.ts
@@ -21,6 +21,10 @@ export class Router {
     return this.routeTrie.get(url);
   }
 
+  matchAll(url: string) {
+    return this.routeTrie.matchAll(url);
+  }
+
   async walk(cb: (urlPath: string, route: Route) => void | Promise<void>) {
     await this.routeTrie.walk(cb);
   }


### PR DESCRIPTION
## Summary
- add `matchAll` to the `Router` class for returning all matching routes
- implement `RouteTrie.matchAll` with helper `collectRoutes`
- test retrieving multiple matches
- rename API from `getAll` to `matchAll`

## Testing
- `pnpm test` *(fails: Corepack tries to fetch pnpm and can't due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687cf4d1a90883238c7e40491b2ef227