### PR TITLE
feat: derive image preview if unspecified

### DIFF
--- a/.changeset/blue-hotels-yawn.md
+++ b/.changeset/blue-hotels-yawn.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: derive image preview if unspecified

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -302,6 +302,10 @@
   width: 100%;
 }
 
+.DocEditor__ArrayField__item__header__preview__image__img--dark {
+  background-color: #000;
+}
+
 .DocEditor__ArrayField__item__header__preview__title {
   font-family: var(--font-family-mono);
   font-weight: 500;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1542,6 +1542,7 @@ function arrayPreviewImage(
   if (schemaLevelTemplates) {
     const value = buildPreviewValue(schemaLevelTemplates, data);
     if (value) {
+      // TODO: This doesn't fetch the `canvasBgColor`, we should see if we can get that too.
       return {src: value};
     }
   }


### PR DESCRIPTION
A week or two ago we added the ability for array items to specify image previews (to go along with their title previews).

- While this works, it's kind of tedious to have to specify this for every potential array item in the system, so instead, if the image preview is unspecified, we can derive the image preview by analyzing the fields and looking up the first image in the module data.
- As an added bonus we can more easily lookup the `canvasBgColor` too.
- Note: this only looks for images one level deep.