### PR TITLE
feat: add strFormatFn for preview lookup

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -71,9 +71,9 @@ import {
 } from '../../utils/doc.js';
 import {extractField} from '../../utils/extract.js';
 import {getDefaultFieldValue} from '../../utils/fields.js';
-import {flattenNestedKeys} from '../../utils/objects.js';
+import {getNestedValue} from '../../utils/objects.js';
 import {autokey} from '../../utils/rand.js';
-import {getPlaceholderKeys, strFormat} from '../../utils/str-format.js';
+import {getPlaceholderKeys, strFormatFn} from '../../utils/str-format.js';
 import {testFieldEmpty} from '../../utils/test-field-empty.js';
 import {formatDateTime} from '../../utils/time.js';
 import {testHasExperimentParam} from '../../utils/url-params.js';
@@ -1449,17 +1449,25 @@ function buildPreviewValue(
   index?: number
 ): string | undefined {
   const templates = Array.isArray(previews) ? [...previews] : [previews];
-  const placeholders = flattenNestedKeys(data);
-  if (index !== undefined) {
-    placeholders._index = String(index);
-    placeholders._index0 = String(index);
-    placeholders._index1 = String(index + 1);
-    placeholders['_index:02'] = placeholders._index.padStart(2, '0');
-    placeholders['_index:03'] = placeholders._index.padStart(3, '0');
-  }
   while (templates.length > 0) {
     const template = templates.shift()!;
-    const preview = strFormat(template, placeholders);
+    const preview = strFormatFn(template, (key) => {
+      if (index !== undefined) {
+        if (key === '_index' || key === '_index0') {
+          return String(index);
+        }
+        if (key === '_index1') {
+          return String(index + 1);
+        }
+        if (key === '_index:02') {
+          return String(index).padStart(2, '0');
+        }
+        if (key === '_index:03') {
+          return String(index).padStart(3, '0');
+        }
+      }
+      return getNestedValue(data, key);
+    });
     if (getPlaceholderKeys(preview).length === 0) {
       return preview;
     }

--- a/packages/root-cms/ui/utils/str-format.test.ts
+++ b/packages/root-cms/ui/utils/str-format.test.ts
@@ -1,0 +1,17 @@
+import {describe, it, expect} from 'vitest';
+import {strFormatFn} from './str-format.js';
+import {getNestedValue} from './objects.js';
+
+describe('strFormatFn', () => {
+  it('replaces placeholders using lookup function', () => {
+    const data = {meta: {title: 'Foo'}};
+    const result = strFormatFn('{meta.title}', (key) => getNestedValue(data, key));
+    expect(result).toBe('Foo');
+  });
+
+  it('leaves unknown placeholders untouched', () => {
+    const data = {meta: {title: 'Foo'}};
+    const result = strFormatFn('{meta.description}', (key) => getNestedValue(data, key));
+    expect(result).toBe('{meta.description}');
+  });
+});

--- a/packages/root-cms/ui/utils/str-format.ts
+++ b/packages/root-cms/ui/utils/str-format.ts
@@ -12,6 +12,27 @@ export function strFormat(
   return template;
 }
 
+/**
+ * Replaces `{placeholder}` values in a template using a callback function.
+ *
+ * The callback is invoked for each placeholder key and should return the
+ * replacement value. If the callback returns `undefined` or `null`, the
+ * placeholder is left untouched.
+ */
+export function strFormatFn(
+  template: string,
+  fn: (key: string) => unknown
+): string {
+  const keys = getPlaceholderKeys(template);
+  for (const key of keys) {
+    const val = fn(key);
+    if (val !== undefined && val !== null) {
+      template = template.replaceAll(`{${key}}`, String(val));
+    }
+  }
+  return template;
+}
+
 export function getPlaceholderKeys(template: string): string[] {
   return Array.from(template.matchAll(/\{(.+?)\}/g)).map((match) => match[1]);
 }


### PR DESCRIPTION
## Summary
- add `strFormatFn` utility for placeholder formatting
- use deep lookup in `buildPreviewValue` and drop `flattenNestedKeys`
- test `strFormatFn` deep lookup behavior

## Testing
- `pnpm lint packages/root-cms/ui/components/DocEditor/DocEditor.tsx packages/root-cms/ui/utils/str-format.ts packages/root-cms/ui/utils/str-format.test.ts` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689ff33a0d4083238b91120b5b64a100