### PR TITLE
fix: support preview image fallback arrays

### DIFF
--- a/.changeset/itchy-pigs-protect.md
+++ b/.changeset/itchy-pigs-protect.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: support preview image fallback arrays (#734)

--- a/packages/root-cms/ui/utils/objects.ts
+++ b/packages/root-cms/ui/utils/objects.ts
@@ -10,6 +10,7 @@ export function isObject(data: any): boolean {
  * ```
  * getNestedValue({meta: {title: 'Foo'}}, 'meta.title');
  * // => Foo
+ *
  * // With fallbacks:
  * getNestedValue(data, ['meta.image', 'meta.thumbnail']);
  * ```
@@ -17,7 +18,7 @@ export function isObject(data: any): boolean {
  * If the value does not exist, `undefined` is returned. When an array of keys
  * is provided, the first defined value is returned.
  */
-export function getNestedValue(data: any, key: string | string[]) {
+export function getNestedValue(data: any, key: string | string[]): any {
   if (Array.isArray(key)) {
     for (const k of key) {
       const value = getNestedValue(data, k);
@@ -33,7 +34,7 @@ export function getNestedValue(data: any, key: string | string[]) {
   const keys = key.split('.');
   let current = data;
   for (const segment of keys) {
-    if (current == null) {
+    if (current === undefined || current === null) {
       return undefined;
     }
     current = current[segment];


### PR DESCRIPTION
## Summary
- allow `getNestedValue` to accept array of keys
- enable array fallbacks for `preview.image`

## Testing
- `pnpm exec eslint packages/root-cms/ui/utils/objects.ts packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx packages/root-cms/ui/components/DocPickerModal/DocPickerModal.tsx packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx` *(failed: Proxy response (403) !== 200 when HTTP Tunneling)*
- `./node_modules/.bin/eslint packages/root-cms/ui/utils/objects.ts packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx packages/root-cms/ui/components/DocPickerModal/DocPickerModal.tsx packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf06b483788323bfc076f66c645dbf

fixes https://github.com/blinkk/rootjs/pull/734