### PR TITLE
fix: array header sizing

### DIFF
--- a/.changeset/rotten-pets-think.md
+++ b/.changeset/rotten-pets-think.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: array header preview sizing

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -213,6 +213,7 @@
 
 .DocEditor__ArrayField__item {
   flex: 1;
+  width: 100%;
 }
 
 .DocEditor__ArrayField__item__handle {
@@ -220,17 +221,20 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .DocEditor__ArrayField__item__header {
   align-items: center;
   background: white;
+  box-sizing: border-box;
   cursor: pointer;
   display: flex;
   position: sticky;
   top: var(--top-bar-height);
   user-select: none;
   z-index: 9;
+  width: 100%;
 }
 
 /** Nested array fields don't get the sticky behavior. */
@@ -264,6 +268,9 @@
   display: flex;
   flex: 1;
   gap: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 1em; /** Facilitates truncating the text preview. */
 }
 
 .DocEditor__ArrayField__item__header__preview__image {


### PR DESCRIPTION
This fixes the sizing/overflow of long text previews in the array header.

- Tested on Chrome + Safari, with/without image previews

<img width="322" height="285" alt="image" src="https://github.com/user-attachments/assets/8fd8813f-1fec-4512-9d6c-f2a15c2584d1" />

<img width="489" height="290" alt="image" src="https://github.com/user-attachments/assets/1c4d4818-31a6-4aea-af36-0ede47ae52f0" />
