### PR TITLE
chore: add gap to preview bar device controls

### DIFF
--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -102,6 +102,7 @@
 .DocumentPage__main__previewBar__buttons {
   display: flex;
   align-items: center;
+  gap: 2px;
 }
 
 .DocumentPage__main__previewBar__devices .mantine-Tooltip-root,


### PR DESCRIPTION
## Summary
- add a small gap between the device selector buttons in the document preview bar to keep them visually separated

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691647fd58948323b6e7d3ce11f50cbf)