### PR TITLE
feat: support mp4s as doc preview image

### DIFF
--- a/.changeset/shaggy-penguins-fold.md
+++ b/.changeset/shaggy-penguins-fold.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: support mp4s as doc preview image (#761)

--- a/docs/collections/Sandbox.schema.ts
+++ b/docs/collections/Sandbox.schema.ts
@@ -7,7 +7,7 @@ export default schema.collection({
   url: '/sandbox/[...slug]',
   preview: {
     title: 'meta.title',
-    image: 'meta.image',
+    image: ['content.modules[0].file', 'meta.image'],
     defaultImage: {
       src: 'https://lh3.googleusercontent.com/c2ECbvhJtxf3xbPIjaXCSpmvAsJkkhzJwG98T9RPvWy4s30jZKClom8pvWTnupRYOnyI3qGhNXPOwqoN6sqljkDO62LIKRtR988',
     },

--- a/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
+++ b/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
@@ -1,6 +1,6 @@
 import './DocPreviewCard.css';
 
-import {Image, Loader} from '@mantine/core';
+import {Loader} from '@mantine/core';
 import {useEffect, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocFromCacheOrFetch} from '../../utils/doc-cache.js';
@@ -8,6 +8,7 @@ import {getDocServingUrl} from '../../utils/doc-urls.js';
 import {notifyErrors} from '../../utils/notifications.js';
 import {getNestedValue} from '../../utils/objects.js';
 import {DocStatusBadges} from '../DocStatusBadges/DocStatusBadges.js';
+import {FilePreview} from '../FilePreview/FilePreview.js';
 
 export interface DocPreviewCardProps {
   className?: string;
@@ -87,8 +88,8 @@ export function DocPreviewCard(props: DocPreviewCardProps) {
       {...attrs}
     >
       <div className="DocPreviewCard__image">
-        <Image
-          src={previewImage?.src}
+        <FilePreview
+          file={previewImage}
           width={80}
           height={60}
           withPlaceholder={!previewImage?.src}

--- a/packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx
+++ b/packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx
@@ -1,11 +1,13 @@
-import {Button, Image, Loader, Select} from '@mantine/core';
+import './DocSelectModal.css';
+
+import {Button, Loader, Select} from '@mantine/core';
 import {ContextModalProps, useModals} from '@mantine/modals';
 import {useState} from 'preact/hooks';
 import {useDocsList} from '../../hooks/useDocsList.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {getDocServingUrl} from '../../utils/doc-urls.js';
 import {getNestedValue} from '../../utils/objects.js';
-import './DocSelectModal.css';
+import {FilePreview} from '../FilePreview/FilePreview.js';
 
 const MODAL_ID = 'DocSelectModal';
 
@@ -172,8 +174,8 @@ DocSelectModal.DocCard = (props: {
   return (
     <div className="DocSelectModal__DocCard">
       <div className="DocSelectModal__DocCard__image">
-        <Image
-          src={previewImage?.src}
+        <FilePreview
+          file={previewImage}
           width={120}
           height={90}
           withPlaceholder={!previewImage?.src}

--- a/packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx
+++ b/packages/root-cms/ui/components/DocSelectModal/DocSelectModal.tsx
@@ -71,8 +71,6 @@ export function DocSelectModal(
     }
   }
 
-  console.log('selected docs:', props.selectedDocIds);
-
   return (
     <div className="DocSelectModal">
       {collections.length === 0 && (

--- a/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
+++ b/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
@@ -1,5 +1,4 @@
 import {Image} from '@mantine/core';
-import {useEffect, useRef} from 'preact/hooks';
 
 export interface FilePreviewFile {
   src?: string;
@@ -46,14 +45,7 @@ export function FilePreview(props: FilePreviewProps) {
     );
   }
 
-  return (
-    <VideoPreviewCanvas
-      className={className}
-      src={src}
-      width={width}
-      height={height}
-    />
-  );
+  return <VideoPreview className={className} src={src} width={width} height={height} />;
 }
 
 function isMp4File(file?: FilePreviewFile | string | null) {
@@ -76,112 +68,28 @@ function isMp4File(file?: FilePreviewFile | string | null) {
   return /\.mp4($|\?)/i.test(src);
 }
 
-function VideoPreviewCanvas(props: {
+function VideoPreview(props: {
   className?: string;
   src: string;
   width: number;
   height: number;
 }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
-
-    const context = canvas.getContext('2d');
-    if (!context) {
-      return;
-    }
-
-    context.fillStyle = '#f1f3f5';
-    context.fillRect(0, 0, props.width, props.height);
-
-    const video = document.createElement('video');
-    let cancelled = false;
-
-    const drawFrame = () => {
-      if (cancelled || !context) {
-        return;
-      }
-      const {videoWidth, videoHeight} = video;
-      if (!videoWidth || !videoHeight) {
-        return;
-      }
-      const aspect = videoWidth / videoHeight;
-      let drawWidth = props.width;
-      let drawHeight = props.height;
-
-      if (props.width / props.height > aspect) {
-        drawWidth = props.height * aspect;
-      } else {
-        drawHeight = props.width / aspect;
-      }
-
-      const offsetX = (props.width - drawWidth) / 2;
-      const offsetY = (props.height - drawHeight) / 2;
-
-      context.clearRect(0, 0, props.width, props.height);
-      context.fillStyle = '#f1f3f5';
-      context.fillRect(0, 0, props.width, props.height);
-      context.drawImage(video, offsetX, offsetY, drawWidth, drawHeight);
-    };
-
-    const handleLoadedData = () => {
-      drawFrame();
-    };
-
-    const handleError = () => {
-      if (cancelled || !context) {
-        return;
-      }
-      context.clearRect(0, 0, props.width, props.height);
-      context.fillStyle = '#f1f3f5';
-      context.fillRect(0, 0, props.width, props.height);
-    };
-
-    video.crossOrigin = 'anonymous';
-    video.preload = 'auto';
-    video.muted = true;
-    video.playsInline = true;
-    video.src = props.src;
-    video.addEventListener('loadeddata', handleLoadedData);
-    video.addEventListener('error', handleError);
-    video.load();
-
-    return () => {
-      cancelled = true;
-      video.removeEventListener('loadeddata', handleLoadedData);
-      video.removeEventListener('error', handleError);
-      video.pause();
-      video.removeAttribute('src');
-      video.load();
-    };
-  }, [props.src, props.width, props.height]);
-
   return (
-    <div
+    <video
       className={props.className}
+      src={props.src}
+      width={props.width}
+      height={props.height}
+      muted
+      playsInline
+      preload="metadata"
       style={{
         width: `${props.width}px`,
         height: `${props.height}px`,
         backgroundColor: '#f1f3f5',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        objectFit: 'cover',
+        display: 'block',
       }}
-    >
-      <canvas
-        ref={canvasRef}
-        width={props.width}
-        height={props.height}
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'block',
-        }}
-      />
-    </div>
+    />
   );
 }

--- a/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
+++ b/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
@@ -19,33 +19,27 @@ export function FilePreview(props: FilePreviewProps) {
   const {file, width, height, withPlaceholder, className, alt} = props;
   const src = typeof file === 'string' ? file : file?.src;
 
-  if (!src) {
+  if (isMp4File(file)) {
     return (
-      <Image
+      <VideoPreview
         className={className}
-        src={undefined}
+        src={src!}
         width={width}
         height={height}
-        withPlaceholder={withPlaceholder}
-        alt={alt}
       />
     );
   }
 
-  if (!isMp4File(file)) {
-    return (
-      <Image
-        className={className}
-        src={src}
-        width={width}
-        height={height}
-        withPlaceholder={withPlaceholder}
-        alt={alt}
-      />
-    );
-  }
-
-  return <VideoPreview className={className} src={src} width={width} height={height} />;
+  return (
+    <Image
+      className={className}
+      src={src}
+      width={width}
+      height={height}
+      withPlaceholder={withPlaceholder}
+      alt={alt}
+    />
+  );
 }
 
 function isMp4File(file?: FilePreviewFile | string | null) {

--- a/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
+++ b/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
@@ -1,0 +1,187 @@
+import {Image} from '@mantine/core';
+import {useEffect, useRef} from 'preact/hooks';
+
+export interface FilePreviewFile {
+  src?: string;
+  mimeType?: string;
+  [key: string]: any;
+}
+
+export interface FilePreviewProps {
+  file?: FilePreviewFile | string | null;
+  width: number;
+  height: number;
+  withPlaceholder?: boolean;
+  className?: string;
+  alt?: string;
+}
+
+export function FilePreview(props: FilePreviewProps) {
+  const {file, width, height, withPlaceholder, className, alt} = props;
+  const src = typeof file === 'string' ? file : file?.src;
+
+  if (!src) {
+    return (
+      <Image
+        className={className}
+        src={undefined}
+        width={width}
+        height={height}
+        withPlaceholder={withPlaceholder}
+        alt={alt}
+      />
+    );
+  }
+
+  if (!isMp4File(file)) {
+    return (
+      <Image
+        className={className}
+        src={src}
+        width={width}
+        height={height}
+        withPlaceholder={withPlaceholder}
+        alt={alt}
+      />
+    );
+  }
+
+  return (
+    <VideoPreviewCanvas
+      className={className}
+      src={src}
+      width={width}
+      height={height}
+    />
+  );
+}
+
+function isMp4File(file?: FilePreviewFile | string | null) {
+  if (!file) {
+    return false;
+  }
+
+  if (typeof file === 'string') {
+    return /\.mp4($|\?)/i.test(file);
+  }
+
+  if (typeof file.mimeType === 'string') {
+    return file.mimeType.toLowerCase() === 'video/mp4';
+  }
+
+  const src = file.src;
+  if (typeof src !== 'string') {
+    return false;
+  }
+  return /\.mp4($|\?)/i.test(src);
+}
+
+function VideoPreviewCanvas(props: {
+  className?: string;
+  src: string;
+  width: number;
+  height: number;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+
+    context.fillStyle = '#f1f3f5';
+    context.fillRect(0, 0, props.width, props.height);
+
+    const video = document.createElement('video');
+    let cancelled = false;
+
+    const drawFrame = () => {
+      if (cancelled || !context) {
+        return;
+      }
+      const {videoWidth, videoHeight} = video;
+      if (!videoWidth || !videoHeight) {
+        return;
+      }
+      const aspect = videoWidth / videoHeight;
+      let drawWidth = props.width;
+      let drawHeight = props.height;
+
+      if (props.width / props.height > aspect) {
+        drawWidth = props.height * aspect;
+      } else {
+        drawHeight = props.width / aspect;
+      }
+
+      const offsetX = (props.width - drawWidth) / 2;
+      const offsetY = (props.height - drawHeight) / 2;
+
+      context.clearRect(0, 0, props.width, props.height);
+      context.fillStyle = '#f1f3f5';
+      context.fillRect(0, 0, props.width, props.height);
+      context.drawImage(video, offsetX, offsetY, drawWidth, drawHeight);
+    };
+
+    const handleLoadedData = () => {
+      drawFrame();
+    };
+
+    const handleError = () => {
+      if (cancelled || !context) {
+        return;
+      }
+      context.clearRect(0, 0, props.width, props.height);
+      context.fillStyle = '#f1f3f5';
+      context.fillRect(0, 0, props.width, props.height);
+    };
+
+    video.crossOrigin = 'anonymous';
+    video.preload = 'auto';
+    video.muted = true;
+    video.playsInline = true;
+    video.src = props.src;
+    video.addEventListener('loadeddata', handleLoadedData);
+    video.addEventListener('error', handleError);
+    video.load();
+
+    return () => {
+      cancelled = true;
+      video.removeEventListener('loadeddata', handleLoadedData);
+      video.removeEventListener('error', handleError);
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
+    };
+  }, [props.src, props.width, props.height]);
+
+  return (
+    <div
+      className={props.className}
+      style={{
+        width: `${props.width}px`,
+        height: `${props.height}px`,
+        backgroundColor: '#f1f3f5',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        width={props.width}
+        height={props.height}
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'block',
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -1,4 +1,4 @@
-import {Button, Image, Loader, Select, Tabs} from '@mantine/core';
+import {Button, Loader, Select, Tabs} from '@mantine/core';
 import {
   IconArrowRoundaboutRight,
   IconCirclePlus,
@@ -10,6 +10,7 @@ import {route} from 'preact-router';
 
 import {DocActionsMenu} from '../../components/DocActionsMenu/DocActionsMenu.js';
 import {DocStatusBadges} from '../../components/DocStatusBadges/DocStatusBadges.js';
+import {FilePreview} from '../../components/FilePreview/FilePreview.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
 import {NewDocModal} from '../../components/NewDocModal/NewDocModal.js';
@@ -299,8 +300,8 @@ CollectionPage.DocsList = (props: {
           >
             <div className="CollectionPage__collection__docsList__doc__image">
               <a href={cmsUrl}>
-                <Image
-                  src={previewImage?.src}
+                <FilePreview
+                  file={previewImage}
                   width={120}
                   height={90}
                   withPlaceholder={!previewImage?.src}

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -1,13 +1,13 @@
+import './CollectionPage.css';
+
 import {Button, Loader, Select, Tabs} from '@mantine/core';
 import {
   IconArrowRoundaboutRight,
   IconCirclePlus,
   IconFolder,
 } from '@tabler/icons-preact';
-
 import {useEffect, useState} from 'preact/hooks';
 import {route} from 'preact-router';
-
 import {DocActionsMenu} from '../../components/DocActionsMenu/DocActionsMenu.js';
 import {DocStatusBadges} from '../../components/DocStatusBadges/DocStatusBadges.js';
 import {FilePreview} from '../../components/FilePreview/FilePreview.js';
@@ -21,7 +21,6 @@ import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocServingUrl} from '../../utils/doc-urls.js';
 import {getNestedValue} from '../../utils/objects.js';
-import './CollectionPage.css';
 
 interface CollectionPageProps {
   collection?: string;


### PR DESCRIPTION
## Summary
- add a reusable FilePreview component that can render the first frame of mp4 assets on a canvas
- update the collection list and doc preview card to consume the new file preview helper

## Testing
- not run (not requested)

fixes #599

------
https://chatgpt.com/codex/tasks/task_e_68cd7b9c1ba88323952c4dff8e893667