### PR TITLE
fix: default groups to open state when first added

### DIFF
--- a/packages/root-cms/ui/components/CollectionTree/CollectionTree.tsx
+++ b/packages/root-cms/ui/components/CollectionTree/CollectionTree.tsx
@@ -20,10 +20,10 @@ interface CollectionTreeProps {
 
 export function CollectionTree(props: CollectionTreeProps) {
   const {collections, activeCollectionId, query = '', projectId} = props;
-  const [openGroups, setOpenGroups] = useLocalStorage<string[]>(
-    `root-cms::${projectId}::open_groups`,
-    // Default to having "Default" group open.
-    ['group:Default']
+  // Track closed groups instead of open groups so that new groups default to open.
+  const [closedGroups, setClosedGroups] = useLocalStorage<string[]>(
+    `root-cms::${projectId}::closed_groups`,
+    []
   );
 
   const collectionTree = useMemo(
@@ -37,11 +37,11 @@ export function CollectionTree(props: CollectionTreeProps) {
 
   const handleAccordionChange = (groupId: string, isOpen: boolean) => {
     if (isOpen) {
-      if (!openGroups.includes(groupId)) {
-        setOpenGroups([...openGroups, groupId]);
-      }
+      setClosedGroups(closedGroups.filter((id) => id !== groupId));
     } else {
-      setOpenGroups(openGroups.filter((id) => id !== groupId));
+      if (!closedGroups.includes(groupId)) {
+        setClosedGroups([...closedGroups, groupId]);
+      }
     }
   };
 
@@ -50,7 +50,7 @@ export function CollectionTree(props: CollectionTreeProps) {
     depth: number,
     label: ComponentChildren
   ) => {
-    const isOpen = openGroups.includes(node.id);
+    const isOpen = !closedGroups.includes(node.id);
 
     return (
       <div


### PR DESCRIPTION
## Summary
Refactored the CollectionTree component to track closed groups instead of open groups. This change improves the default behavior so that new groups automatically appear open without requiring explicit configuration.

## Key Changes
- Changed state from `openGroups` to `closedGroups` with inverted logic
- Updated localStorage key from `open_groups` to `closed_groups`
- Changed default state from `['group:Default']` to `[]` (empty array)
- Inverted the `isOpen` check from `openGroups.includes(node.id)` to `!closedGroups.includes(node.id)`
- Simplified the accordion change handler to filter out closed groups when opening and add to closed groups when closing

## Implementation Details
This approach provides a better user experience because:
- New groups that don't exist in the closed groups list will default to open
- Only groups explicitly closed by the user are tracked in state
- Eliminates the need to maintain a hardcoded list of groups that should be open by default

https://claude.ai/code/session_015qVTE1Y44n56EkxevkXiG7