### PR TITLE
chore: add publish message to action logs

### DIFF
--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -166,7 +166,11 @@ export async function cmsPublishDocs(
   }
 
   for (const docId of docIds) {
-    logAction('doc.publish', {metadata: {docId}});
+    const metadata: Record<string, unknown> = {docId};
+    if (options?.publishMessage) {
+      metadata.publishMessage = options.publishMessage;
+    }
+    logAction('doc.publish', {metadata});
   }
 
   // Reset doc cache for published docs.

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -123,10 +123,18 @@ export async function publishRelease(id: string) {
   if (dataSourceIds.length > 0) {
     await cmsPublishDataSources(dataSourceIds, {batch, commitBatch: false});
   }
-  await cmsPublishDocs(docIds, {batch, releaseId: id});
+  await cmsPublishDocs(docIds, {
+    batch,
+    releaseId: id,
+    publishMessage: release.description,
+  });
   console.log(`published release: ${id}`);
+  const metadata: Record<string, unknown> = {releaseId: id, docIds, dataSourceIds};
+  if (release.description) {
+    metadata.publishMessage = release.description;
+  }
   logAction('release.publish', {
-    metadata: {releaseId: id, docIds, dataSourceIds},
+    metadata,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Use the release `description` as the publish message for release publishes and remove the external `publishMessage` option from `publishRelease` so action logs consistently reflect the release content.

### Description
- Update `publishRelease` to remove the `options`/`publishMessage` parameter, pass `release.description` as `publishMessage` to `cmsPublishDocs`, and include `release.description` as `publishMessage` in the `release.publish` action metadata.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960ff15a48832387a442e38095f80e)