### PR TITLE
chore: add no-cache header to server-side redirects

### DIFF
--- a/.changeset/early-panthers-invent.md
+++ b/.changeset/early-panthers-invent.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+chore: add no-cache header to server-side redirects (#782)

--- a/packages/root/src/middleware/redirects.ts
+++ b/packages/root/src/middleware/redirects.ts
@@ -26,7 +26,10 @@ export function redirectsMiddleware(options: RedirectsMiddlewareOptions) {
     if (redirect) {
       const destination = replaceParams(redirect.destination!, params);
       const code = redirect.type || 302;
-      res.setHeader('cache-control', 'no-cache');
+      res.setHeader(
+        'cache-control',
+        'no-cache, no-store, max-age=0, must-revalidate'
+      );
       res.redirect(code, destination);
       return;
     }


### PR DESCRIPTION
## Summary
- set a no-cache Cache-Control header before issuing server-configured redirects

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa5fb6a40c83239af5bcbff63fe2b9