### PR TITLE
Add streaming AI chat with tool call support

### DIFF
--- a/packages/root-cms/core/ai-stream.ts
+++ b/packages/root-cms/core/ai-stream.ts
@@ -1,0 +1,143 @@
+import {createVertex} from '@ai-sdk/google-vertex';
+import {
+  convertToModelMessages,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+} from 'ai';
+import {z} from 'zod';
+import {RootCMSClient, parseDocId, unmarshalData} from './client.js';
+import {CMSPluginOptions} from './plugin.js';
+
+const DEFAULT_STREAM_MODEL = 'gemini-2.5-flash';
+
+function resolveStreamModel(options: CMSPluginOptions): string {
+  if (options.ai?.model) {
+    return options.ai.model;
+  }
+  if (
+    typeof options.experiments?.ai === 'object' &&
+    options.experiments.ai.model
+  ) {
+    return options.experiments.ai.model;
+  }
+  return DEFAULT_STREAM_MODEL;
+}
+
+function buildVertexProvider(cmsClient: RootCMSClient) {
+  const cmsPluginOptions = cmsClient.cmsPlugin.getConfig();
+  const firebaseConfig = cmsPluginOptions.firebaseConfig;
+  const project =
+    cmsPluginOptions.ai?.gemini?.projectId || firebaseConfig.projectId;
+  const location =
+    cmsPluginOptions.ai?.gemini?.location ||
+    firebaseConfig.location ||
+    'us-central1';
+  return createVertex({project, location});
+}
+
+function buildSystemPrompt(cmsClient: RootCMSClient): string {
+  const cmsPluginOptions = cmsClient.cmsPlugin.getConfig();
+  const projectName = cmsPluginOptions.name || cmsPluginOptions.id || 'website';
+  return [
+    `You are an assistant for a headless CMS called Root CMS, working on the "${projectName}" site.`,
+    'You can help answer questions about the docs in the system, and propose or apply edits to them.',
+    'Use the provided tools to look up and modify docs instead of guessing content.',
+    '',
+    'Tool usage guidance:',
+    '- Call `readDoc` to fetch the current fields of a doc before answering questions about it or editing it.',
+    '- Call `editDoc` only when the user explicitly asks you to change content. Edits save to the draft version.',
+    '- Doc IDs are formatted as "CollectionId/slug" (e.g. "Pages/home").',
+    '',
+    'Respond in GitHub-flavored markdown. If you are unsure of an answer, say so rather than making one up.',
+  ].join('\n');
+}
+
+function buildDocTools(cmsClient: RootCMSClient, modifiedBy: string) {
+  return {
+    readDoc: tool({
+      description:
+        'Read the fields of a CMS doc. Returns the fields of the draft version by default. Use this before answering questions about doc content or making edits.',
+      inputSchema: z.object({
+        docId: z
+          .string()
+          .describe('The doc id, formatted as "CollectionId/slug".'),
+        mode: z
+          .enum(['draft', 'published'])
+          .optional()
+          .describe(
+            'Which version to read. Defaults to "draft". Use "published" to read the live version.'
+          ),
+      }),
+      execute: async ({docId, mode}) => {
+        try {
+          const {collection, slug} = parseDocId(docId);
+          const rawDoc = await cmsClient.getRawDoc(collection, slug, {
+            mode: mode || 'draft',
+          });
+          if (!rawDoc) {
+            return {found: false, docId};
+          }
+          const data = unmarshalData(rawDoc) || {};
+          return {
+            found: true,
+            docId,
+            fields: data.fields ?? {},
+            sys: data.sys ?? null,
+          };
+        } catch (err: any) {
+          return {found: false, docId, error: err?.message || String(err)};
+        }
+      },
+    }),
+    editDoc: tool({
+      description:
+        'Edit a CMS doc by saving new draft field data. The provided `fields` object replaces the entire `fields` map of the draft. Call `readDoc` first to see the current fields so you can merge your changes.',
+      inputSchema: z.object({
+        docId: z
+          .string()
+          .describe('The doc id, formatted as "CollectionId/slug".'),
+        fields: z
+          .record(z.any())
+          .describe(
+            'The full fields object to save as the draft. Overwrites existing fields.'
+          ),
+      }),
+      execute: async ({docId, fields}) => {
+        try {
+          await cmsClient.saveDraftData(docId, fields, {modifiedBy});
+          return {success: true, docId};
+        } catch (err: any) {
+          return {
+            success: false,
+            docId,
+            error: err?.message || String(err),
+          };
+        }
+      },
+    }),
+  };
+}
+
+export interface StreamChatOptions {
+  cmsClient: RootCMSClient;
+  messages: UIMessage[];
+  user: string;
+}
+
+export function streamChat(options: StreamChatOptions) {
+  const {cmsClient, messages, user} = options;
+  const cmsPluginOptions = cmsClient.cmsPlugin.getConfig();
+  const vertex = buildVertexProvider(cmsClient);
+  const modelId = resolveStreamModel(cmsPluginOptions);
+  const tools = buildDocTools(cmsClient, user);
+
+  return streamText({
+    model: vertex(modelId),
+    messages: convertToModelMessages(messages),
+    system: buildSystemPrompt(cmsClient),
+    tools,
+    stopWhen: stepCountIs(5),
+  });
+}

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -19,6 +19,46 @@ function testValidCollectionId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
 }
 
+/**
+ * Pipes a web `Response` (as returned by the Vercel AI SDK) into an Express
+ * `Response`, forwarding status, headers, and streaming body chunks.
+ */
+async function pipeWebResponseToExpress(
+  webResponse: globalThis.Response,
+  expressRes: Response
+): Promise<void> {
+  expressRes.status(webResponse.status);
+  webResponse.headers.forEach((value, key) => {
+    expressRes.setHeader(key, value);
+  });
+  if (!webResponse.body) {
+    expressRes.end();
+    return;
+  }
+  const reader = webResponse.body.getReader();
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const {value, done} = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        expressRes.write(Buffer.from(value));
+        // `flush()` is added by the `compression` middleware; call if available
+        // so chunks reach the browser immediately.
+        const flush = (expressRes as any).flush;
+        if (typeof flush === 'function') {
+          flush.call(expressRes);
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    expressRes.end();
+  }
+}
+
 type DocVersion = 'draft' | 'published';
 
 interface BuildDocDiffOptions {
@@ -387,6 +427,49 @@ export function api(server: Server, options: ApiOptions) {
     } catch (err) {
       console.error(err.stack || err);
       res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * AI chatbot streaming endpoint powered by the Vercel AI SDK. Accepts a
+   * list of UI messages and streams the model's response (text + tool calls)
+   * back as a UI-message SSE stream.
+   */
+  server.use('/cms/api/ai.stream', async (req: Request, res: Response) => {
+    if (
+      req.method !== 'POST' ||
+      !String(req.get('content-type')).startsWith('application/json')
+    ) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    if (!req.user?.email) {
+      res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      return;
+    }
+    const reqBody = req.body || {};
+    const messages = Array.isArray(reqBody.messages) ? reqBody.messages : null;
+    if (!messages || messages.length === 0) {
+      res.status(400).json({success: false, error: 'MISSING_MESSAGES'});
+      return;
+    }
+    try {
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const {streamChat} = await import('./ai-stream.js');
+      const result = streamChat({
+        cmsClient,
+        messages,
+        user: req.user.email,
+      });
+      const response = result.toUIMessageStreamResponse();
+      pipeWebResponseToExpress(response, res);
+    } catch (err: any) {
+      console.error(err.stack || err);
+      if (!res.headersSent) {
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      } else {
+        res.end();
+      }
     }
   });
 

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -72,12 +72,14 @@
     "@ag-grid-community/core": "32.3.9",
     "@ag-grid-community/react": "32.3.9",
     "@ag-grid-community/styles": "32.3.9",
+    "@ai-sdk/google-vertex": "^3.0.0",
     "@genkit-ai/ai": "1.26.0",
     "@genkit-ai/core": "1.26.0",
     "@genkit-ai/google-genai": "1.26.0",
     "@google-cloud/firestore": "7.11.3",
     "@hello-pangea/dnd": "18.0.1",
     "@types/cli-progress": "3.11.6",
+    "ai": "^5.0.0",
     "body-parser": "1.20.2",
     "cli-progress": "3.12.0",
     "commander": "11.0.0",
@@ -92,7 +94,8 @@
     "jsonwebtoken": "9.0.2",
     "kleur": "4.1.5",
     "sirv": "2.0.3",
-    "tiny-glob": "0.2.9"
+    "tiny-glob": "0.2.9",
+    "zod": "^3.23.8"
   },
   "//": "NOTE(stevenle): due to compat issues with mantine and preact, mantine is pinned to v4.2.12",
   "devDependencies": {

--- a/packages/root-cms/ui/components/ChatBar/ChatBar.tsx
+++ b/packages/root-cms/ui/components/ChatBar/ChatBar.tsx
@@ -15,6 +15,11 @@ export interface Message {
   blocks: MessageBlock[];
   key?: string;
   data?: Record<string, any>;
+  /**
+   * When true, the message is being updated in-place (e.g. from a streaming
+   * response). Consumers should avoid remounting animations while streaming.
+   */
+  streaming?: boolean;
 }
 
 export interface ImageMessageBlock {
@@ -38,12 +43,28 @@ export interface PendingMessageBlock {
 export interface TextMessageBlock {
   type: 'text';
   text: string;
+  /** When true, disables the typewriter animation and renders the text as-is. */
+  streaming?: boolean;
+}
+
+/**
+ * Represents an AI tool invocation (read/edit docs, etc.) surfaced in the chat.
+ */
+export interface ToolCallMessageBlock {
+  type: 'tool';
+  toolCallId: string;
+  toolName: string;
+  state: 'pending' | 'completed' | 'error';
+  input?: any;
+  output?: any;
+  errorMessage?: string;
 }
 
 export type MessageBlock =
   | ImageMessageBlock
   | PendingMessageBlock
-  | TextMessageBlock;
+  | TextMessageBlock
+  | ToolCallMessageBlock;
 
 export function ChatBar(props: {
   chat: ChatController;

--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -177,6 +177,90 @@
   max-width: 100%;
 }
 
+.AIPage__ToolCallBlock {
+  border: 1px solid #DADCE0;
+  border-radius: 8px;
+  background: #f8f9fa;
+  font-size: 14px;
+  overflow: hidden;
+}
+
+.AIPage__ToolCallBlock__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  color: inherit;
+}
+
+.AIPage__ToolCallBlock__header:hover {
+  background: #eef0f2;
+}
+
+.AIPage__ToolCallBlock__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  color: #1a73e8;
+}
+
+.AIPage__ToolCallBlock__name {
+  font-family: var(--font-family-mono);
+  font-weight: 600;
+}
+
+.AIPage__ToolCallBlock__summary {
+  color: #5f6368;
+  font-family: var(--font-family-mono);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.AIPage__ToolCallBlock__toggle {
+  color: #80868b;
+}
+
+.AIPage__ToolCallBlock__body {
+  padding: 8px 12px 12px;
+  border-top: 1px solid #DADCE0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.AIPage__ToolCallBlock__section__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.AIPage__ToolCallBlock__section__content {
+  font-family: var(--font-family-mono);
+  font-size: 13px;
+  line-height: 1.4;
+  background: #fff;
+  border: 1px solid #DADCE0;
+  border-radius: 4px;
+  padding: 8px;
+  margin: 0;
+  white-space: pre-wrap;
+  overflow: auto;
+  max-height: 240px;
+}
+
 .AIPage__CursorDot {
   --dot-size: 12px;
   width: calc(var(--dot-size) + 8px);

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -24,6 +24,7 @@ import {
   MessageBlock,
   PendingMessageBlock,
   TextMessageBlock,
+  ToolCallMessageBlock,
 } from '../../components/ChatBar/ChatBar.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
@@ -154,9 +155,338 @@ export function useChat(): ChatController {
   };
 }
 
+/** A message in the Vercel AI SDK `UIMessage` format. */
+interface UIMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  parts: Array<{type: 'text'; text: string}>;
+}
+
+/**
+ * Streaming chat hook backed by the `/cms/api/ai.stream` endpoint (Vercel AI
+ * SDK). Maintains a UIMessage history for the server and a display-friendly
+ * Message list for the UI, updating the active bot message in place as text
+ * and tool-call events stream in.
+ */
+export function useStreamingChat(): ChatController {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const historyRef = useRef<UIMessage[]>([]);
+
+  const addMessage = (message: Message) => {
+    let messageId = 0;
+    setMessages((current) => {
+      const pendingMessage: Message = {
+        sender: 'bot',
+        blocks: [{type: 'pending'}],
+        key: autokey(),
+        streaming: true,
+      };
+      const newMessages = [
+        ...current,
+        {...message, key: autokey()},
+        pendingMessage,
+      ];
+      messageId = newMessages.length - 1;
+      return newMessages;
+    });
+    return messageId;
+  };
+
+  const updateMessage = (messageId: number, message: Message) => {
+    setMessages((current) => {
+      const newMessages = [...current];
+      const existing = newMessages[messageId];
+      newMessages[messageId] = {
+        ...message,
+        // Preserve the original key while streaming to avoid unmounting the
+        // message (which would reset rendered state).
+        key: message.streaming
+          ? existing?.key || autokey()
+          : autokey(),
+      };
+      return newMessages;
+    });
+  };
+
+  const patchMessage = (
+    messageId: number,
+    updater: (current: Message) => Message
+  ) => {
+    setMessages((current) => {
+      const newMessages = [...current];
+      const existing = newMessages[messageId];
+      if (!existing) {
+        return current;
+      }
+      newMessages[messageId] = {
+        ...updater(existing),
+        key: existing.key,
+      };
+      return newMessages;
+    });
+  };
+
+  function promptToText(prompt: ChatPrompt | ChatPrompt[]): string {
+    const parts = Array.isArray(prompt) ? prompt.flat() : [prompt];
+    const texts: string[] = [];
+    for (const part of parts) {
+      if (part && typeof (part as any).text === 'string') {
+        texts.push((part as any).text);
+      }
+    }
+    return texts.join('\n');
+  }
+
+  const sendPrompt = async (
+    messageId: number,
+    prompt: ChatPrompt | ChatPrompt[]
+  ): Promise<AiResponse> => {
+    const endpoint = '/cms/api/ai.stream';
+    const userText = promptToText(prompt);
+    const userMessage: UIMessage = {
+      id: autokey(),
+      role: 'user',
+      parts: [{type: 'text', text: userText}],
+    };
+    historyRef.current = [...historyRef.current, userMessage];
+
+    let res: globalThis.Response;
+    try {
+      res = await window.fetch(endpoint, {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({messages: historyRef.current}),
+      });
+    } catch (err: any) {
+      const errorMessage = `Network error: ${err?.message || err}`;
+      updateMessage(messageId, {
+        sender: 'bot',
+        blocks: [{type: 'text', text: errorMessage}],
+      });
+      return {message: errorMessage, data: null, error: String(err)};
+    }
+
+    if (!res.ok || !res.body) {
+      const errText = await res.text().catch(() => 'request failed');
+      const errorMessage = ['Something went wrong:', '```', errText, '```'].join(
+        '\n'
+      );
+      updateMessage(messageId, {
+        sender: 'bot',
+        blocks: [{type: 'text', text: errorMessage}],
+      });
+      return {message: errorMessage, data: null, error: errText};
+    }
+
+    // Initialize the bot message with a streaming text block; tool blocks get
+    // appended as they come in.
+    let assistantText = '';
+    const toolBlocks = new Map<string, ToolCallMessageBlock>();
+
+    const renderBlocks = (): MessageBlock[] => {
+      const blocks: MessageBlock[] = [];
+      for (const tool of toolBlocks.values()) {
+        blocks.push({...tool});
+      }
+      if (assistantText) {
+        blocks.push({type: 'text', text: assistantText, streaming: true});
+      } else if (blocks.length === 0) {
+        blocks.push({type: 'pending'});
+      }
+      return blocks;
+    };
+
+    const commitBlocks = () => {
+      patchMessage(messageId, () => ({
+        sender: 'bot',
+        blocks: renderBlocks(),
+        streaming: true,
+      }));
+    };
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const handleEvent = (jsonText: string) => {
+      if (!jsonText || jsonText === '[DONE]') {
+        return;
+      }
+      let event: any;
+      try {
+        event = JSON.parse(jsonText);
+      } catch {
+        return;
+      }
+      switch (event.type) {
+        case 'text-delta': {
+          const delta = typeof event.delta === 'string' ? event.delta : '';
+          assistantText += delta;
+          commitBlocks();
+          break;
+        }
+        case 'tool-input-start':
+        case 'tool-call': {
+          const id = event.toolCallId;
+          if (!id) break;
+          toolBlocks.set(id, {
+            type: 'tool',
+            toolCallId: id,
+            toolName: event.toolName || 'tool',
+            state: 'pending',
+            input: event.input,
+          });
+          commitBlocks();
+          break;
+        }
+        case 'tool-input-available': {
+          const id = event.toolCallId;
+          if (!id) break;
+          const current =
+            toolBlocks.get(id) ||
+            ({
+              type: 'tool',
+              toolCallId: id,
+              toolName: event.toolName || 'tool',
+              state: 'pending',
+            } as ToolCallMessageBlock);
+          toolBlocks.set(id, {...current, input: event.input});
+          commitBlocks();
+          break;
+        }
+        case 'tool-output-available':
+        case 'tool-result': {
+          const id = event.toolCallId;
+          if (!id) break;
+          const current =
+            toolBlocks.get(id) ||
+            ({
+              type: 'tool',
+              toolCallId: id,
+              toolName: event.toolName || 'tool',
+              state: 'pending',
+            } as ToolCallMessageBlock);
+          toolBlocks.set(id, {
+            ...current,
+            state: 'completed',
+            output: event.output ?? event.result,
+          });
+          commitBlocks();
+          break;
+        }
+        case 'tool-output-error':
+        case 'tool-error': {
+          const id = event.toolCallId;
+          if (!id) break;
+          const current =
+            toolBlocks.get(id) ||
+            ({
+              type: 'tool',
+              toolCallId: id,
+              toolName: event.toolName || 'tool',
+              state: 'pending',
+            } as ToolCallMessageBlock);
+          toolBlocks.set(id, {
+            ...current,
+            state: 'error',
+            errorMessage:
+              event.errorText || event.error?.message || 'tool error',
+          });
+          commitBlocks();
+          break;
+        }
+        case 'error': {
+          const errorText =
+            event.errorText || event.error?.message || 'stream error';
+          assistantText += `\n\n> ⚠️ ${errorText}`;
+          commitBlocks();
+          break;
+        }
+        default:
+          break;
+      }
+    };
+
+    const consumeBuffer = () => {
+      // UI Message stream is SSE: events are separated by blank lines; each
+      // `data:` line contains a JSON payload.
+      let idx: number;
+      while ((idx = buffer.indexOf('\n\n')) !== -1) {
+        const raw = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const lines = raw.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            handleEvent(line.slice(5).trim());
+          }
+        }
+      }
+    };
+
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const {value, done} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream: true});
+        consumeBuffer();
+      }
+      buffer += decoder.decode();
+      consumeBuffer();
+    } catch (err: any) {
+      const errorMessage = `Stream error: ${err?.message || err}`;
+      assistantText += `\n\n> ⚠️ ${errorMessage}`;
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // ignore
+      }
+    }
+
+    // Finalize the message (no streaming flag so the text renders without the
+    // blinking cursor).
+    const finalBlocks: MessageBlock[] = [];
+    for (const tool of toolBlocks.values()) {
+      finalBlocks.push({...tool});
+    }
+    if (assistantText) {
+      finalBlocks.push({type: 'text', text: assistantText});
+    }
+    if (finalBlocks.length === 0) {
+      finalBlocks.push({type: 'text', text: ''});
+    }
+    patchMessage(messageId, () => ({
+      sender: 'bot',
+      blocks: finalBlocks,
+      streaming: false,
+    }));
+
+    historyRef.current = [
+      ...historyRef.current,
+      {
+        id: autokey(),
+        role: 'assistant',
+        parts: assistantText
+          ? [{type: 'text', text: assistantText}]
+          : [{type: 'text', text: ''}],
+      },
+    ];
+
+    return {message: assistantText, data: null};
+  };
+
+  return {
+    messages,
+    addMessage,
+    updateMessage,
+    sendPrompt,
+  };
+}
+
 export function AIPage() {
   usePageTitle('AI');
-  const chat = useChat();
+  const chat = useStreamingChat();
 
   const isEnabled =
     window.__ROOT_CTX.ai?.enabled || window.__ROOT_CTX.experiments?.ai || false;
@@ -225,7 +555,9 @@ function ChatMessage(props: {message: Message}) {
   const message = props.message;
   const username = message.sender === 'user' ? 'You' : 'Root AI';
   const user = window.firebase.user;
-  const animated = message.sender === 'bot';
+  // Skip the typewriter animation for streaming bot messages since the server
+  // already streams tokens incrementally.
+  const animated = message.sender === 'bot' && !message.streaming;
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -262,16 +594,26 @@ function ChatMessage(props: {message: Message}) {
 
 function ChatMessageBlocks(props: {message: Message; animated: boolean}) {
   const message = props.message;
-  const [blocks, setBlocks] = useState<MessageBlock[]>(
+  const [animatedBlocks, setAnimatedBlocks] = useState<MessageBlock[]>(
     props.animated ? [] : message.blocks
   );
+  // When the message is streaming, bypass the staggered animation buffer and
+  // always render the latest blocks directly so new tokens/tool calls appear
+  // immediately.
+  const blocks = message.streaming ? message.blocks : animatedBlocks;
 
   function addNextBlock() {
-    if (blocks.length >= message.blocks.length) {
+    if (message.streaming) {
       return;
     }
-    const newBlocks = [...blocks, message.blocks[blocks.length]];
-    setBlocks(newBlocks);
+    if (animatedBlocks.length >= message.blocks.length) {
+      return;
+    }
+    const newBlocks = [
+      ...animatedBlocks,
+      message.blocks[animatedBlocks.length],
+    ];
+    setAnimatedBlocks(newBlocks);
   }
 
   useEffect(() => {
@@ -308,6 +650,16 @@ function ChatMessageBlocks(props: {message: Message; animated: boolean}) {
           return (
             <ChatMessageTextBlock
               key={key}
+              block={block}
+              animated={props.animated && !block.streaming}
+              onAnimationComplete={() => addNextBlock()}
+            />
+          );
+        }
+        if (block.type === 'tool') {
+          return (
+            <ChatMessageToolBlock
+              key={block.toolCallId || key}
               block={block}
               animated={props.animated}
               onAnimationComplete={() => addNextBlock()}
@@ -372,6 +724,23 @@ function ChatMessageTextBlock(props: {
     });
     return tree;
   }, [props.block.text]);
+
+  // For streaming text blocks, bypass the animated-nodes buffer so re-renders
+  // always reflect the latest markdown tree.
+  if (props.block.streaming) {
+    return (
+      <div className="AIPage__ChatMessageTextBlock">
+        {markdownTree.children.map((node, i) => (
+          <MarkdownNode
+            key={i}
+            node={node}
+            animated={false}
+            onAnimationComplete={() => {}}
+          />
+        ))}
+      </div>
+    );
+  }
 
   const {nodes, next} = useAnimatedNodes({
     nodes: markdownTree.children,
@@ -659,6 +1028,94 @@ function ChatMessagePendingBlock(props: {
 
 function CursorDot() {
   return <div className="AIPage__CursorDot" />;
+}
+
+function ChatMessageToolBlock(props: {
+  block: ToolCallMessageBlock;
+  animated: boolean;
+  onAnimationComplete: () => void;
+}) {
+  const {block} = props;
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (props.animated) {
+      props.onAnimationComplete();
+    }
+  }, []);
+
+  const icon =
+    block.state === 'pending'
+      ? '◌'
+      : block.state === 'error'
+        ? '✗'
+        : '✓';
+  const summary = summarizeToolInput(block.toolName, block.input);
+
+  return (
+    <div className="AIPage__ToolCallBlock">
+      <button
+        className="AIPage__ToolCallBlock__header"
+        onClick={() => setExpanded((v) => !v)}
+        type="button"
+      >
+        <span className="AIPage__ToolCallBlock__icon">{icon}</span>
+        <span className="AIPage__ToolCallBlock__name">{block.toolName}</span>
+        {summary && (
+          <span className="AIPage__ToolCallBlock__summary">{summary}</span>
+        )}
+        <span className="AIPage__ToolCallBlock__toggle">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+      {expanded && (
+        <div className="AIPage__ToolCallBlock__body">
+          {block.input !== undefined && (
+            <div className="AIPage__ToolCallBlock__section">
+              <div className="AIPage__ToolCallBlock__section__label">input</div>
+              <pre className="AIPage__ToolCallBlock__section__content">
+                {safeStringify(block.input)}
+              </pre>
+            </div>
+          )}
+          {block.output !== undefined && (
+            <div className="AIPage__ToolCallBlock__section">
+              <div className="AIPage__ToolCallBlock__section__label">
+                output
+              </div>
+              <pre className="AIPage__ToolCallBlock__section__content">
+                {safeStringify(block.output)}
+              </pre>
+            </div>
+          )}
+          {block.errorMessage && (
+            <div className="AIPage__ToolCallBlock__section">
+              <div className="AIPage__ToolCallBlock__section__label">error</div>
+              <pre className="AIPage__ToolCallBlock__section__content">
+                {block.errorMessage}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function summarizeToolInput(toolName: string, input: any): string {
+  if (!input || typeof input !== 'object') return '';
+  if (toolName === 'readDoc' || toolName === 'editDoc') {
+    return typeof input.docId === 'string' ? `(${input.docId})` : '';
+  }
+  return '';
+}
+
+function safeStringify(value: any): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function ChatMessageImageBlock(props: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       '@ag-grid-community/styles':
         specifier: 32.3.9
         version: 32.3.9
+      '@ai-sdk/google-vertex':
+        specifier: ^3.0.0
+        version: 3.0.130(zod@3.25.76)
       '@genkit-ai/ai':
         specifier: 1.26.0
         version: 1.26.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@12.2.1)(genkit@1.26.0)
@@ -376,6 +379,9 @@ importers:
       '@types/cli-progress':
         specifier: 3.11.6
         version: 3.11.6
+      ai:
+        specifier: ^5.0.0
+        version: 5.0.176(zod@3.25.76)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -421,6 +427,9 @@ importers:
       tiny-glob:
         specifier: 0.2.9
         version: 0.2.9
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@babel/core':
         specifier: 7.17.9
@@ -709,6 +718,87 @@ packages:
 
   /@ag-grid-community/styles@32.3.9:
     resolution: {integrity: sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==}
+    dev: false
+
+  /@ai-sdk/anthropic@2.0.75(zod@3.25.76):
+    resolution: {integrity: sha512-ggiWzdjnOFOh02PrrkoYwHS1kNUvalUFOTp6cVaNPYKbNnp3e4j0N2tgroWHw+Pbuhzc4w8GLKuRmE+aTH9zyw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/gateway@2.0.80(zod@3.25.76):
+    resolution: {integrity: sha512-LzhdP2qCtI1SMUsFCwc4Zx5vHYAQklZkk//MnPMAaLGA24+UKOIjsOsBGT8olCH4XApr1gevmXn0wVl5pAhp3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/google-vertex@3.0.130(zod@3.25.76):
+    resolution: {integrity: sha512-/TJXy6yxA4CyobwY/NHrNDx1unhusgqKoJh9ILulsQEzZN7ri0dfRlQ+aLb6xji7iyaZUBLe7657Sz1H+8KMWQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/anthropic': 2.0.75(zod@3.25.76)
+      '@ai-sdk/google': 2.0.69(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 1.0.35(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      google-auth-library: 10.6.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@ai-sdk/google@2.0.69(zod@3.25.76):
+    resolution: {integrity: sha512-oD8Je9P2VsMcPiqPF7wuPY6LP7wje1RQl11vNTvgZsZoEAiqJFcZsbVK6DhHNeOkBcXLrb2MyIQy1wQ3u9MpTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/openai-compatible@1.0.35(zod@3.25.76):
+    resolution: {integrity: sha512-wDN0NfYNfe/i+12YR3n6g7zETHNQrw8WJhL9IjgNG1shXdoFDCqzitSz2rYqfqbuKirUIcChrMvjIpcr5nX14w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/provider-utils@3.0.23(zod@3.25.76):
+    resolution: {integrity: sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/provider@2.0.1:
+    resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
+    engines: {node: '>=18'}
+    dependencies:
+      json-schema: 0.4.0
     dev: false
 
   /@ampproject/remapping@2.1.2:
@@ -3640,22 +3730,22 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@maxim_mazurok/gapi.client.discovery-v1@0.4.20200806:
-    resolution: {integrity: sha512-Jeo/KZqK39DI6ExXHcJ4lqnn1O/wEqboQ6eQ8WnNpu5eJ7wUnX/C5KazOgs1aRhnIB/dVzDe8wm62nmtkMIoaw==}
+  /@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806:
+    resolution: {integrity: sha512-oVq9hnnI5VhAtsx55iJbPz8NRfJtWFpI1kINKeuygzCvsx90b1GQDeN3MDUvhADXiQ7+Izs316cqBnJjoDxCow==}
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
     dev: true
 
-  /@maxim_mazurok/gapi.client.drive-v3@0.1.20260305:
-    resolution: {integrity: sha512-i5D44X8hazSANFGOwzs6ONwB70fV+dTCsrodsbcjx1Cz+4UVC/QLPtnH/suSe7McHZOkUcrOzzbW8d2NAjCRMA==}
+  /@maxim_mazurok/gapi.client.drive-v3@0.2.20260311:
+    resolution: {integrity: sha512-2SVn8bIFZB9pq1JjqBNY/Agebv8gjHdr5k+ippSVsz07eWpl7d0Vxj4huX1O60ev0NDqrIx6a7w6MFFUIKlN6w==}
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
     dev: true
 
-  /@maxim_mazurok/gapi.client.sheets-v4@0.2.20260304:
-    resolution: {integrity: sha512-zrVgWMTZfaQ9h9cGgZLKu/2XKjLl/Rj8z7mz/WvtnA1eLfbLE0RG3zaN3IxMGcAXKfPSBw1/n2igi3iKEwVEgg==}
+  /@maxim_mazurok/gapi.client.sheets-v4@0.2.20260311:
+    resolution: {integrity: sha512-vQIXInvthytk29BQD+jwEKEDF95YijbTihVqzb/q0tr1lAvazAybM9iTaJ2W6bVUkcq8ydvTiYr8mKFicm3Mkw==}
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
@@ -3706,7 +3796,7 @@ packages:
     dependencies:
       agent-base: 7.1.0
       http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -5403,7 +5493,6 @@ packages:
 
   /@standard-schema/spec@1.0.0:
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-    dev: true
 
   /@tabler/icons-preact@2.39.0(preact@10.27.1):
     resolution: {integrity: sha512-3E82meMKs8BQkMGHWBCsoFqv8awqI1cK9OfHpm7nOYU+GLum+4gRgToFrgFVrVADIYw1IW1YIix3HPhWpdXAFQ==}
@@ -5619,19 +5708,19 @@ packages:
   /@types/gapi.client.discovery-v1@0.0.4:
     resolution: {integrity: sha512-uevhRumNE65F5mf2gABLaReOmbFSXONuzFZjNR3dYv6BmkHg+wciubHrfBAsp3554zNo3Dcg6dUAlwMqQfpwjQ==}
     dependencies:
-      '@maxim_mazurok/gapi.client.discovery-v1': 0.4.20200806
+      '@maxim_mazurok/gapi.client.discovery-v1': 0.5.20200806
     dev: true
 
   /@types/gapi.client.drive-v3@0.0.4:
     resolution: {integrity: sha512-jE37dJ0EzAdY0aJPFOp20xmec/aO0P4HtUIA9k07RMPyedFDOcuMlSac1r0PklwQdgXF7BHaMoObNHNAnwSQUQ==}
     dependencies:
-      '@maxim_mazurok/gapi.client.drive-v3': 0.1.20260305
+      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260311
     dev: true
 
   /@types/gapi.client.sheets-v4@0.0.4:
     resolution: {integrity: sha512-6kTJ7aDMAElfdQV1XzVJmZWjgbibpa84DMuKuaN8Cwqci/dkglPyHXKvsGrRugmuYvgFYr35AQqwz6j3q8R0dw==}
     dependencies:
-      '@maxim_mazurok/gapi.client.sheets-v4': 0.2.20260304
+      '@maxim_mazurok/gapi.client.sheets-v4': 0.2.20260311
     dev: true
 
   /@types/gapi.client@1.0.8:
@@ -6024,6 +6113,11 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
+  /@vercel/oidc@3.1.0:
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+    dev: false
+
   /@vitest/browser-playwright@4.0.10(playwright@1.56.1)(vite@7.1.4)(vitest@4.0.10):
     resolution: {integrity: sha512-pm7Hl7BNyluox+uGJPnT7vCRDSI+ibHcWQRtnCACAZWxD6/b2gN+8pO0qTDPHpxDSTPKDS5sT2dKTHLcr+lsng==}
     peerDependencies:
@@ -6267,11 +6361,11 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-    dev: true
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -6282,6 +6376,19 @@ packages:
       indent-string: 4.0.0
     dev: true
     optional: true
+
+  /ai@5.0.176(zod@3.25.76):
+    resolution: {integrity: sha512-qO8cLBcgeVQx7F1nAbNiVrtgaGeVC6PO10F5BYJiSp2J+BXBqH/dkbtEMEKzWwTWma0d1NJZYW0sWW4F1F7oyA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/gateway': 2.0.80(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
+    dev: false
 
   /ajv-formats@2.1.1(ajv@8.17.1):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -6788,7 +6895,7 @@ packages:
     dev: true
 
   /buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -8641,7 +8748,6 @@ packages:
   /eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
-    dev: true
 
   /eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -9648,13 +9754,24 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /gcp-metadata@5.2.0:
     resolution: {integrity: sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==}
@@ -9678,6 +9795,17 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /genkit@1.26.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@12.2.1):
     resolution: {integrity: sha512-+bfQWefF56mZU8RTH0zHwlXyreA1rMkEXBBb5mNqP1OVuv92F8eJWP80/8M+wvL8OeaxBiejtbGIjcepOJRgpA==}
@@ -9898,6 +10026,20 @@ packages:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: false
 
+  /google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /google-auth-library@8.7.0:
     resolution: {integrity: sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==}
     engines: {node: '>=12'}
@@ -9977,6 +10119,11 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+    dev: false
 
   /google-p12-pem@4.0.1:
     resolution: {integrity: sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==}
@@ -10239,15 +10386,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /https-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-
   /https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -10256,7 +10394,6 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -12715,7 +12852,7 @@ packages:
       debug: 4.3.4
       get-uri: 6.0.2
       http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       pac-resolver: 7.0.0
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -13352,7 +13489,7 @@ packages:
       agent-base: 7.1.0
       debug: 4.3.4
       http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
       pac-proxy-agent: 7.0.1
       proxy-from-env: 1.1.0


### PR DESCRIPTION
## Summary
Replaces the existing non-streaming AI chat implementation with a new streaming-based chat system powered by the Vercel AI SDK. The new implementation streams text tokens and tool invocations (read/edit docs) in real-time, providing a more responsive user experience.

## Key Changes

- **New streaming chat hook** (`useStreamingChat`): Replaces `useChat` as the primary chat controller. Maintains message history in Vercel AI SDK's `UIMessage` format and streams responses from the `/cms/api/ai.stream` endpoint.

- **Server-side streaming endpoint** (`/cms/api/ai.stream`): New API route that accepts messages and streams AI responses as Server-Sent Events (SSE). Uses Google Vertex AI with Gemini models and provides tools for reading/editing CMS docs.

- **Tool call visualization** (`ChatMessageToolBlock`): New UI component to display tool invocations (pending/completed/error states) with expandable sections showing input, output, and error details.

- **Streaming-aware rendering**: Updated `ChatMessageBlocks` and `ChatMessageTextBlock` to bypass staggered animations when messages are streaming, allowing new tokens and tool calls to appear immediately without animation delays.

- **New message block type**: Added `ToolCallMessageBlock` to represent AI tool invocations in the message structure, with support for tracking state and results.

- **Updated animation logic**: Modified typewriter animation to skip streaming messages, preventing cursor blinking during active streams.

## Implementation Details

- The streaming chat maintains a `UIMessage[]` history for the server and a display-friendly `Message[]` list for the UI, syncing them as responses complete.
- SSE parsing handles multiple event types: `text-delta`, `tool-input-start`, `tool-call`, `tool-input-available`, `tool-output-available`, `tool-result`, `tool-error`, and `error`.
- Tool blocks are tracked in a `Map` and updated in-place as tool execution progresses through pending → completed/error states.
- The `pipeWebResponseToExpress` utility forwards Vercel AI SDK's web `Response` to Express, enabling streaming to the client.
- System prompt and tool definitions are built server-side based on CMS configuration.

https://claude.ai/code/session_01P2BzEZSnxxUdYVsFFi5GFT