### PR TITLE
fix: improve ssg build concurrency

### DIFF
--- a/.changeset/fair-dogs-wave.md
+++ b/.changeset/fair-dogs-wave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: improve ssg build concurrency

--- a/packages/root/src/utils/batch.ts
+++ b/packages/root/src/utils/batch.ts
@@ -1,14 +1,22 @@
 export async function batchAsyncCalls<T, U>(
   data: T[],
-  batchSize: number,
+  concurrency: number,
   asyncFunction: (item: T) => Promise<U>
 ): Promise<U[]> {
-  const result: U[] = [];
-  const batches = Math.ceil(data.length / batchSize);
-  for (let i = 0; i < batches; i++) {
-    const batch = data.slice(i * batchSize, (i + 1) * batchSize);
-    const batchResults = await Promise.all(batch.map(asyncFunction));
-    result.push(...batchResults);
+  const result: U[] = new Array(data.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < data.length) {
+      const index = nextIndex++;
+      result[index] = await asyncFunction(data[index]);
+    }
   }
+
+  const workers = Array.from(
+    {length: Math.min(concurrency, data.length)},
+    () => worker()
+  );
+  await Promise.all(workers);
   return result;
 }


### PR DESCRIPTION
**Problem:** `batchAsyncCalls` used a **fixed-batch** pattern — it started N items, waited for ALL N to complete, then started the next N. This explains the "renders 5-10 quickly then pauses" behavior: if even one page in a batch is slow (e.g., slow `getStaticProps`, `htmlPretty`, or `htmlMinify`), the remaining workers sit idle until the slowest one finishes.

**Fix:** Replaced with a **worker-pool** pattern. Instead of processing in discrete batches, it spawns N concurrent workers that each pull the next item from a shared queue as soon as they finish their current item. This keeps all workers busy at all times — no more waiting for the slowest page in a batch.