### PR TITLE
chore: remove VirtualClipboardProvider

### DIFF
--- a/packages/root-cms/ui/hooks/useVirtualClipboard.tsx
+++ b/packages/root-cms/ui/hooks/useVirtualClipboard.tsx
@@ -1,6 +1,3 @@
-import {ComponentChildren, createContext} from 'preact';
-import {useContext} from 'preact/hooks';
-
 /**
  * JSON data that can be read/write in the virtual clipboard. Null data
  * indicates there's no content (it's either empty, or the navigator clipboard
@@ -15,45 +12,26 @@ export interface VirtualClipboard {
   set: (value: ClipboardData) => void;
 }
 
-/** The virtual clipboard is a simple wrapper around the navigator clipboard that normalizes access to JSON data. */
-const VirtualClipboardContext = createContext<VirtualClipboard | null>(null);
-
-export function VirtualClipboardProvider(props: {
-  children?: ComponentChildren;
-}) {
-  const virtualClipboard: VirtualClipboard = {
-    get: async () => {
-      try {
-        const text = await getNavigatorClipboardText();
-        return text ? JSON.parse(text) : null;
-      } catch (error) {
-        return null;
-      }
-    },
-    set: (value) => {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard
-          .writeText(JSON.stringify(value, undefined, 2))
-          .catch(console.error);
-      }
-    },
-  };
-
-  return (
-    <VirtualClipboardContext.Provider value={virtualClipboard}>
-      {props.children}
-    </VirtualClipboardContext.Provider>
-  );
-}
+const VIRTUAL_CLIPBOARD: VirtualClipboard = {
+  get: async () => {
+    try {
+      const text = await getNavigatorClipboardText();
+      return text ? JSON.parse(text) : null;
+    } catch (error) {
+      return null;
+    }
+  },
+  set: (value) => {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard
+        .writeText(JSON.stringify(value, undefined, 2))
+        .catch(console.error);
+    }
+  },
+};
 
 export function useVirtualClipboard(): VirtualClipboard {
-  const virtualClipboard = useContext(VirtualClipboardContext);
-  if (!virtualClipboard) {
-    throw new Error(
-      'virtualClipboard is null, make sure to add <VirtualClipboardProvider>'
-    );
-  }
-  return virtualClipboard;
+  return VIRTUAL_CLIPBOARD;
 }
 
 async function getNavigatorClipboardText(): Promise<string | null> {
@@ -61,8 +39,8 @@ async function getNavigatorClipboardText(): Promise<string | null> {
     if (navigator.clipboard && navigator.clipboard.readText) {
       return await navigator.clipboard.readText();
     }
-  } catch (error) {
-    // Clipboard access denied or not available
+  } catch (err) {
+    // Clipboard access denied or not available.
   }
   return null;
 }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -28,7 +28,6 @@ import {FirebaseContext, FirebaseContextObject} from './hooks/useFirebase.js';
 import {SiteSettingsProvider} from './hooks/useSiteSettings.js';
 import {SSEProvider} from './hooks/useSSE.js';
 import {UserPreferencesProvider} from './hooks/useUserPreferences.js';
-import {VirtualClipboardProvider} from './hooks/useVirtualClipboard.js';
 import {AIPage} from './pages/AIPage/AIPage.js';
 import {AssetsPage} from './pages/AssetsPage/AssetsPage.js';
 import {CollectionPage} from './pages/CollectionPage/CollectionPage.js';
@@ -105,89 +104,81 @@ function App() {
     >
       <NotificationsProvider>
         <FirebaseContext.Provider value={window.firebase}>
-          <VirtualClipboardProvider>
-            <SSEProvider>
-              <SiteSettingsProvider>
-                <UserPreferencesProvider>
-                  <ModalsProvider
-                    modals={{
-                      [AiEditModal.id]: AiEditModal,
-                      [CopyDocModal.id]: CopyDocModal,
-                      [DocPickerModal.id]: DocPickerModal,
-                      [DocSelectModal.id]: DocSelectModal,
-                      [DataSourceSelectModal.id]: DataSourceSelectModal,
-                      [EditJsonModal.id]: EditJsonModal,
-                      [EditTranslationsModal.id]: EditTranslationsModal,
-                      [ExportSheetModal.id]: ExportSheetModal,
-                      [LocalizationModal.id]: LocalizationModal,
-                      [LockPublishingModal.id]: LockPublishingModal,
-                      [PublishDocModal.id]: PublishDocModal,
-                      [ScheduleReleaseModal.id]: ScheduleReleaseModal,
-                      [VersionHistoryModal.id]: VersionHistoryModal,
-                    }}
-                  >
-                    <Router>
-                      <Route path="/cms" component={ProjectPage} />
-                      <Route path="/cms/ai" component={AIPage} />
-                      <Route path="/cms/assets" component={AssetsPage} />
-                      <Route path="/cms/compare" component={ComparePage} />
-                      <Route
-                        path="/cms/content/:collection?"
-                        component={CollectionPage}
-                      />
-                      <Route
-                        path="/cms/content/:collection/:slug"
-                        component={DocumentPage}
-                      />
-                      <Route path="/cms/data" component={DataPage} />
-                      <Route
-                        path="/cms/data/new"
-                        component={NewDataSourcePage}
-                      />
-                      <Route path="/cms/data/:id" component={DataSourcePage} />
-                      <Route
-                        path="/cms/data/:id/edit"
-                        component={EditDataSourcePage}
-                      />
-                      <Route path="/cms/logs" component={LogsPage} />
-                      <Route path="/cms/releases" component={ReleasesPage} />
-                      <Route
-                        path="/cms/releases/new"
-                        component={NewReleasePage}
-                      />
-                      <Route path="/cms/releases/:id" component={ReleasePage} />
-                      <Route
-                        path="/cms/releases/:id/edit"
-                        component={EditReleasePage}
-                      />
-                      <Route path="/cms/settings" component={SettingsPage} />
-                      <Route
-                        path="/cms/tools/:id"
-                        component={SidebarToolsPage}
-                      />
-                      <Route
-                        path="/cms/translations"
-                        component={TranslationsPage}
-                      />
-                      <Route
-                        path="/cms/translations/arb"
-                        component={TranslationsArbPage}
-                      />
-                      <Route
-                        path="/cms/translations/:hash"
-                        component={TranslationsEditPage}
-                      />
-                      <Route
-                        path="/cms/translations/:collection/:slug"
-                        component={DocTranslationsPage}
-                      />
-                      <Route default component={NotFoundPage} />
-                    </Router>
-                  </ModalsProvider>
-                </UserPreferencesProvider>
-              </SiteSettingsProvider>
-            </SSEProvider>
-          </VirtualClipboardProvider>
+          <SSEProvider>
+            <SiteSettingsProvider>
+              <UserPreferencesProvider>
+                <ModalsProvider
+                  modals={{
+                    [AiEditModal.id]: AiEditModal,
+                    [CopyDocModal.id]: CopyDocModal,
+                    [DocPickerModal.id]: DocPickerModal,
+                    [DocSelectModal.id]: DocSelectModal,
+                    [DataSourceSelectModal.id]: DataSourceSelectModal,
+                    [EditJsonModal.id]: EditJsonModal,
+                    [EditTranslationsModal.id]: EditTranslationsModal,
+                    [ExportSheetModal.id]: ExportSheetModal,
+                    [LocalizationModal.id]: LocalizationModal,
+                    [LockPublishingModal.id]: LockPublishingModal,
+                    [PublishDocModal.id]: PublishDocModal,
+                    [ScheduleReleaseModal.id]: ScheduleReleaseModal,
+                    [VersionHistoryModal.id]: VersionHistoryModal,
+                  }}
+                >
+                  <Router>
+                    <Route path="/cms" component={ProjectPage} />
+                    <Route path="/cms/ai" component={AIPage} />
+                    <Route path="/cms/assets" component={AssetsPage} />
+                    <Route path="/cms/compare" component={ComparePage} />
+                    <Route
+                      path="/cms/content/:collection?"
+                      component={CollectionPage}
+                    />
+                    <Route
+                      path="/cms/content/:collection/:slug"
+                      component={DocumentPage}
+                    />
+                    <Route path="/cms/data" component={DataPage} />
+                    <Route path="/cms/data/new" component={NewDataSourcePage} />
+                    <Route path="/cms/data/:id" component={DataSourcePage} />
+                    <Route
+                      path="/cms/data/:id/edit"
+                      component={EditDataSourcePage}
+                    />
+                    <Route path="/cms/logs" component={LogsPage} />
+                    <Route path="/cms/releases" component={ReleasesPage} />
+                    <Route
+                      path="/cms/releases/new"
+                      component={NewReleasePage}
+                    />
+                    <Route path="/cms/releases/:id" component={ReleasePage} />
+                    <Route
+                      path="/cms/releases/:id/edit"
+                      component={EditReleasePage}
+                    />
+                    <Route path="/cms/settings" component={SettingsPage} />
+                    <Route path="/cms/tools/:id" component={SidebarToolsPage} />
+                    <Route
+                      path="/cms/translations"
+                      component={TranslationsPage}
+                    />
+                    <Route
+                      path="/cms/translations/arb"
+                      component={TranslationsArbPage}
+                    />
+                    <Route
+                      path="/cms/translations/:hash"
+                      component={TranslationsEditPage}
+                    />
+                    <Route
+                      path="/cms/translations/:collection/:slug"
+                      component={DocTranslationsPage}
+                    />
+                    <Route default component={NotFoundPage} />
+                  </Router>
+                </ModalsProvider>
+              </UserPreferencesProvider>
+            </SiteSettingsProvider>
+          </SSEProvider>
         </FirebaseContext.Provider>
       </NotificationsProvider>
     </MantineProvider>


### PR DESCRIPTION
The VirtualClipboard was recently updated to use the Clipboard API directly, which no longer requires a provider for handling clipboard state.