### PR TITLE
feat: add references field

### DIFF
--- a/.changeset/warm-rings-tell.md
+++ b/.changeset/warm-rings-tell.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add references field

--- a/docs/collections/BlogPosts.schema.ts
+++ b/docs/collections/BlogPosts.schema.ts
@@ -41,6 +41,11 @@ export default schema.collection({
           label: 'Image',
           help: 'Meta image for social shares. Recommended size: 1200x600.',
         }),
+        schema.references({
+          id: 'relatedPosts',
+          label: 'Related Posts',
+          collections: ['BlogPosts'],
+        }),
       ],
     }),
     schema.object({

--- a/docs/root-cms.d.ts
+++ b/docs/root-cms.d.ts
@@ -65,6 +65,8 @@ export interface BlogPostsFields {
     description?: string;
     /** Image. Meta image for social shares. Recommended size: 1200x600. */
     image?: RootCMSImage;
+    /** Related Posts */
+    relatedPosts?: RootCMSReference[];
   };
   /** Content */
   content?: {

--- a/packages/root-cms/cli/generate-types.ts
+++ b/packages/root-cms/cli/generate-types.ts
@@ -329,6 +329,10 @@ function fieldType(field: Field, options: FieldPropertyOptions): dom.Type {
     const referenceType = dom.create.namedTypeReference('RootCMSReference');
     return referenceType;
   }
+  if (field.type === 'references') {
+    const referenceType = dom.create.namedTypeReference('RootCMSReference');
+    return dom.create.arrayType(referenceType);
+  }
   if (field.type === 'richtext') {
     const richtextType = dom.create.namedTypeReference('RootCMSRichText');
     return richtextType;

--- a/packages/root-cms/cli/generate-types.ts
+++ b/packages/root-cms/cli/generate-types.ts
@@ -331,7 +331,7 @@ function fieldType(field: Field, options: FieldPropertyOptions): dom.Type {
   }
   if (field.type === 'references') {
     const referenceType = dom.create.namedTypeReference('RootCMSReference');
-    return dom.create.arrayType(referenceType);
+    return dom.type.array(referenceType);
   }
   if (field.type === 'richtext') {
     const richtextType = dom.create.namedTypeReference('RootCMSRichText');

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -416,4 +416,3 @@ test('define schema', () => {
     }
   `);
 });
-

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -221,6 +221,22 @@ export function reference(field: Omit<ReferenceField, 'type'>): ReferenceField {
   return {type: 'reference', ...field};
 }
 
+export type ReferencesField = CommonFieldProps & {
+  type: 'references';
+  /** List of collection ids the references can be chosen from. */
+  collections?: string[];
+  /** Initial collection to show when picking a reference. */
+  initialCollection?: string;
+  /** Label for the button. Defaults to "Select". */
+  buttonLabel?: string;
+};
+
+export function references(
+  field: Omit<ReferencesField, 'type'>
+): ReferencesField {
+  return {...field, type: 'references'};
+}
+
 export type Field =
   | StringField
   | NumberField
@@ -235,7 +251,8 @@ export type Field =
   | ArrayField
   | OneOfField
   | RichTextField
-  | ReferenceField;
+  | ReferenceField
+  | ReferencesField;
 
 /**
  * Similar to {@link Field} but with a required `id`.

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -100,6 +100,7 @@ import {ImageField} from './fields/ImageField.js';
 import {MultiSelectField} from './fields/MultiSelectField.js';
 import {NumberField} from './fields/NumberField.js';
 import {ReferenceField} from './fields/ReferenceField.js';
+import {ReferencesField} from './fields/ReferencesField.js';
 import {RichTextField} from './fields/RichTextField.js';
 import {SelectField} from './fields/SelectField.js';
 import {StringField} from './fields/StringField.js';
@@ -370,6 +371,8 @@ DocEditor.Field = (props: FieldProps) => {
           <DocEditor.OneOfField {...props} />
         ) : field.type === 'reference' ? (
           <ReferenceField {...props} />
+        ) : field.type === 'references' ? (
+          <ReferencesField {...props} />
         ) : field.type === 'richtext' ? (
           <RichTextField {...props} />
         ) : field.type === 'select' ? (

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.css
@@ -1,0 +1,27 @@
+.ReferencesField__none {
+  font-family: var(--font-family-mono);
+  margin-bottom: 16px;
+}
+
+.ReferencesField__refs {
+  margin-bottom: 16px;
+}
+
+.ReferencesField__card {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ReferencesField__card:first-child {
+  border-top: 1px solid var(--color-border);
+}
+
+.ReferencesField__card__preview {
+  flex: 1;
+}
+
+.ReferencesField__card__controls {
+  display: flex;
+  align-items: flex-start;
+}

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.tsx
@@ -1,0 +1,106 @@
+import {ActionIcon, Button, Tooltip} from '@mantine/core';
+import {IconTrash} from '@tabler/icons-preact';
+import {useEffect, useState} from 'preact/hooks';
+import * as schema from '../../../../core/schema.js';
+import {useDocSelectModal} from '../../DocSelectModal/DocSelectModal.js';
+import {DocPreviewCard} from '../../DocPreviewCard/DocPreviewCard.js';
+import {FieldProps} from './FieldProps.js';
+import './ReferencesField.css';
+
+export function ReferencesField(props: FieldProps) {
+  const field = props.field as schema.ReferencesField;
+  const [refIds, setRefIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = props.draft.subscribe(
+      props.deepKey,
+      (newValue?: Array<{id: string}>) => {
+        if (Array.isArray(newValue)) {
+          setRefIds(newValue.map((v) => v.id));
+        } else {
+          setRefIds([]);
+        }
+      }
+    );
+    return unsubscribe;
+  }, [props.deepKey]);
+
+  function onChange(newIds: string[]) {
+    if (newIds.length) {
+      const refs = newIds.map((id) => {
+        const [collection, slug] = id.split('/');
+        return {id, collection, slug};
+      });
+      props.draft.updateKey(props.deepKey, refs);
+    } else {
+      props.draft.removeKey(props.deepKey);
+    }
+    setRefIds(newIds);
+  }
+
+  const docSelectModal = useDocSelectModal();
+
+  function openDocSelectModal() {
+    docSelectModal.open({
+      collections: field.collections,
+      initialCollection: field.initialCollection,
+      selectedDocIds: refIds,
+      onChange: (docId: string, selected: boolean) => {
+        setRefIds((old) => {
+          const next = [...old];
+          if (selected) {
+            if (!next.includes(docId)) {
+              next.push(docId);
+            }
+          } else {
+            const i = next.indexOf(docId);
+            if (i > -1) {
+              next.splice(i, 1);
+            }
+          }
+          next.sort();
+          onChange(next);
+          return next;
+        });
+      },
+    });
+  }
+
+  function removeDoc(id: string) {
+    const next = refIds.filter((x) => x !== id);
+    onChange(next);
+  }
+
+  return (
+    <div className="ReferencesField">
+      {refIds.length > 0 ? (
+        <div className="ReferencesField__refs">
+          {refIds.map((id) => (
+            <div key={id} className="ReferencesField__card">
+              <DocPreviewCard
+                className="ReferencesField__card__preview"
+                docId={id}
+                variant="compact"
+              />
+              <div className="ReferencesField__card__controls">
+                <Tooltip label="Remove">
+                  <ActionIcon
+                    className="ReferencesField__card__controls__remove"
+                    onClick={() => removeDoc(id)}
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="ReferencesField__none">None selected</div>
+      )}
+      <Button color="dark" size="xs" onClick={() => openDocSelectModal()}>
+        {field.buttonLabel || 'Select'}
+      </Button>
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferencesField.tsx
@@ -2,8 +2,8 @@ import {ActionIcon, Button, Tooltip} from '@mantine/core';
 import {IconTrash} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
-import {useDocSelectModal} from '../../DocSelectModal/DocSelectModal.js';
 import {DocPreviewCard} from '../../DocPreviewCard/DocPreviewCard.js';
+import {useDocSelectModal} from '../../DocSelectModal/DocSelectModal.js';
 import {FieldProps} from './FieldProps.js';
 import './ReferencesField.css';
 
@@ -58,7 +58,6 @@ export function ReferencesField(props: FieldProps) {
               next.splice(i, 1);
             }
           }
-          next.sort();
           onChange(next);
           return next;
         });

--- a/packages/root-cms/ui/utils/test-field-empty.ts
+++ b/packages/root-cms/ui/utils/test-field-empty.ts
@@ -34,6 +34,8 @@ export function testFieldEmpty(
       return !value || !value.src;
     case 'reference':
       return !value || !value.id;
+    case 'references':
+      return !Array.isArray(value) || value.length === 0;
     case 'richtext':
       return !testValidRichTextData(value);
     case 'object':


### PR DESCRIPTION
## Summary
- add `schema.references` for selecting multiple docs
- render new `ReferencesField` in DocEditor

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a8e0528832399687ade21ecd5f7