### PR TITLE
feat: add opt+drag to clone array items in CMS doc editor

### DIFF
--- a/.changeset/opt-drag-clone-array-items.md
+++ b/.changeset/opt-drag-clone-array-items.md
@@ -1,0 +1,5 @@
+---
+"@blinkk/root-cms": patch
+---
+
+Add opt+drag to clone array items in the CMS doc editor.

--- a/docs/scripts/env-init.sh
+++ b/docs/scripts/env-init.sh
@@ -10,10 +10,19 @@ ENV_FILE="$DOCS_DIR/.env"
 PROJECT="rootjs-dev"
 SECRET_NAME="docs-env"
 
-if [[ -f "$ENV_FILE" ]]; then
+if [[ -s "$ENV_FILE" ]]; then
   exit 0
 fi
 
 echo ".env file not found, downloading from Google Secrets Manager..."
-gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT" > "$ENV_FILE"
+ENV_CONTENT="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT")" || {
+  echo "ERROR: Failed to download .env from Google Secrets Manager." >&2
+  echo "Ensure gcloud is installed, you are authenticated, and have access to project '$PROJECT'." >&2
+  exit 1
+}
+if [[ -z "$ENV_CONTENT" ]]; then
+  echo "ERROR: Secret '$SECRET_NAME' returned empty content." >&2
+  exit 1
+fi
+echo "$ENV_CONTENT" > "$ENV_FILE"
 echo "Downloaded .env file."

--- a/packages/root-cms/signin/signin.tsx
+++ b/packages/root-cms/signin/signin.tsx
@@ -153,9 +153,26 @@ function loginSuccessRedirect() {
   window.location.replace(redirectUrl);
 }
 
-const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
-const auth = getAuth(app);
-window.firebase = {app, auth};
-const root = document.getElementById('root')!;
-root.innerHTML = '';
-render(<SignIn />, root);
+try {
+  const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
+  const auth = getAuth(app);
+  window.firebase = {app, auth};
+  const root = document.getElementById('root')!;
+  root.innerHTML = '';
+  render(<SignIn />, root);
+} catch (err) {
+  console.error(err);
+  const root = document.getElementById('root')!;
+  root.innerHTML = '';
+  render(<BootstrapError message={(err as Error).message} />, root);
+}
+
+function BootstrapError(props: {message: string}) {
+  return (
+    <div className="bootstrap">
+      <div className="bootstrap-warning">
+        Something went wrong: {props.message}
+      </div>
+    </div>
+  );
+}

--- a/packages/root-cms/signin/styles/global.css
+++ b/packages/root-cms/signin/styles/global.css
@@ -102,6 +102,18 @@ body.menu\:open {
   padding: 0 24px;
 }
 
+.bootstrap-warning {
+  max-width: 520px;
+  padding: 12px;
+  border: 1px solid #fbbc04;
+  border-radius: 8px;
+  background: #fff9db;
+  color: #5f370e;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 @keyframes bootstrap-loading-error {
   0% {
     opacity: 0;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1439,7 +1439,41 @@ DocEditor.ArrayField = (props: FieldProps) => {
           }
         }}
       >
-        <Droppable droppableId="dnd-list" direction="vertical">
+        <Droppable
+          droppableId="dnd-list"
+          direction="vertical"
+          renderClone={(provided, snapshot, rubric) => {
+            const dragIndex = rubric.source.index;
+            const dragKey = order[dragIndex];
+            return (
+              <div
+                ref={provided.innerRef}
+                {...provided.draggableProps}
+                {...provided.dragHandleProps}
+                className={joinClassNames(
+                  'DocEditor__ArrayField__item__wrapper',
+                  'DocEditor__ArrayField__item__wrapper--dragging'
+                )}
+              >
+                <div className="DocEditor__ArrayField__item__handle">
+                  <IconGripVertical size={18} stroke={'1.5'} />
+                </div>
+                <details className="DocEditor__ArrayField__item">
+                  <summary className="DocEditor__ArrayField__item__header">
+                    <div className="DocEditor__ArrayField__item__header__icon">
+                      <IconTriangleFilled size={6} />
+                    </div>
+                    <DocEditor.ArrayFieldPreview
+                      field={field}
+                      deepKey={`${props.deepKey}.${dragKey}`}
+                      index={dragIndex}
+                    />
+                  </summary>
+                </details>
+              </div>
+            );
+          }}
+        >
           {(provided: DroppableProvided) => (
             <div
               {...provided.droppableProps}
@@ -1450,7 +1484,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
                 return (
                   <Draggable key={key} index={i} draggableId={key}>
                     {(provided, snapshot) => (
-                      <>
                         <div
                           ref={provided.innerRef}
                           {...provided.draggableProps}
@@ -1637,29 +1670,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
                           </div>
                         </details>
                       </div>
-                      {snapshot.isDragging && _cloneDragActive && (
-                        <div
-                          className="DocEditor__ArrayField__item__wrapper"
-                          style={{transform: 'none !important'}}
-                        >
-                          <div className="DocEditor__ArrayField__item__handle">
-                            <IconGripVertical size={18} stroke={'1.5'} />
-                          </div>
-                          <details className="DocEditor__ArrayField__item">
-                            <summary className="DocEditor__ArrayField__item__header">
-                              <div className="DocEditor__ArrayField__item__header__icon">
-                                <IconTriangleFilled size={6} />
-                              </div>
-                              <DocEditor.ArrayFieldPreview
-                                field={field}
-                                deepKey={`${props.deepKey}.${key}`}
-                                index={i}
-                              />
-                            </summary>
-                          </details>
-                        </div>
-                      )}
-                      </>
                     )}
                   </Draggable>
                 );

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -7,69 +7,6 @@ import {
   DroppableProvided,
   DropResult,
 } from '@hello-pangea/dnd';
-
-// Monkeypatch: the @hello-pangea/dnd mouse sensor rejects mousedown events when
-// modifier keys (including Alt/Option) are held. To support Alt+drag for cloning
-// array items, we intercept mousedown at the capture phase *before* the library
-// registers its own listener, and override `altKey` on the event instance.
-//
-// Flow: Alt+mousedown → clone item in state → stopPropagation → after re-render,
-// dispatch a synthetic mousedown so the library starts a normal drag on the
-// original item (which now sits next to its clone).
-let _cloneDragActive = false;
-let _syntheticMousedown = false;
-let _cloneFn: ((index: number) => void) | null = null;
-if (typeof window !== 'undefined') {
-  window.addEventListener(
-    'mousedown',
-    (e: MouseEvent) => {
-      if (_syntheticMousedown) {
-        _syntheticMousedown = false;
-        return;
-      }
-      if (!e.altKey) {
-        _cloneDragActive = false;
-        return;
-      }
-      const target = e.target as Element | null;
-      const handle = target?.closest?.('.DocEditor__ArrayField__item__handle') as HTMLElement | null;
-      if (!handle) return;
-
-      _cloneDragActive = true;
-      e.stopPropagation();
-
-      // Determine which item index was clicked.
-      const wrapper = handle.closest('.DocEditor__ArrayField__item__wrapper');
-      const container = wrapper?.parentElement;
-      if (!wrapper || !container) return;
-      const siblings = container.querySelectorAll(
-        ':scope > .DocEditor__ArrayField__item__wrapper'
-      );
-      const index = Array.from(siblings).indexOf(wrapper);
-      if (index < 0 || !_cloneFn) return;
-
-      // Clone the item in state (inserts duplicate at index + 1).
-      _cloneFn(index);
-
-      // After Preact re-renders, re-dispatch a plain mousedown so the library
-      // picks up a normal drag on the original item.
-      const {clientX, clientY, button} = e;
-      requestAnimationFrame(() => {
-        _syntheticMousedown = true;
-        handle.dispatchEvent(
-          new MouseEvent('mousedown', {
-            bubbles: true,
-            cancelable: true,
-            clientX,
-            clientY,
-            button,
-          })
-        );
-      });
-    },
-    {capture: true}
-  );
-}
 import {
   ActionIcon,
   Button,
@@ -1200,15 +1137,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
     });
   };
 
-  // Register the clone callback so the module-level mousedown handler can
-  // duplicate an item before the drag starts.
-  useEffect(() => {
-    _cloneFn = (index: number) => duplicate(index);
-    return () => {
-      if (_cloneFn) _cloneFn = null;
-    };
-  });
-
   const removeAt = (index: number) => {
     dispatch({
       type: 'removeAt',
@@ -1421,7 +1349,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
     <div className="DocEditor__ArrayField">
       <DragDropContext
         onDragEnd={(result: DropResult) => {
-          _cloneDragActive = false;
           const {source, destination} = result;
           if (!destination) {
             return;
@@ -1435,41 +1362,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
           });
         }}
       >
-        <Droppable
-          droppableId="dnd-list"
-          direction="vertical"
-          renderClone={(provided, snapshot, rubric) => {
-            const dragIndex = rubric.source.index;
-            const dragKey = order[dragIndex];
-            return (
-              <div
-                ref={provided.innerRef}
-                {...provided.draggableProps}
-                {...provided.dragHandleProps}
-                className={joinClassNames(
-                  'DocEditor__ArrayField__item__wrapper',
-                  'DocEditor__ArrayField__item__wrapper--dragging'
-                )}
-              >
-                <div className="DocEditor__ArrayField__item__handle">
-                  <IconGripVertical size={18} stroke={'1.5'} />
-                </div>
-                <details className="DocEditor__ArrayField__item">
-                  <summary className="DocEditor__ArrayField__item__header">
-                    <div className="DocEditor__ArrayField__item__header__icon">
-                      <IconTriangleFilled size={6} />
-                    </div>
-                    <DocEditor.ArrayFieldPreview
-                      field={field}
-                      deepKey={`${props.deepKey}.${dragKey}`}
-                      index={dragIndex}
-                    />
-                  </summary>
-                </details>
-              </div>
-            );
-          }}
-        >
+        <Droppable droppableId="dnd-list" direction="vertical">
           {(provided: DroppableProvided) => (
             <div
               {...provided.droppableProps}
@@ -1494,7 +1387,13 @@ DocEditor.ArrayField = (props: FieldProps) => {
                         <div
                           className="DocEditor__ArrayField__item__handle"
                           {...provided.dragHandleProps}
-                          onClick={() => focusFieldHeader(props.deepKey, i)}
+                          onClick={(e: MouseEvent) => {
+                            if (e.altKey) {
+                              duplicate(i);
+                              return;
+                            }
+                            focusFieldHeader(props.deepKey, i);
+                          }}
                         >
                           <IconGripVertical size={18} stroke={'1.5'} />
                         </div>

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -7,6 +7,29 @@ import {
   DroppableProvided,
   DropResult,
 } from '@hello-pangea/dnd';
+
+// Monkeypatch: the @hello-pangea/dnd mouse sensor rejects mousedown events when
+// modifier keys (including Alt/Option) are held. To support Alt+drag for cloning
+// array items, we intercept mousedown at the capture phase *before* the library
+// registers its own listener, and override `altKey` on the event instance.
+let _cloneDragActive = false;
+if (typeof window !== 'undefined') {
+  window.addEventListener(
+    'mousedown',
+    (e: MouseEvent) => {
+      if (!e.altKey) {
+        _cloneDragActive = false;
+        return;
+      }
+      const target = e.target as Element | null;
+      if (target?.closest?.('.DocEditor__ArrayField__item__handle')) {
+        _cloneDragActive = true;
+        Object.defineProperty(e, 'altKey', {value: false});
+      }
+    },
+    {capture: true}
+  );
+}
 import {
   ActionIcon,
   Button,
@@ -1093,7 +1116,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
   const deeplink = useDeeplink();
   const virtualClipboard = useVirtualClipboard();
   const experiments = window.__ROOT_CTX.experiments || {};
-  const altKeyRef = useRef(false);
 
   const data = value ?? {};
   const order = data._array || [];
@@ -1101,33 +1123,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
   // Keep track of newly-added keys, which should start in the "open" state.
   const newlyAdded = value._new || [];
   const [cutIndex, setCutIndex] = useState<number | null>(null);
-
-  // Track the Alt/Option key state for opt+drag cloning. The drag library
-  // blocks drag initiation when modifier keys are held, so the user must
-  // start dragging first, then hold Alt/Option to clone on drop.
-  useEffect(() => {
-    const onMouseMove = (e: MouseEvent) => {
-      altKeyRef.current = e.altKey;
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Alt') {
-        altKeyRef.current = true;
-      }
-    };
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Alt') {
-        altKeyRef.current = false;
-      }
-    };
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('keydown', onKeyDown, true);
-    window.addEventListener('keyup', onKeyUp, true);
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('keydown', onKeyDown, true);
-      window.removeEventListener('keyup', onKeyUp, true);
-    };
-  }, []);
 
   useDraftDocField(props.deepKey, (newValue: ArrayFieldValue) => {
     dispatch({type: 'update', newValue});
@@ -1424,7 +1419,8 @@ DocEditor.ArrayField = (props: FieldProps) => {
           if (!destination) {
             return;
           }
-          if (altKeyRef.current) {
+          if (_cloneDragActive) {
+            _cloneDragActive = false;
             dispatch({
               type: 'cloneTo',
               fromIndex: source.index,

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -908,6 +908,7 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
         [newKey]: clonedValue,
         _array: order,
         _new: action.skipOpen ? newlyAdded : [...newlyAdded, newKey],
+        _moved: action.skipOpen ? newKey : undefined,
       };
     }
     case 'moveUp': {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -12,20 +12,60 @@ import {
 // modifier keys (including Alt/Option) are held. To support Alt+drag for cloning
 // array items, we intercept mousedown at the capture phase *before* the library
 // registers its own listener, and override `altKey` on the event instance.
+//
+// Flow: Alt+mousedown → clone item in state → stopPropagation → after re-render,
+// dispatch a synthetic mousedown so the library starts a normal drag on the
+// original item (which now sits next to its clone).
 let _cloneDragActive = false;
+let _syntheticMousedown = false;
+let _cloneFn: ((index: number) => void) | null = null;
 if (typeof window !== 'undefined') {
   window.addEventListener(
     'mousedown',
     (e: MouseEvent) => {
+      if (_syntheticMousedown) {
+        _syntheticMousedown = false;
+        return;
+      }
       if (!e.altKey) {
         _cloneDragActive = false;
         return;
       }
       const target = e.target as Element | null;
-      if (target?.closest?.('.DocEditor__ArrayField__item__handle')) {
-        _cloneDragActive = true;
-        Object.defineProperty(e, 'altKey', {value: false});
-      }
+      const handle = target?.closest?.('.DocEditor__ArrayField__item__handle') as HTMLElement | null;
+      if (!handle) return;
+
+      _cloneDragActive = true;
+      e.stopPropagation();
+
+      // Determine which item index was clicked.
+      const wrapper = handle.closest('.DocEditor__ArrayField__item__wrapper');
+      const container = wrapper?.parentElement;
+      if (!wrapper || !container) return;
+      const siblings = container.querySelectorAll(
+        ':scope > .DocEditor__ArrayField__item__wrapper'
+      );
+      const index = Array.from(siblings).indexOf(wrapper);
+      if (index < 0 || !_cloneFn) return;
+
+      // Clone the item in state (inserts duplicate at index + 1).
+      _cloneFn(index);
+
+      // After Preact re-renders, re-dispatch a plain mousedown so the library
+      // picks up a normal drag on the original item.
+      const {clientX, clientY, button} = e;
+      requestAnimationFrame(() => {
+        _syntheticMousedown = true;
+        handle.dispatchEvent(
+          new MouseEvent('mousedown', {
+            bubbles: true,
+            cancelable: true,
+            clientX,
+            clientY,
+            button,
+          })
+        );
+      });
     },
     {capture: true}
   );
@@ -807,14 +847,6 @@ interface ArrayMoveTo {
   deepKey: string;
 }
 
-interface ArrayCloneTo {
-  type: 'cloneTo';
-  fromIndex: number;
-  toIndex: number;
-  draft: DraftDocController;
-  deepKey: string;
-}
-
 interface ArrayRemoveAt {
   type: 'removeAt';
   index: number;
@@ -840,7 +872,6 @@ interface ArrayPasteBefore {
 
 type ArrayAction =
   | ArrayAdd
-  | ArrayCloneTo
   | ArrayDuplicate
   | ArrayInsertAfter
   | ArrayInsertBefore
@@ -994,40 +1025,6 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
         ...data,
         _array: order,
         _moved: itemKey,
-      };
-    }
-    case 'cloneTo': {
-      const data = state ?? {};
-      const order = [...(data._array || [])];
-      if (
-        action.fromIndex < 0 ||
-        action.fromIndex >= order.length ||
-        action.toIndex < 0 ||
-        action.toIndex >= order.length
-      ) {
-        console.error('Invalid cloneTo index', action);
-        return state;
-      }
-      const sourceKey = order[action.fromIndex];
-      const clonedValue = structuredClone(data[sourceKey] || {});
-      const newKey = autokey();
-      // Adjust insert index: the drag library reports toIndex assuming the
-      // source was removed. Since we keep the source, shift by 1 when
-      // dragging downward.
-      const insertIndex =
-        action.fromIndex < action.toIndex
-          ? action.toIndex + 1
-          : action.toIndex;
-      order.splice(insertIndex, 0, newKey);
-      action.draft.updateKeys({
-        [`${action.deepKey}._array`]: order,
-        [`${action.deepKey}.${newKey}`]: clonedValue,
-      });
-      return {
-        ...data,
-        [newKey]: clonedValue,
-        _array: order,
-        _pasted: newKey,
       };
     }
     case 'removeAt': {
@@ -1202,6 +1199,15 @@ DocEditor.ArrayField = (props: FieldProps) => {
       value: getItemValue(index),
     });
   };
+
+  // Register the clone callback so the module-level mousedown handler can
+  // duplicate an item before the drag starts.
+  useEffect(() => {
+    _cloneFn = (index: number) => duplicate(index);
+    return () => {
+      if (_cloneFn) _cloneFn = null;
+    };
+  });
 
   const removeAt = (index: number) => {
     dispatch({
@@ -1415,28 +1421,18 @@ DocEditor.ArrayField = (props: FieldProps) => {
     <div className="DocEditor__ArrayField">
       <DragDropContext
         onDragEnd={(result: DropResult) => {
+          _cloneDragActive = false;
           const {source, destination} = result;
           if (!destination) {
             return;
           }
-          if (_cloneDragActive) {
-            _cloneDragActive = false;
-            dispatch({
-              type: 'cloneTo',
-              fromIndex: source.index,
-              toIndex: destination.index,
-              draft,
-              deepKey: props.deepKey,
-            });
-          } else {
-            dispatch({
-              type: 'moveTo',
-              fromIndex: source.index,
-              toIndex: destination.index,
-              draft,
-              deepKey: props.deepKey,
-            });
-          }
+          dispatch({
+            type: 'moveTo',
+            fromIndex: source.index,
+            toIndex: destination.index,
+            draft,
+            deepKey: props.deepKey,
+          });
         }}
       >
         <Droppable

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -760,6 +760,7 @@ interface ArrayDuplicate {
   draft: DraftDocController;
   deepKey: string;
   value: ArrayItemValue;
+  skipOpen?: boolean;
 }
 
 interface ArrayMoveUp {
@@ -906,7 +907,7 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
         ...data,
         [newKey]: clonedValue,
         _array: order,
-        _new: [...newlyAdded, newKey],
+        _new: action.skipOpen ? newlyAdded : [...newlyAdded, newKey],
       };
     }
     case 'moveUp': {
@@ -1389,7 +1390,14 @@ DocEditor.ArrayField = (props: FieldProps) => {
                           {...provided.dragHandleProps}
                           onClick={(e: MouseEvent) => {
                             if (e.altKey) {
-                              duplicate(i);
+                              dispatch({
+                                type: 'duplicate',
+                                draft,
+                                deepKey: props.deepKey,
+                                index: i,
+                                value: getItemValue(i),
+                                skipOpen: true,
+                              });
                               return;
                             }
                             focusFieldHeader(props.deepKey, i);

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1450,17 +1450,18 @@ DocEditor.ArrayField = (props: FieldProps) => {
                 return (
                   <Draggable key={key} index={i} draggableId={key}>
                     {(provided, snapshot) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        className={joinClassNames(
-                          'DocEditor__ArrayField__item__wrapper',
-                          snapshot.isDragging &&
-                            'DocEditor__ArrayField__item__wrapper--dragging',
-                          cutIndex === i &&
-                            'DocEditor__ArrayField__item__wrapper--cut'
-                        )}
-                      >
+                      <>
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          className={joinClassNames(
+                            'DocEditor__ArrayField__item__wrapper',
+                            snapshot.isDragging &&
+                              'DocEditor__ArrayField__item__wrapper--dragging',
+                            cutIndex === i &&
+                              'DocEditor__ArrayField__item__wrapper--cut'
+                          )}
+                        >
                         <div
                           className="DocEditor__ArrayField__item__handle"
                           {...provided.dragHandleProps}
@@ -1636,6 +1637,29 @@ DocEditor.ArrayField = (props: FieldProps) => {
                           </div>
                         </details>
                       </div>
+                      {snapshot.isDragging && _cloneDragActive && (
+                        <div
+                          className="DocEditor__ArrayField__item__wrapper"
+                          style={{transform: 'none !important'}}
+                        >
+                          <div className="DocEditor__ArrayField__item__handle">
+                            <IconGripVertical size={18} stroke={'1.5'} />
+                          </div>
+                          <details className="DocEditor__ArrayField__item">
+                            <summary className="DocEditor__ArrayField__item__header">
+                              <div className="DocEditor__ArrayField__item__header__icon">
+                                <IconTriangleFilled size={6} />
+                              </div>
+                              <DocEditor.ArrayFieldPreview
+                                field={field}
+                                deepKey={`${props.deepKey}.${key}`}
+                                index={i}
+                              />
+                            </summary>
+                          </details>
+                        </div>
+                      )}
+                      </>
                     )}
                   </Draggable>
                 );

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1102,7 +1102,13 @@ DocEditor.ArrayField = (props: FieldProps) => {
   const newlyAdded = value._new || [];
   const [cutIndex, setCutIndex] = useState<number | null>(null);
 
+  // Track the Alt/Option key state for opt+drag cloning. The drag library
+  // blocks drag initiation when modifier keys are held, so the user must
+  // start dragging first, then hold Alt/Option to clone on drop.
   useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      altKeyRef.current = e.altKey;
+    };
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Alt') {
         altKeyRef.current = true;
@@ -1113,11 +1119,13 @@ DocEditor.ArrayField = (props: FieldProps) => {
         altKeyRef.current = false;
       }
     };
-    window.addEventListener('keydown', onKeyDown);
-    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keyup', onKeyUp, true);
     return () => {
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('keyup', onKeyUp, true);
     };
   }, []);
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -784,6 +784,14 @@ interface ArrayMoveTo {
   deepKey: string;
 }
 
+interface ArrayCloneTo {
+  type: 'cloneTo';
+  fromIndex: number;
+  toIndex: number;
+  draft: DraftDocController;
+  deepKey: string;
+}
+
 interface ArrayRemoveAt {
   type: 'removeAt';
   index: number;
@@ -809,6 +817,7 @@ interface ArrayPasteBefore {
 
 type ArrayAction =
   | ArrayAdd
+  | ArrayCloneTo
   | ArrayDuplicate
   | ArrayInsertAfter
   | ArrayInsertBefore
@@ -964,6 +973,40 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
         _moved: itemKey,
       };
     }
+    case 'cloneTo': {
+      const data = state ?? {};
+      const order = [...(data._array || [])];
+      if (
+        action.fromIndex < 0 ||
+        action.fromIndex >= order.length ||
+        action.toIndex < 0 ||
+        action.toIndex >= order.length
+      ) {
+        console.error('Invalid cloneTo index', action);
+        return state;
+      }
+      const sourceKey = order[action.fromIndex];
+      const clonedValue = structuredClone(data[sourceKey] || {});
+      const newKey = autokey();
+      // Adjust insert index: the drag library reports toIndex assuming the
+      // source was removed. Since we keep the source, shift by 1 when
+      // dragging downward.
+      const insertIndex =
+        action.fromIndex < action.toIndex
+          ? action.toIndex + 1
+          : action.toIndex;
+      order.splice(insertIndex, 0, newKey);
+      action.draft.updateKeys({
+        [`${action.deepKey}._array`]: order,
+        [`${action.deepKey}.${newKey}`]: clonedValue,
+      });
+      return {
+        ...data,
+        [newKey]: clonedValue,
+        _array: order,
+        _pasted: newKey,
+      };
+    }
     case 'removeAt': {
       const data = {...(state ?? {})};
       const order = data._array || [];
@@ -1050,6 +1093,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
   const deeplink = useDeeplink();
   const virtualClipboard = useVirtualClipboard();
   const experiments = window.__ROOT_CTX.experiments || {};
+  const altKeyRef = useRef(false);
 
   const data = value ?? {};
   const order = data._array || [];
@@ -1057,6 +1101,25 @@ DocEditor.ArrayField = (props: FieldProps) => {
   // Keep track of newly-added keys, which should start in the "open" state.
   const newlyAdded = value._new || [];
   const [cutIndex, setCutIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') {
+        altKeyRef.current = true;
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') {
+        altKeyRef.current = false;
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
 
   useDraftDocField(props.deepKey, (newValue: ArrayFieldValue) => {
     dispatch({type: 'update', newValue});
@@ -1353,13 +1416,23 @@ DocEditor.ArrayField = (props: FieldProps) => {
           if (!destination) {
             return;
           }
-          dispatch({
-            type: 'moveTo',
-            fromIndex: source.index,
-            toIndex: destination.index,
-            draft,
-            deepKey: props.deepKey,
-          });
+          if (altKeyRef.current) {
+            dispatch({
+              type: 'cloneTo',
+              fromIndex: source.index,
+              toIndex: destination.index,
+              draft,
+              deepKey: props.deepKey,
+            });
+          } else {
+            dispatch({
+              type: 'moveTo',
+              fromIndex: source.index,
+              toIndex: destination.index,
+              draft,
+              deepKey: props.deepKey,
+            });
+          }
         }}
       >
         <Droppable droppableId="dnd-list" direction="vertical">

--- a/packages/root-cms/ui/styles/global.css
+++ b/packages/root-cms/ui/styles/global.css
@@ -108,6 +108,18 @@ body.menu\:open {
   padding: 0 24px;
 }
 
+.bootstrap-warning {
+  max-width: 520px;
+  padding: 12px;
+  border: 1px solid #fbbc04;
+  border-radius: 8px;
+  background: #fff9db;
+  color: #5f370e;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -176,7 +176,12 @@ declare global {
         channel: true | false | 'to-preview' | 'from-preview';
       };
       /** Checks registered via the CMS plugin config. */
-      checks?: Array<{id: string; label: string; description?: string; collections?: string[]}>;
+      checks?: Array<{
+        id: string;
+        label: string;
+        description?: string;
+        collections?: string[];
+      }>;
     };
     firebase: FirebaseContextObject;
   }
@@ -316,35 +321,52 @@ function registerDevServerRedirectShortcut() {
 
 registerDevServerRedirectShortcut();
 
-const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
-const databaseId = window.__ROOT_CTX.firebaseConfig.databaseId || '(default)';
-// const db = getFirestore(app);
-// NOTE(stevenle): the firestore web channel rpc sometimes has issues in
-// collections with a large number of docs. Forcing long polling and disabling
-// fetch streams seems to work for some people. This may cause performance
-// issues however.
-const db = initializeFirestore(
-  app,
-  {
-    experimentalForceLongPolling: true,
-    useFetchStreams: false,
-  } as any,
-  databaseId
-);
-const auth = getAuth(app);
-const storage = getStorage(app);
-auth.onAuthStateChanged((user) => {
-  if (!user) {
-    loginRedirect();
-    return;
-  }
-  window.firebase = {app, auth, db, storage, user};
+try {
+  const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
+  const databaseId = window.__ROOT_CTX.firebaseConfig.databaseId || '(default)';
+  // const db = getFirestore(app);
+  // NOTE(stevenle): the firestore web channel rpc sometimes has issues in
+  // collections with a large number of docs. Forcing long polling and disabling
+  // fetch streams seems to work for some people. This may cause performance
+  // issues however.
+  const db = initializeFirestore(
+    app,
+    {
+      experimentalForceLongPolling: true,
+      useFetchStreams: false,
+    } as any,
+    databaseId
+  );
+  const auth = getAuth(app);
+  const storage = getStorage(app);
+  auth.onAuthStateChanged((user) => {
+    if (!user) {
+      loginRedirect();
+      return;
+    }
+    window.firebase = {app, auth, db, storage, user};
+    const root = document.getElementById('root')!;
+    root.innerHTML = '';
+    render(<App />, root);
+
+    updateSession(user);
+  });
+} catch (err) {
+  console.error(err);
   const root = document.getElementById('root')!;
   root.innerHTML = '';
-  render(<App />, root);
+  render(<BootstrapError message={(err as Error).message} />, root);
+}
 
-  updateSession(user);
-});
+function BootstrapError(props: {message: string}) {
+  return (
+    <div className="bootstrap">
+      <div className="bootstrap-warning">
+        Something went wrong: {props.message}
+      </div>
+    </div>
+  );
+}
 
 async function updateSession(user: User) {
   const idToken = await user.getIdToken();


### PR DESCRIPTION
Adds the ability to hold Option (Alt) while dragging array items in the CMS doc editor to clone them instead of moving them.

## Changes

- Track Alt/Option key state via a ref in the `ArrayField` component
- On drag end, if Alt is held, dispatch a new `cloneTo` action instead of `moveTo`
- The `cloneTo` reducer action deep-clones the dragged item's data and inserts it at the drop position while keeping the original in place