### PR TITLE
feat: add ability to unpublish data sources

### DIFF
--- a/.changeset/healthy-garlics-train.md
+++ b/.changeset/healthy-garlics-train.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add ability to unpublish data sources

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -1412,6 +1412,46 @@ export class RootCMSClient {
     console.log(`published by: ${publishedBy}`);
   }
 
+  /**
+   * Unpublishes a data source. Removes the `publishedAt`/`publishedBy`
+   * metadata from the DataSource doc and deletes the `Data/published` doc.
+   */
+  async unpublishDataSource(dataSourceId: string) {
+    const dataSource = await this.getDataSource(dataSourceId);
+    if (!dataSource) {
+      throw new Error(`data source not found: ${dataSourceId}`);
+    }
+
+    const dataSourceDocRef = this.db.doc(
+      `Projects/${this.projectId}/DataSources/${dataSourceId}`
+    );
+    const dataDocRefDraft = this.db.doc(
+      `Projects/${this.projectId}/DataSources/${dataSourceId}/Data/draft`
+    );
+    const dataDocRefPublished = this.db.doc(
+      `Projects/${this.projectId}/DataSources/${dataSourceId}/Data/published`
+    );
+
+    const batch = this.db.batch();
+    batch.update(dataSourceDocRef, {
+      publishedAt: FieldValue.delete(),
+      publishedBy: FieldValue.delete(),
+    });
+    // Also remove the embedded `publishedAt`/`publishedBy` from the draft data
+    // doc so it stays in sync.
+    const draftSnapshot = await dataDocRefDraft.get();
+    if (draftSnapshot.exists) {
+      batch.update(dataDocRefDraft, {
+        'dataSource.publishedAt': FieldValue.delete(),
+        'dataSource.publishedBy': FieldValue.delete(),
+      });
+    }
+    batch.delete(dataDocRefPublished);
+    await batch.commit();
+
+    console.log(`unpublished data source: ${dataSourceId}`);
+  }
+
   async publishDataSources(
     dataSourceIds: string[],
     options?: {publishedBy: string; batch?: WriteBatch; commitBatch?: boolean}

--- a/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.tsx
@@ -1,7 +1,12 @@
 import {ActionIcon, Breadcrumbs, Tooltip} from '@mantine/core';
 import {useModals} from '@mantine/modals';
 import {showNotification, updateNotification} from '@mantine/notifications';
-import {IconArchive, IconRestore, IconTrashFilled} from '@tabler/icons-preact';
+import {
+  IconArchive,
+  IconCloudOff,
+  IconRestore,
+  IconTrashFilled,
+} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
@@ -18,6 +23,7 @@ import {
   deleteDataSource,
   getDataSource,
   unarchiveDataSource,
+  unpublishDataSource,
 } from '../../utils/data-source.js';
 import {testCanPublish} from '../../utils/permissions.js';
 import './EditDataSourcePage.css';
@@ -78,6 +84,7 @@ export function EditDataSourcePage(props: {id: string}) {
 
   function onArchiveClicked() {
     const notificationId = `archive-data-source-${props.id}`;
+    const isPublished = Boolean(dataSource?.publishedAt);
     const modalId = modals.openConfirmModal({
       ...modalTheme,
       title: 'Archive data source',
@@ -85,6 +92,13 @@ export function EditDataSourcePage(props: {id: string}) {
         <Text size="body-sm" weight="semi-bold">
           Are you sure you want to archive data source <code>{props.id}</code>?
           Archived data sources cannot be synced or published.
+          {isPublished && (
+            <>
+              {' '}
+              Note: previously published data will remain available until the
+              data source is unpublished.
+            </>
+          )}
         </Text>
       ),
       labels: {confirm: 'Archive', cancel: 'Cancel'},
@@ -156,6 +170,49 @@ export function EditDataSourcePage(props: {id: string}) {
     });
   }
 
+  function onUnpublishClicked() {
+    const notificationId = `unpublish-data-source-${props.id}`;
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: 'Unpublish data source',
+      children: (
+        <Text size="body-sm" weight="semi-bold">
+          Are you sure you want to unpublish data source{' '}
+          <code>{props.id}</code>? The published data will be removed and will
+          no longer be available to production. There is no undo.
+        </Text>
+      ),
+      labels: {confirm: 'Unpublish', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      onCancel: () => console.log('Cancel'),
+      closeOnConfirm: false,
+      onConfirm: async () => {
+        showNotification({
+          id: notificationId,
+          title: 'Unpublishing data source',
+          message: `Unpublishing ${props.id}...`,
+          loading: true,
+          autoClose: false,
+        });
+        await unpublishDataSource(props.id);
+        const newDataSource = await getDataSource(props.id);
+        setDataSource(newDataSource);
+        updateNotification({
+          id: notificationId,
+          title: 'Unpublished data source',
+          message: `Successfully unpublished ${props.id}`,
+          loading: false,
+          autoClose: 5000,
+        });
+        modals.closeModal(modalId);
+      },
+    });
+  }
+
+  const isPublished = Boolean(dataSource?.publishedAt);
+  const isArchived = Boolean(dataSource?.archivedAt);
+
   return (
     <Layout>
       <div className="EditDataSourcePage">
@@ -168,11 +225,27 @@ export function EditDataSourcePage(props: {id: string}) {
           <div className="EditDataSourcePage__header__titleWrap">
             <Heading size="h1">Edit Data Source: {props.id}</Heading>
             <div className="EditDataSourcePage__header__controls">
+              {isPublished && !isArchived && (
+                <ConditionalTooltip
+                  label="You don't have access to unpublish data sources"
+                  condition={!canPublish}
+                >
+                  <Tooltip label="Unpublish" disabled={!canPublish}>
+                    <ActionIcon
+                      onClick={onUnpublishClicked}
+                      loading={!roles}
+                      disabled={!canPublish}
+                    >
+                      <IconCloudOff size={20} stroke="1.5" />
+                    </ActionIcon>
+                  </Tooltip>
+                </ConditionalTooltip>
+              )}
               <ConditionalTooltip
                 label="You don't have access to archive data sources"
                 condition={!canPublish}
               >
-                {dataSource?.archivedAt ? (
+                {isArchived ? (
                   <Tooltip label="Unarchive" disabled={!canPublish}>
                     <ActionIcon
                       onClick={onUnarchiveClicked}

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -295,6 +295,57 @@ export async function publishDataSource(id: string) {
   logAction('datasource.publish', {metadata: {datasourceId: id}});
 }
 
+export async function unpublishDataSource(id: string) {
+  const dataSource = await getDataSource(id);
+  if (!dataSource) {
+    throw new Error(`data source not found: ${id}`);
+  }
+
+  const projectId = window.__ROOT_CTX.rootConfig.projectId;
+  const db = window.firebase.db;
+  const dataSourceDocRef = doc(db, 'Projects', projectId, 'DataSources', id);
+  const dataDocRefDraft = doc(
+    db,
+    'Projects',
+    projectId,
+    'DataSources',
+    id,
+    'Data',
+    'draft'
+  );
+  const dataDocRefPublished = doc(
+    db,
+    'Projects',
+    projectId,
+    'DataSources',
+    id,
+    'Data',
+    'published'
+  );
+
+  const batch = writeBatch(db);
+  // Remove the "published" metadata from the DataSource document.
+  batch.update(dataSourceDocRef, {
+    publishedAt: deleteField(),
+    publishedBy: deleteField(),
+  });
+  // Also remove the "published" metadata from the embedded `dataSource`
+  // object on the draft data doc so it stays in sync.
+  const draftSnapshot = await getDoc(dataDocRefDraft);
+  if (draftSnapshot.exists()) {
+    batch.update(dataDocRefDraft, {
+      'dataSource.publishedAt': deleteField(),
+      'dataSource.publishedBy': deleteField(),
+    });
+  }
+  // Delete the "published" data doc.
+  batch.delete(dataDocRefPublished);
+  await batch.commit();
+
+  console.log(`unpublished data source: ${id}`);
+  logAction('datasource.unpublish', {metadata: {datasourceId: id}});
+}
+
 export async function cmsPublishDataSources(
   ids: string[],
   options?: {batch?: WriteBatch; commitBatch?: boolean}


### PR DESCRIPTION
## Summary
This PR adds the ability to unpublish data sources, allowing users to remove published data and revert a data source to draft-only status. This complements the existing publish functionality and provides users with more control over their data source lifecycle.

## Key Changes
- **UI Updates**: Added unpublish button to the EditDataSourcePage header that appears when a data source is published and not archived
  - New `IconCloudOff` icon imported from tabler/icons
  - Button includes permission checks and conditional tooltips
  - Confirmation modal warns users that unpublishing is irreversible
  
- **Archive Modal Enhancement**: Updated archive confirmation dialog to inform users that previously published data will remain available until the data source is unpublished

- **Backend Implementation**: Added `unpublishDataSource()` function in both the UI utils and core client that:
  - Removes `publishedAt` and `publishedBy` metadata from the DataSource document
  - Removes the same metadata from the embedded `dataSource` object in the draft Data doc to keep them in sync
  - Deletes the `Data/published` document entirely
  - Uses batch writes for atomic operations
  - Logs the unpublish action for audit purposes

- **State Management**: Added computed variables (`isPublished`, `isArchived`) to simplify conditional rendering logic

## Notable Implementation Details
- The unpublish operation uses Firestore batch writes to ensure atomicity across multiple document updates and deletions
- The draft data document's embedded `dataSource` object is updated to maintain consistency with the parent DataSource document
- Permission checks use the existing `canPublish` flag to control access to the unpublish feature
- The implementation mirrors the structure of the existing `publishDataSource()` function for consistency

https://claude.ai/code/session_01WnuzDiauR42zP2wxG6s6FZ