### PR TITLE
chore: enable sticky header for nested array headers

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -238,8 +238,23 @@
   width: 100%;
 }
 
-/** Nested array fields don't get the sticky behavior. */
 .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+  top: calc(var(--top-bar-height) + 30px);
+  z-index: 8;
+}
+
+.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+  top: calc(var(--top-bar-height) + 60px);
+  z-index: 7;
+}
+
+.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+  top: calc(var(--top-bar-height) + 90px);
+  z-index: 6;
+}
+
+/** Nested array fields more than three levels deep don't get the sticky behavior. */
+.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField  .DocEditor__ArrayField  .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
   border-bottom: unset;
   position: static;
 }


### PR DESCRIPTION
- the basic issue is that when modules are deeply nested it can be difficult to understand "where" in the tree you are
- by adding additional stickiness to nested fields, it makes it a bit easier to understand your position
- for now, i've added the sticky behavior for the first three levels of nested array items
- keep the change a minimal / surgical one in CSS only

<img width="763" height="556" alt="image" src="https://github.com/user-attachments/assets/b0c23e13-f5c2-4575-8b54-b09da3271a4e" />
