### PR TITLE
fix: limit image preview width

### DIFF
--- a/packages/root-cms/ui/components/FileUploadField/FileUploadField.css
+++ b/packages/root-cms/ui/components/FileUploadField/FileUploadField.css
@@ -135,7 +135,7 @@
 }
 
 .FileUploadField__Preview__Image {
-  width: 100%;
+  max-width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: center;


### PR DESCRIPTION
## Summary
- ensure uploaded image previews don't stretch beyond their container by using `max-width`

## Testing
- `corepack prepare pnpm@8.9.0 --activate` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68926a84e3188323b086e158975925f9