### PR TITLE
chore: clear stall timeout after _any_ progress was made

### DIFF
--- a/packages/root-cms/ui/utils/gcs.ts
+++ b/packages/root-cms/ui/utils/gcs.ts
@@ -76,6 +76,10 @@ export async function uploadFileToGCS(
     task.on(
       'state_changed',
       (snapshot) => {
+        // The upload has actually started, so we can clear the timeout that was checking for a stall.
+        if (snapshot.bytesTransferred > 0) {
+          clearInterval(progressTimeout);
+        }
         console.log(
           `uploading ${file.name}: ${snapshot.bytesTransferred} / ${snapshot.totalBytes} bytes`
         );


### PR DESCRIPTION
- Previously, it would reject if the whole file wasn't uploaded within 10 seconds
- Really, we just wanted to check for stalls, so after _any_ progress is made, we can clear the stall timeout

fixes #650