### PR TITLE
chore: update mobile preview dimensions

### DIFF
--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -233,7 +233,7 @@ interface PreviewProps {
 type Device = 'mobile' | 'tablet' | 'desktop' | '';
 
 const DeviceResolution = {
-  mobile: [360, 800],
+  mobile: [430, 932],
   tablet: [768, 1024],
   desktop: [1440, 800],
 };


### PR DESCRIPTION
## Summary
- update the default CMS preview mobile viewport to 430x932 to reflect modern device sizes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0d8501b08323a2c343284a1fc6cd)