### PR TITLE
fix: handle missing AI edit data

### DIFF
--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.tsx
@@ -102,14 +102,16 @@ export function AiEditModal(modalProps: ContextModalProps<AiEditModalProps>) {
         </div>
         <div className="AiEditModal__SplitPanel__ChatPanel">
           <ChatPanel
-            editModeData={JSON.parse(value)}
+            editModeData={valid ? JSON.parse(value) : undefined}
             onEditModeResponse={(resp: AiResponse) => {
-              const newValue = JSON.stringify(resp.data, null, 2);
-              setValue(newValue);
-              setChanged(newValue !== originalValue);
-              // Show the diff automatically when the AI is done editing.
-              if (diffTabRef.current) {
-                diffTabRef.current.click();
+              if (resp.data) {
+                const newValue = JSON.stringify(resp.data, null, 2);
+                setValue(newValue);
+                setChanged(newValue !== originalValue);
+                // Show the diff automatically when the AI is done editing.
+                if (diffTabRef.current) {
+                  diffTabRef.current.click();
+                }
               }
             }}
           >


### PR DESCRIPTION
## Summary
- guard against undefined AI edit responses
- only parse JSON when it is valid before sending to chat

## Testing
- `pnpm exec eslint packages/root-cms/ui/components/AiEditModal/AiEditModal.tsx` *(fails: Proxy response (403) when fetching pnpm)*
- `npx eslint packages/root-cms/ui/components/AiEditModal/AiEditModal.tsx` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b96975008323967cb1fdd7a42de1