### PR TITLE
Add ability to expand/collapse preview and improve iframe loading

### DIFF
--- a/.changeset/wet-zebras-sort.md
+++ b/.changeset/wet-zebras-sort.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add expand/collapse for cms preview

--- a/packages/root-cms/ui/components/DocDiffViewer/DocDiffViewer.tsx
+++ b/packages/root-cms/ui/components/DocDiffViewer/DocDiffViewer.tsx
@@ -1,13 +1,13 @@
 import {Button, Loader} from '@mantine/core';
 import {Differ, Viewer as JsonDiffViewer} from 'json-diff-kit';
 import {useEffect, useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
 import {CMSDoc, cmsReadDocVersion, unmarshalData} from '../../utils/doc.js';
+import {getTimeAgo} from '../../utils/time.js';
 
 import 'json-diff-kit/dist/viewer.css';
 import 'json-diff-kit/dist/viewer-monokai.css';
 import './DocDiffViewer.css';
-import {getTimeAgo} from '../../utils/time.js';
-import {joinClassNames} from '../../utils/classes.js';
 
 export interface DocVersionId {
   /** Doc id, e.g. `Pages/foo`. */

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -39,6 +39,18 @@
   margin-left: 4px;
 }
 
+.DocEditor__statusBar__previewControls {
+  margin-left: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.DocEditor__statusBar__previewControls__openNewTab,
+.DocEditor__statusBar__previewControls__toggle {
+  color: var(--color-text-default);
+}
+
 .DocEditor__fields {
   display: flex;
   flex-direction: column;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -39,18 +39,6 @@
   margin-left: 4px;
 }
 
-.DocEditor__statusBar__previewControls {
-  margin-left: 4px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.DocEditor__statusBar__previewControls__openNewTab,
-.DocEditor__statusBar__previewControls__toggle {
-  color: var(--color-text-default);
-}
-
 .DocEditor__fields {
   display: flex;
   flex-direction: column;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -58,6 +58,10 @@ import {extractField} from '../../utils/extract.js';
 import {getDefaultFieldValue} from '../../utils/fields.js';
 import {flattenNestedKeys} from '../../utils/objects.js';
 import {autokey} from '../../utils/rand.js';
+import {
+  cancelIdleCallbackPolyfill,
+  requestIdleCallbackPolyfill,
+} from '../../utils/request-idle-callback.js';
 import {getPlaceholderKeys, strFormat} from '../../utils/str-format.js';
 import {testFieldEmpty} from '../../utils/test-field-empty.js';
 import {formatDateTime} from '../../utils/time.js';
@@ -151,12 +155,12 @@ export function DocEditor(props: DocEditorProps) {
   // Notify parent when fields are rendered (for deferred iframe loading)
   useEffect(() => {
     if (!loading && props.onFieldsRendered) {
-      // Use a small delay to ensure fields are actually rendered in DOM
-      const timer = setTimeout(() => {
-        props.onFieldsRendered();
-      }, 100);
-      return () => clearTimeout(timer);
+      const timer = requestIdleCallbackPolyfill(() => {
+        props.onFieldsRendered && props.onFieldsRendered();
+      });
+      return () => cancelIdleCallbackPolyfill(timer as number);
     }
+    return () => {};
   }, [loading, props.onFieldsRendered]);
 
   return (

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -44,7 +44,10 @@ import {
   SaveState,
   UseDraftHook,
 } from '../../hooks/useDraft.js';
-import {useVirtualClipboard, VirtualClipboard} from '../../hooks/useVirtualClipboard.js';
+import {
+  useVirtualClipboard,
+  VirtualClipboard,
+} from '../../hooks/useVirtualClipboard.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {
   CMSDoc,
@@ -56,6 +59,7 @@ import {getDefaultFieldValue} from '../../utils/fields.js';
 import {flattenNestedKeys} from '../../utils/objects.js';
 import {autokey} from '../../utils/rand.js';
 import {getPlaceholderKeys, strFormat} from '../../utils/str-format.js';
+import {testFieldEmpty} from '../../utils/test-field-empty.js';
 import {formatDateTime} from '../../utils/time.js';
 import {
   DocActionEvent,
@@ -68,18 +72,17 @@ import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Viewers} from '../Viewers/Viewers.js';
 import {BooleanField} from './fields/BooleanField.js';
-import {DateTimeField} from './fields/DateTimeField.js';
 import {DateField} from './fields/DateField.js';
+import {DateTimeField} from './fields/DateTimeField.js';
 import {FieldProps} from './fields/FieldProps.js';
 import {FileField} from './fields/FileField.js';
 import {ImageField} from './fields/ImageField.js';
 import {MultiSelectField} from './fields/MultiSelectField.js';
+import {NumberField} from './fields/NumberField.js';
 import {ReferenceField} from './fields/ReferenceField.js';
 import {RichTextField} from './fields/RichTextField.js';
 import {SelectField} from './fields/SelectField.js';
 import {StringField} from './fields/StringField.js';
-import {NumberField} from './fields/NumberField.js';
-import {testFieldEmpty} from '../../utils/test-field-empty.js';
 
 interface DocEditorProps {
   docId: string;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -25,6 +25,9 @@ import {
   IconRowInsertTop,
   IconTrash,
   IconTriangleFilled,
+  IconArrowUpRight,
+  IconLayoutSidebarRightCollapse,
+  IconLayoutSidebarRightExpand,
 } from '@tabler/icons-preact';
 import {createContext} from 'preact';
 import {
@@ -85,6 +88,10 @@ interface DocEditorProps {
   docId: string;
   collection: schema.Collection;
   draft: UseDraftHook;
+  isPreviewVisible?: boolean;
+  onTogglePreviewVisibility?: () => void;
+  onOpenPreviewInNewTab?: () => void;
+  onFieldsRendered?: () => void;
 }
 
 const DEEPLINK_CONTEXT = createContext('');
@@ -143,6 +150,17 @@ export function DocEditor(props: DocEditorProps) {
       setDeeplink(deeplink);
     }
   }, [loading]);
+
+  // Notify parent when fields are rendered (for deferred iframe loading)
+  useEffect(() => {
+    if (!loading && props.onFieldsRendered) {
+      // Use a small delay to ensure fields are actually rendered in DOM
+      const timer = setTimeout(() => {
+        props.onFieldsRendered();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [loading, props.onFieldsRendered]);
 
   return (
     <VIRTUAL_CLIPBOARD_CONTEXT.Provider
@@ -240,6 +258,32 @@ export function DocEditor(props: DocEditorProps) {
                   onAction={onDocAction}
                 />
               </div>
+              {props.onTogglePreviewVisibility && (
+                <div className="DocEditor__statusBar__previewControls">
+                  {!props.isPreviewVisible && props.onOpenPreviewInNewTab && (
+                    <Tooltip label="Open preview in new tab">
+                      <ActionIcon
+                        className="DocEditor__statusBar__previewControls__openNewTab"
+                        onClick={props.onOpenPreviewInNewTab}
+                      >
+                        <IconArrowUpRight size={16} />
+                      </ActionIcon>
+                    </Tooltip>
+                  )}
+                  <Tooltip label={props.isPreviewVisible ? "Hide preview" : "Show preview"}>
+                    <ActionIcon
+                      className="DocEditor__statusBar__previewControls__toggle"
+                      onClick={props.onTogglePreviewVisibility}
+                    >
+                      {props.isPreviewVisible ? (
+                        <IconLayoutSidebarRightCollapse size={16} />
+                      ) : (
+                        <IconLayoutSidebarRightExpand size={16} />
+                      )}
+                    </ActionIcon>
+                  </Tooltip>
+                </div>
+              )}
             </div>
             <div className="DocEditor__fields">
               {fields.map((field) => (

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -158,7 +158,7 @@ export function DocEditor(props: DocEditorProps) {
       const timer = requestIdleCallbackPolyfill(() => {
         props.onFieldsRendered && props.onFieldsRendered();
       });
-      return () => cancelIdleCallbackPolyfill(timer as number);
+      return () => cancelIdleCallbackPolyfill(timer);
     }
     return () => {};
   }, [loading, props.onFieldsRendered]);

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -90,7 +90,6 @@ interface DocEditorProps {
   draft: UseDraftHook;
   isPreviewVisible?: boolean;
   onTogglePreviewVisibility?: () => void;
-  onOpenPreviewInNewTab?: () => void;
   onFieldsRendered?: () => void;
 }
 
@@ -260,16 +259,6 @@ export function DocEditor(props: DocEditorProps) {
               </div>
               {props.onTogglePreviewVisibility && (
                 <div className="DocEditor__statusBar__previewControls">
-                  {!props.isPreviewVisible && props.onOpenPreviewInNewTab && (
-                    <Tooltip label="Open preview in new tab">
-                      <ActionIcon
-                        className="DocEditor__statusBar__previewControls__openNewTab"
-                        onClick={props.onOpenPreviewInNewTab}
-                      >
-                        <IconArrowUpRight size={16} />
-                      </ActionIcon>
-                    </Tooltip>
-                  )}
                   <Tooltip label={props.isPreviewVisible ? "Hide preview" : "Show preview"}>
                     <ActionIcon
                       className="DocEditor__statusBar__previewControls__toggle"

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -25,9 +25,6 @@ import {
   IconRowInsertTop,
   IconTrash,
   IconTriangleFilled,
-  IconArrowUpRight,
-  IconLayoutSidebarRightCollapse,
-  IconLayoutSidebarRightExpand,
 } from '@tabler/icons-preact';
 import {createContext} from 'preact';
 import {
@@ -88,8 +85,6 @@ interface DocEditorProps {
   docId: string;
   collection: schema.Collection;
   draft: UseDraftHook;
-  isPreviewVisible?: boolean;
-  onTogglePreviewVisibility?: () => void;
   onFieldsRendered?: () => void;
 }
 
@@ -257,22 +252,6 @@ export function DocEditor(props: DocEditorProps) {
                   onAction={onDocAction}
                 />
               </div>
-              {props.onTogglePreviewVisibility && (
-                <div className="DocEditor__statusBar__previewControls">
-                  <Tooltip label={props.isPreviewVisible ? "Hide preview" : "Show preview"}>
-                    <ActionIcon
-                      className="DocEditor__statusBar__previewControls__toggle"
-                      onClick={props.onTogglePreviewVisibility}
-                    >
-                      {props.isPreviewVisible ? (
-                        <IconLayoutSidebarRightCollapse size={16} />
-                      ) : (
-                        <IconLayoutSidebarRightExpand size={16} />
-                      )}
-                    </ActionIcon>
-                  </Tooltip>
-                </div>
-              )}
             </div>
             <div className="DocEditor__fields">
               {fields.map((field) => (

--- a/packages/root-cms/ui/components/EditJsonModal/EditJsonModal.tsx
+++ b/packages/root-cms/ui/components/EditJsonModal/EditJsonModal.tsx
@@ -9,6 +9,7 @@ const MODAL_ID = 'EditJsonModal';
 
 export interface EditJsonModalProps {
   [key: string]: unknown;
+  title?: string;
   data?: any;
   onSave: (data: any) => void;
 }
@@ -20,6 +21,7 @@ export function useEditJsonModal() {
     open: (props: EditJsonModalProps) => {
       modals.openContextModal(MODAL_ID, {
         ...modalTheme,
+        title: props.title || 'Edit JSON',
         innerProps: props,
         size: '680px',
       });
@@ -62,7 +64,6 @@ export function EditJsonModal(
 
   return (
     <div className="EditJsonModal">
-      <h3>EditJsonModal</h3>
       <JsonInput
         value={value}
         onChange={onChange}
@@ -71,7 +72,6 @@ export function EditJsonModal(
         minRows={4}
         maxRows={25}
       />
-
       <div className="EditJsonModal__buttons">
         <Button
           variant="default"

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -7,6 +7,19 @@
   overflow: auto;
 }
 
+.DocumentPage__side--expanded {
+  flex: 1 !important;
+  max-width: none !important;
+}
+
+.DocumentPage__side--expanded + .SplitPanel__divider {
+  display: none !important;
+}
+
+.DocumentPage__side--expanded + .SplitPanel__divider + .DocumentPage__main--hidden {
+  display: none !important;
+}
+
 .DocumentPage__side__header {
   font-weight: 600;
   font-size: 12px;
@@ -44,12 +57,31 @@
   gap: 4px;
 }
 
+.DocumentPage__side__header__showPreview {
+  color: var(--color-text-default);
+}
+
 .DocumentPage__side__editor {
   padding: 16px 16px 400px;
 }
 
+.DocumentPage__side__editor--centered {
+  display: flex;
+  justify-content: center;
+  padding: 16px;
+}
+
+.DocumentPage__side__editor--centered > * {
+  width: 100%;
+  max-width: 800px;
+}
+
 .DocumentPage__main {
   width: 100%;
+}
+
+.DocumentPage__main--hidden {
+  display: none;
 }
 
 .DocumentPage__main__preview {

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -57,10 +57,6 @@
   gap: 4px;
 }
 
-.DocumentPage__side__header__showPreview {
-  color: var(--color-text-default);
-}
-
 .DocumentPage__side__editor {
   padding: 16px 16px 400px;
 }

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -25,6 +25,7 @@ import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocPreviewPath, getDocServingPath} from '../../utils/doc-urls.js';
 import './DocumentPage.css';
+import {requestIdleCallbackPolyfill} from '../../utils/request-idle-callback.js';
 
 interface DocumentPageProps {
   collection: string;
@@ -294,13 +295,13 @@ DocumentPage.Preview = (props: PreviewProps) => {
     }
     const iframe = iframeRef.current!;
     iframe.src = 'about:blank';
-    window.setTimeout(() => {
+    requestIdleCallbackPolyfill(() => {
       if (iframe.src !== localizedPreviewUrl) {
         iframe.src = localizedPreviewUrl;
       } else {
         iframe.contentWindow!.location.reload();
       }
-    }, 30);
+    });
   }
 
   useEffect(() => {
@@ -503,7 +504,11 @@ DocumentPage.Preview = (props: PreviewProps) => {
           </div>
         )}
         <div className="DocumentPage__main__previewFrame__iframeWrap">
-          <iframe ref={iframeRef} src={previewUrl} title="iframe preview" />
+          <iframe
+            ref={iframeRef}
+            src={props.allowIframePreview ? previewUrl : undefined}
+            title="iframe preview"
+          />
         </div>
       </div>
     </div>

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -11,6 +11,8 @@ import {
   IconDotsVertical,
   IconReload,
   IconWorld,
+  IconLayoutSidebarRightCollapse,
+  IconLayoutSidebarRightExpand,
 } from '@tabler/icons-preact';
 import {useEffect, useRef, useState} from 'preact/hooks';
 
@@ -118,6 +120,14 @@ export function DocumentPage(props: DocumentPageProps) {
               <div className="DocumentPage__side__header__docId">{docId}</div>
             </div>
             <div className="DocumentPage__side__header__buttons">
+              <Tooltip label="Edit JSON">
+                <ActionIcon
+                  className="DocumentPage__side__header__editJson"
+                  onClick={() => editJson()}
+                >
+                  <IconBraces size={16} />
+                </ActionIcon>
+              </Tooltip>
               <Button
                 variant="filled"
                 color="dark"
@@ -128,32 +138,26 @@ export function DocumentPage(props: DocumentPageProps) {
               >
                 Save
               </Button>
-              <Menu
-                className="DocumentPage__side__header__menu"
-                position="bottom"
-                control={
-                  <ActionIcon className="DocumentPage__side__header__menu__dots">
-                    <IconDotsVertical size={16} />
-                  </ActionIcon>
-                }
-              >
-                <Menu.Item
-                  icon={<IconBraces size={20} />}
-                  onClick={() => editJson()}
+              <Tooltip label={isPreviewVisible ? "Hide preview" : "Show preview"}>
+                <ActionIcon
+                  className="DocumentPage__side__header__previewToggle"
+                  onClick={() => setIsPreviewVisible(!isPreviewVisible)}
                 >
-                  Edit JSON
-                </Menu.Item>
-              </Menu>
-              {!isPreviewVisible && (
-                <Tooltip label="Open preview in new tab">
-                  <ActionIcon
-                    className="DocumentPage__side__header__openNewTab"
-                    onClick={openPreviewInNewTab}
-                  >
-                    <IconArrowUpRight size={16} />
-                  </ActionIcon>
-                </Tooltip>
-              )}
+                  {isPreviewVisible ? (
+                    <IconLayoutSidebarRightCollapse size={16} />
+                  ) : (
+                    <IconLayoutSidebarRightExpand size={16} />
+                  )}
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Open preview in new tab">
+                <ActionIcon
+                  className="DocumentPage__side__header__openNewTab"
+                  onClick={openPreviewInNewTab}
+                >
+                  <IconArrowUpRight size={16} />
+                </ActionIcon>
+              </Tooltip>
             </div>
           </div>
           <div className={joinClassNames(
@@ -165,8 +169,6 @@ export function DocumentPage(props: DocumentPageProps) {
               collection={collection}
               docId={docId}
               draft={draft}
-              isPreviewVisible={isPreviewVisible}
-              onTogglePreviewVisibility={() => setIsPreviewVisible(!isPreviewVisible)}
               onFieldsRendered={() => setFieldsRendered(true)}
             />
           </div>

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -204,7 +204,7 @@ export function DocumentPage(props: DocumentPageProps) {
               isVisible={isPreviewVisible}
               onToggleVisibility={() => setIsPreviewVisible(!isPreviewVisible)}
               getPreviewUrl={getPreviewUrl}
-              shouldLoadIframe={fieldsRendered}
+              allowIframePreview={fieldsRendered}
             />
           )}
         </SplitPanel.Item>
@@ -219,7 +219,7 @@ interface PreviewProps {
   isVisible: boolean;
   onToggleVisibility: () => void;
   getPreviewUrl: (selectedLocale?: string) => string;
-  shouldLoadIframe: boolean;
+  allowIframePreview: boolean;
 }
 
 type Device = 'mobile' | 'tablet' | 'desktop' | '';
@@ -289,7 +289,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
   ];
 
   function reloadIframe() {
-    if (!props.shouldLoadIframe) {
+    if (!props.allowIframePreview) {
       return;
     }
     const iframe = iframeRef.current!;
@@ -339,7 +339,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
   }, []);
 
   useEffect(() => {
-    if (!props.shouldLoadIframe) {
+    if (!props.allowIframePreview) {
       return;
     }
     const iframe = iframeRef.current!;
@@ -350,17 +350,17 @@ DocumentPage.Preview = (props: PreviewProps) => {
       return;
     }
     iframe.src = localizedPreviewUrl;
-  }, [selectedLocale, props.shouldLoadIframe]);
+  }, [selectedLocale, props.allowIframePreview]);
 
-  // Initial iframe load when shouldLoadIframe becomes true
+  // Initial iframe load when allowIframePreview becomes true
   useEffect(() => {
-    if (props.shouldLoadIframe) {
+    if (props.allowIframePreview) {
       const iframe = iframeRef.current!;
       if (!iframe.src || iframe.src === 'about:blank') {
         iframe.src = localizedPreviewUrl;
       }
     }
-  }, [props.shouldLoadIframe, localizedPreviewUrl]);
+  }, [props.allowIframePreview, localizedPreviewUrl]);
 
   function toggleDevice(device: Device) {
     setDevice((current) => {

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -144,6 +144,16 @@ export function DocumentPage(props: DocumentPageProps) {
                   Edit JSON
                 </Menu.Item>
               </Menu>
+              {!isPreviewVisible && (
+                <Tooltip label="Open preview in new tab">
+                  <ActionIcon
+                    className="DocumentPage__side__header__openNewTab"
+                    onClick={openPreviewInNewTab}
+                  >
+                    <IconArrowUpRight size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
             </div>
           </div>
           <div className={joinClassNames(
@@ -157,7 +167,6 @@ export function DocumentPage(props: DocumentPageProps) {
               draft={draft}
               isPreviewVisible={isPreviewVisible}
               onTogglePreviewVisibility={() => setIsPreviewVisible(!isPreviewVisible)}
-              onOpenPreviewInNewTab={openPreviewInNewTab}
               onFieldsRendered={() => setFieldsRendered(true)}
             />
           </div>

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -122,15 +122,6 @@ export function DocumentPage(props: DocumentPageProps) {
               <div className="DocumentPage__side__header__docId">{docId}</div>
             </div>
             <div className="DocumentPage__side__header__buttons">
-              <Tooltip label="Edit JSON">
-                <ActionIcon
-                  onClick={() => editJson()}
-                  variant="default"
-                  size="sm"
-                >
-                  <IconBraces size={14} />
-                </ActionIcon>
-              </Tooltip>
               <Button
                 variant="filled"
                 color="dark"
@@ -141,7 +132,22 @@ export function DocumentPage(props: DocumentPageProps) {
               >
                 Save
               </Button>
-
+              <Menu
+                className="DocumentPage__side__header__menu"
+                position="bottom"
+                control={
+                  <ActionIcon className="DocumentPage__side__header__menu__dots">
+                    <IconDotsVertical size={16} />
+                  </ActionIcon>
+                }
+              >
+                <Menu.Item
+                  icon={<IconBraces size={20} />}
+                  onClick={() => editJson()}
+                >
+                  Edit JSON
+                </Menu.Item>
+              </Menu>
               <Tooltip
                 label={isPreviewVisible ? 'Hide preview' : 'Show preview'}
               >
@@ -313,6 +319,9 @@ DocumentPage.Preview = (props: PreviewProps) => {
         !iframeWindow.location.href.startsWith('about:blank')
       ) {
         const currentPath = iframeWindow.location.pathname;
+        if (currentPath === iframeUrl) {
+          return; // No change in URL
+        }
         console.log(`iframe url change: ${currentPath}`);
         setIframeUrl(`${domain}${currentPath}`);
       }
@@ -334,6 +343,12 @@ DocumentPage.Preview = (props: PreviewProps) => {
       return;
     }
     const iframe = iframeRef.current!;
+    if (
+      new URL(iframe.src, document.baseURI).href ===
+      new URL(localizedPreviewUrl, document.baseURI).href
+    ) {
+      return;
+    }
     iframe.src = localizedPreviewUrl;
   }, [selectedLocale, props.shouldLoadIframe]);
 
@@ -488,7 +503,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
           </div>
         )}
         <div className="DocumentPage__main__previewFrame__iframeWrap">
-          <iframe ref={iframeRef} src={previewUrl} />
+          <iframe ref={iframeRef} src={previewUrl} title="iframe preview" />
         </div>
       </div>
     </div>

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -81,10 +81,6 @@ export function DocumentPage(props: DocumentPageProps) {
     }
   }
 
-  if (!collection) {
-    return <div>Could not find collection.</div>;
-  }
-
   function saveDraft() {
     draft.controller.flush();
   }
@@ -205,7 +201,6 @@ export function DocumentPage(props: DocumentPageProps) {
               docId={docId}
               draft={draft}
               isVisible={isPreviewVisible}
-              onToggleVisibility={() => setIsPreviewVisible(!isPreviewVisible)}
               allowIframePreview={fieldsRendered}
             />
           )}
@@ -219,7 +214,6 @@ interface PreviewProps {
   docId: string;
   draft: UseDraftHook;
   isVisible: boolean;
-  onToggleVisibility: () => void;
   allowIframePreview: boolean;
 }
 
@@ -312,7 +306,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
         !iframeWindow.location.href.startsWith('about:blank')
       ) {
         const currentPath = iframeWindow.location.pathname;
-        if (currentPath === iframeUrl) {
+        if (currentPath === new URL(iframeUrl, document.baseURI).pathname) {
           return; // No change in URL
         }
         console.log(`iframe url change: ${currentPath}`);

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -37,10 +37,10 @@ export function DocumentPage(props: DocumentPageProps) {
   const docId = `${collectionId}/${slug}`;
   const collection = window.__ROOT_CTX.collections[collectionId];
   const draft = useDraft(docId);
-  
-  // State to track when fields have been rendered 
+
+  // State to track when fields have been rendered
   const [fieldsRendered, setFieldsRendered] = useState(false);
-  
+
   // Local storage for preview panel visibility per collection
   const [isPreviewVisible, setIsPreviewVisible] = useLocalStorage<boolean>(
     `root::DocumentPage::previewVisible::${collectionId}`,
@@ -57,7 +57,7 @@ export function DocumentPage(props: DocumentPageProps) {
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.set('preview', 'true');
     const query = `${searchParams.toString()}${window.location.hash}`;
-    
+
     if (selectedLocale) {
       const localizedPreviewPath = getDocPreviewPath({
         collectionId,
@@ -66,7 +66,7 @@ export function DocumentPage(props: DocumentPageProps) {
       });
       return `${localizedPreviewPath}?${query}`;
     }
-    
+
     return `${basePreviewPath}?${query}`;
   }
 
@@ -106,10 +106,12 @@ export function DocumentPage(props: DocumentPageProps) {
   return (
     <Layout>
       <SplitPanel className="DocumentPage" localStorageId="DocumentPage">
-        <SplitPanel.Item className={joinClassNames(
-          'DocumentPage__side',
-          !isPreviewVisible && 'DocumentPage__side--expanded'
-        )}>
+        <SplitPanel.Item
+          className={joinClassNames(
+            'DocumentPage__side',
+            !isPreviewVisible && 'DocumentPage__side--expanded'
+          )}
+        >
           <div className="DocumentPage__side__header">
             <div className="DocumentPage__side__header__nav">
               <a href={`/cms/content/${collectionId}`}>
@@ -122,10 +124,11 @@ export function DocumentPage(props: DocumentPageProps) {
             <div className="DocumentPage__side__header__buttons">
               <Tooltip label="Edit JSON">
                 <ActionIcon
-                  className="DocumentPage__side__header__editJson"
                   onClick={() => editJson()}
+                  variant="default"
+                  size="sm"
                 >
-                  <IconBraces size={16} />
+                  <IconBraces size={14} />
                 </ActionIcon>
               </Tooltip>
               <Button
@@ -133,12 +136,15 @@ export function DocumentPage(props: DocumentPageProps) {
                 color="dark"
                 size="xs"
                 compact
-                leftIcon={<IconDeviceFloppy size={14} />}
+                leftIcon={<IconDeviceFloppy size={16} />}
                 onClick={() => saveDraft()}
               >
                 Save
               </Button>
-              <Tooltip label={isPreviewVisible ? "Hide preview" : "Show preview"}>
+
+              <Tooltip
+                label={isPreviewVisible ? 'Hide preview' : 'Show preview'}
+              >
                 <ActionIcon
                   className="DocumentPage__side__header__previewToggle"
                   onClick={() => setIsPreviewVisible(!isPreviewVisible)}
@@ -150,20 +156,24 @@ export function DocumentPage(props: DocumentPageProps) {
                   )}
                 </ActionIcon>
               </Tooltip>
-              <Tooltip label="Open preview in new tab">
-                <ActionIcon
-                  className="DocumentPage__side__header__openNewTab"
-                  onClick={openPreviewInNewTab}
-                >
-                  <IconArrowUpRight size={16} />
-                </ActionIcon>
-              </Tooltip>
+              {!isPreviewVisible && (
+                <Tooltip label="Open preview in new tab">
+                  <ActionIcon
+                    className="DocumentPage__side__header__openNewTab"
+                    onClick={openPreviewInNewTab}
+                  >
+                    <IconArrowUpRight size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
             </div>
           </div>
-          <div className={joinClassNames(
-            'DocumentPage__side__editor',
-            !isPreviewVisible && 'DocumentPage__side__editor--centered'
-          )}>
+          <div
+            className={joinClassNames(
+              'DocumentPage__side__editor',
+              !isPreviewVisible && 'DocumentPage__side__editor--centered'
+            )}
+          >
             <DocEditor
               key={docId}
               collection={collection}
@@ -173,18 +183,18 @@ export function DocumentPage(props: DocumentPageProps) {
             />
           </div>
         </SplitPanel.Item>
-        <SplitPanel.Item 
+        <SplitPanel.Item
           className={joinClassNames(
             'DocumentPage__main',
             !isPreviewVisible && 'DocumentPage__main--hidden'
-          )} 
+          )}
           fluid
         >
           {isPreviewVisible && (
-            <DocumentPage.Preview 
-              key={docId} 
-              docId={docId} 
-              draft={draft} 
+            <DocumentPage.Preview
+              key={docId}
+              docId={docId}
+              draft={draft}
               isVisible={isPreviewVisible}
               onToggleVisibility={() => setIsPreviewVisible(!isPreviewVisible)}
               getPreviewUrl={getPreviewUrl}

--- a/packages/root-cms/ui/utils/request-idle-callback.ts
+++ b/packages/root-cms/ui/utils/request-idle-callback.ts
@@ -1,0 +1,21 @@
+export const requestIdleCallbackPolyfill =
+  typeof window !== 'undefined' && window.requestIdleCallback
+    ? window.requestIdleCallback
+    : function (cb: IdleRequestCallback) {
+        const start = Date.now();
+        return setTimeout(() => {
+          cb({
+            didTimeout: false,
+            timeRemaining: function () {
+              return Math.max(0, 50 - (Date.now() - start));
+            },
+          });
+        }, 1);
+      };
+
+export const cancelIdleCallbackPolyfill =
+  typeof window !== 'undefined' && window.cancelIdleCallback
+    ? window.cancelIdleCallback
+    : function (id: number) {
+        clearTimeout(id);
+      };

--- a/packages/root-cms/ui/utils/request-idle-callback.ts
+++ b/packages/root-cms/ui/utils/request-idle-callback.ts
@@ -16,6 +16,6 @@ export const requestIdleCallbackPolyfill =
 export const cancelIdleCallbackPolyfill =
   typeof window !== 'undefined' && window.cancelIdleCallback
     ? window.cancelIdleCallback
-    : function (id: number) {
+    : function (id: number | NodeJS.Timeout) {
         clearTimeout(id);
       };


### PR DESCRIPTION
Threw away most of what Copilot did in #610.

This PR adds the ability to expand/collapse the preview:

- Adds expand/collapse button next to the "Save" button
- Makes no other UI changes (keep JSON inside the three dots menu)
- Tidy up Edit JSON dialog

This PR also defers the iframe loading until after the fields have rendered, in order to reduce resource consumption that occurs when both rendering the fields _and_ loading the iframe. This is useful for pages with intensive fields and intensive previews.

Default:

<img width="2033" height="1167" alt="image" src="https://github.com/user-attachments/assets/5f5de50f-1a60-46c5-8d69-7264c59e2ad7" />

Hidden:

<img width="2033" height="1167" alt="image" src="https://github.com/user-attachments/assets/990c4935-95fb-40cd-9807-fdc828cfc37d" />
