### PR TITLE
fix: clone schemas before walking in convertOneOfTypes

### DIFF
--- a/.changeset/twenty-adults-drum.md
+++ b/.changeset/twenty-adults-drum.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: clone schemas before walking in convertOneOfTypes

--- a/packages/root-cms/core/project.test.ts
+++ b/packages/root-cms/core/project.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, test} from 'vitest';
+import {convertOneOfTypes, SchemaModule} from './project.js';
+import * as schema from './schema.js';
+
+describe('convertOneOfTypes', () => {
+  test('registers inline oneof types from pattern-matched schemas', () => {
+    // An inline schema that lives inside /modules/ModuleA.schema.ts but isn't
+    // itself a top-level default export.
+    const InlineChild = schema.define({
+      name: 'InlineChild',
+      fields: [schema.string({id: 'text'})],
+    });
+    const ModuleA = schema.define({
+      name: 'ModuleA',
+      fields: [schema.oneOf({id: 'inner', types: [InlineChild]})],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/ModuleA.schema.ts': {default: ModuleA},
+    };
+    const collection = (): schema.Collection => ({
+      id: 'pages',
+      name: 'Pages',
+      url: '/[...slug]',
+      fields: [
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({
+            types: schema.glob('/modules/*.schema.ts'),
+          }),
+        }),
+      ],
+    });
+
+    const first = convertOneOfTypes(collection(), schemaModules);
+    expect(Object.keys(first.types || {})).toEqual(
+      expect.arrayContaining(['ModuleA', 'InlineChild'])
+    );
+
+    // The source ModuleA must not have been mutated — its nested oneof types
+    // should still be the original array of Schema objects.
+    const moduleAOneOf = ModuleA.fields[0] as schema.OneOfField;
+    expect(moduleAOneOf.types).toEqual([InlineChild]);
+
+    // A second invocation against the same schemaModules must still produce
+    // the full types map. Prior to the fix this regressed because SCHEMA_MODULES
+    // was mutated in place and the inline types couldn't be recovered from the
+    // top-level name map on the second pass.
+    const second = convertOneOfTypes(collection(), schemaModules);
+    expect(second.types?.InlineChild).toBeDefined();
+    expect(second.types?.ModuleA).toBeDefined();
+  });
+
+  test('does not mutate source schemas resolved via string reference', () => {
+    const InlineChild = schema.define({
+      name: 'InlineChild',
+      fields: [schema.string({id: 'text'})],
+    });
+    const Container = schema.define({
+      name: 'Container',
+      fields: [schema.oneOf({id: 'inner', types: [InlineChild]})],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/schemas/Container.schema.ts': {default: Container},
+    };
+    const collection: schema.Collection = {
+      id: 'pages',
+      name: 'Pages',
+      url: '/[...slug]',
+      fields: [
+        schema.oneOf({id: 'root', types: ['Container']}),
+      ],
+    };
+
+    const result = convertOneOfTypes(collection, schemaModules);
+    expect(result.types?.Container).toBeDefined();
+    expect(result.types?.InlineChild).toBeDefined();
+
+    // Source Container must be left untouched.
+    const containerOneOf = Container.fields[0] as schema.OneOfField;
+    expect(containerOneOf.types).toEqual([InlineChild]);
+  });
+});

--- a/packages/root-cms/core/project.ts
+++ b/packages/root-cms/core/project.ts
@@ -110,10 +110,12 @@ function isSchemaPattern(value: unknown): value is schema.SchemaPattern {
 /**
  * Build a map of schema name to schema for resolving string references.
  */
-function buildSchemaNameMap(): Record<string, schema.Schema> {
+function buildSchemaNameMap(
+  schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
+): Record<string, schema.Schema> {
   const nameMap: Record<string, schema.Schema> = {};
-  for (const fileId in SCHEMA_MODULES) {
-    const module = SCHEMA_MODULES[fileId];
+  for (const fileId in schemaModules) {
+    const module = schemaModules[fileId];
     if (module.default && module.default.name) {
       nameMap[module.default.name] = module.default;
     }
@@ -141,8 +143,15 @@ function globToRegex(pattern: string): RegExp {
 
 /**
  * Resolves a SchemaPattern to an array of schema names.
+ *
+ * Returned schemas are deep-cloned so that callers may safely mutate them
+ * (e.g. by rewriting nested `oneof` `types` in place) without leaking those
+ * mutations back into `SCHEMA_MODULES`.
  */
-function resolveSchemaPattern(pattern: schema.SchemaPattern): {
+function resolveSchemaPattern(
+  pattern: schema.SchemaPattern,
+  schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
+): {
   names: string[];
   schemas: Record<string, schema.Schema>;
 } {
@@ -151,11 +160,11 @@ function resolveSchemaPattern(pattern: schema.SchemaPattern): {
   const names: string[] = [];
   const schemas: Record<string, schema.Schema> = {};
 
-  for (const fileId in SCHEMA_MODULES) {
+  for (const fileId in schemaModules) {
     if (!regex.test(fileId)) {
       continue;
     }
-    const module = SCHEMA_MODULES[fileId];
+    const module = schemaModules[fileId];
     if (!module.default || !module.default.name) {
       continue;
     }
@@ -164,17 +173,14 @@ function resolveSchemaPattern(pattern: schema.SchemaPattern): {
       continue;
     }
 
-    let schemaObj = module.default;
+    const schemaObj = structuredClone(module.default);
 
     // Apply field omissions if specified.
     if (pattern.omitFields && pattern.omitFields.length > 0) {
       const omitSet = new Set(pattern.omitFields);
-      schemaObj = {
-        ...schemaObj,
-        fields: schemaObj.fields.filter(
-          (f: schema.Field) => !omitSet.has(f.id || '')
-        ),
-      };
+      schemaObj.fields = schemaObj.fields.filter(
+        (f: schema.Field) => !omitSet.has(f.id || '')
+      );
     }
 
     names.push(schemaName);
@@ -190,16 +196,24 @@ function resolveSchemaPattern(pattern: schema.SchemaPattern): {
  *
  * String references (used for self-referencing schemas) are resolved from the
  * project's schema modules. SchemaPatterns are resolved by matching file paths.
+ *
+ * Schemas pulled in via SchemaPattern or string-name reference are always
+ * deep-cloned before being walked. The walk rewrites `oneof` fields in place,
+ * and skipping the clone would mutate the shared entries in `SCHEMA_MODULES`
+ * and corrupt subsequent calls (e.g. when building multiple collections).
  */
-function convertOneOfTypes(collection: schema.Collection): schema.Collection {
+export function convertOneOfTypes(
+  collection: schema.Collection,
+  schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
+): schema.Collection {
   const clone: schema.Collection = structuredClone(collection);
   const types: Record<string, schema.Schema> = clone.types || {};
-  const schemaNameMap = buildSchemaNameMap();
+  const schemaNameMap = buildSchemaNameMap(schemaModules);
 
   function handleOneOfField(field: schema.OneOfField) {
     // Handle SchemaPattern (from schema.glob()).
     if (isSchemaPattern(field.types)) {
-      const resolved = resolveSchemaPattern(field.types);
+      const resolved = resolveSchemaPattern(field.types, schemaModules);
       // Process nested oneOf fields in the resolved schemas.
       // Only process schemas that haven't been added to types yet to prevent
       // infinite recursion with self-referencing schemas (e.g., a Container
@@ -222,7 +236,7 @@ function convertOneOfTypes(collection: schema.Collection): schema.Collection {
         names.push(sub);
         // Resolve string references from the project schemas.
         if (!types[sub] && schemaNameMap[sub]) {
-          const resolvedSchema = schemaNameMap[sub];
+          const resolvedSchema = structuredClone(schemaNameMap[sub]);
           types[sub] = resolvedSchema;
           if (resolvedSchema.fields) {
             walk(resolvedSchema);


### PR DESCRIPTION
## Summary
Fixed a bug where `convertOneOfTypes()` was mutating shared schema objects from `SCHEMA_MODULES`, causing subsequent calls to lose inline type information and fail to properly resolve nested oneOf types.

## Key Changes
- **Deep-clone schemas before mutation**: Modified `resolveSchemaPattern()` to use `structuredClone()` on resolved schemas and updated `convertOneOfTypes()` to clone schemas resolved via string references. This prevents mutations from leaking back into the shared `SCHEMA_MODULES`.

- **Made functions testable**: Exported `convertOneOfTypes()` and added optional `schemaModules` parameter to `buildSchemaNameMap()`, `resolveSchemaPattern()`, and `convertOneOfTypes()` to allow dependency injection for testing.

- **Improved documentation**: Added clarifying comments explaining that schemas are deep-cloned to prevent mutations and that the walk rewrites oneOf fields in place.

- **Added comprehensive tests**: Created `project.test.ts` with two test cases:
  - Verifies inline oneOf types are properly registered and that multiple invocations work correctly
  - Ensures source schemas are not mutated when resolved via string references

## Implementation Details
- The core issue was that `resolveSchemaPattern()` was directly using `module.default` without cloning, and string-referenced schemas were also used directly. When `convertOneOfTypes()` rewrote nested oneOf `types` arrays in place, these mutations persisted in `SCHEMA_MODULES`.
- The fix uses `structuredClone()` to create deep copies before any mutations occur, ensuring the original schemas remain pristine for subsequent operations.
- All three functions now accept an optional `schemaModules` parameter (defaulting to `SCHEMA_MODULES`) to support testing with custom schema collections.

https://claude.ai/code/session_01DaRYSgzjxPRdSKDYqnpfBr