### PR TITLE
chore: small style updates to file field

### DIFF
--- a/packages/root-cms/ui/components/FileUploadField/FileUploadField.css
+++ b/packages/root-cms/ui/components/FileUploadField/FileUploadField.css
@@ -35,8 +35,8 @@
 .FileUploadField__Preview__InfoButton {
   pointer-events: all;
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 8px;
+  right: 8px;
   z-index: 2;
   display: flex;
   flex-direction: row;
@@ -44,6 +44,7 @@
 }
 
 .FileUploadField__Preview__InfoButton__Icon {
+  color: #333;
   background-color: white;
 }
 
@@ -51,12 +52,23 @@
   background-color: #efefef;
 }
 
+.FileUploadField__reupload {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  z-index: 1;
+}
+
+.FileUploadField__Canvas--infoOpened .FileUploadField__reupload {
+  display: none;
+}
+
 .FileUploadField__Preview:has(.FileUploadField__Canvas) {
   padding: 0;
 }
 
 .DocEditor__ImageField__imagePreview__Image__Alt {
-  padding: 10px;
+  padding: 8px;
   border-top: 1px solid #ced4da;
 }
 
@@ -70,8 +82,8 @@
 
 .FileUploadField__Preview__Info {
   position: absolute;
-  bottom: 0px;
-  right: 0px;
+  top: 0px;
+  left: 0px;
   background: #000;
   color: #fff;
   font-size: 8px;
@@ -95,7 +107,7 @@
 
 .FileUploadField__Canvas__Info__Icon {
   position: absolute;
-  top: 10px;
+  top: 12px;
   left: 10px;
 }
 
@@ -114,12 +126,13 @@
 }
 
 .FileUploadField__Canvas {
+  --checkered-bg-color: #e5e5e5;
   aspect-ratio: var(--canvas-aspect-ratio, 16 / 9);
   max-height: 280px;
   width: 100%;
   position: relative;
-  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc),
-                    linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc);
+  background-image: linear-gradient(45deg, var(--checkered-bg-color) 25%, transparent 25%, transparent 75%, var(--checkered-bg-color) 75%, var(--checkered-bg-color)),
+                    linear-gradient(45deg, var(--checkered-bg-color) 25%, transparent 25%, transparent 75%, var(--checkered-bg-color) 75%, var(--checkered-bg-color));
   background-size: 20px 20px; /* Adjust the size of the squares */
   background-position: 0 0, 10px 10px; /* Adjust the position to offset the second gradient */
   background-color: #fff; /* A solid color to serve as the second color of the checkerboard */
@@ -212,10 +225,15 @@
   font-weight: 600;
 }
 
+.FileUploadField__FileUploadButton--compact {
+  padding: 2px 6px;
+  gap: 6px;
+  font-size: 12px;
+}
+
 .FileUploadField__Empty__AcceptTypes {
   font-size: 10px;
   display: inline;
   position: relative;
   z-index: 1;
 }
-

--- a/packages/root-cms/ui/components/FileUploadField/FileUploadField.tsx
+++ b/packages/root-cms/ui/components/FileUploadField/FileUploadField.tsx
@@ -424,7 +424,7 @@ FileUploadField.Preview = () => {
             </ActionIcon>
           </Tooltip>
         )}
-        <Tooltip label="Replace file" position="top" withArrow>
+        {/* <Tooltip label="Replace file" position="top" withArrow>
           <ActionIcon
             onClick={() => ctx.requestFileUpload()}
             size="sm"
@@ -437,7 +437,7 @@ FileUploadField.Preview = () => {
               <IconFileUpload size={16} />
             )}
           </ActionIcon>
-        </Tooltip>
+        </Tooltip> */}
         <Menu
           className="FileUploadField__Preview__Menu"
           shadow="sm"
@@ -518,6 +518,7 @@ FileUploadField.Preview = () => {
           </Menu.Item>
         </Menu>
       </div>
+
       <div
         className={joinClassNames(
           'FileUploadField__Canvas',
@@ -559,7 +560,7 @@ FileUploadField.Preview = () => {
         {infoOpened ? (
           <div className="FileUploadField__Canvas__Info">
             <IconPaperclip
-              size={20}
+              size={16}
               className="FileUploadField__Canvas__Info__Icon"
             />
             <Table
@@ -657,6 +658,12 @@ FileUploadField.Preview = () => {
             )}
           </>
         )}
+        <div className="FileUploadField__reupload">
+          <FileUploadField.UploadButton
+            className="FileUploadField__reupload__button"
+            compact
+          />
+        </div>
       </div>
       {ctx.alt !== false &&
         (uploadedFile.alt ||
@@ -681,54 +688,60 @@ FileUploadField.Preview = () => {
   );
 };
 
-FileUploadField.UploadButton = forwardRef<HTMLLabelElement, {}>(
-  (props, ref) => {
-    const context = useContext(FileUploadFileContext);
-    const uploading = context?.fileUpload?.state === 'uploading';
-    if (!context) {
-      return null;
-    }
-    return (
-      <label
-        {...props}
-        ref={ref}
-        className="FileUploadField__FileUploadButton"
-        tabIndex={0}
-      >
-        <input
-          disabled={uploading}
-          type="file"
-          accept={
-            context.acceptedFileTypes.length > 0
-              ? context.acceptedFileTypes.join(',')
-              : undefined
-          }
-          className="FileUploadField__FileUploadButton__Input"
-          onChange={(e) => {
-            const target = e.target as HTMLInputElement;
-            if (target.files && context) {
-              context.handleFile(target.files[0]);
-            }
-          }}
-        />
-        {uploading ? (
-          <Loader size={16} />
-        ) : context?.variant === 'image' ? (
-          <IconPhotoUp size={16} />
-        ) : (
-          <IconFileUpload size={16} />
-        )}
-        <div className="FileUploadField__FileUploadButton__Title">
-          {uploading
-            ? 'Uploading...'
-            : context?.fileUpload?.uploadedFile?.src
-            ? 'Upload'
-            : 'Paste, drop, or click to upload'}
-        </div>
-      </label>
-    );
+FileUploadField.UploadButton = (props: {
+  className?: string;
+  compact?: boolean;
+}) => {
+  const context = useContext(FileUploadFileContext);
+  const uploading = context?.fileUpload?.state === 'uploading';
+  if (!context) {
+    return null;
   }
-);
+  const iconSize = props.compact ? 14 : 16;
+  return (
+    <label
+      {...props}
+      className={joinClassNames(
+        'FileUploadField__FileUploadButton',
+        props.compact && 'FileUploadField__FileUploadButton--compact',
+        props.className
+      )}
+      tabIndex={0}
+    >
+      <input
+        disabled={uploading}
+        type="file"
+        accept={
+          context.acceptedFileTypes.length > 0
+            ? context.acceptedFileTypes.join(',')
+            : undefined
+        }
+        className="FileUploadField__FileUploadButton__Input"
+        onChange={(e) => {
+          const target = e.target as HTMLInputElement;
+          if (target.files && context) {
+            context.handleFile(target.files[0]);
+          }
+        }}
+      />
+
+      {uploading ? (
+        <Loader size={iconSize} />
+      ) : context?.variant === 'image' ? (
+        <IconPhotoUp size={iconSize} />
+      ) : (
+        <IconFileUpload size={iconSize} />
+      )}
+      <div className="FileUploadField__FileUploadButton__Title">
+        {uploading
+          ? 'Uploading...'
+          : context?.fileUpload?.uploadedFile?.src
+          ? 'Upload'
+          : 'Paste, drop, or click to upload'}
+      </div>
+    </label>
+  );
+};
 
 FileUploadField.Empty = () => {
   const context = useContext(FileUploadFileContext);


### PR DESCRIPTION
- Dimensions moved to the top-left corner (from bottom-right)
- Re-upload button added to the bottom-right (hidden for non-image/video files)
- Reduced padding on the outer alt text box

Empty state:
<img width="623" height="149" alt="Screenshot 2025-08-06 at 9 12 28 PM" src="https://github.com/user-attachments/assets/249f1a70-dba3-441d-8c01-ed7d50eb8e5d" />

Various file type previews:
<img width="573" height="1031" alt="Screenshot 2025-08-06 at 9 11 56 PM" src="https://github.com/user-attachments/assets/8e11a4aa-4c86-4b9d-953d-74a387a5173a" />
