### PR TITLE
fix: exception handling for collection not found

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ReferenceField.tsx
@@ -106,8 +106,8 @@ ReferenceField.Preview = (props: ReferencePreviewProps) => {
         <ReferenceField.DocCard doc={previewDoc} />
       ) : (
         <div className="ReferenceField__Preview__notfound">
-          Doc Not found: "{props.id}" (was it deleted?). Select a new doc or
-          remove using the trash icon to the right.
+          Doc not found: <b>{props.id}</b> (was it deleted?). Select a new doc
+          or remove using the trash icon to the right.
         </div>
       )}
     </div>

--- a/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
+++ b/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
@@ -56,7 +56,12 @@ export function DocPreviewCard(props: DocPreviewCardProps) {
   const fields = doc.fields || {};
   const rootCollection = window.__ROOT_CTX.collections[collection];
   if (!rootCollection) {
-    throw new Error(`could not find collection: ${collection}`);
+    console.error(`could not find collection: ${collection}`);
+    return (
+      <div className="DocPreviewCard">
+        Collection <b>{collection}</b> not found.
+      </div>
+    );
   }
   const previewTitle = getNestedValue(
     fields,


### PR DESCRIPTION
- Previously, an exception would be thrown and the UI would die, requiring a hard refresh
- Now, we show an error message
- This could happen when a developer adds a field reference to a collection that doesn't yet have a schema defined (either a typo, or when running a content migration)