### PR TITLE
chore: improve keyboard/find behavior in doc editor

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -330,6 +330,10 @@
   text-overflow: ellipsis;
 }
 
+.DocEditor__ArrayField__item__header__preview__title::before {
+  content: attr(data-preview);
+}
+
 .DocEditor__ArrayField__item__header__controls {
   flex-shrink: 0;
   display: flex;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -440,6 +440,7 @@ DocEditor.FieldHeader = (props: FieldProps & {className?: string}) => {
             <a
               className="DocEditor__FieldHeader__label__deeplink"
               href={deeplinkUrl}
+              tabIndex={-1}
               title="Link to field"
               onClick={(e) => {
                 e.preventDefault();
@@ -1540,9 +1541,10 @@ DocEditor.ArrayFieldPreview = (props: ArrayFieldPreviewProps) => {
           />
         </div>
       )}
-      <div className="DocEditor__ArrayField__item__header__preview__title">
-        {previewText}
-      </div>
+      <div
+        className="DocEditor__ArrayField__item__header__preview__title"
+        data-preview={previewText}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### Motivation

- Prevent the field deeplink anchor from being included in keyboard tab navigation so it doesn't interrupt tab order. 
- Reduce spurious matches when using browser find (Ctrl+F) on the editor list by moving preview text out of the direct DOM text node.

### Description

- Set the deeplink anchor to `tabIndex={-1}` in `packages/root-cms/ui/components/DocEditor/DocEditor.tsx` so the `#` link is skipped by tab navigation. 
- Render the array item preview title using a `data-preview` attribute (`data-preview={previewText}`) instead of a direct text child in `DocEditor.ArrayFieldPreview`. 
- Add a CSS rule in `packages/root-cms/ui/components/DocEditor/DocEditor.css` that displays the preview via `.DocEditor__ArrayField__item__header__preview__title::before { content: attr(data-preview); }` to preserve visual output while removing the preview from the element's text node.

### Testing

- Ran `git diff` and `git status` to verify the changes were applied and staged, which succeeded. 
- Committed the changes with message `fix(cms): improve keyboard/find behavior in doc editor`, which succeeded. 
- Attempted an automated Playwright page screenshot to validate the UI, but the run failed due to no local web server responding (`net::ERR_EMPTY_RESPONSE`). No other automated tests were run per the request to avoid running tests unless explicitly prompted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e586bb60c8323b33525e643e65553)