### PR TITLE
fix: default non-EN locale

### DIFF
--- a/.changeset/default-locale.md
+++ b/.changeset/default-locale.md
@@ -1,0 +1,4 @@
+---
+'@blinkk/root-cms': patch
+---
+Default localization modal to first non-EN locale when available.

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -291,7 +291,9 @@ interface TranslationsProps {
 LocalizationModal.Translations = (props: TranslationsProps) => {
   const [loading, setLoading] = useState(true);
   const [sourceStrings, setSourceStrings] = useState<string[]>([]);
-  const [selectedLocale, setSelectedLocale] = useState('en');
+  const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
+  const defaultLocale = locales.find((l) => l !== 'en') || 'en';
+  const [selectedLocale, setSelectedLocale] = useState(defaultLocale);
   const [localeTranslations, setLocaleTranslations] = useState<
     Record<string, string>
   >({});
@@ -308,7 +310,6 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
     return results;
   }, [translationsMap]);
 
-  const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
   const localeOptions = locales.map((locale) => ({
     value: locale,
     label: getLocaleLabel(locale),


### PR DESCRIPTION
## Summary
- default localization modal to first non-EN locale when available
- add changeset for localization default

## Testing
- `pnpm lint packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test packages/root-cms` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689232e8b0d883239f3956d47e453395