### PR TITLE
add support for props.notFound to getStaticContent()

### DIFF
--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -417,6 +417,9 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
                 rootConfig, params:
                 sitemapItem.params,
               });
+              if (props?.notFound) {
+                return;
+              }
             } else {
               props = {rootConfig, params: sitemapItem.params};
             }

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -218,6 +218,9 @@ export class Renderer {
             rootConfig: this.rootConfig,
             params: routeParams,
           });
+          if (props?.notFound) {
+            return render404();
+          }
         } else {
           props = {rootConfig: this.rootConfig, params: routeParams};
         }


### PR DESCRIPTION
## Summary
- skip static content build when `getStaticProps` signals `notFound`
- handle `notFound` in dev server for `getStaticContent`

## Testing
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d0ac1bfa08323bf7e88edd57a8326