### PR TITLE
refactor draft field value flow

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/fields/BooleanField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/BooleanField.tsx
@@ -6,7 +6,7 @@ import {FieldProps} from './FieldProps.js';
 export function BooleanField(props: FieldProps) {
   const field = props.field as schema.BooleanField;
   const label = field.checkboxLabel || 'Enabled';
-  const [value, setValue] = useState<boolean>(false);
+  const [value, setValue] = useState<boolean>(props.value || false);
 
   const onChange = useCallback(
     (newValue: boolean) => {
@@ -17,14 +17,8 @@ export function BooleanField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: boolean) => {
-        setValue(newValue);
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || false);
+  }, [props.value]);
 
   return (
     <div className="DocEditor__BooleanField">

--- a/packages/root-cms/ui/components/DocEditor/fields/DateField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/DateField.tsx
@@ -4,7 +4,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function DateField(props: FieldProps) {
   const field = props.field as schema.DateField;
-  const [value, setValue] = useState(field.default || '');
+  const [value, setValue] = useState(props.value || field.default || '');
 
   const onChange = useCallback(
     (newValue: string) => {
@@ -24,14 +24,8 @@ export function DateField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newVal: string) => {
-        setValue(newVal || '');
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || '');
+  }, [props.value]);
 
   return (
     <div className="DocEditor__DateField">

--- a/packages/root-cms/ui/components/DocEditor/fields/DateTimeField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/DateTimeField.tsx
@@ -4,7 +4,9 @@ import {FieldProps} from './FieldProps.js';
 
 export function DateTimeField(props: FieldProps) {
   // const field = props.field as schema.DateTimeField;
-  const [dateStr, setDateStr] = useState('');
+  const [dateStr, setDateStr] = useState(() =>
+    props.value ? toDateStr(props.value as Timestamp) : ''
+  );
 
   const onChange = useCallback(
     (newDateStr: string) => {
@@ -22,18 +24,12 @@ export function DateTimeField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: Timestamp) => {
-        if (newValue) {
-          setDateStr(toDateStr(newValue));
-        } else {
-          setDateStr('');
-        }
-      }
-    );
-    return unsubscribe;
-  }, []);
+    if (props.value) {
+      setDateStr(toDateStr(props.value as Timestamp));
+    } else {
+      setDateStr('');
+    }
+  }, [props.value]);
 
   return (
     <div className="DocEditor__DateTimeField">

--- a/packages/root-cms/ui/components/DocEditor/fields/FieldProps.ts
+++ b/packages/root-cms/ui/components/DocEditor/fields/FieldProps.ts
@@ -12,5 +12,6 @@ export interface FieldProps {
   shallowKey: string;
   deepKey: string;
   draft: DraftController;
+  value?: any;
   isArrayChild?: boolean;
 }

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -6,18 +6,12 @@ import {FieldProps} from './FieldProps.js';
 
 export function FileField(props: FieldProps) {
   const field = props.field as schema.FileField;
-  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(
+    props.value || null
+  );
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newUploadedFile: UploadedFile | null) => {
-        setUploadedFile(newUploadedFile);
-      }
-    );
-    return () => {
-      unsubscribe();
-    };
-  }, []);
+    setUploadedFile(props.value || null);
+  }, [props.value]);
 
   return (
     <FileUploadField

--- a/packages/root-cms/ui/components/DocEditor/fields/ImageField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ImageField.tsx
@@ -6,18 +6,12 @@ import {FieldProps} from './FieldProps.js';
 
 export function ImageField(props: FieldProps) {
   const field = props.field as schema.ImageField;
-  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(
+    props.value || null
+  );
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newUploadedFile: UploadedFile | null) => {
-        setUploadedFile(newUploadedFile);
-      }
-    );
-    return () => {
-      unsubscribe();
-    };
-  }, []);
+    setUploadedFile(props.value || null);
+  }, [props.value]);
 
   return (
     <FileUploadField

--- a/packages/root-cms/ui/components/DocEditor/fields/MultiSelectField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/MultiSelectField.tsx
@@ -5,7 +5,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function MultiSelectField(props: FieldProps) {
   const field = props.field as schema.MultiSelectField;
-  const [value, setValue] = useState<string[]>([]);
+  const [value, setValue] = useState<string[]>(props.value || []);
 
   const options = (field.options || []).map((option) => {
     // Mantine requires both label and value to be set.
@@ -27,14 +27,8 @@ export function MultiSelectField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: string[]) => {
-        setValue(newValue || []);
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || []);
+  }, [props.value]);
 
   return (
     <div className="DocEditor__MultiSelectField">

--- a/packages/root-cms/ui/components/DocEditor/fields/NumberField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/NumberField.tsx
@@ -5,7 +5,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function NumberField(props: FieldProps) {
   const field = props.field as schema.NumberField;
-  const [value, setValue] = useState(field.default || 0);
+  const [value, setValue] = useState(props.value ?? field.default ?? 0);
 
   const onChange = useCallback(
     (newValue: number) => {
@@ -16,14 +16,8 @@ export function NumberField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: number) => {
-        setValue(newValue);
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value ?? field.default ?? 0);
+  }, [props.value]);
 
   return (
     <NumberInput

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
@@ -11,7 +11,7 @@ import './ReferenceField.css';
 
 export function ReferenceField(props: FieldProps) {
   const field = props.field as schema.ReferenceField;
-  const [refId, setRefId] = useState('');
+  const [refId, setRefId] = useState(props.value?.id || '');
 
   const onChange = useCallback(
     (newRefId: string) => {
@@ -27,14 +27,8 @@ export function ReferenceField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue?: {id: string}) => {
-        setRefId(newValue?.id || '');
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setRefId(props.value?.id || '');
+  }, [props.value]);
 
   const docPickerModal = useDocPickerModal();
 

--- a/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
@@ -6,7 +6,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function RichTextField(props: FieldProps) {
   const field = props.field as schema.RichTextField;
-  const [value, setValue] = useState<RichTextData | null>(null);
+  const [value, setValue] = useState<RichTextData | null>(props.value || null);
 
   const onChange = useCallback(
     (newValue: RichTextData) => {
@@ -21,14 +21,8 @@ export function RichTextField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: RichTextData) => {
-        setValue(newValue);
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || null);
+  }, [props.value]);
 
   return (
     <RichTextEditor

--- a/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
@@ -5,7 +5,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function SelectField(props: FieldProps) {
   const field = props.field as schema.SelectField;
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   const options = (field.options || []).map((option) => {
     // Mantine requires both label and value to be set.
@@ -27,14 +27,8 @@ export function SelectField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: string) => {
-        setValue(newValue || '');
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || '');
+  }, [props.value]);
 
   return (
     <div className="DocEditor__SelectField">

--- a/packages/root-cms/ui/components/DocEditor/fields/StringField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/StringField.tsx
@@ -7,7 +7,7 @@ import {FieldProps} from './FieldProps.js';
 
 export function StringField(props: FieldProps) {
   const field = props.field as schema.StringField;
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   const onChange = useCallback(
     (newValue: string) => {
@@ -18,14 +18,8 @@ export function StringField(props: FieldProps) {
   );
 
   useEffect(() => {
-    const unsubscribe = props.draft.subscribe(
-      props.deepKey,
-      (newValue: string) => {
-        setValue(newValue);
-      }
-    );
-    return unsubscribe;
-  }, []);
+    setValue(props.value || '');
+  }, [props.value]);
 
   if (field.variant === 'textarea') {
     return (


### PR DESCRIPTION
## Summary
- remove field subscription system from draft controller
- pass field values from DocEditor to field components
- update field components to use provided value props

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b9bd11608323a27c4cf6c7fc45a6