### PR TITLE
Add Z-A sort option

### DIFF
--- a/.changeset/old-badgers-attend.md
+++ b/.changeset/old-badgers-attend.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add Z-A sort option

--- a/packages/root-cms/ui/hooks/useDocsList.ts
+++ b/packages/root-cms/ui/hooks/useDocsList.ts
@@ -39,6 +39,8 @@ export function useDocsList(collectionId: string, options: {orderBy: string}) {
       dbQuery = query(dbCollection, queryOrderby('sys.createdAt'));
     } else if (orderBy === 'slug') {
       dbQuery = query(dbCollection, queryOrderby(documentId()));
+    } else if (orderBy === 'slugDesc') {
+      dbQuery = query(dbCollection, queryOrderby(documentId(), 'desc'));
     }
     await notifyErrors(async () => {
       const snapshot = await getDocs(dbQuery);

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -195,6 +195,7 @@ CollectionPage.Collection = (props: CollectionProps) => {
                         }
                         data={[
                           {value: 'slug', label: 'A-Z'},
+                          {value: 'slugDesc', label: 'Z-A'},
                           {value: 'newest', label: 'Newest'},
                           {value: 'oldest', label: 'Oldest'},
                           {value: 'modifiedAt', label: 'Last modified'},


### PR DESCRIPTION
## Summary
- add slugDesc option for descending slug order
- expose Z-A choice in CollectionPage sort select

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_688bc04a11c483238f91de37fa855e68