### PR TITLE
feat: add button to apply tag to doc's strings

### DIFF
--- a/.changeset/curly-eyes-design.md
+++ b/.changeset/curly-eyes-design.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add button for appending tag to a doc's string


### PR DESCRIPTION
Sometimes translations are imported via doc A and the same strings are used on doc B, but since those translations aren't tagged for doc B, the translations aren't loaded when the page renders.

This change gives content editors a quick way to "sync" all translations available in the system by applying the doc's tags for all strings extracted from the doc.

<img width="2168" height="1402" alt="Screenshot 2026-02-12 at 8 18 24 PM" src="https://github.com/user-attachments/assets/8786936a-cb42-4179-bc40-756c926cb695" />

<img width="2168" height="1402" alt="Screenshot 2026-02-12 at 8 18 30 PM" src="https://github.com/user-attachments/assets/0c8c9495-d25e-49ff-a20c-8bbfadaa8f22" />

fixes #774 