### PR TITLE
feat: allow custom collection sort

### DIFF
--- a/.changeset/gentle-sorts-add.md
+++ b/.changeset/gentle-sorts-add.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add custom sort options to schema.collection()

--- a/docs/collections/Pages.schema.ts
+++ b/docs/collections/Pages.schema.ts
@@ -19,6 +19,9 @@ export default schema.collection({
     },
   },
   autolock: true,
+  sort: [
+    {id: 'title', label: 'Title A-Z', field: 'fields.meta.title'},
+  ],
 
   fields: [
     schema.object({

--- a/docs/collections/Pages.schema.ts
+++ b/docs/collections/Pages.schema.ts
@@ -19,7 +19,7 @@ export default schema.collection({
     },
   },
   autolock: true,
-  sort: [
+  sortOptions: [
     {id: 'title', label: 'Title A-Z', field: 'fields.meta.title'},
   ],
 

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -417,11 +417,3 @@ test('define schema', () => {
   `);
 });
 
-test('define collection with custom sort', () => {
-  const col = schema.collection({
-    name: 'Test',
-    fields: [],
-    sort: [{id: 'title', label: 'Title A-Z', field: 'fields.title'}],
-  });
-  expect(col.sort?.[0].field).toBe('fields.title');
-});

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -416,3 +416,12 @@ test('define schema', () => {
     }
   `);
 });
+
+test('define collection with custom sort', () => {
+  const col = schema.collection({
+    name: 'Test',
+    fields: [],
+    sort: [{id: 'title', label: 'Title A-Z', field: 'fields.title'}],
+  });
+  expect(col.sort?.[0].field).toBe('fields.title');
+});

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -333,7 +333,7 @@ export type Collection = Schema & {
   /**
    * Custom sort options available when listing documents in the CMS.
    */
-  sort?: Array<{
+  sortOptions?: Array<{
     /** Unique identifier for the sort option. */
     id: string;
     /** Label displayed in the CMS UI. */

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -332,13 +332,17 @@ export type Collection = Schema & {
   };
   /**
    * Custom sort options available when listing documents in the CMS.
+   *
+   * NOTE: a new DB index may need to be created for the sort option. The first
+   * time using the sort option, you will get an error that provides a link for
+   * creating the index.
    */
   sortOptions?: Array<{
     /** Unique identifier for the sort option. */
     id: string;
     /** Label displayed in the CMS UI. */
     label: string;
-    /** Firestore field path to sort by, e.g. 'fields.meta.title'. */
+    /** DB field path to sort by, e.g. 'fields.meta.title'. */
     field: string;
     /** Sort direction. Defaults to ascending. */
     direction?: 'asc' | 'desc';

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -331,6 +331,19 @@ export type Collection = Schema & {
     };
   };
   /**
+   * Custom sort options available when listing documents in the CMS.
+   */
+  sort?: Array<{
+    /** Unique identifier for the sort option. */
+    id: string;
+    /** Label displayed in the CMS UI. */
+    label: string;
+    /** Firestore field path to sort by, e.g. 'fields.meta.title'. */
+    field: string;
+    /** Sort direction. Defaults to ascending. */
+    direction?: 'asc' | 'desc';
+  }>;
+  /**
    * Regular expression used to validate document slugs. Should be provided as a
    * string so it can be serialized to the CMS UI.
    */

--- a/packages/root-cms/ui/hooks/useDocsList.ts
+++ b/packages/root-cms/ui/hooks/useDocsList.ts
@@ -41,6 +41,15 @@ export function useDocsList(collectionId: string, options: {orderBy: string}) {
       dbQuery = query(dbCollection, queryOrderby(documentId()));
     } else if (orderBy === 'slugDesc') {
       dbQuery = query(dbCollection, queryOrderby(documentId(), 'desc'));
+    } else {
+      const col = window.__ROOT_CTX.collections[collectionId] as any;
+      const custom = col?.sort?.find((s: any) => s.id === orderBy);
+      if (custom) {
+        dbQuery =
+          custom.direction === 'desc'
+            ? query(dbCollection, queryOrderby(custom.field, 'desc'))
+            : query(dbCollection, queryOrderby(custom.field));
+      }
     }
     await notifyErrors(async () => {
       const snapshot = await getDocs(dbQuery);

--- a/packages/root-cms/ui/hooks/useDocsList.ts
+++ b/packages/root-cms/ui/hooks/useDocsList.ts
@@ -43,7 +43,7 @@ export function useDocsList(collectionId: string, options: {orderBy: string}) {
       dbQuery = query(dbCollection, queryOrderby(documentId(), 'desc'));
     } else {
       const col = window.__ROOT_CTX.collections[collectionId] as any;
-      const custom = col?.sort?.find((s: any) => s.id === orderBy);
+      const custom = col?.sortOptions?.find((s: any) => s.id === orderBy);
       if (custom) {
         dbQuery =
           custom.direction === 'desc'

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -153,13 +153,13 @@ CollectionPage.Collection = (props: CollectionProps) => {
     return <></>;
   }
 
-  const sortData = [
+  const sortOptions = [
     {value: 'slug', label: 'A-Z'},
     {value: 'slugDesc', label: 'Z-A'},
     {value: 'newest', label: 'Newest'},
     {value: 'oldest', label: 'Oldest'},
     {value: 'modifiedAt', label: 'Last modified'},
-    ...(collection.sort?.map((s: any) => ({value: s.id, label: s.label})) || []),
+    ...(collection.sortOptions?.map((s: any) => ({value: s.id, label: s.label})) || []),
   ];
 
   const [loading, listDocs, docs] = useDocsList(props.collection, {orderBy});
@@ -202,7 +202,7 @@ CollectionPage.Collection = (props: CollectionProps) => {
                         onChange={(value: any) =>
                           setOrderBy(value || 'modifiedAt')
                         }
-                        data={sortData}
+                        data={sortOptions}
                       />
                     </div>
                     <div className="CollectionPage__collection__docsTab__controls__newDoc">

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -153,6 +153,15 @@ CollectionPage.Collection = (props: CollectionProps) => {
     return <></>;
   }
 
+  const sortData = [
+    {value: 'slug', label: 'A-Z'},
+    {value: 'slugDesc', label: 'Z-A'},
+    {value: 'newest', label: 'Newest'},
+    {value: 'oldest', label: 'Oldest'},
+    {value: 'modifiedAt', label: 'Last modified'},
+    ...(collection.sort?.map((s: any) => ({value: s.id, label: s.label})) || []),
+  ];
+
   const [loading, listDocs, docs] = useDocsList(props.collection, {orderBy});
 
   return (
@@ -193,13 +202,7 @@ CollectionPage.Collection = (props: CollectionProps) => {
                         onChange={(value: any) =>
                           setOrderBy(value || 'modifiedAt')
                         }
-                        data={[
-                          {value: 'slug', label: 'A-Z'},
-                          {value: 'slugDesc', label: 'Z-A'},
-                          {value: 'newest', label: 'Newest'},
-                          {value: 'oldest', label: 'Oldest'},
-                          {value: 'modifiedAt', label: 'Last modified'},
-                        ]}
+                        data={sortData}
                       />
                     </div>
                     <div className="CollectionPage__collection__docsTab__controls__newDoc">


### PR DESCRIPTION
## Summary
- allow collections to define custom sort options
- surface custom sort choices in docs list
- document collection sort usage

## Testing
- `pnpm exec eslint packages/root-cms/core/schema.ts packages/root-cms/ui/hooks/useDocsList.ts packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx docs/collections/Pages.schema.ts packages/root-cms/core/schema.test.ts` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm --filter @blinkk/root-cms test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b867e76bec8323aca2a081b9adc6f2

fixes https://github.com/blinkk/rootjs/issues/710