### PR TITLE
feat: fetch doc diff data on server

### DIFF
--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -905,28 +905,14 @@ export function unmarshalArray(arrObject: ArrayObject): any[] {
 }
 
 export async function cmsGetDocDiffSummary(docId: string): Promise<string> {
-  const [publishedDoc, draftDoc] = await Promise.all([
-    cmsReadDocVersion(docId, 'published'),
-    cmsReadDocVersion(docId, 'draft'),
-  ]);
-
-  if (!draftDoc && !publishedDoc) {
-    return '';
-  }
-
-  const payload = {
-    before: publishedDoc
-      ? unmarshalData(publishedDoc.fields || {}, {removeArrayKey: true})
-      : null,
-    after: draftDoc
-      ? unmarshalData(draftDoc.fields || {}, {removeArrayKey: true})
-      : null,
-  };
-
   const res = await window.fetch('/cms/api/ai.diff', {
     method: 'POST',
     headers: {'content-type': 'application/json'},
-    body: JSON.stringify(payload),
+    body: JSON.stringify({
+      docId,
+      beforeVersion: 'published',
+      afterVersion: 'draft',
+    }),
   });
 
   const responseText = await res.text();


### PR DESCRIPTION
## Summary
- fetch draft and published doc data directly in the `ai.diff` API using the CMS client
- trim `_arrayKey` metadata and handle missing docs before summarizing
- send lightweight docId-based requests from the UI when requesting diff summaries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce9f4d25188323a4824a807a84b927