### PR TITLE
feat: add ability to deeplink fields in the doc editor

### DIFF
--- a/.changeset/cold-feet-kneel.md
+++ b/.changeset/cold-feet-kneel.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add ability to request deeplinks from the iframe

--- a/docs/blocks/CopyBlock/CopyBlock.tsx
+++ b/docs/blocks/CopyBlock/CopyBlock.tsx
@@ -1,4 +1,5 @@
 import {useTranslations} from '@blinkk/root';
+import {n} from '@/components/NodeEditor/NodeEditor.js';
 import {RichText} from '@/components/RichText/RichText.js';
 import {Text, TextSize} from '@/components/Text/Text.js';
 import {CopyBlockFields} from '@/root-cms.js';
@@ -16,17 +17,17 @@ export function CopyBlock(props: CopyBlockProps) {
     <div className={styles.copyBlock}>
       {props.eyebrow && (
         <Text className={styles.eyebrow} size="h6">
-          {t(props.eyebrow)}
+          {n('eyebrow', t(props.eyebrow))}
         </Text>
       )}
       {props.title && (
         <Text as="h2" className={styles.title} size={titleSize}>
-          {t(props.title)}
+          {n('title', t(props.title))}
         </Text>
       )}
       {props.body && (
         <Text className={styles.body} size={bodySize}>
-          <RichText data={props.body} />
+          {n('body', <RichText data={props.body} />)}
         </Text>
       )}
     </div>

--- a/docs/components/Block/Block.tsx
+++ b/docs/components/Block/Block.tsx
@@ -1,5 +1,7 @@
 import path from 'node:path';
 import {FunctionalComponent} from 'preact';
+import {buildModuleInfo, ModuleInfoContext} from '@/hooks/useModuleInfo.js';
+import {NodeEditor} from '../NodeEditor/NodeEditor.js';
 
 const blockModules = import.meta.glob('/blocks/*/*.tsx', {
   eager: true,
@@ -21,7 +23,7 @@ export type BlockProps = {
   _type: string;
 };
 
-export default function Block(props: BlockProps) {
+export default function Block(props: BlockProps & {fieldKey?: string}) {
   if (!props._type) {
     return null;
   }
@@ -29,5 +31,11 @@ export default function Block(props: BlockProps) {
   if (!Component) {
     return <h2>{`Not found: ${props._type}`}</h2>;
   }
-  return <Component {...(props as any)} />;
+  return (
+    <ModuleInfoContext.Provider value={buildModuleInfo(props, props.fieldKey)}>
+      <NodeEditor.Overlay>
+        <Component {...(props as any)} />
+      </NodeEditor.Overlay>
+    </ModuleInfoContext.Provider>
+  );
 }

--- a/docs/components/NodeEditor/NodeEditor.module.scss
+++ b/docs/components/NodeEditor/NodeEditor.module.scss
@@ -1,0 +1,18 @@
+.overlay {
+  position: relative;
+}
+
+.overlayButton {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  position: absolute;
+  inset: 0;
+  user-select: none;
+}
+
+.overlayButton:hover {
+  background-color: #e7f6ff;
+  mix-blend-mode: darken;
+}

--- a/docs/components/NodeEditor/NodeEditor.tsx
+++ b/docs/components/NodeEditor/NodeEditor.tsx
@@ -1,0 +1,15 @@
+import {useRequestContext} from '@blinkk/root';
+import {useModuleInfo} from '@/hooks/useModuleInfo.js';
+
+export function NodeEditor() {
+  const ctx = useRequestContext();
+  if (!ctx.props.req?.query?.preview) {
+    return null;
+  }
+  const moduleInfo = useModuleInfo();
+  return (
+    <root-node-editor data-deep-key={moduleInfo.deepKey}>
+      <button data-slot="button">Edit</button>
+    </root-node-editor>
+  );
+}

--- a/docs/components/NodeEditor/NodeEditor.tsx
+++ b/docs/components/NodeEditor/NodeEditor.tsx
@@ -1,15 +1,48 @@
-import {useRequestContext} from '@blinkk/root';
-import {useModuleInfo} from '@/hooks/useModuleInfo.js';
+import {ComponentChildren} from 'preact';
+import {joinDeepKey, useModuleInfo} from '@/hooks/useModuleInfo.js';
+import {testPreviewMode, testQueryParam} from '@/utils/mode.js';
+import styles from './NodeEditor.module.scss';
 
-export function NodeEditor() {
-  const ctx = useRequestContext();
-  if (!ctx.props.req?.query?.preview) {
+/** An "Edit" button that sends a message to the DocEditor to focus the selected node. */
+export function NodeEditor(props?: {fieldKey?: string}) {
+  if (!testPreviewMode() || !testQueryParam('embed')) {
     return null;
   }
   const moduleInfo = useModuleInfo();
   return (
-    <root-node-editor data-deep-key={moduleInfo.deepKey}>
+    <root-node-editor
+      data-deep-key={joinDeepKey(moduleInfo.deepKey, props?.fieldKey)}
+    >
       <button data-slot="button">Edit</button>
     </root-node-editor>
+  );
+}
+
+/** An overlay that wraps around children and serves as a target for the edit button. */
+NodeEditor.Overlay = (props: {fieldKey?: string; children: any}) => {
+  if (!testPreviewMode() || !testQueryParam('embed')) {
+    return props.children;
+  }
+  const moduleInfo = useModuleInfo();
+  return (
+    <root-node-editor
+      data-deep-key={joinDeepKey(moduleInfo.deepKey, props?.fieldKey)}
+    >
+      <div className={styles.overlay}>
+        <div
+          className={styles.overlayButton}
+          data-slot="button"
+          title="Edit in CMS"
+        ></div>
+        {props.children}
+      </div>
+    </root-node-editor>
+  );
+};
+
+/** Convenience function for creating a NodeEditor overlay. */
+export function n(fieldKey: string, children: ComponentChildren) {
+  return (
+    <NodeEditor.Overlay fieldKey={fieldKey}>{children}</NodeEditor.Overlay>
   );
 }

--- a/docs/components/PageModules/PageModules.tsx
+++ b/docs/components/PageModules/PageModules.tsx
@@ -66,8 +66,9 @@ PageModules.Module = (props: {fields: PageModuleFields; fieldKey: string}) => {
   }
   return (
     <ModuleInfoContext.Provider value={buildModuleInfo(fields, fieldKey)}>
-      <NodeEditor />
-      <Template {...fields} />
+      <NodeEditor.Overlay>
+        <Template {...fields} />
+      </NodeEditor.Overlay>
     </ModuleInfoContext.Provider>
   );
 };

--- a/docs/elements/root-node-editor/root-node-editor.ts
+++ b/docs/elements/root-node-editor/root-node-editor.ts
@@ -11,10 +11,6 @@ class RootNodeEditor extends HTMLElement {
   buttonElement: HTMLButtonElement;
 
   connectedCallback() {
-    // Do nothing if the page isn't in an iframe.
-    if (window.self === window.top) {
-      return;
-    }
     this.deepKey = this.getAttribute('data-deep-key');
     this.buttonElement = this.getSlotElement('button');
     this.buttonElement.addEventListener('click', () =>
@@ -27,7 +23,8 @@ class RootNodeEditor extends HTMLElement {
   }
 
   requestDeepLinkScroll() {
-    // Send a message to the
+    // Send a message to the CMS DocPage requesting the field be focused.
+    // TODO: This should be bundled into the CMS package so that sites can consume it.
     window.parent.postMessage(
       {
         scrollToDeeplink: {

--- a/docs/elements/root-node-editor/root-node-editor.ts
+++ b/docs/elements/root-node-editor/root-node-editor.ts
@@ -1,0 +1,44 @@
+declare module 'preact' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'root-node-editor': preact.JSX.HTMLAttributes;
+    }
+  }
+}
+
+class RootNodeEditor extends HTMLElement {
+  private deepKey: string;
+  buttonElement: HTMLButtonElement;
+
+  connectedCallback() {
+    // Do nothing if the page isn't in an iframe.
+    if (window.self === window.top) {
+      return;
+    }
+    this.deepKey = this.getAttribute('data-deep-key');
+    this.buttonElement = this.getSlotElement('button');
+    this.buttonElement.addEventListener('click', () =>
+      this.requestDeepLinkScroll()
+    );
+  }
+
+  getSlotElement<T = HTMLElement>(name: string): T {
+    return this.querySelector(`[data-slot="${name}"]`) as T;
+  }
+
+  requestDeepLinkScroll() {
+    // Send a message to the
+    window.parent.postMessage(
+      {
+        scrollToDeeplink: {
+          deepKey: this.deepKey,
+        },
+      },
+      '*'
+    );
+  }
+}
+
+if (!customElements.get('root-node-editor')) {
+  customElements.define('root-node-editor', RootNodeEditor);
+}

--- a/docs/hooks/useModuleInfo.ts
+++ b/docs/hooks/useModuleInfo.ts
@@ -1,6 +1,8 @@
 import {createContext} from 'preact';
 import {useContext} from 'preact/hooks';
 
+type ConditionalString = string | false | null | undefined;
+
 export interface ModuleInfo {
   /** A UUID associated with the module instance. */
   uuid: string;
@@ -42,9 +44,16 @@ function buildDeepKey(
   fieldKey: string
 ) {
   if (parent) {
-    return `${parent.deepKey}.${fieldKey}.${moduleFields._arrayKey}`;
+    return joinDeepKey(parent.deepKey, fieldKey, moduleFields._arrayKey);
   }
-  return `${fieldKey}.${moduleFields._arrayKey}`;
+  return joinDeepKey(fieldKey, moduleFields._arrayKey);
+}
+
+/**
+ * Utility method for joining the parts of a deepKey together.
+ */
+export function joinDeepKey(...classNames: ConditionalString[]) {
+  return classNames.filter((c) => !!c).join('.');
 }
 
 /** Builds the `ModuleInfo` data for a module. */

--- a/docs/hooks/useModuleInfo.ts
+++ b/docs/hooks/useModuleInfo.ts
@@ -1,0 +1,67 @@
+import {createContext} from 'preact';
+import {useContext} from 'preact/hooks';
+
+export interface ModuleInfo {
+  /** A UUID associated with the module instance. */
+  uuid: string;
+  /** Typically the tracking ID of the module. */
+  id?: string;
+  /** The template name, e.g. `TemplateFoo`. */
+  name: string;
+  /** A description of the module (intended for humans). */
+  description?: string;
+  /** The position of the module on the page. */
+  position?: number;
+  /** The parent module (i.e. for nested modules). */
+  parent?: ModuleInfo;
+  /** The key for the module's fields. */
+  fieldKey?: string;
+  /** A deep key for the module's fields. */
+  deepKey?: string;
+}
+
+export const ModuleInfoContext = createContext<ModuleInfo>(null);
+
+export function useModuleInfo() {
+  return useContext(ModuleInfoContext);
+}
+
+type PageModuleFields<T = {[key: string]: any}> = T & {
+  _type?: string;
+};
+
+/** Creates a unique ID for the module. */
+function createId() {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2, 9);
+}
+
+/** Builds the deeplink key for a given module. */
+function buildDeepKey(
+  parent: ModuleInfo,
+  moduleFields: PageModuleFields,
+  fieldKey: string
+) {
+  if (parent) {
+    return `${parent.deepKey}.${fieldKey}.${moduleFields._arrayKey}`;
+  }
+  return `${fieldKey}.${moduleFields._arrayKey}`;
+}
+
+/** Builds the `ModuleInfo` data for a module. */
+export function buildModuleInfo(
+  moduleFields: PageModuleFields,
+  fieldKey: string
+): ModuleInfo {
+  const parent = useModuleInfo();
+  return {
+    fieldKey: fieldKey,
+    deepKey: fieldKey
+      ? buildDeepKey(parent, moduleFields, fieldKey)
+      : undefined,
+    uuid: createId(),
+    id: moduleFields.id,
+    name: moduleFields._type,
+    description: moduleFields.description,
+    parent: parent,
+  };
+}

--- a/docs/routes/[[...page]].tsx
+++ b/docs/routes/[[...page]].tsx
@@ -18,7 +18,7 @@ export default function Page(props: PageProps) {
   const modules: PageModuleFields[] = fields.content?.modules || [];
   return (
     <BaseLayout title={title} description={description} image={image}>
-      <PageModules modules={modules} />
+      <PageModules modules={modules} fieldKey="fields.content.modules" />
     </BaseLayout>
   );
 }

--- a/docs/templates/Section/Section.tsx
+++ b/docs/templates/Section/Section.tsx
@@ -10,7 +10,7 @@ export function Section(props: SectionFields) {
   const t = useTranslations();
   return (
     <section id={props.id} aria-label={t(props.description)}>
-      <PageModules modules={modules} />
+      <PageModules modules={modules} fieldKey="modules" />
     </section>
   );
 }

--- a/docs/templates/Template50x50/Template50x50.tsx
+++ b/docs/templates/Template50x50/Template50x50.tsx
@@ -23,13 +23,17 @@ export function Template50x50(props: Template50x50Props) {
           className={styles.layoutSection}
           data-type={props.leftSection?._type}
         >
-          {props.leftSection?._type && <Block {...props.leftSection} />}
+          {props.leftSection?._type && (
+            <Block {...props.leftSection} fieldKey="leftSection" />
+          )}
         </div>
         <div
           className={styles.layoutSection}
           data-type={props.rightSection?._type}
         >
-          {props.rightSection?._type && <Block {...props.rightSection} />}
+          {props.rightSection?._type && (
+            <Block {...props.rightSection} fieldKey="rightSection" />
+          )}
         </div>
       </div>
     </Container>

--- a/docs/templates/TemplateHeadline/TemplateHeadline.tsx
+++ b/docs/templates/TemplateHeadline/TemplateHeadline.tsx
@@ -1,6 +1,7 @@
 import {useTranslations} from '@blinkk/root';
 import {ButtonsBlock} from '@/blocks/ButtonsBlock/ButtonsBlock.js';
 import {Container} from '@/components/Container/Container.js';
+import {n} from '@/components/NodeEditor/NodeEditor.js';
 import {RichText} from '@/components/RichText/RichText.js';
 import {Text} from '@/components/Text/Text.js';
 import {TemplateHeadlineFields} from '@/root-cms.js';
@@ -26,17 +27,17 @@ export function TemplateHeadline(props: TemplateHeadlineProps) {
     >
       {props.eyebrow && (
         <Text className={styles.eyebrow} size="h6">
-          {t(props.eyebrow)}
+          {n('eyebrow', t(props.eyebrow))}
         </Text>
       )}
       {props.title && (
         <Text as={titleSize} className={styles.title} size={titleSize}>
-          {t(props.title)}
+          {n('title', t(props.title))}
         </Text>
       )}
       {props.body && (
         <Text className={styles.body} size="p-large">
-          <RichText data={props.body} />
+          {n('body', <RichText data={props.body} />)}
         </Text>
       )}
       {props.buttons && (

--- a/docs/utils/mode.ts
+++ b/docs/utils/mode.ts
@@ -1,0 +1,10 @@
+import {useRequestContext} from '@blinkk/root';
+
+export function testPreviewMode() {
+  return !!testQueryParam('preview');
+}
+
+export function testQueryParam(param: string) {
+  const ctx = useRequestContext();
+  return ctx.props.req?.query?.[param];
+}

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -100,6 +100,22 @@ interface DocEditorProps {
   draft: UseDraftHook;
 }
 
+/** Messages that can be sent to the DocEditor window. */
+interface DocEditorMessage {
+  /** Scrolls to a specific deeplink within the field editor. */
+  scrollToDeeplink?: {
+    /** The key of the field to scroll to. */
+    deepKey: string;
+  };
+}
+
+interface ScrollToDeeplinkOptions {
+  /** If true, will scroll to the deeplink even if the user has scrolled. */
+  force?: boolean;
+  /** Options for the scroll behavior. */
+  behavior: 'auto' | 'smooth';
+}
+
 const DOC_DATA_CONTEXT = createContext(null);
 
 const DEEPLINK_CONTEXT = createContext<{
@@ -169,6 +185,29 @@ export function DocEditor(props: DocEditorProps) {
       setDeepLinkTarget(deeplink);
     }
   }, [loading]);
+
+  /** Enable posting messages from the preview frame to the DocEditor so that fields can be focused. */
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const req = event.data as DocEditorMessage;
+      if (req.scrollToDeeplink) {
+        const deepKey = req.scrollToDeeplink.deepKey;
+        const element = document.getElementById(deepKey);
+        if (element) {
+          setDeepLinkTarget(deepKey);
+          scrollToDeeplink(element, {behavior: 'smooth', force: true});
+          // Update the URL without modifying the history.
+          const url = new URL(window.location.href);
+          url.searchParams.set('deeplink', deepKey);
+          window.history.replaceState({}, '', url.toString());
+        }
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
 
   return (
     <VIRTUAL_CLIPBOARD_CONTEXT.Provider
@@ -1500,17 +1539,72 @@ function arrayPreview(
   return buildPreviewValue(field.preview, data, index) ?? `item ${index}`;
 }
 
-function scrollToDeeplink(deeplinkEl: HTMLElement) {
-  const parent = document.querySelector('.DocumentPage__side');
-  if (parent) {
-    // If the user has already scrolled anywhere, don't scroll to the deeplink.
-    if (parent.scrollTop > 0) {
-      return;
+/** Opens all the ancestor detail elements. */
+function setAncestorsOpen(deeplinkEl: HTMLElement) {
+  let current = deeplinkEl;
+  while (current && current !== document.body) {
+    const detailsParent = current.closest<HTMLDetailsElement>('details');
+    if (detailsParent && detailsParent.parentElement) {
+      detailsParent.open = true;
+      current = detailsParent.parentElement;
+    } else {
+      break;
     }
-    // Use a brief timeout to ensure the DOM is at rest before scrolling.
-    requestAnimationFrame(() => {
-      const offsetTop = deeplinkEl.offsetTop;
-      parent.scroll({top: offsetTop, behavior: 'auto'});
-    });
   }
+}
+
+/** Finds all the ancestor array item headers for a given deeplink element. */
+function getArrayItemHeaderAncestors(deeplinkEl: HTMLElement): HTMLElement[] {
+  const detailsAncestors: HTMLElement[] = [];
+  let current: HTMLElement | null = deeplinkEl;
+  while (current && current !== document.body) {
+    const parent = current.closest<HTMLElement>('.DocEditor__ArrayField__item');
+    if (!parent) {
+      break;
+    }
+    const summary = parent.querySelector<HTMLElement>(
+      '.DocEditor__ArrayField__item__header'
+    );
+    if (summary && !detailsAncestors.includes(summary)) {
+      detailsAncestors.push(summary);
+      current = parent.parentElement;
+    } else {
+      break;
+    }
+  }
+  return detailsAncestors;
+}
+
+/** Scrolls to a deep link field after opening all ancestor details. */
+function scrollToDeeplink(
+  deeplinkEl: HTMLElement,
+  options: ScrollToDeeplinkOptions = {
+    behavior: 'auto',
+  }
+) {
+  setTimeout(
+    () => {
+      const parent = document.querySelector('.DocumentPage__side');
+      if (!parent) {
+        return;
+      }
+
+      // If the user has already scrolled anywhere, don't scroll to the deeplink.
+      if (parent.scrollTop > 0 && !options.force) {
+        return;
+      }
+
+      // First, ensure all ancestor details elements are open so the element can be scrolled to.
+      setAncestorsOpen(deeplinkEl);
+
+      // Build an offset (the array item headers) so the deeplink is not obscured by the header.
+      const ancestors = getArrayItemHeaderAncestors(deeplinkEl);
+      const modifier = ancestors.reduce((acc, el) => acc + el.offsetHeight, 0);
+      const offsetTop = deeplinkEl.offsetTop - modifier;
+      parent.scroll({top: offsetTop, behavior: options.behavior});
+    },
+    // If the deeplink is being forced, no timeout is needed as the document is already at rest.
+    // If the deeplink isn't being forced, wait a bit to ensure the document is at rest before scrolling.
+    options.force ? 0 : 100
+  );
 }

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import {ActionIcon, Button, Menu, Select, Tooltip} from '@mantine/core';
+import {ActionIcon, Button, Select, Tooltip} from '@mantine/core';
 import {useHotkeys} from '@mantine/hooks';
 import {
   IconArrowLeft,
@@ -8,12 +8,10 @@ import {
   IconDeviceFloppy,
   IconDeviceIpad,
   IconDeviceMobile,
-  IconDotsVertical,
   IconReload,
   IconWorld,
   IconLayoutSidebarRightCollapse,
   IconLayoutSidebarRightExpand,
-  IconJson,
 } from '@tabler/icons-preact';
 import {useEffect, useRef, useState} from 'preact/hooks';
 
@@ -36,10 +34,14 @@ interface DocumentPageProps {
 function getPreviewUrl(
   collectionId: string,
   slug: string,
-  selectedLocale = ''
+  selectedLocale = '',
+  embed = true
 ) {
   const basePreviewPath = getDocPreviewPath({collectionId, slug});
   const searchParams = new URLSearchParams(window.location.search);
+  if (embed) {
+    searchParams.set('embed', 'true');
+  }
   searchParams.set('preview', 'true');
   const query = `${searchParams.toString()}${window.location.hash}`;
   if (selectedLocale) {
@@ -334,7 +336,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
   }
 
   function openNewTab() {
-    const previewUrl = getPreviewUrl(collectionId, slug, selectedLocale);
+    const previewUrl = getPreviewUrl(collectionId, slug, selectedLocale, false);
     const tab = window.open(previewUrl, '_blank');
     if (tab) {
       tab.focus();


### PR DESCRIPTION
This PR does a few things:

1. Tidies up the "target" / deeplink logic in the `DocEditor` -- previously it was still sometimes inconsistent and scrolling to the wrong place. This PR should wholly fix that.
2. Adds a listener in the `DocEditor` for receiving a message with field `scrollToDeeplink`. If this field is populated, the deeplink will be targeted. The idea is that sites can post messages to the `DocEditor` using their own inspect / editing tools to make it easier to edit field values from the iframe preview.
3. Adds a sample implementation in the `docs` package for doing (2) above. The sample implementation uses an overlay, but it's not exactly expected that all sites will also use the overlay approach (and may opt, instead, to use a discrete link for each field).

https://github.com/user-attachments/assets/947e628c-ed21-4313-b9a4-21a5ea2b256f


