### PR TITLE
fix: wrap status badges in doc picker modal to fix overflow

### DIFF
--- a/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.css
+++ b/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.css
@@ -82,6 +82,7 @@
   text-decoration: none;
   flex: 1;
   flex-direction: column;
+  min-width: 0;
 }
 
 .DocPickerModal__DocCard__content__header {
@@ -115,6 +116,7 @@
 
 .DocPickerModal__DocCard__content__badges {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 4px;
   margin-top: 4px;


### PR DESCRIPTION
## Summary
Fixed layout issues in the DocPickerModal component where content could overflow its container and badges could be cut off.

## Key Changes
- Added `min-width: 0` to `.DocPickerModal__DocCard__content` to prevent flex children from overflowing their container
- Added `flex-wrap: wrap` to `.DocPickerModal__DocCard__content__badges` to allow badges to wrap to multiple lines instead of overflowing

## Implementation Details
These are common flexbox fixes for overflow issues:
- `min-width: 0` allows flex items to shrink below their content size, preventing overflow when content is too wide
- `flex-wrap: wrap` enables the badges container to wrap items to the next line when space is constrained, improving the layout on smaller screens or with many badges

https://claude.ai/code/session_01JhoJNd8LyhcidNTU8XKchE