### PR TITLE
fix: dedupe version history entries for published docs

### DIFF
--- a/packages/root-cms/core/versions.ts
+++ b/packages/root-cms/core/versions.ts
@@ -38,6 +38,7 @@ interface PartialCMSDoc {
   sys: {
     modifiedAt: Timestamp;
     modifiedBy: string;
+    publishedAt?: Timestamp;
   };
 }
 
@@ -69,7 +70,17 @@ export class VersionsService {
     const now = Timestamp.now().toMillis();
     const versions = changedDocs.filter((doc) => {
       const modifiedAt = doc.sys.modifiedAt.toMillis();
-      return modifiedAt <= now - DOCUMENT_SAVE_OFFSET;
+      if (modifiedAt > now - DOCUMENT_SAVE_OFFSET) {
+        return false;
+      }
+      // Skip docs where the last modification was from a publish action.
+      // Publishing already saves a version snapshot, so the cron job
+      // doesn't need to save another one.
+      const publishedAt = doc.sys.publishedAt?.toMillis?.();
+      if (publishedAt && Math.abs(publishedAt - modifiedAt) < 5000) {
+        return false;
+      }
+      return true;
     });
     if (versions.length > 0) {
       this.saveVersionsToFirestore(versions);


### PR DESCRIPTION
When a doc is published from the UI, both `modifiedAt` and `publishedAt`
are set to `serverTimestamp()`, and a version snapshot is saved. The cron
job then picks up the doc (due to the updated `modifiedAt`) and saves a
second version of the same state. Skip docs in the cron where
`publishedAt ≈ modifiedAt` (within 5s) since publishing already saved
a version.

https://claude.ai/code/session_011JTm5bTcF6vp8RWP89ZYbp