### PR TITLE
feat: add ability to archive docs

### DIFF
--- a/.changeset/nervous-peas-know.md
+++ b/.changeset/nervous-peas-know.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add ability to archive docs #1032

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
@@ -439,13 +439,15 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
           Unarchive
         </Menu.Item>
       ) : (
-        <Menu.Item
-          icon={<IconArchive size={20} />}
-          onClick={() => onArchiveDoc()}
-          disabled={!canEdit}
-        >
-          Archive
-        </Menu.Item>
+        !sys.publishedAt && (
+          <Menu.Item
+            icon={<IconArchive size={20} />}
+            onClick={() => onArchiveDoc()}
+            disabled={!canEdit}
+          >
+            Archive
+          </Menu.Item>
+        )
       )}
       <Menu.Item
         icon={<IconTrash size={20} />}

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
@@ -69,6 +69,7 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
   const docId = props.docId;
   const data = (props.data || {}) as CMSDoc;
   const sys = data.sys || {};
+  const isArchived = testIsArchived(data);
   const modals = useModals();
   const copyDocModal = useCopyDocModal({fromDocId: docId});
   const modalTheme = useModalTheme();
@@ -358,13 +359,15 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
         </ActionIcon>
       }
     >
-      <Menu.Item
-        icon={<IconPackage size={20} />}
-        onClick={() => addToReleaseModal.open()}
-        disabled={!canPublish}
-      >
-        Add to release
-      </Menu.Item>
+      {!isArchived && (
+        <Menu.Item
+          icon={<IconPackage size={20} />}
+          onClick={() => addToReleaseModal.open()}
+          disabled={!canPublish}
+        >
+          Add to release
+        </Menu.Item>
+      )}
       <Menu.Item
         icon={<IconHistory size={20} />}
         onClick={() => versionHistoryModal.open()}
@@ -378,7 +381,8 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
       >
         Copy
       </Menu.Item>
-      {sys.modifiedAt &&
+      {!isArchived &&
+        sys.modifiedAt &&
         sys.publishedAt &&
         sys.modifiedAt > sys.publishedAt && (
           <Menu.Item
@@ -389,7 +393,7 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
             Discard draft edits
           </Menu.Item>
         )}
-      {sys.firstPublishedAt && (
+      {!isArchived && sys.firstPublishedAt && (
         <Menu.Item
           icon={<IconCloudOff size={20} />}
           onClick={() => onUnpublishDoc()}
@@ -398,7 +402,7 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
           Unpublish
         </Menu.Item>
       )}
-      {sys.scheduledAt && (
+      {!isArchived && sys.scheduledAt && (
         <Menu.Item
           icon={<IconAlarmOff size={20} />}
           onClick={() => onUnscheduleDoc()}
@@ -407,30 +411,31 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
           Unschedule
         </Menu.Item>
       )}
-      {testPublishingLocked(data) ? (
-        <Menu.Item
-          icon={<IconLockOpen size={20} />}
-          onClick={() =>
-            lockPublishingModal.open({unlock: true, onChange: onLockChanged})
-          }
-          disabled={!canEdit}
-        >
-          Unlock publishing
-        </Menu.Item>
-      ) : (
-        <Menu.Item
-          icon={<IconLock size={20} />}
-          onClick={() =>
-            lockPublishingModal.open({unlock: false, onChange: onLockChanged})
-          }
-          // Prevent "publishing lock" if the doc has an existing scheduled
-          // publish.
-          disabled={!canEdit || testIsScheduled(data)}
-        >
-          Lock publishing
-        </Menu.Item>
-      )}
-      {testIsArchived(data) ? (
+      {!isArchived &&
+        (testPublishingLocked(data) ? (
+          <Menu.Item
+            icon={<IconLockOpen size={20} />}
+            onClick={() =>
+              lockPublishingModal.open({unlock: true, onChange: onLockChanged})
+            }
+            disabled={!canEdit}
+          >
+            Unlock publishing
+          </Menu.Item>
+        ) : (
+          <Menu.Item
+            icon={<IconLock size={20} />}
+            onClick={() =>
+              lockPublishingModal.open({unlock: false, onChange: onLockChanged})
+            }
+            // Prevent "publishing lock" if the doc has an existing scheduled
+            // publish.
+            disabled={!canEdit || testIsScheduled(data)}
+          >
+            Lock publishing
+          </Menu.Item>
+        ))}
+      {isArchived ? (
         <Menu.Item
           icon={<IconArchiveOff size={20} />}
           onClick={() => onUnarchiveDoc()}

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
@@ -3,6 +3,8 @@ import {useModals} from '@mantine/modals';
 import {showNotification, updateNotification} from '@mantine/notifications';
 import {
   IconAlarmOff,
+  IconArchive,
+  IconArchiveOff,
   IconArrowBack,
   IconCloudOff,
   IconCopy,
@@ -17,10 +19,13 @@ import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {
   CMSDoc,
+  cmsArchiveDoc,
   cmsDeleteDoc,
   cmsRevertDraft,
+  cmsUnarchiveDoc,
   cmsUnpublishDoc,
   cmsUnscheduleDoc,
+  testIsArchived,
   testIsScheduled,
   testPublishingLocked,
 } from '../../utils/doc.js';
@@ -36,9 +41,11 @@ import './DocActionsMenu.css';
 
 export interface DocActionEvent {
   action:
+    | 'archive'
     | 'copy'
     | 'delete'
     | 'revert-draft'
+    | 'unarchive'
     | 'unpublish'
     | 'unschedule'
     | 'locked'
@@ -222,6 +229,76 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
     });
   };
 
+  const onArchiveDoc = () => {
+    const notificationId = `archive-doc-${docId}`;
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: `Archive ${docId}`,
+      children: (
+        <>
+          <Text
+            size="body-sm"
+            weight="semi-bold"
+            className="DocActionsMenu__confirmText"
+          >
+            Are you sure you want to archive the following doc? Archived docs
+            are hidden from the collection list by default but can be restored
+            later.
+          </Text>
+          <DocIdBadge docId={docId} />
+        </>
+      ),
+      labels: {confirm: 'Archive', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      onCancel: () => console.log('Cancel'),
+      closeOnConfirm: false,
+      onConfirm: async () => {
+        showNotification({
+          id: notificationId,
+          title: 'Archiving doc',
+          message: `Requesting archive of ${docId}...`,
+          loading: true,
+          autoClose: false,
+        });
+        await cmsArchiveDoc(docId);
+        updateNotification({
+          id: notificationId,
+          title: 'Archived!',
+          message: `Successfully archived ${docId}!`,
+          loading: false,
+          autoClose: 5000,
+        });
+        modals.closeModal(modalId);
+        if (props.onAction) {
+          props.onAction({action: 'archive'});
+        }
+      },
+    });
+  };
+
+  const onUnarchiveDoc = async () => {
+    const notificationId = `unarchive-doc-${docId}`;
+    showNotification({
+      id: notificationId,
+      title: 'Unarchiving doc',
+      message: `Requesting unarchive of ${docId}...`,
+      loading: true,
+      autoClose: false,
+    });
+    await cmsUnarchiveDoc(docId);
+    updateNotification({
+      id: notificationId,
+      title: 'Unarchived!',
+      message: `Successfully unarchived ${docId}!`,
+      loading: false,
+      autoClose: 5000,
+    });
+    if (props.onAction) {
+      props.onAction({action: 'unarchive'});
+    }
+  };
+
   const onDeleteDoc = () => {
     const notificationId = `delete-doc-${docId}`;
     const modalId = modals.openConfirmModal({
@@ -351,6 +428,23 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
           disabled={!canEdit || testIsScheduled(data)}
         >
           Lock publishing
+        </Menu.Item>
+      )}
+      {testIsArchived(data) ? (
+        <Menu.Item
+          icon={<IconArchiveOff size={20} />}
+          onClick={() => onUnarchiveDoc()}
+          disabled={!canEdit}
+        >
+          Unarchive
+        </Menu.Item>
+      ) : (
+        <Menu.Item
+          icon={<IconArchive size={20} />}
+          onClick={() => onArchiveDoc()}
+          disabled={!canEdit}
+        >
+          Archive
         </Menu.Item>
       )}
       <Menu.Item

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -86,6 +86,20 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           </Badge>
         </Tooltip>
       )}
+      {!!sys.archivedAt && (
+        <Tooltip
+          {...tooltipProps}
+          label={`Archived ${timeDiff(sys.archivedAt)} by ${sys.archivedBy}`}
+        >
+          <Badge
+            size="xs"
+            variant="gradient"
+            gradient={{from: 'gray', to: 'dark'}}
+          >
+            Archived
+          </Badge>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/packages/root-cms/ui/hooks/useDocsList.ts
+++ b/packages/root-cms/ui/hooks/useDocsList.ts
@@ -11,13 +11,26 @@ import {setDocToCache} from '../utils/doc-cache.js';
 import {notifyErrors} from '../utils/notifications.js';
 import {useFirebase} from './useFirebase.js';
 
-export function useDocsList(collectionId: string, options: {orderBy: string}) {
+export interface UseDocsListOptions {
+  orderBy: string;
+  /**
+   * When true, archived docs are included in the results. Defaults to false,
+   * meaning archived docs are filtered out.
+   */
+  includeArchived?: boolean;
+}
+
+export function useDocsList(
+  collectionId: string,
+  options: UseDocsListOptions
+) {
   const [docs, setDocs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const firebase = useFirebase();
   const db = firebase.db;
 
   const projectId = window.__ROOT_CTX.rootConfig.projectId || 'default';
+  const includeArchived = options.includeArchived ?? false;
 
   const listDocs = async () => {
     setLoading(true);
@@ -63,8 +76,12 @@ export function useDocsList(collectionId: string, options: {orderBy: string}) {
           id: docId,
           slug: slug,
         };
-        docs.push(docData);
+        // Always cache the doc, regardless of archive state.
         setDocToCache(docId, docData);
+        if (!includeArchived && (docData as any)?.sys?.archivedAt) {
+          return;
+        }
+        docs.push(docData);
       });
       setDocs(docs);
     });
@@ -74,7 +91,7 @@ export function useDocsList(collectionId: string, options: {orderBy: string}) {
   useEffect(() => {
     setLoading(true);
     listDocs();
-  }, [collectionId, options.orderBy]);
+  }, [collectionId, options.orderBy, includeArchived]);
 
   return [loading, listDocs, docs] as const;
 }

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -120,6 +120,11 @@
   align-items: center;
 }
 
+.CollectionPage__collection__docsTab__controls__showArchived {
+  display: flex;
+  align-items: center;
+}
+
 .CollectionPage__collection__docsTab__controls__sort__label {
   font-weight: 600;
 }

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -176,7 +176,8 @@ CollectionPage.Collection = (props: CollectionProps) => {
                   <div className="CollectionPage__collection__docsTab__controls">
                     <div className="CollectionPage__collection__docsTab__controls__showArchived">
                       <Switch
-                        size="xs"
+                        size="sm"
+                        color="dark"
                         label="Show archived"
                         checked={showArchived}
                         onChange={(e: any) =>

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -1,6 +1,6 @@
 import './CollectionPage.css';
 
-import {Button, Loader, Select, Tabs, Tooltip} from '@mantine/core';
+import {Button, Loader, Select, Switch, Tabs, Tooltip} from '@mantine/core';
 import {IconArrowRoundaboutRight, IconCirclePlus} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
@@ -117,6 +117,10 @@ CollectionPage.Collection = (props: CollectionProps) => {
     `root::CollectionPage:${props.collection}:orderBy`,
     'modifiedAt'
   );
+  const [showArchived, setShowArchived] = useLocalStorage<boolean>(
+    `root::CollectionPage:${props.collection}:showArchived`,
+    false
+  );
   const [newDocModalOpen, setNewDocModalOpen] = useState(false);
 
   const collection = window.__ROOT_CTX.collections[props.collection];
@@ -137,7 +141,10 @@ CollectionPage.Collection = (props: CollectionProps) => {
     })) || []),
   ];
 
-  const [loading, listDocs, docs] = useDocsList(props.collection, {orderBy});
+  const [loading, listDocs, docs] = useDocsList(props.collection, {
+    orderBy,
+    includeArchived: showArchived,
+  });
 
   return (
     <>
@@ -161,12 +168,22 @@ CollectionPage.Collection = (props: CollectionProps) => {
         <Tabs className="CollectionPage__collection__tabs" active={1}>
           <Tabs.Tab label="Docs">
             <div className="CollectionPage__collection__docsTab">
-              {!loading && docs.length > 0 && (
+              {!loading && (
                 <div className="CollectionPage__collection__docsTab__header">
                   <Heading className="CollectionPage__collection__docsTab__header__title">
                     {collection.name || props.collection}
                   </Heading>
                   <div className="CollectionPage__collection__docsTab__controls">
+                    <div className="CollectionPage__collection__docsTab__controls__showArchived">
+                      <Switch
+                        size="xs"
+                        label="Show archived"
+                        checked={showArchived}
+                        onChange={(e: any) =>
+                          setShowArchived(Boolean(e.currentTarget.checked))
+                        }
+                      />
+                    </div>
                     <div className="CollectionPage__collection__docsTab__controls__sort">
                       <div className="CollectionPage__collection__docsTab__controls__sort__label">
                         Sort:
@@ -320,6 +337,8 @@ CollectionPage.DocsList = (props: {
                 data={doc}
                 onAction={(e) => {
                   if (
+                    e.action === 'archive' ||
+                    e.action === 'unarchive' ||
                     e.action === 'delete' ||
                     e.action === 'unpublish' ||
                     e.action === 'locked' ||

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -53,6 +53,8 @@ export interface CMSDoc {
       reason: string;
       until?: Timestamp;
     };
+    archivedAt?: Timestamp;
+    archivedBy?: string;
     /** Google Sheet linked for translations. */
     l10nSheet?: {
       spreadsheetId: string;
@@ -489,6 +491,38 @@ export async function cmsUnlockPublishing(docId: string) {
   };
   await updateDoc(docRef, updates);
   logAction('doc.unlock_publishing', {metadata: {docId}});
+}
+
+/**
+ * Archives a doc. Archived docs are hidden from list views by default but are
+ * otherwise left intact. Use {@link cmsUnarchiveDoc} to restore.
+ */
+export async function cmsArchiveDoc(docId: string) {
+  const docRef = getDraftDocRef(docId);
+  await updateDoc(docRef, {
+    'sys.archivedAt': serverTimestamp(),
+    'sys.archivedBy': window.firebase.user.email,
+  });
+  logAction('doc.archive', {metadata: {docId}});
+}
+
+/**
+ * Unarchives a previously archived doc.
+ */
+export async function cmsUnarchiveDoc(docId: string) {
+  const docRef = getDraftDocRef(docId);
+  await updateDoc(docRef, {
+    'sys.archivedAt': deleteField(),
+    'sys.archivedBy': deleteField(),
+  });
+  logAction('doc.unarchive', {metadata: {docId}});
+}
+
+/**
+ * Checks if a doc is archived.
+ */
+export function testIsArchived(docData: CMSDoc) {
+  return Boolean(docData?.sys?.archivedAt);
 }
 
 /**

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -199,6 +199,10 @@ function updatePublishedDocDataInBatch(
     throw new Error(`publishing is locked for doc: ${draftData.id}`);
   }
 
+  if (testIsArchived(draftData)) {
+    throw new Error(`cannot publish archived doc: ${draftData.id}`);
+  }
+
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   const db = window.firebase.db;
   const [collectionId, slug] = docId.split('/');


### PR DESCRIPTION
## Summary
This PR adds the ability to archive and unarchive documents in the CMS. Archived documents are hidden from collection list views by default but can be restored later, providing a softer alternative to permanent deletion.

## Key Changes
- **Archive/Unarchive Actions**: Added `cmsArchiveDoc()` and `cmsUnarchiveDoc()` functions to manage document archive state by setting/clearing `sys.archivedAt` and `sys.archivedBy` fields
- **UI Controls**: 
  - Added Archive/Unarchive menu items in `DocActionsMenu` with confirmation dialog for archiving
  - Added "Show archived" toggle switch in `CollectionPage` to control visibility of archived documents
  - Added archive status badge in `DocStatusBadges` showing when and by whom a document was archived
- **Filtering Logic**: Updated `useDocsList` hook to filter out archived documents by default, with an `includeArchived` option to show them when the toggle is enabled
- **State Tracking**: Extended `CMSDoc` interface to include `archivedAt` timestamp and `archivedBy` email fields
- **Action Events**: Added 'archive' and 'unarchive' action types to `DocActionEvent` for proper event handling

## Implementation Details
- Archive state is persisted in Firestore under `sys.archivedAt` and `sys.archivedBy`
- Archived documents remain fully intact and cached; they're only hidden from list views
- The archive toggle state is persisted to localStorage per collection for user preference
- All archive/unarchive operations are logged via the existing `logAction()` utility

https://claude.ai/code/session_01LZBF4kWyaz1eNVWSHLTkzy