### PR TITLE
feat: copy versions to new docs

### DIFF
--- a/.changeset/wise-ways-pretend.md
+++ b/.changeset/wise-ways-pretend.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: copy versions to new docs (#751)

--- a/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
+++ b/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
@@ -17,6 +17,7 @@ export interface CopyDocModalProps {
   fromDocId: string;
   fields?: Record<string, any>;
   fromLabel?: string;
+  onSuccess?: (newDocId: string) => void;
 }
 
 export function useCopyDocModal(props: CopyDocModalProps) {
@@ -78,6 +79,9 @@ export function CopyDocModal(modalProps: ContextModalProps<CopyDocModalProps>) {
         message: `Succesfully copied ${sourceLabel} to ${toDocId}.`,
         autoClose: 5000,
       });
+      if (props.onSuccess) {
+        props.onSuccess(toDocId);
+      }
     } catch (err) {
       const errMsg = String(err);
       setError(errMsg);

--- a/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
+++ b/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
@@ -1,12 +1,13 @@
 import {Button, Loader, Table} from '@mantine/core';
 import {ContextModalProps, useModals} from '@mantine/modals';
 import {showNotification} from '@mantine/notifications';
-import {IconArrowUpRight, IconHistory} from '@tabler/icons-preact';
+import {IconArrowUpRight, IconCopy, IconHistory} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {Version, cmsListVersions, cmsRestoreVersion} from '../../utils/doc.js';
 import {Heading} from '../Heading/Heading.js';
 import {Text} from '../Text/Text.js';
+import {useCopyDocModal} from '../CopyDocModal/CopyDocModal.js';
 import './VersionHistoryModal.css';
 
 const MODAL_ID = 'VersionHistoryModal';
@@ -38,6 +39,7 @@ export function VersionHistoryModal(
   const docId = props.docId;
   const [loading, setLoading] = useState(true);
   const [versions, setVersions] = useState<Version[]>([]);
+  const copyDocModal = useCopyDocModal({fromDocId: docId});
 
   const dateFormat = new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
@@ -66,6 +68,18 @@ export function VersionHistoryModal(
     if (props.onRestore) {
       props.onRestore({version});
     }
+  }
+
+  function copyToNewDoc(version: Version) {
+    const modifiedAt = version.sys?.modifiedAt?.toDate();
+    let label = `${docId}@${version._versionId}`;
+    if (modifiedAt) {
+      label = `${docId} @ ${dateFormat.format(modifiedAt)}`;
+    }
+    copyDocModal.open({
+      fields: version.fields || {},
+      fromLabel: label,
+    });
   }
 
   function getCompareUrl(version: Version) {
@@ -127,6 +141,15 @@ export function VersionHistoryModal(
                       onClick={() => restore(version)}
                     >
                       restore
+                    </Button>
+                    <Button
+                      variant="default"
+                      size="xs"
+                      compact
+                      onClick={() => copyToNewDoc(version)}
+                      leftIcon={<IconCopy size={12} />}
+                    >
+                      copy to doc
                     </Button>
                     <Button
                       className="VersionHistoryModal__versions__buttons__compare"

--- a/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
+++ b/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
@@ -5,9 +5,9 @@ import {IconArrowUpRight, IconCopy, IconHistory} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {Version, cmsListVersions, cmsRestoreVersion} from '../../utils/doc.js';
+import {useCopyDocModal} from '../CopyDocModal/CopyDocModal.js';
 import {Heading} from '../Heading/Heading.js';
 import {Text} from '../Text/Text.js';
-import {useCopyDocModal} from '../CopyDocModal/CopyDocModal.js';
 import './VersionHistoryModal.css';
 
 const MODAL_ID = 'VersionHistoryModal';
@@ -35,7 +35,7 @@ export function useVersionHistoryModal(props: VersionHistoryModalProps) {
 export function VersionHistoryModal(
   modalProps: ContextModalProps<VersionHistoryModalProps>
 ) {
-  const {innerProps: props} = modalProps;
+  const {innerProps: props, context, id} = modalProps;
   const docId = props.docId;
   const [loading, setLoading] = useState(true);
   const [versions, setVersions] = useState<Version[]>([]);
@@ -71,14 +71,18 @@ export function VersionHistoryModal(
   }
 
   function copyToNewDoc(version: Version) {
-    const modifiedAt = version.sys?.modifiedAt?.toDate();
     let label = `${docId}@${version._versionId}`;
+    const modifiedAt = version.sys?.modifiedAt?.toDate();
     if (modifiedAt) {
-      label = `${docId} @ ${dateFormat.format(modifiedAt)}`;
+      const isoDate = formatIsoDate(modifiedAt);
+      label = `${docId}@${isoDate}`;
     }
     copyDocModal.open({
       fields: version.fields || {},
       fromLabel: label,
+      onSuccess: () => {
+        context.closeModal(id);
+      },
     });
   }
 
@@ -178,6 +182,15 @@ function toUrlParam(docId: string, versionId: string): string {
   return encodeURIComponent(`${docId}@${versionId}`)
     .replaceAll('%2F', '/')
     .replaceAll('%40', '@');
+}
+
+function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 VersionHistoryModal.id = MODAL_ID;


### PR DESCRIPTION
## Summary
- add a copy-to-doc action in the version history modal that opens the copy modal prefilled with the selected version
- extend the copy doc modal so it can duplicate arbitrary field data (like historical versions) into a new document while keeping its existing behavior

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ca118918c483239b39f3f1ec64614c

fixes #607