### PR TITLE
cache preview placeholders

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.test.ts
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.test.ts
@@ -1,0 +1,11 @@
+import {expect, test} from 'vitest';
+
+import {buildPreviewValue} from './DocEditor.js';
+
+test('buildPreviewValue updates when item data mutates', () => {
+  const data: any = {meta: {title: 'Foo'}};
+  const template = '{meta.title}';
+  expect(buildPreviewValue(template, data)).toBe('Foo');
+  data.meta.title = 'Bar';
+  expect(buildPreviewValue(template, data)).toBe('Bar');
+});


### PR DESCRIPTION
## Summary
- cache flattened placeholder keys per item to reuse across renders
- reuse cached placeholders in preview builder and recompute on data change
- add regression test confirming previews update after item mutation

## Testing
- `pnpm --filter @blinkk/root-cms test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689fee0303e083238de585f58aecd530