### PR TITLE
feat: custom cms favicon

### DIFF
--- a/.changeset/custom-favicon.md
+++ b/.changeset/custom-favicon.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: allow configuring custom CMS favicon

--- a/docs/root.config.ts
+++ b/docs/root.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     cmsPlugin({
       id: 'www',
       name: 'Root.js',
+      favicon: 'https://rootjs.dev/favicon.png',
       firebaseConfig: {
         apiKey: 'AIzaSyDIoi6zECKeyJoCduYEmV5j9PIF-wbpaPo',
         authDomain: 'rootjs-dev.firebaseapp.com',

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -10,9 +10,13 @@ import {Collection} from './schema.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const DEFAULT_FAVICON_URL =
+  'https://lh3.googleusercontent.com/ijK50TfQlV_yJw3i-CMlnD6osH4PboZBILZrJcWhoNMEmoyCD5e1bAxXbaOPe5w4gG_Scf37EXrmZ6p8sP2lue5fLZ419m5JyLMs=e385-w256';
+
 interface AppProps {
   title: string;
   ctx: any;
+  favicon?: string;
 }
 
 function App(props: AppProps) {
@@ -40,7 +44,7 @@ function App(props: AppProps) {
         />
         <link
           rel="icon"
-          href="https://lh3.googleusercontent.com/ijK50TfQlV_yJw3i-CMlnD6osH4PboZBILZrJcWhoNMEmoyCD5e1bAxXbaOPe5w4gG_Scf37EXrmZ6p8sP2lue5fLZ419m5JyLMs=e385-w256"
+          href={props.favicon || DEFAULT_FAVICON_URL}
           type="image/png"
         />
         <link
@@ -114,7 +118,9 @@ export async function renderApp(
   const projectName = cmsConfig.name || cmsConfig.id || '';
   const title = projectName ? `${projectName} – Root CMS` : 'Root CMS';
 
-  const mainHtml = renderToString(<App title={title} ctx={ctx} />);
+  const mainHtml = renderToString(
+    <App title={title} ctx={ctx} favicon={cmsConfig.favicon} />
+  );
   let html = `<!doctype html>\n${mainHtml}`;
   const nonce = generateNonce();
   if (req.viteServer) {
@@ -163,6 +169,7 @@ function serializeCollection(collection: Collection): Partial<Collection> {
 interface SignInProps {
   title: string;
   ctx: any;
+  favicon?: string;
 }
 
 function SignIn(props: SignInProps) {
@@ -186,7 +193,7 @@ function SignIn(props: SignInProps) {
         />
         <link
           rel="icon"
-          href="https://lh3.googleusercontent.com/ijK50TfQlV_yJw3i-CMlnD6osH4PboZBILZrJcWhoNMEmoyCD5e1bAxXbaOPe5w4gG_Scf37EXrmZ6p8sP2lue5fLZ419m5JyLMs=e385-w256"
+          href={props.favicon || DEFAULT_FAVICON_URL}
           type="image/png"
         />
         <link rel="stylesheet" href="{CSS_URL}" nonce="{NONCE}" />
@@ -221,7 +228,13 @@ export async function renderSignIn(
     name: options.cmsConfig.name || options.cmsConfig.id || '',
     firebaseConfig: options.cmsConfig.firebaseConfig,
   };
-  const mainHtml = renderToString(<SignIn title="Sign in" ctx={ctx} />);
+  const mainHtml = renderToString(
+    <SignIn
+      title="Sign in"
+      ctx={ctx}
+      favicon={options.cmsConfig.favicon}
+    />
+  );
   let html = `<!doctype html>\n${mainHtml}`;
   const nonce = generateNonce();
   if (req.viteServer) {

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -155,6 +155,11 @@ export type CMSPluginOptions = {
   };
 
   /**
+   * URL for a custom favicon used by the CMS UI.
+   */
+  favicon?: string;
+
+  /**
    * Callback when an action occurs.
    */
   onAction?: (action: Action) => any;


### PR DESCRIPTION
## Summary
- allow configuring a custom favicon for the CMS
- document favicon option in docs config

## Testing
- `pnpm lint packages/root-cms/core/app.tsx packages/root-cms/core/plugin.ts docs/root.config.ts` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689125e758948323ad403ff5485105d8