### PR TITLE
fix: stabilize scroll position when using details element

### DIFF
--- a/.changeset/slimy-rivers-smoke.md
+++ b/.changeset/slimy-rivers-smoke.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: stabilize scroll position when using details element

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -214,6 +214,8 @@
 
 .DocEditor__ArrayField__item {
   flex: 1;
+  /** Prevent details elements from pushing the page contents _upwards_ when opened. */
+  overflow-anchor: none;
   width: 100%;
 }
 

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -5,6 +5,8 @@
 .DocumentPage__side {
   max-height: calc(100vh - 48px);
   overflow: auto;
+  /** Prevent details elements from pushing the page contents _upwards_ when opened. */
+  overflow-anchor: none;
 }
 
 .DocumentPage__side--expanded {


### PR DESCRIPTION
This stabilizes the scroll position when using the array item toggles in the document editor.

- Previously, if the scroll position was towards the bottom, the browser might attempt to use scroll anchoring to keep the content in place, but this actually wasn't what we wanted because it would cause you to lose place of the array item header when expanding it
- In reality, we always want to keep the array item header _itself_ in place (similar to any standard document tree, Figma's layers planel, etc.)
- Disable the browser anchoring by using `overflow-anchor: none` to stop the browser from anchoring incorrectly

Keeping the array item in place when toggling it is especially important when dealing with nested documents where it can be difficult to remember your position while managing a lot of content.

After/before screencast:

(We _want_ the contents to be pushed down when opened, and _not_ expand upwards)

https://github.com/user-attachments/assets/72a818a1-f18f-4520-8bb4-5ef06f887cd2

---

See explanation from Chat:

Got it — you want it to expand *below* and push only what’s underneath, without `position: absolute`. Two things usually cause the “page jumps up” feeling:

1. **Scroll anchoring** (browser tries to keep what you’re looking at in place)
2. **Flex/Grid distribution** (space gets reallocated vertically)

Here’s how to make it consistently push content downward in normal flow:

### 1) Disable scroll anchoring where the `<details>` lives

This stops the browser from nudging the viewport upward when the panel opens near the bottom.

```css
/* On the scrolling container (often html/body) */
html, body {
  overflow-anchor: none;
}

/* If you have a custom scrollable wrapper */
.scroll-container {
  overflow: auto;
  overflow-anchor: none; /* important if not scrolling the body */
}

/* Optional: also exclude the details node from anchoring */
details {
  overflow-anchor: none;
}
```

Fixes https://github.com/blinkk/rootjs/issues/693