### PR TITLE
chore: add script for starting a cms dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@8.9.0",
   "main": "index.js",
   "scripts": {
+    "cms:dev": "./scripts/dev_cms.sh",
     "build": "turbo run build --filter=\"@blinkk/*\"",
     "changeset": "changeset",
     "lint": "eslint . --ext .ts,.tsx",

--- a/scripts/dev_cms.sh
+++ b/scripts/dev_cms.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+cmsdev() {
+  pnpm --filter="@blinkk/root-cms" run dev
+}
+
+docsdev() {
+  pnpm --filter="@private/docs" run dev
+}
+
+# Start the CMS dev watcher, wait 2s, then start the docs Root server.
+cmsdev & sleep 2; docsdev


### PR DESCRIPTION
The command `pnpm cms:dev` will now start a file watcher for the root-cms package, wait 2 seconds, then start the docs Root server.