### PR TITLE
Fix block and inline component modals stacking order

### DIFF
--- a/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/InlineComponentModal.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/InlineComponentModal.tsx
@@ -1,25 +1,30 @@
-import {Button, Group, Modal, Stack, Text, TextInput} from '@mantine/core';
+import {Button, Group, Stack, Text, TextInput} from '@mantine/core';
+import {ContextModalProps, useModals} from '@mantine/modals';
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import * as schema from '../../../../../core/schema.js';
 import {
   DraftDocContext,
   DraftDocContextProvider,
 } from '../../../../hooks/useDraftDoc.js';
+import {useModalTheme} from '../../../../hooks/useModalTheme.js';
 import {cloneData} from '../../../../utils/objects.js';
 import {DocEditor} from '../../../DocEditor/DocEditor.js';
 import {InMemoryDraftDocController} from '../utils/InMemoryDraftDocController.js';
 
-interface InlineComponentModalProps {
+const MODAL_ID = 'InlineComponentModal';
+
+export interface InlineComponentModalProps {
   schema: schema.Schema;
-  opened: boolean;
   componentId: string;
   initialValue: Record<string, any>;
   mode?: 'create' | 'edit';
-  onClose: () => void;
   onSubmit: (value: {componentId: string; data: Record<string, any>}) => void;
 }
 
-export function InlineComponentModal(props: InlineComponentModalProps) {
+export function InlineComponentModal(
+  modalProps: ContextModalProps<InlineComponentModalProps>
+) {
+  const {innerProps: props, context, id} = modalProps;
   const [componentId, setComponentId] = useState(props.componentId);
 
   useEffect(() => {
@@ -55,45 +60,52 @@ export function InlineComponentModal(props: InlineComponentModalProps) {
     const value = controller.getValue('component') || {};
     const clonedValue = cloneData(value);
     props.onSubmit({componentId: componentId.trim(), data: clonedValue});
+    context.closeModal(id);
   };
 
   return (
-    <Modal
-      opened={props.opened}
-      onClose={props.onClose}
-      title={props.schema.label || props.schema.name}
-      size="lg"
-    >
-      <Stack spacing="md">
-        <TextInput
-          label="Component ID"
-          value={componentId}
-          onChange={(event) => setComponentId(event.currentTarget.value)}
-          placeholder="component-id"
-          required
-        />
-        {props.schema.fields.length > 0 ? (
-          <DraftDocContextProvider value={draftContext}>
-            <DocEditor.ObjectField field={objectField} deepKey="component" />
-          </DraftDocContextProvider>
-        ) : (
-          <Text size="sm" color="dimmed">
-            This component does not define any editable fields.
-          </Text>
-        )}
-        <Group position="right" spacing="sm">
-          <Button variant="default" size="xs" onClick={props.onClose}>
-            Cancel
-          </Button>
-          <Button
-            size="xs"
-            onClick={handleSubmit}
-            disabled={!componentId.trim()}
-          >
-            {props.mode === 'edit' ? 'Save component' : 'Insert component'}
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
+    <Stack spacing="md">
+      <TextInput
+        label="Component ID"
+        value={componentId}
+        onChange={(event) => setComponentId(event.currentTarget.value)}
+        placeholder="component-id"
+        required
+      />
+      {props.schema.fields.length > 0 ? (
+        <DraftDocContextProvider value={draftContext}>
+          <DocEditor.ObjectField field={objectField} deepKey="component" />
+        </DraftDocContextProvider>
+      ) : (
+        <Text size="sm" color="dimmed">
+          This component does not define any editable fields.
+        </Text>
+      )}
+      <Group position="right" spacing="sm">
+        <Button variant="default" size="xs" onClick={() => context.closeModal(id)}>
+          Cancel
+        </Button>
+        <Button size="xs" onClick={handleSubmit} disabled={!componentId.trim()}>
+          {props.mode === 'edit' ? 'Save component' : 'Insert component'}
+        </Button>
+      </Group>
+    </Stack>
   );
+}
+
+InlineComponentModal.id = MODAL_ID;
+
+export function useInlineComponentModal() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  return {
+    open: (props: InlineComponentModalProps) =>
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        innerProps: props,
+        size: 'lg',
+        title: props.schema.label || props.schema.name,
+      }),
+    close: () => modals.closeModal(MODAL_ID),
+  };
 }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -39,6 +39,8 @@ import {DocTranslationsPage} from './pages/DocTranslationsPage/DocTranslationsPa
 import {DocumentPage} from './pages/DocumentPage/DocumentPage.js';
 import {EditDataSourcePage} from './pages/EditDataSourcePage/EditDataSourcePage.js';
 import {EditReleasePage} from './pages/EditReleasePage/EditReleasePage.js';
+import {BlockComponentModal} from './components/RichTextEditor/lexical/nodes/BlockComponentModal.js';
+import {InlineComponentModal} from './components/RichTextEditor/lexical/nodes/InlineComponentModal.js';
 import {LogsPage} from './pages/LogsPage/LogsPage.js';
 import {NewDataSourcePage} from './pages/NewDataSourcePage/NewDataSourcePage.js';
 import {NewReleasePage} from './pages/NewReleasePage/NewReleasePage.js';
@@ -125,6 +127,8 @@ function App() {
                     [EditJsonModal.id]: EditJsonModal,
                     [EditTranslationsModal.id]: EditTranslationsModal,
                     [ExportSheetModal.id]: ExportSheetModal,
+                    [BlockComponentModal.id]: BlockComponentModal,
+                    [InlineComponentModal.id]: InlineComponentModal,
                     [LocalizationModal.id]: LocalizationModal,
                     [LockPublishingModal.id]: LockPublishingModal,
                     [PublishDocModal.id]: PublishDocModal,


### PR DESCRIPTION
## Summary
- switch the block and inline component editors to Mantine's modal manager so they stack correctly with other dialogs
- replace the inline modal rendering logic in the lexical editor with hooks that open the managed modals
- register the new modals with the shared ModalsProvider

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e1179fb8832399cd94f216b78b21)