### PR TITLE
Map schema defs in collection API

### DIFF
--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -9,6 +9,7 @@ import {ChatClient, RootAiModel} from './ai.js';
 import {RootCMSClient} from './client.js';
 import {runCronJobs} from './cron.js';
 import {arrayToCsv, csvToArray} from './csv.js';
+import {toSchemaMap} from './schema.js';
 
 type AppModule = typeof import('./app.js');
 
@@ -76,7 +77,8 @@ export function api(server: Server, options: ApiOptions) {
         res.status(404).json({success: false, error: 'NOT_FOUND'});
         return;
       }
-      res.status(200).json({success: true, data: collection});
+      const {schema: mapped, schemaMap} = toSchemaMap(collection);
+      res.status(200).json({success: true, data: {collection: mapped, schemaMap}});
     } catch (err) {
       console.error(err.stack || err);
       res.status(500).json({success: false, error: 'UNKNOWN'});

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -416,3 +416,27 @@ test('define schema', () => {
     }
   `);
 });
+
+test('schema map', () => {
+  const Embed = schema.define({
+    name: 'Embed',
+    fields: [schema.string({id: 'url'})],
+  });
+  const Block = schema.define({
+    name: 'Block',
+    fields: [
+      schema.oneOf({
+        id: 'embed',
+        types: [Embed, schema.define({name: 'Inline', fields: []})],
+      }),
+    ],
+  });
+
+  const {schema: mapped, schemaMap} = schema.toSchemaMap(Block);
+  expect(Object.keys(schemaMap)).toEqual(['Embed', 'Inline']);
+  const oneOfField = mapped.fields[0] as any;
+  expect(oneOfField.types).toEqual(['Embed', 'Inline']);
+
+  const restored = schema.fromSchemaMap(mapped, schemaMap);
+  expect(restored).toEqual(Block);
+});

--- a/packages/root-cms/ui/utils/collection.ts
+++ b/packages/root-cms/ui/utils/collection.ts
@@ -1,4 +1,4 @@
-import {Collection} from '../../core/schema.js';
+import {Collection, fromSchemaMap} from '../../core/schema.js';
 
 export async function fetchCollectionSchema(
   collectionId: string
@@ -17,5 +17,6 @@ export async function fetchCollectionSchema(
     throw new Error(errorText);
   }
   const resData = (await res.json()).data;
-  return resData;
+  const {collection, schemaMap} = resData;
+  return fromSchemaMap(collection, schemaMap) as Collection;
 }


### PR DESCRIPTION
## Summary
- map named schemas into a shared schema map
- hydrate schema map on client side when fetching collections
- test schema map conversion

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a11684d29c83238efda5fc99b89ec9