### PR TITLE
refactor: flatten one-of types in collection API

### DIFF
--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -192,7 +192,12 @@ export function array(field: Omit<ArrayField, 'type'>): ArrayField {
 
 export type OneOfField = CommonFieldProps & {
   type: 'oneof';
-  types: Schema[];
+  /**
+   * List of content type definitions. In the editor runtime, this will be a
+   * string array of type names with the definitions provided separately via a
+   * map. During schema authoring, an array of {@link Schema} objects is
+   * expected. */
+  types: Schema[] | string[];
 };
 
 export function oneOf(field: Omit<OneOfField, 'type'>): OneOfField {
@@ -259,6 +264,11 @@ export interface Schema {
   description?: string;
   /** Fields describe the structure of the content. */
   fields: FieldWithId[];
+  /**
+   * Map of reusable content type definitions referenced by one-of fields. The
+   * key is the schema name and the value is the schema definition.
+   */
+  types?: Record<string, Schema>;
   /** Defines the preview displayed within the CMS UI. Overrides the `preview` definition for the `array` field. */
   preview?: {
     /**

--- a/packages/root-cms/ui/utils/test-field-empty.ts
+++ b/packages/root-cms/ui/utils/test-field-empty.ts
@@ -9,7 +9,11 @@ import {isObject} from './objects.js';
  * This helper is primarily used to hide deprecated fields when they
  * contain no meaningful data.
  */
-export function testFieldEmpty(field: schema.Field, value: any): boolean {
+export function testFieldEmpty(
+  field: schema.Field,
+  value: any,
+  types: Record<string, schema.Schema> = {}
+): boolean {
   if (value === undefined || value === null) {
     return true;
   }
@@ -40,7 +44,7 @@ export function testFieldEmpty(field: schema.Field, value: any): boolean {
         if (!child.id) {
           continue;
         }
-        if (!testFieldEmpty(child, value[child.id])) {
+        if (!testFieldEmpty(child, value[child.id], types)) {
           return false;
         }
       }
@@ -54,7 +58,7 @@ export function testFieldEmpty(field: schema.Field, value: any): boolean {
         return true;
       }
       for (const key of value._array) {
-        if (!testFieldEmpty(field.of, value[key])) {
+        if (!testFieldEmpty(field.of, value[key], types)) {
           return false;
         }
       }
@@ -63,7 +67,15 @@ export function testFieldEmpty(field: schema.Field, value: any): boolean {
       if (!isObject(value) || !value._type) {
         return true;
       }
-      const sub = (field.types || []).find((t) => t.name === value._type);
+      let sub: schema.Schema | undefined;
+      const fieldTypes = field.types || [];
+      if (typeof fieldTypes[0] === 'string') {
+        if ((fieldTypes as string[]).includes(value._type)) {
+          sub = types[value._type];
+        }
+      } else {
+          sub = (fieldTypes as any[]).find((t) => t.name === value._type);
+      }
       if (!sub) {
         return true;
       }
@@ -71,7 +83,7 @@ export function testFieldEmpty(field: schema.Field, value: any): boolean {
         if (!child.id) {
           continue;
         }
-        if (!testFieldEmpty(child, value[child.id])) {
+        if (!testFieldEmpty(child, value[child.id], types)) {
           return false;
         }
       }


### PR DESCRIPTION
## Summary
- convert one-of fields in `collection.get` to reference a shared `types` map
- expose optional `types` map in schema and support string-based one-of type lists
- wire DocEditor and utilities to consume the shared types map

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c8b464ac8323bf14bb676fd193c2