### PR TITLE
chore: remove "Root CMS" in meta title with minimalBranding

### DIFF
--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -78,6 +78,18 @@ interface RenderOptions {
   cmsConfig: CMSPluginOptions;
 }
 
+function getCmsTitle(projectName: string, minimalBranding?: boolean): string {
+  if (!projectName) {
+    return 'Root CMS';
+  }
+
+  if (minimalBranding) {
+    return projectName;
+  }
+
+  return `${projectName} – Root CMS`;
+}
+
 export async function renderApp(
   req: Request,
   res: Response,
@@ -119,7 +131,7 @@ export async function renderApp(
     },
   };
   const projectName = cmsConfig.name || cmsConfig.id || '';
-  const title = projectName ? `${projectName} – Root CMS` : 'Root CMS';
+  const title = getCmsTitle(projectName, cmsConfig.minimalBranding);
 
   const mainHtml = renderToString(
     <App title={title} ctx={ctx} favicon={cmsConfig.favicon} />


### PR DESCRIPTION
### Motivation
- Improve readability and address inline feedback by moving the nested inline conditional that builds the page `<title>` into a small, explicit helper.

### Description
- Add `getCmsTitle(projectName: string, minimalBranding?: boolean)` to `packages/root-cms/core/app.tsx` and replace the inline nested ternary in `renderApp()` with `getCmsTitle(projectName, cmsConfig.minimalBranding)`, preserving the prior behavior where the title is `'Root CMS'` when no project name is present, the project name alone when `minimalBranding` is true, and `<projectName> – Root CMS` otherwise.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ac87828c8323a17c53b2a41bd9d4)