### PR TITLE
feat: add ai summary to publish doc modal

### DIFF
--- a/.changeset/rude-pumpkins-fetch.md
+++ b/.changeset/rude-pumpkins-fetch.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add ai summary to publish doc modal (#756)

--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -63,6 +63,7 @@ export async function summarizeDiff(
     'You are an assistant that summarizes changes made to CMS documents stored as JSON.',
     'Provide a concise description of the most important updates using short bullet points.',
     'If there are no meaningful differences, respond with "No significant changes."',
+    'Focus on just the content changes, ignore insignificant changes to richtext blocks and structure, such as updates to the richtext block\'s "timestamp" and "version" fields.',
   ].join('\n');
 
   const diffPrompt = [

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
@@ -88,6 +88,10 @@
   margin-top: 24px;
 }
 
+.PublishDocModal__ShowChanges + .PublishDocModal__ShowChanges {
+  margin-top: 12px;
+}
+
 .PublishDocModal__ShowChanges .mantine-Accordion-control[aria-expanded="true"] {
   background: #fff;
 }
@@ -99,4 +103,11 @@
 
 .PublishDocModal__ShowChanges .mantine-Accordion-contentInner {
   padding: 0;
+}
+
+.PublishDocModal__ShowChanges__aiSummary {
+  padding: 12px 16px 24px;
+  white-space: pre-wrap;
+  font-family: var(--font-family-mono);
+  color: black;
 }

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
@@ -92,6 +92,10 @@
   margin-top: 12px;
 }
 
+.PublishDocModal__ShowChanges__loading {
+  padding: 12px 16px 24px;
+}
+
 .PublishDocModal__ShowChanges .mantine-Accordion-control[aria-expanded="true"] {
   background: #fff;
 }

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -242,9 +242,9 @@ export function PublishDocModal(
 
 function AiSummary(props: {docId: string}) {
   const docId = props.docId;
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>(
-    'idle'
-  );
+  const [status, setStatus] = useState<
+    'idle' | 'loading' | 'success' | 'error'
+  >('idle');
   const [summary, setSummary] = useState('');
   const [error, setError] = useState('');
   const hasRequestedRef = useRef(false);
@@ -274,7 +274,11 @@ function AiSummary(props: {docId: string}) {
     content = <Loader />;
   } else if (status === 'error') {
     content = (
-      <Text size="body-sm" color="gray">
+      <Text
+        className="PublishDocModal__ShowChanges__aiSummary"
+        size="body-sm"
+        color="gray"
+      >
         Failed to load AI summary.
         {error && (
           <>
@@ -286,13 +290,21 @@ function AiSummary(props: {docId: string}) {
     );
   } else if (!summary) {
     content = (
-      <Text size="body-sm" color="gray">
+      <Text
+        className="PublishDocModal__ShowChanges__aiSummary"
+        size="body-sm"
+        color="gray"
+      >
         No AI summary available for this draft yet.
       </Text>
     );
   } else {
     content = (
-      <Text as="pre" size="body-sm">
+      <Text
+        className="PublishDocModal__ShowChanges__aiSummary"
+        as="pre"
+        size="body-sm"
+      >
         {summary}
       </Text>
     );
@@ -301,7 +313,9 @@ function AiSummary(props: {docId: string}) {
   return (
     <div className="PublishDocModal__ShowChanges">
       <Accordion iconPosition="right" onChange={() => handleToggle()}>
-        <Accordion.Item label="AI summary of changes">{content}</Accordion.Item>
+        <Accordion.Item label="Summarize changes (AI)">
+          {content}
+        </Accordion.Item>
       </Accordion>
     </div>
   );

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -271,7 +271,11 @@ function AiSummary(props: {docId: string}) {
 
   let content = null;
   if (status === 'idle' || status === 'loading') {
-    content = <Loader />;
+    content = (
+      <div className="PublishDocModal__ShowChanges__loading">
+        <Loader size="md" color="gray" />
+      </div>
+    );
   } else if (status === 'error') {
     content = (
       <Text
@@ -340,7 +344,9 @@ function ShowChanges(props: {docId: string}) {
               showExpandButton={true}
             />
           ) : (
-            <Loader />
+            <div className="PublishDocModal__ShowChanges__loading">
+              <Loader size="md" color="gray" />
+            </div>
           )}
         </Accordion.Item>
       </Accordion>

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -904,6 +904,39 @@ export function unmarshalArray(arrObject: ArrayObject): any[] {
   return arr;
 }
 
+export async function cmsGetDocDiffSummary(docId: string): Promise<string> {
+  const res = await window.fetch('/cms/api/ai.doc_diff_summary', {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify({docId}),
+  });
+
+  const responseText = await res.text();
+  let resData: any = null;
+  try {
+    resData = JSON.parse(responseText);
+  } catch (err) {
+    // Ignore JSON parsing errors and fall back to the response text below.
+  }
+
+  if (!res.ok || resData?.success === false) {
+    const errorMessage =
+      (resData && (resData.error || resData.message)) || responseText;
+    throw new Error(errorMessage || 'Failed to fetch AI summary');
+  }
+
+  if (typeof resData?.summary === 'string') {
+    return resData.summary;
+  }
+  if (typeof resData?.data?.summary === 'string') {
+    return resData.data.summary;
+  }
+  if (!resData && responseText) {
+    return responseText;
+  }
+  return '';
+}
+
 function isObject(data: any): boolean {
   return typeof data === 'object' && !Array.isArray(data) && data !== null;
 }


### PR DESCRIPTION
## Summary
- add an AI summary accordion to the publish modal that loads when experiments.ai is enabled
- fetch AI diff summaries via a new cmsGetDocDiffSummary helper
- relabel the existing diff accordion to "Show changes (JSON)"

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68cc33b658488323bf5b69bc2fd32f99