### PR TITLE
feat: add preview text for richtext data

### DIFF
--- a/.changeset/dirty-phones-move.md
+++ b/.changeset/dirty-phones-move.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add preview text for richtext data (#737)

--- a/.changeset/richtext-array-preview.md
+++ b/.changeset/richtext-array-preview.md
@@ -1,4 +1,0 @@
----
-'@blinkk/root-cms': patch
----
-Return the first paragraph line for rich text fields in array previews.

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -48,7 +48,10 @@ import {
 } from 'preact/hooks';
 import {route} from 'preact-router';
 import * as schema from '../../../core/schema.js';
-import {updateRichTextDataTime, testValidRichTextData} from '../../../shared/richtext.js';
+import {
+  updateRichTextDataTime,
+  testValidRichTextData,
+} from '../../../shared/richtext.js';
 import type {RichTextData} from '../../../shared/richtext.js';
 import {useCollectionSchema} from '../../hooks/useCollectionSchema.js';
 import {
@@ -1532,13 +1535,14 @@ function getSchemaPreviewTemplates(
           (schema) => schema.name === selectedTypeName
         );
       }
-  return selectedSchema?.preview?.[key] || null;
+      return selectedSchema?.preview?.[key] || null;
     }
   }
   return null;
 }
 
-function richTextFirstLine(data: RichTextData): string | undefined {
+/** Returns the first line of text from rich text data. */
+function getRichTextPreview(data: RichTextData): string | undefined {
   const blocks = data?.blocks || [];
   for (const block of blocks) {
     if (block.type === 'paragraph') {
@@ -1587,11 +1591,10 @@ function buildPreviewValue(
       throw new PlaceholderNotFoundError(key);
     }
     if (testValidRichTextData(val)) {
-      const text = richTextFirstLine(val as RichTextData);
-      if (!text) {
-        throw new PlaceholderNotFoundError(key);
+      const richTextPreview = getRichTextPreview(val as RichTextData);
+      if (richTextPreview) {
+        return richTextPreview;
       }
-      return text;
     }
     return String(val);
   };


### PR DESCRIPTION
## Summary
- handle rich text fields in array previews by extracting the first paragraph line
- add changeset entry for root-cms

## Testing
- `pnpm lint packages/root-cms/ui/components/DocEditor/DocEditor.tsx` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68c03148b0bc8323b82647d07d724d76