### PR TITLE
fix: add backwards-compatible deprecated caption field to lexical data

### DIFF
--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
@@ -141,6 +141,14 @@ const INSERT_IMAGE_BLOCK = schema.define({
       id: 'file',
       label: 'Image',
     }),
+    // Provides backwards compatibility with EditorJS caption field.
+    schema.string({
+      id: 'caption',
+      label: 'Caption',
+      variant: 'textarea',
+      translate: true,
+      deprecated: true,
+    }),
   ],
 });
 


### PR DESCRIPTION
Looks like this just works to fix https://github.com/blinkk/rootjs/issues/817

I tested swapping back and forth between Editor JS and Lexical and it worked well.

<img width="655" height="452" alt="image" src="https://github.com/user-attachments/assets/d2f16321-582c-469a-9b38-6489a4a5b160" />
