### PR TITLE
feat: make publishing lock badge clickable to edit or remove

### DIFF
--- a/.changeset/tender-moons-confess.md
+++ b/.changeset/tender-moons-confess.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: make publishing lock badge clickable to edit or remove #1039

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -81,7 +81,7 @@ import {
 import {extractField} from '../../utils/extract.js';
 import {getDefaultFieldValue} from '../../utils/fields.js';
 import {requestHighlightNode} from '../../utils/iframe-preview.js';
-import {testCanPublish} from '../../utils/permissions.js';
+import {testCanEdit, testCanPublish} from '../../utils/permissions.js';
 import {autokey} from '../../utils/rand.js';
 import {buildPreviewValue} from '../../utils/schema-previews.js';
 import {testFieldEmpty} from '../../utils/test-field-empty.js';
@@ -99,6 +99,7 @@ import {
 import {useEditJsonModal} from '../EditJsonModal/EditJsonModal.js';
 import {useEditTranslationsModal} from '../EditTranslationsModal/EditTranslationsModal.js';
 import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
+import {useLockPublishingModal} from '../LockPublishingModal/LockPublishingModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Viewers} from '../Viewers/Viewers.js';
 import {BooleanField} from './fields/BooleanField.js';
@@ -182,6 +183,7 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
   const {roles} = useProjectRoles();
   const currentUserEmail = window.firebase.user.email || '';
   const canPublish = testCanPublish(roles, currentUserEmail);
+  const canEdit = testCanEdit(roles, currentUserEmail);
 
   const draft = props.draft;
   const [data, setData] = useState<Partial<CMSDoc> | null>(
@@ -192,6 +194,24 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
   useDraftDocField('sys', (sys: any) => {
     const data: Partial<CMSDoc> = {sys};
     setData(data);
+  });
+
+  const onLockChanged = useCallback(
+    (state: 'locked' | 'unlocked') => {
+      if (state === 'unlocked') {
+        // NOTE(stevenle): for some reason, the unlock publishing doesn't
+        // properly trigger the `onSnapshot()` callback with
+        // `{hasPendingWrites: false}`. This is a temporary fix.
+        // TODO(stevenle): avoid the extra db write here.
+        draft.controller.removePublishingLock();
+      }
+    },
+    [draft.controller]
+  );
+
+  const lockPublishingModal = useLockPublishingModal({
+    docId: props.docId,
+    onChange: onLockChanged,
   });
 
   const onDocAction = useCallback(
@@ -209,6 +229,22 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
     },
     [props.docId]
   );
+
+  const onPublishingLockClick = useCallback(() => {
+    if (!canEdit) {
+      return;
+    }
+    const lock = data?.sys?.publishingLocked;
+    if (!lock) {
+      return;
+    }
+    lockPublishingModal.open({
+      existingLock: {
+        reason: lock.reason,
+        until: lock.until ? lock.until.toMillis() : undefined,
+      },
+    });
+  }, [canEdit, data?.sys?.publishingLocked, lockPublishingModal]);
 
   const publishDocModal = usePublishDocModal({docId: props.docId});
   const localizationModal = useLocalizationModal();
@@ -258,7 +294,13 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
       <DocEditor.SaveState />
       {data?.sys && (
         <div className="DocEditor__statusBar__statusBadges">
-          <DocStatusBadges doc={data as CMSDoc} docId={props.docId} />
+          <DocStatusBadges
+            doc={data as CMSDoc}
+            docId={props.docId}
+            onPublishingLockClick={
+              canEdit ? onPublishingLockClick : undefined
+            }
+          />
         </div>
       )}
       {(window.__ROOT_CTX.checks || []).length > 0 && (

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -18,7 +18,7 @@
 }
 
 .DocStatusBadges__badge--clickable:hover {
-  opacity: 0.85;
+  opacity: 0.9;
 }
 
 .DocStatusBadges__badge--clickable:focus-visible {

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -11,3 +11,17 @@
 .DocStatusBadges .mantine-Badge-root {
   display: flex;
 }
+
+.DocStatusBadges__badge--clickable {
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.DocStatusBadges__badge--clickable:hover {
+  opacity: 0.85;
+}
+
+.DocStatusBadges__badge--clickable:focus-visible {
+  outline: 2px solid var(--mantine-color-blue-6, #339af0);
+  outline-offset: 2px;
+}

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -12,6 +12,11 @@ interface DocStatusBadgesProps {
   docId?: string;
   tooltipPosition?: 'bottom' | 'top';
   hideReleases?: boolean;
+  /**
+   * Optional click handler for the "Locked" publishing-lock badge. When set,
+   * the badge becomes interactive (clickable) so callers can open an edit UI.
+   */
+  onPublishingLockClick?: () => void;
 }
 
 export function DocStatusBadges(props: DocStatusBadgesProps) {
@@ -81,6 +86,27 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
             size="xs"
             variant="gradient"
             gradient={{from: 'orange', to: 'red'}}
+            className={
+              props.onPublishingLockClick
+                ? 'DocStatusBadges__badge--clickable'
+                : undefined
+            }
+            style={
+              props.onPublishingLockClick ? {cursor: 'pointer'} : undefined
+            }
+            role={props.onPublishingLockClick ? 'button' : undefined}
+            tabIndex={props.onPublishingLockClick ? 0 : undefined}
+            onClick={props.onPublishingLockClick}
+            onKeyDown={
+              props.onPublishingLockClick
+                ? (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      props.onPublishingLockClick!();
+                    }
+                  }
+                : undefined
+            }
           >
             Locked
           </Badge>

--- a/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.css
+++ b/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.css
@@ -9,6 +9,10 @@
   gap: 12px;
 }
 
+.LockPublishingModal__buttons__unlock {
+  margin-right: auto;
+}
+
 .LockPublishingModal__body {
   text-wrap: pretty;
 }

--- a/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.tsx
+++ b/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.tsx
@@ -63,9 +63,9 @@ export function useLockPublishingModal(props: LockPublishingModalProps) {
 function toLocalDateTimeString(millis: number): string {
   const pad = (n: number) => (n < 10 ? '0' + n : n);
   const d = new Date(millis);
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
-    d.getDate()
-  )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
 }
 
 export function LockPublishingModal(
@@ -135,12 +135,14 @@ LockPublishingModal.Lock = (
   }
 
   const bodyText = isEdit
-    ? 'Update the publishing lock details below, or remove the lock to re-enable publishing.'
+    ? 'Publishing is currently locked. Update the publishing lock details below, or remove the lock to re‑enable publishing.'
     : 'Are you sure you want to lock publishing? Content editors will not be able to publish until publishing is unlocked.';
 
   return (
     <div className="LockPublishingModal LockPublishingModal--lock">
-      <Text className="LockPublishingModal__body">{bodyText}</Text>
+      <Text className="LockPublishingModal__body" size="body-sm">
+        {bodyText}
+      </Text>
 
       <form className="LockPublishingModal__form" onSubmit={(e) => onSubmit(e)}>
         <div className="LockPublishingModal__form__section">
@@ -183,7 +185,7 @@ LockPublishingModal.Lock = (
         <div className="LockPublishingModal__buttons">
           {isEdit && (
             <Button
-              variant="outline"
+              variant="filled"
               size="xs"
               color="red"
               type="button"

--- a/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.tsx
+++ b/packages/root-cms/ui/components/LockPublishingModal/LockPublishingModal.tsx
@@ -15,10 +15,21 @@ import './LockPublishingModal.css';
 
 const MODAL_ID = 'LockPublishingModal';
 
+export interface ExistingLockInfo {
+  reason: string;
+  until?: number;
+}
+
 export interface LockPublishingModalProps {
   [key: string]: unknown;
   docId: string;
   unlock?: boolean;
+  /**
+   * When provided, the modal opens in "edit" mode with the current lock values
+   * pre-filled. The user can either update the lock (by submitting the form)
+   * or remove it (via the inline "Unlock" button).
+   */
+  existingLock?: ExistingLockInfo;
   onChange?: (state: 'locked' | 'unlocked') => void;
 }
 
@@ -28,9 +39,14 @@ export function useLockPublishingModal(props: LockPublishingModalProps) {
   return {
     open: (options?: Partial<LockPublishingModalProps>) => {
       const modalProps = {...props, ...options};
-      const title = modalProps.unlock
-        ? `Unlock publishing for ${props.docId}`
-        : `Lock publishing for ${props.docId}`;
+      let title: string;
+      if (modalProps.unlock) {
+        title = `Unlock publishing for ${props.docId}`;
+      } else if (modalProps.existingLock) {
+        title = `Edit publishing lock for ${props.docId}`;
+      } else {
+        title = `Lock publishing for ${props.docId}`;
+      }
       modals.openContextModal(MODAL_ID, {
         ...modalTheme,
         title,
@@ -39,6 +55,17 @@ export function useLockPublishingModal(props: LockPublishingModalProps) {
       });
     },
   };
+}
+
+/**
+ * Formats a millis timestamp for a `datetime-local` input's local time value.
+ */
+function toLocalDateTimeString(millis: number): string {
+  const pad = (n: number) => (n < 10 ? '0' + n : n);
+  const d = new Date(millis);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
+    d.getDate()
+  )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 export function LockPublishingModal(
@@ -55,9 +82,11 @@ LockPublishingModal.Lock = (
   modalProps: ContextModalProps<LockPublishingModalProps>
 ) => {
   const {innerProps: props, context, id} = modalProps;
-  const [reason, setReason] = useState('');
-  const [until, setUntil] = useState(0);
+  const isEdit = Boolean(props.existingLock);
+  const [reason, setReason] = useState(props.existingLock?.reason || '');
+  const [until, setUntil] = useState(props.existingLock?.until || 0);
   const [loading, setLoading] = useState(false);
+  const [unlocking, setUnlocking] = useState(false);
   const modals = useModals();
 
   function toTimestamp(datestr: string) {
@@ -74,8 +103,10 @@ LockPublishingModal.Lock = (
     await notifyErrors(async () => {
       await cmsLockPublishing(props.docId, {reason, until});
       showNotification({
-        title: 'Locked!',
-        message: `Publishing is locked for ${props.docId}.`,
+        title: isEdit ? 'Updated!' : 'Locked!',
+        message: isEdit
+          ? `Publishing lock updated for ${props.docId}.`
+          : `Publishing is locked for ${props.docId}.`,
         autoClose: 10000,
       });
       modals.closeModal(id);
@@ -83,14 +114,33 @@ LockPublishingModal.Lock = (
         props.onChange('locked');
       }
     });
+    setLoading(false);
   }
+
+  async function onUnlock() {
+    setUnlocking(true);
+    await notifyErrors(async () => {
+      await cmsUnlockPublishing(props.docId);
+      showNotification({
+        title: 'Unlocked!',
+        message: `Publishing is unlocked for ${props.docId}.`,
+        autoClose: 10000,
+      });
+      modals.closeModal(id);
+      if (props.onChange) {
+        props.onChange('unlocked');
+      }
+    });
+    setUnlocking(false);
+  }
+
+  const bodyText = isEdit
+    ? 'Update the publishing lock details below, or remove the lock to re-enable publishing.'
+    : 'Are you sure you want to lock publishing? Content editors will not be able to publish until publishing is unlocked.';
 
   return (
     <div className="LockPublishingModal LockPublishingModal--lock">
-      <Text className="LockPublishingModal__body">
-        Are you sure you want to lock publishing? Content editors will not be
-        able to publish until publishing is unlocked.
-      </Text>
+      <Text className="LockPublishingModal__body">{bodyText}</Text>
 
       <form className="LockPublishingModal__form" onSubmit={(e) => onSubmit(e)}>
         <div className="LockPublishingModal__form__section">
@@ -100,6 +150,7 @@ LockPublishingModal.Lock = (
             description="Specify a short reason so other content editors know why publishing is locked."
             size="xs"
             radius={0}
+            value={reason}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
               setReason(e.currentTarget.value);
             }}
@@ -116,6 +167,7 @@ LockPublishingModal.Lock = (
                 name="until"
                 type="datetime-local"
                 min={getLocalISOString()}
+                defaultValue={until ? toLocalDateTimeString(until) : ''}
                 onChange={(e: Event) => {
                   const target = e.target as HTMLInputElement;
                   const datestr = target.value;
@@ -129,6 +181,21 @@ LockPublishingModal.Lock = (
           </InputWrapper>
         </div>
         <div className="LockPublishingModal__buttons">
+          {isEdit && (
+            <Button
+              variant="outline"
+              size="xs"
+              color="red"
+              type="button"
+              leftIcon={<IconLockOpen size={14} />}
+              loading={unlocking}
+              disabled={loading}
+              onClick={() => onUnlock()}
+              className="LockPublishingModal__buttons__unlock"
+            >
+              Unlock
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={() => context.closeModal(id)}
@@ -143,11 +210,11 @@ LockPublishingModal.Lock = (
             size="xs"
             color="dark"
             leftIcon={<IconLock size={14} />}
-            disabled={!reason}
+            disabled={!reason || unlocking}
             type="submit"
             loading={loading}
           >
-            Lock
+            {isEdit ? 'Save' : 'Lock'}
           </Button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
Enhanced the publishing lock modal to support editing existing locks and unlocking from within the modal. Users can now click on the "Locked" status badge to open the modal in edit mode, where they can update lock details or remove the lock entirely.

## Key Changes
- **New `ExistingLockInfo` interface**: Defines the structure for passing existing lock data (reason and until timestamp) to the modal
- **Edit mode support**: Added `existingLock` prop to `LockPublishingModalProps` to enable pre-filling form fields with current lock values
- **Unlock functionality**: Implemented inline "Unlock" button in the modal that removes the publishing lock without closing the modal first
- **Interactive status badge**: Made the "Locked" publishing status badge clickable when `onPublishingLockClick` handler is provided, with proper keyboard accessibility (Enter/Space keys)
- **Modal title updates**: Dynamic title changes based on context ("Lock publishing", "Edit publishing lock", or "Unlock publishing")
- **Form state management**: Pre-populate reason and until fields when editing existing locks; added separate `unlocking` state to track unlock operation
- **Notification updates**: Different success messages for lock creation vs. updates
- **Styling enhancements**: Added hover and focus-visible states for clickable badges, and positioned the unlock button to the left with `margin-right: auto`

## Implementation Details
- Added `toLocalDateTimeString()` utility function to format millisecond timestamps for `datetime-local` input fields
- Integrated `useLockPublishingModal` hook into `DocEditor.StatusBar` with `onChange` callback to handle lock state updates
- Added permission check (`canEdit`) to ensure only authorized users can interact with the lock badge
- Properly handles the `hasPendingWrites` issue by calling `removePublishingLock()` on unlock
- Maintains backward compatibility with existing lock creation flow

## Screenshots
<img width="1561" height="1098" alt="Screenshot 2026-04-16 at 08 58 45" src="https://github.com/user-attachments/assets/08aa7021-c833-4ecb-aab5-af5cfa8cbc90" />


https://claude.ai/code/session_01VeBJKbhqP82Uz6w39WzNNJ