### PR TITLE
feat: redesign pages with new bg color and surfaces

### DIFF
--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
@@ -1,4 +1,6 @@
 import {
+  Accordion,
+  Avatar,
   Button,
   Loader,
   MultiSelect,
@@ -13,6 +15,7 @@ import {IconSearch} from '@tabler/icons-preact';
 import {Timestamp} from 'firebase/firestore';
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import {Action, listActions} from '../../utils/actions.js';
+import {joinClassNames} from '../../utils/classes.js';
 import {getSpreadsheetUrl} from '../../utils/gsheets.js';
 import './ActionsLogs.css';
 
@@ -36,9 +39,25 @@ const TIME_FILTERS = [
   {value: '30d', label: 'Last 30 days'},
 ];
 
-export function ActionLogs(props: ActionLogsProps) {
+function useActions(limit?: number) {
   const [loading, setLoading] = useState(true);
   const [actions, setActions] = useState<Action[]>([]);
+
+  useEffect(() => {
+    // Fetch actions, applying limit if specified.
+    listActions(limit ? {limit: limit} : undefined).then((actions) => {
+      setActions(actions);
+      setLoading(false);
+    });
+  }, [limit]);
+
+  return {loading, actions};
+}
+
+export function ActionLogs(props: ActionLogsProps) {
+  if (props.compact) {
+    return <ActionLogsCompact {...props} />;
+  }
 
   // Filter state.
   const [searchQuery, setSearchQuery] = useState('');
@@ -50,18 +69,7 @@ export function ActionLogs(props: ActionLogsProps) {
   // Pagination state.
   const [currentPage, setCurrentPage] = useState(1);
 
-  async function init() {
-    // Fetch actions, applying limit if specified.
-    const actions = await listActions(
-      props.limit ? {limit: props.limit} : undefined
-    );
-    setActions(actions);
-    setLoading(false);
-  }
-
-  useEffect(() => {
-    init();
-  }, []);
+  const {actions, loading} = useActions();
 
   // Derive unique action types and users for filter dropdowns.
   const actionTypes = useMemo(() => {
@@ -284,8 +292,8 @@ function MetadataDisplay(props: {metadata: any}) {
   const entries = Object.entries(metadata);
   return (
     <div className="ActionsLogs__metadata">
-      {entries.map(([key, value], index) => (
-        <div key={index} className="ActionsLogs__metadata__item">
+      {entries.map(([key, value]) => (
+        <div key={key} className="ActionsLogs__metadata__item">
           <span className="ActionsLogs__metadata__key">{key}:</span>{' '}
           <span className="ActionsLogs__metadata__value">
             {formatMetadataValue(value)}
@@ -311,15 +319,39 @@ function formatMetadataValue(value: any): string {
     return `${value.slice(0, 3).join(', ')} (+${value.length - 3} more)`;
   }
   if (typeof value === 'object') {
-    return JSON.stringify(value);
+    const obj = cleanObject(value);
+    try {
+      return JSON.stringify(obj);
+    } catch (e) {
+      console.error(e);
+      console.error('failed to stringify json:', obj);
+    }
   }
   return String(value);
 }
 
+/**
+ * Removes keys starting with `_` from the object. Without this for some reason
+ * there are circular issues when trying to stringify to JSON.
+ */
+function cleanObject(obj: any) {
+  const newObj: any = {};
+  Object.entries(obj).forEach(([key, val]) => {
+    if (!key.startsWith('_')) {
+      newObj[key] = val;
+    }
+  });
+  return newObj;
+}
+
 /** Displays quick links for an action. */
-function QuickLinks(props: {action: Action}) {
+function QuickLinks(props: {action: Action; label?: string; limit?: number}) {
   const {action} = props;
-  const links: preact.JSX.Element[] = [];
+  let links: preact.JSX.Element[] = [];
+
+  function label(defaultLabel: string) {
+    return props.label || defaultLabel;
+  }
 
   if (action.action !== 'doc.delete' && action.metadata?.docId) {
     links.push(
@@ -331,7 +363,7 @@ function QuickLinks(props: {action: Action}) {
           compact
           href={`/cms/content/${action.metadata.docId}`}
         >
-          Open doc
+          {label('Open doc')}
         </Button>
       </Tooltip>
     );
@@ -351,7 +383,7 @@ function QuickLinks(props: {action: Action}) {
           compact
           href={`/cms/data/${action.metadata.datasourceId}`}
         >
-          Open data source
+          {label('Open data source')}
         </Button>
       </Tooltip>
     );
@@ -367,7 +399,7 @@ function QuickLinks(props: {action: Action}) {
           compact
           href={`/cms/releases/${action.metadata.releaseId}`}
         >
-          Open release
+          {label('Open release')}
         </Button>
       </Tooltip>
     );
@@ -384,7 +416,7 @@ function QuickLinks(props: {action: Action}) {
         href={getSpreadsheetUrl(action.metadata.sheetId)}
         target="_blank"
       >
-        Open sheet
+        {label('Open sheet')}
       </Button>
     );
   }
@@ -399,7 +431,7 @@ function QuickLinks(props: {action: Action}) {
         compact
         href="/cms/settings"
       >
-        Open settings
+        {label('Open settings')}
       </Button>
     );
   }
@@ -423,10 +455,112 @@ function QuickLinks(props: {action: Action}) {
   }
 
   if (links.length === 0) {
-    return <span className="ActionsLogs__links--empty">—</span>;
+    return <span className="ActionsLogs__links--empty"></span>;
+  }
+
+  if (props.limit) {
+    links = links.slice(0, props.limit);
   }
 
   return <div className="ActionsLogs__table__buttons">{links}</div>;
+}
+
+/**
+ * Compact variant of the action logs. Used primarily by the main ProjectPage.
+ */
+function ActionLogsCompact(props: ActionLogsProps) {
+  const {actions, loading} = useActions(props.limit || 10);
+
+  if (loading) {
+    return (
+      <div
+        className={joinClassNames(
+          props.className,
+          'ActionLogsCompact',
+          'ActionLogsCompact--loading'
+        )}
+      >
+        <Loader color="gray" size="xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={joinClassNames(
+        props.className,
+        'ActionLogsCompact',
+        'ActionLogsCompact--loading'
+      )}
+    >
+      {/* {loading &&  */}
+      <Accordion className="ActionLogsCompact__table" multiple>
+        {actions.map((action, i) => (
+          <Accordion.Item
+            label={<ActionLogsCompactItemPreview action={action} />}
+            key={i}
+          >
+            <ActionLogsCompactItemDetails action={action} />
+          </Accordion.Item>
+        ))}
+      </Accordion>
+    </div>
+  );
+}
+
+function ActionLogsCompactItemPreview(props: {action: Action}) {
+  const action = props.action;
+  const actionMetaId = getFirstMetadataId(action);
+  const actionBy = props.action.by || 'unknown';
+  const actionByInitial =
+    actionBy === 'unknown' ? '?' : actionBy.at(0)?.toUpperCase();
+
+  return (
+    <div className="ActionLogsCompactItemPreview">
+      <div className="ActionLogsCompactItemPreview__user">
+        <Tooltip label={actionBy} position="bottom" withArrow>
+          <Avatar alt={actionBy} size={20} radius="xl">
+            {actionByInitial}
+          </Avatar>
+        </Tooltip>
+      </div>
+      <div className="ActionLogsCompactItemPreview__timestamp">
+        {formatDate(action.timestamp)}
+      </div>
+      <div className="ActionLogsCompactItemPreview__action">
+        {action.action}
+      </div>
+      <div className="ActionLogsCompactItemPreview__actionMetaId">
+        {actionMetaId}
+      </div>
+      <div className="ActionLogsCompactItemPreview__buttons">
+        <QuickLinks action={action} label="Open" limit={1} />
+      </div>
+    </div>
+  );
+}
+
+function ActionLogsCompactItemDetails(props: {action: Action}) {
+  const action = props.action;
+  const metadata = {
+    user: action.by,
+    ...action.metadata,
+  };
+  return (
+    <div className="ActionLogsCompactItemDetails">
+      <MetadataDisplay metadata={metadata} />
+      <QuickLinks action={action} />
+    </div>
+  );
+}
+
+function getFirstMetadataId(action: Action) {
+  for (const key of Object.keys(action.metadata || {})) {
+    if (key.toLowerCase().endsWith('id')) {
+      return action.metadata[key];
+    }
+  }
+  return '';
 }
 
 /**
@@ -463,10 +597,11 @@ function formatDate(timestamp: Timestamp) {
     return 'Invalid date';
   }
   const date = validTs.toDate();
-  return date.toLocaleString('sv-SE', {
-    dateStyle: 'short',
-    timeStyle: 'medium',
-  });
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${mm}/${dd} ${hh}:${min}`;
 }
 
 /** A pretty printer for JavaScript objects. */

--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
@@ -17,6 +17,7 @@ import {useEffect, useMemo, useState} from 'preact/hooks';
 import {Action, listActions} from '../../utils/actions.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getSpreadsheetUrl} from '../../utils/gsheets.js';
+import {Surface} from '../Surface/Surface.js';
 import './ActionsLogs.css';
 
 export interface ActionLogsProps {
@@ -179,94 +180,96 @@ export function ActionLogs(props: ActionLogsProps) {
   return (
     <div className={`ActionsLog ${props.className || ''}`}>
       {!props.compact && (
-        <div className="ActionsLog__filters">
-          <TextInput
-            className="ActionsLog__filters__search"
-            placeholder="Search actions..."
-            icon={<IconSearch size={16} />}
-            value={searchQuery}
-            onChange={(e: Event) =>
-              setSearchQuery((e.target as HTMLInputElement).value)
-            }
-          />
-          <MultiSelect
-            className="ActionsLog__filters__select"
-            placeholder="Filter by action"
-            clearable
-            searchable
-            data={actionTypes}
-            value={actionFilters}
-            onChange={setActionFilters}
-          />
-          <MultiSelect
-            className="ActionsLog__filters__select"
-            placeholder="Filter by user"
-            clearable
-            searchable
-            data={users}
-            value={userFilters}
-            onChange={setUserFilters}
-          />
-          <Select
-            className="ActionsLog__filters__select"
-            placeholder="Filter by time"
-            data={TIME_FILTERS}
-            value={timeFilter}
-            onChange={setTimeFilter}
-          />
+        <div className="ActionsLog__tableHeader">
+          <div className="ActionsLog__filters">
+            <TextInput
+              className="ActionsLog__filters__search"
+              placeholder="Search actions..."
+              icon={<IconSearch size={16} />}
+              value={searchQuery}
+              onChange={(e: Event) =>
+                setSearchQuery((e.target as HTMLInputElement).value)
+              }
+            />
+            <MultiSelect
+              className="ActionsLog__filters__select"
+              placeholder="Filter by action"
+              clearable
+              searchable
+              data={actionTypes}
+              value={actionFilters}
+              onChange={setActionFilters}
+            />
+            <MultiSelect
+              className="ActionsLog__filters__select"
+              placeholder="Filter by user"
+              clearable
+              searchable
+              data={users}
+              value={userFilters}
+              onChange={setUserFilters}
+            />
+            <Select
+              className="ActionsLog__filters__select"
+              placeholder="Filter by time"
+              data={TIME_FILTERS}
+              value={timeFilter}
+              onChange={setTimeFilter}
+            />
+          </div>
+          <div className="ActionsLog__summary">
+            Showing {paginatedActions.length} of {filteredActions.length}{' '}
+            actions
+            {filteredActions.length !== actions.length &&
+              ` (filtered from ${actions.length} total)`}
+          </div>
         </div>
       )}
 
-      {!props.compact && (
-        <div className="ActionsLog__summary">
-          Showing {paginatedActions.length} of {filteredActions.length} actions
-          {filteredActions.length !== actions.length &&
-            ` (filtered from ${actions.length} total)`}
-        </div>
-      )}
-
-      <Table className="ActionsLog__table">
-        <thead>
-          <tr className="ActionsLogs__table__row ActionsLogs__table__row--header">
-            <th className="ActionsLogs__table__header">Timestamp</th>
-            <th className="ActionsLogs__table__header">User</th>
-            <th className="ActionsLogs__table__header">Action</th>
-            <th className="ActionsLogs__table__header">Details</th>
-            <th className="ActionsLogs__table__header">Links</th>
-          </tr>
-        </thead>
-        <tbody>
-          {paginatedActions.map((action, index) => (
-            <tr key={index} className="ActionsLogs__table__row">
-              <td className="ActionsLogs__table__col ActionsLogs__table__col--nowrap">
-                {formatDate(action.timestamp)}
-              </td>
-              <td className="ActionsLogs__table__col ActionsLogs__table__col--nowrap">
-                <span className="ActionsLogs__user">{action.by}</span>
-              </td>
-              <td className="ActionsLogs__table__col ActionsLogs__table__col--action">
-                <span className="ActionsLogs__action">{action.action}</span>
-              </td>
-              <td className="ActionsLogs__table__col ActionsLogs__table__col--metadata">
-                <MetadataDisplay metadata={action.metadata} />
-              </td>
-              <td className="ActionsLogs__table__col ActionsLogs__table__col--links">
-                <QuickLinks action={action} />
-              </td>
+      <Surface className="ActionsLog__tableSurface">
+        <Table className="ActionsLog__table">
+          <thead>
+            <tr className="ActionsLogs__table__row ActionsLogs__table__row--header">
+              <th className="ActionsLogs__table__header">Timestamp</th>
+              <th className="ActionsLogs__table__header">User</th>
+              <th className="ActionsLogs__table__header">Action</th>
+              <th className="ActionsLogs__table__header">Details</th>
+              <th className="ActionsLogs__table__header">Links</th>
             </tr>
-          ))}
-          {paginatedActions.length === 0 && (
-            <tr>
-              <td
-                colSpan={5}
-                className="ActionsLogs__table__col ActionsLogs__table__col--empty"
-              >
-                No actions found matching your filters.
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </Table>
+          </thead>
+          <tbody>
+            {paginatedActions.map((action, index) => (
+              <tr key={index} className="ActionsLogs__table__row">
+                <td className="ActionsLogs__table__col ActionsLogs__table__col--nowrap">
+                  {formatDate(action.timestamp)}
+                </td>
+                <td className="ActionsLogs__table__col ActionsLogs__table__col--nowrap">
+                  <span className="ActionsLogs__user">{action.by}</span>
+                </td>
+                <td className="ActionsLogs__table__col ActionsLogs__table__col--action">
+                  <span className="ActionsLogs__action">{action.action}</span>
+                </td>
+                <td className="ActionsLogs__table__col ActionsLogs__table__col--metadata">
+                  <MetadataDisplay metadata={action.metadata} />
+                </td>
+                <td className="ActionsLogs__table__col ActionsLogs__table__col--links">
+                  <QuickLinks action={action} />
+                </td>
+              </tr>
+            ))}
+            {paginatedActions.length === 0 && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="ActionsLogs__table__col ActionsLogs__table__col--empty"
+                >
+                  No actions found matching your filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </Surface>
 
       {!props.compact && totalPages > 1 && (
         <div className="ActionsLog__pagination">

--- a/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
+++ b/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
@@ -128,3 +128,75 @@
   justify-content: center;
   padding: 16px 0;
 }
+
+.ActionLogsCompactItemPreview {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  color: var(--color-text-dark);
+  letter-spacing: -0.4px;
+}
+
+.ActionLogsCompact__table .mantine-Accordion-control {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.ActionLogsCompact__table .mantine-Accordion-icon {
+  transform: rotate(-90deg);
+}
+
+.ActionLogsCompact__table [aria-expanded="true"] .mantine-Accordion-icon {
+  transform: rotate(0deg) !important;
+}
+
+.ActionLogsCompactItemPreview__timestamp {
+  white-space: nowrap;
+}
+
+.ActionLogsCompactItemPreview__action {
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--chip-background);
+  color: var(--chip-text-color);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.ActionLogsCompactItemPreview__actionMetaId {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.ActionLogsCompactItemPreview__buttons {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.ActionLogsCompactItemPreview__user .mantine-Tooltip-root {
+  display: block;
+}
+
+.ActionLogsCompactItemPreview__user .mantine-Avatar-placeholder {
+  background-color: #333;
+  color: #fff;
+}
+
+.ActionLogsCompact__table .mantine-Accordion-content {
+  background: var(--page-background);
+  border-top: 1px dashed var(--color-border);
+}
+
+.ActionLogsCompact__table .mantine-Accordion-contentInner {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.ActionLogsCompactItemDetails .ActionsLogs__table__buttons {
+  margin-top: 8px;
+}

--- a/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
+++ b/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
@@ -33,7 +33,19 @@
   color: var(--color-text-secondary);
 }
 
+.ActionsLog__tableHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 60px;
+}
+
+.ActionsLog__tableSurface {
+  padding: 0;
+}
+
 .ActionsLog__table {
+  border: none;
   font-family: var(--font-family-mono);
 }
 

--- a/packages/root-cms/ui/components/CollectionTree/CollectionTree.css
+++ b/packages/root-cms/ui/components/CollectionTree/CollectionTree.css
@@ -11,9 +11,10 @@
 
 .CollectionTree__collection {
   display: grid;
-  grid-template-columns: 20px 1fr;
+  grid-template-columns: 28px 1fr;
   align-items: center;
   padding: 8px 12px;
+  padding-left: 12px !important;
   column-gap: 12px;
   row-gap: 4px;
   width: 100%;
@@ -25,41 +26,51 @@
   text-decoration: none;
   transition: background-color 0.18s ease;
   position: relative;
+  border: 1px solid var(--color-border);
+  background: var(--surface-background);
+  border-radius: var(--surface-border-radius);
 }
 
 .CollectionTree__collection.active {
-  color: black;
-  background-color: #efefef;
+  background: #fff;
+  border-color: #000;
 }
 
 .CollectionTree__collection:hover {
-  background-color: var(--button-background-hover);
+  background: var(--surface-background-hover);
 }
 
 .CollectionTree__collection:active {
-  background-color: var(--button-background-active);
+  background: var(--surface-background-active);
+  transform: translateY(2px);
 }
 
 .CollectionTree__collection__icon {
   margin-top: 2px;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
+  background: var(--chip-background);
+  border-radius: var(--surface-border-radius);
 }
 
 .CollectionTree__collection__icon svg:first-child {
   cursor: pointer;
   flex-shrink: 0;
+  width: 16px;
 }
 
 .CollectionTree__collection__content {
-  color: #333;
+  color: var(--color-text-default);
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 
 .CollectionTree__collection__desc {
+  color: var(--color-text-gray);
   grid-column: 2 / span 1;
   font-size: 12px;
 }
@@ -75,15 +86,10 @@
 }
 
 .CollectionTree__accordion .mantine-Accordion-control {
-  padding: 16px 8px;
+  padding: 12px 0;
   font-size: 14px;
   font-weight: 600;
   background: transparent;
-  transition: background-color 0.18s ease;
-}
-
-.CollectionTree__accordion .mantine-Accordion-control:hover {
-  background-color: var(--button-background-hover);
 }
 
 .CollectionTree__accordion .mantine-Accordion-label {
@@ -92,6 +98,23 @@
 
 .CollectionTree__accordion .mantine-Accordion-contentInner {
   padding: 0;
+}
+
+.CollectionTree__accordion .mantine-Accordion-icon {
+  transform: rotate(-90deg);
+  margin-right: 8px;
+}
+
+.CollectionTree__accordion [aria-expanded="true"] .mantine-Accordion-icon {
+  transform: rotate(0deg) !important;
+}
+
+.CollectionTree__accordion__children {
+  margin-bottom: 12px;
+}
+
+.CollectionTree__accordion:last-child .CollectionTree__accordion__children {
+  margin-bottom: 0;
 }
 
 .CollectionTree__group__label,
@@ -106,9 +129,17 @@
   color: #333;
 }
 
+.CollectionTree__group__label__dividerLine {
+  height: 1px;
+  background: var(--color-border);
+  flex: 1;
+  margin-left: 8px;
+}
+
 .CollectionTree__accordion__children {
   display: flex;
   flex-direction: column;
+  gap: 8px;
 }
 
 .CollectionTree__group-empty {
@@ -138,11 +169,11 @@
 }
 
 .CollectionTree__group:hover {
-  background-color: var(--button-background-hover);
+  background-color: var(--surface-background-hover);
 }
 
 .CollectionTree__group:active {
-  background-color: var(--button-background-active);
+  background-color: var(--surface-background-active);
 }
 
 .CollectionTree__group__icon {

--- a/packages/root-cms/ui/components/CollectionTree/CollectionTree.tsx
+++ b/packages/root-cms/ui/components/CollectionTree/CollectionTree.tsx
@@ -1,6 +1,7 @@
 import './CollectionTree.css';
+
 import {Accordion} from '@mantine/core';
-import {IconBox, IconFolder} from '@tabler/icons-preact';
+import {IconFolder} from '@tabler/icons-preact';
 import {ComponentChildren} from 'preact';
 import {useMemo} from 'preact/hooks';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
@@ -8,107 +9,111 @@ import {joinClassNames} from '../../utils/classes.js';
 import {
   buildCollectionTree,
   CollectionNode,
-  filterCollectionTree,
 } from '../../utils/collection-tree.js';
 
 interface CollectionTreeProps {
+  className?: string;
   collections: Record<string, any>;
   activeCollectionId?: string;
-  query?: string;
   projectId: string;
 }
 
 export function CollectionTree(props: CollectionTreeProps) {
-  const {collections, activeCollectionId, query = '', projectId} = props;
-  const [openGroups, setOpenGroups] = useLocalStorage<string[]>(
-    `root-cms::${projectId}::open_groups`,
-    // Default to having "Default" group open.
-    ['group:Default']
+  const {collections, activeCollectionId, projectId} = props;
+  // Track closed groups instead of open groups so that new groups default to open.
+  const [closedGroups, setClosedGroups] = useLocalStorage<string[]>(
+    `root-cms::${projectId}::closed_groups`,
+    []
   );
 
-  const collectionTree = useMemo(
-    () => buildCollectionTree(collections),
-    [collections]
-  );
-  const filteredTree = useMemo(
-    () => filterCollectionTree(collectionTree, query),
-    [collectionTree, query]
-  );
+  const collectionTree = useMemo(() => buildCollectionTree(collections), []);
 
   const handleAccordionChange = (groupId: string, isOpen: boolean) => {
     if (isOpen) {
-      if (!openGroups.includes(groupId)) {
-        setOpenGroups([...openGroups, groupId]);
-      }
+      setClosedGroups(closedGroups.filter((id) => id !== groupId));
     } else {
-      setOpenGroups(openGroups.filter((id) => id !== groupId));
+      if (!closedGroups.includes(groupId)) {
+        setClosedGroups([...closedGroups, groupId]);
+      }
     }
   };
 
-  const renderAccordion = (
-    node: CollectionNode,
-    depth: number,
-    label: ComponentChildren
-  ) => {
-    const isOpen = openGroups.includes(node.id);
+  return (
+    <div className={joinClassNames(props.className, 'CollectionTree')}>
+      {collectionTree.map((node) => (
+        <CollectionNodeItem
+          key={node.id}
+          node={node}
+          depth={0}
+          activeCollectionId={activeCollectionId}
+          closedGroups={closedGroups}
+          onAccordionChange={handleAccordionChange}
+        />
+      ))}
+      {collectionTree.length === 0 && (
+        <div className="CollectionTree__collections__empty">
+          No collections match your query.
+        </div>
+      )}
+    </div>
+  );
+}
 
-    return (
-      <div
-        key={node.id}
-        className="CollectionTree__accordion"
-        style={{paddingLeft: `${depth * 16}px`}}
-      >
-        <Accordion
-          transitionDuration={0}
-          iconPosition="right"
-          initialItem={isOpen ? 0 : -1}
-          onChange={() => handleAccordionChange(node.id, !isOpen)}
+interface CollectionNodeItemProps {
+  node: CollectionNode;
+  depth: number;
+  activeCollectionId?: string;
+  closedGroups: string[];
+  onAccordionChange: (groupId: string, isOpen: boolean) => void;
+}
+
+/** Renders a single node in the collection tree (group or collection). */
+function CollectionNodeItem(props: CollectionNodeItemProps) {
+  const {node, depth, activeCollectionId, closedGroups, onAccordionChange} =
+    props;
+  const hasChildren = node.children.length > 0;
+
+  if (node.isGroup) {
+    // Render a group node using Accordion.
+    if (!hasChildren) {
+      // Group with no children, just render the label.
+      return (
+        <div
+          className="CollectionTree__group-empty"
+          style={{paddingLeft: `${depth * 16}px`}}
         >
-          <Accordion.Item label={label}>
-            <div className="CollectionTree__accordion__children">
-              {node.children.map((child) =>
-                renderCollectionNode(child, depth + 1)
-              )}
-            </div>
-          </Accordion.Item>
-        </Accordion>
-      </div>
-    );
-  };
-
-  const renderCollectionNode = (node: CollectionNode, depth: number = 0) => {
-    const hasChildren = node.children.length > 0;
-
-    if (node.isGroup) {
-      // Render a group node using Accordion.
-      if (!hasChildren) {
-        // Group with no children, just render the label.
-        return (
-          <div
-            key={node.id}
-            className="CollectionTree__group-empty"
-            style={{paddingLeft: `${depth * 16}px`}}
-          >
-            <IconFolder size={20} strokeWidth="1.75" />
-            <span>{node.name}</span>
-          </div>
-        );
-      }
-
-      return renderAccordion(
-        node,
-        depth,
-        <div className="CollectionTree__group__label">
-          <IconBox size={20} strokeWidth="1.75" />
+          <IconFolder size={20} strokeWidth="1.75" />
           <span>{node.name}</span>
         </div>
       );
-    } else {
-      // Render a collection node.
-      if (hasChildren) {
-        return renderAccordion(
-          node,
-          depth,
+    }
+
+    return (
+      <CollectionAccordion
+        node={node}
+        depth={depth}
+        activeCollectionId={activeCollectionId}
+        closedGroups={closedGroups}
+        onAccordionChange={onAccordionChange}
+        label={
+          <div className="CollectionTree__group__label">
+            <span>{node.name}</span>
+          </div>
+        }
+      />
+    );
+  }
+
+  // Render a collection node.
+  if (hasChildren) {
+    return (
+      <CollectionAccordion
+        node={node}
+        depth={depth}
+        activeCollectionId={activeCollectionId}
+        closedGroups={closedGroups}
+        onAccordionChange={onAccordionChange}
+        label={
           <div className="CollectionTree__collection__label">
             <a
               className={joinClassNames(
@@ -121,46 +126,79 @@ export function CollectionTree(props: CollectionTreeProps) {
               {node.name}
             </a>
           </div>
-        );
-      } else {
-        // Collection without children - simple link.
-        return (
-          <a
-            key={node.id}
-            className={joinClassNames(
-              'CollectionTree__collection',
-              node.id === activeCollectionId && 'active'
-            )}
-            href={`/cms/content/${node.id}`}
-            style={{paddingLeft: `${depth * 16 + 8}px`}}
-          >
-            <div className="CollectionTree__collection__icon">
-              <IconFolder size={20} strokeWidth="1.75" />
-            </div>
-            <div className="CollectionTree__collection__content">
-              <div className="CollectionTree__collection__name">
-                {node.name}
-              </div>
-              {node.description && (
-                <div className="CollectionTree__collection__desc">
-                  {node.description}
-                </div>
-              )}
-            </div>
-          </a>
-        );
-      }
-    }
-  };
+        }
+      />
+    );
+  }
+
+  // Collection without children - simple link.
+  return (
+    <a
+      className={joinClassNames(
+        'CollectionTree__collection',
+        node.id === activeCollectionId && 'active'
+      )}
+      href={`/cms/content/${node.id}`}
+    >
+      <div className="CollectionTree__collection__icon">
+        <IconFolder size={20} strokeWidth="1.75" />
+      </div>
+      <div className="CollectionTree__collection__content">
+        <div className="CollectionTree__collection__name">{node.name}</div>
+        {node.description && (
+          <div className="CollectionTree__collection__desc">
+            {node.description}
+          </div>
+        )}
+      </div>
+    </a>
+  );
+}
+
+interface CollectionAccordionProps {
+  node: CollectionNode;
+  depth: number;
+  label: ComponentChildren;
+  activeCollectionId?: string;
+  closedGroups: string[];
+  onAccordionChange: (groupId: string, isOpen: boolean) => void;
+}
+
+/** Renders an accordion wrapper for a collection tree node with children. */
+function CollectionAccordion(props: CollectionAccordionProps) {
+  const {
+    node,
+    depth,
+    label,
+    activeCollectionId,
+    closedGroups,
+    onAccordionChange,
+  } = props;
+  const isOpen = !closedGroups.includes(node.id);
 
   return (
-    <>
-      {filteredTree.map((node) => renderCollectionNode(node))}
-      {filteredTree.length === 0 && (
-        <div className="CollectionTree__collections__empty">
-          No collections match your query.
-        </div>
-      )}
-    </>
+    <div className="CollectionTree__accordion">
+      <Accordion
+        iconPosition="left"
+        initialItem={isOpen ? 0 : -1}
+        offsetIcon={false}
+        onChange={() => onAccordionChange(node.id, !isOpen)}
+      >
+        <Accordion.Item label={label}>
+          <div className="CollectionTree__accordion__children">
+            {node.children.map((child) => (
+              <CollectionNodeItem
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                activeCollectionId={activeCollectionId}
+                closedGroups={closedGroups}
+                onAccordionChange={onAccordionChange}
+              />
+            ))}
+          </div>
+        </Accordion.Item>
+      </Accordion>
+    </div>
   );
 }

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -12,6 +12,14 @@
   gap: 8px;
 }
 
+.ShareBox__user {
+  padding: 6px 16px;
+}
+
+.ShareBox__user:hover {
+  background-color: rgb(248, 249, 250);
+}
+
 .ShareBox__addUser__email {
   width: 100%;
 }
@@ -19,11 +27,10 @@
 .ShareBox__users {
   display: flex;
   flex-direction: column;
-  gap: 12px;
   margin-top: 12px;
   max-height: 640px;
   overflow: auto;
-  padding: 20px;
+  padding: 10px 0;
   border: 1px solid var(--color-border);
 }
 

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -1,6 +1,5 @@
 .ShareBox {
   position: relative;
-  max-width: 420px;
   min-height: 120px;
 }
 
@@ -22,7 +21,7 @@
   flex-direction: column;
   gap: 12px;
   margin-top: 12px;
-  max-height: 500px;
+  max-height: 640px;
   overflow: auto;
   padding: 20px;
   border: 1px solid var(--color-border);

--- a/packages/root-cms/ui/components/Surface/Surface.css
+++ b/packages/root-cms/ui/components/Surface/Surface.css
@@ -1,0 +1,6 @@
+.Surface {
+  background: var(--surface-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--surface-border-radius);
+  overflow: hidden;
+}

--- a/packages/root-cms/ui/components/Surface/Surface.tsx
+++ b/packages/root-cms/ui/components/Surface/Surface.tsx
@@ -1,0 +1,17 @@
+import './Surface.css';
+
+import {ComponentChildren} from 'preact';
+import {joinClassNames} from '../../utils/classes.js';
+
+export interface SurfaceProps {
+  className?: string;
+  children?: ComponentChildren;
+}
+
+export function Surface(props: SurfaceProps) {
+  return (
+    <div className={joinClassNames(props.className, 'Surface')}>
+      {props.children}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/hooks/useSiteSettings.tsx
+++ b/packages/root-cms/ui/hooks/useSiteSettings.tsx
@@ -37,9 +37,8 @@ export const SITE_SETTINGS: Setting[] = [
       return (
         <Button
           disabled={!value}
-          variant="outline"
-          size="compact-sm"
-          color="dark"
+          variant="default"
+          compact
           rightIcon={<IconExternalLink size={16} />}
           onClick={() => {
             if (value) {

--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -1,4 +1,5 @@
 .AIPage {
+  background: var(--page-background);
   width: 100%;
   height: 100%;
   display: flex;
@@ -202,7 +203,7 @@
 .AIPage__ChatBar {
   flex-shrink: 0;
   padding: 0 20px 20px;
-  background: #fff;
+  background: var(--page-background);
   position: relative;
   z-index: 10;
 }
@@ -215,7 +216,11 @@
   right: 0;
   bottom: 100%;
   height: 40px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(255, 255, 255, 0.90) 100%);
+  background: linear-gradient(
+    to bottom,
+    rgba(251, 251, 249, 0) 0%,
+    rgba(251, 251, 249, 0.9) 100%
+  );
   pointer-events: none;
 }
 
@@ -234,7 +239,8 @@
   resize: none;
   padding: 12px 48px;
   border-radius: 24px;
-  border: 1px solid #dedede;
+  border: 1px solid var(--color-border);
+  background: var(--surface-background);
   font-size: 16px;
   line-height: 26px;
   font-weight: 400;

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
@@ -1,5 +1,6 @@
 .AssetsPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .AssetsPage__header {
@@ -7,8 +8,13 @@
 }
 
 .AssetsPage p {
-  margin-top: 16px;
+  margin-top: 8px;
   max-width: 600px;
+}
+
+.AssetsPage__content {
+  max-width: 600px;
+  width: 100%;
 }
 
 .AssetsPage__urlGroup {

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
@@ -13,8 +13,9 @@
 }
 
 .AssetsPage__content {
-  max-width: 600px;
+  max-width: 640px;
   width: 100%;
+  padding: 20px;
 }
 
 .AssetsPage__urlGroup {

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
@@ -22,7 +22,7 @@ export function AssetsPage() {
           <Heading size="h1">Assets</Heading>
           <Text as="p">Upload assets to the project's GCS bucket.</Text>
         </div>
-        <div style={{maxWidth: 600, width: '100%'}}>
+        <div className="AssetsPage__content">
           <FileUploader
             value={file}
             onChange={setFile}

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
@@ -3,6 +3,7 @@ import {IconCopy} from '@tabler/icons-preact';
 import {useState} from 'preact/hooks';
 import {FileUploader} from '../../components/DocEditor/fields/FileUploader.js';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
@@ -22,7 +23,7 @@ export function AssetsPage() {
           <Heading size="h1">Assets</Heading>
           <Text as="p">Upload assets to the project's GCS bucket.</Text>
         </div>
-        <div className="AssetsPage__content">
+        <Surface className="AssetsPage__content">
           <FileUploader
             value={file}
             onChange={setFile}
@@ -52,7 +53,7 @@ export function AssetsPage() {
               Upload another file
             </Button>
           )}
-        </div>
+        </Surface>
       </div>
     </Layout>
   );

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -1,24 +1,42 @@
-/* .CollectionPage {
-  padding: 8px;
-} */
+.CollectionPage {
+  --side-width: 400px;
+  background: var(--page-background);
+}
+
+.CollectionPage__layout {
+  position: relative;
+  min-height: calc(100vh - var(--header-height));
+}
+
+.CollectionPage__side {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  overflow: auto;
+  width: var(--side-width);
+  z-index: 10;
+  padding-top: var(--page-padding);
+  padding-left: var(--page-padding);
+  padding-bottom: var(--page-padding);
+}
+
 .CollectionPage__side__title {
-  padding: 8px 12px;
-  /* border-bottom: 1px solid var(--color-border); */
-  text-transform: uppercase;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.2;
+  font-weight: 600;
+  margin-bottom: 12px;
 }
 
 .CollectionPage__side__search input {
   display: block;
   width: 100%;
   border: 1px solid var(--color-border);
-  border-left: none;
-  border-right: none;
-  border-radius: 0;
+  border-radius: var(--surface-border-radius);
   line-height: 24px;
   padding: 4px 12px;
   font-family: inherit;
+  margin-bottom: 8px;
 }
 
 .CollectionPage__side__search input:focus {
@@ -29,70 +47,16 @@
   color: #E5E5E5;
 }
 
-.CollectionPage__main__unselected {
-  padding: 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.CollectionPage__main__unselected svg {
-  transform: rotate(180deg);
-}
-
-.CollectionPage__main__unselected__title {
-  font-size: 14px;
-  font-weight: 500;
-}
-
-.CollectionPage__collection__header {
-  padding: 12px;
-  display: none;
-}
-
-.CollectionPage__collection__header__title {
-  font-size: 20px;
-  font-weight: 700;
-}
-
-.CollectionPage__collection__header__description {
-  font-size: 14px;
-  font-weight: 500;
-  margin-top: 4px;
-
-}
-
-.CollectionPage__collection__header__description a {
-  font-weight: 700;
-}
-
-.CollectionPage__collection__header__description a:hover {
-  color: black;
-}
-
-/* Tabs are hidden until there are more than one. */
-.CollectionPage__collection__tabs .mantine-Tabs-tabsListWrapper {
-  display: none;
-}
-
-.CollectionPage__collection__tabs .mantine-Tabs-body {
-  padding-top: 0;
-}
-
-.CollectionPage__collection__tabs [role="tab"] {
-  font-weight: 500;
-}
-
-.CollectionPage__collection__tabs [role="tab"][data-active] {
-  border-color: lightblue;
-}
-
-.CollectionPage__collection__tabs [role="tablist"] {
-  border-color: var(--color-border);
+.CollectionPage__main {
+  padding-left: calc(var(--side-width) + var(--page-padding));
+  padding-top: var(--page-padding);
+  padding-right: var(--page-padding);
+  max-height: calc(100vh - var(--header-height));
+  overflow: auto;
 }
 
 .CollectionPage__collection__docsTab {
-  padding: 16px 12px 250px;
+  padding: 0 0 120px;
 }
 
 .CollectionPage__collection__docsTab__header {
@@ -100,10 +64,14 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
+  margin-bottom: 12px;
 }
 
 .CollectionPage__collection__docsTab__header__title {
   flex: 1;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .CollectionPage__collection__docsTab__controls {
@@ -120,21 +88,32 @@
   align-items: center;
 }
 
-.CollectionPage__collection__docsTab__controls__sort__label {
-  font-weight: 600;
+.CollectionPage__collection__docsTab__controls__showArchived .mantine-Switch-root {
+  display: flex;
+  align-items: center;
+  flex-direction: row-reverse;
+  gap: 8px;
 }
 
-.CollectionPage__collection__docsList {
-  margin-top: 16px;
-  border-bottom: 1px solid var(--color-border);
+.CollectionPage__collection__docsTab__controls__showArchived .mantine-Switch-label {
+  color: var(--color-text-default);
+  font-weight: 500;
+  margin-left: 0;
+}
+
+.CollectionPage__collection__docsTab__controls__sort__label {
+  font-weight: 500;
 }
 
 .CollectionPage__collection__docsList__doc {
   display: flex;
   align-items: center;
-  padding: 8px 0;
-  border-top: 1px solid var(--color-border);
+  padding: 12px;
   overflow: hidden;
+}
+
+.CollectionPage__collection__docsList__doc + .CollectionPage__collection__docsList__doc {
+  border-top: 1px solid var(--color-border);
 }
 
 .CollectionPage__collection__docsList__doc__content {

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -1,7 +1,7 @@
 import './CollectionPage.css';
 
-import {Button, Loader, Select, Tabs, Tooltip} from '@mantine/core';
-import {IconArrowRoundaboutRight, IconCirclePlus} from '@tabler/icons-preact';
+import {Button, Loader, Select, Switch} from '@mantine/core';
+import {IconCirclePlus} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {CollectionTree} from '../../components/CollectionTree/CollectionTree.js';
@@ -9,10 +9,8 @@ import {ConditionalTooltip} from '../../components/ConditionalTooltip/Conditiona
 import {DocActionsMenu} from '../../components/DocActionsMenu/DocActionsMenu.js';
 import {DocStatusBadges} from '../../components/DocStatusBadges/DocStatusBadges.js';
 import {FilePreview} from '../../components/FilePreview/FilePreview.js';
-import {Heading} from '../../components/Heading/Heading.js';
-import {Markdown} from '../../components/Markdown/Markdown.js';
 import {NewDocModal} from '../../components/NewDocModal/NewDocModal.js';
-import {SplitPanel} from '../../components/SplitPanel/SplitPanel.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {useDocsList} from '../../hooks/useDocsList.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
@@ -28,7 +26,6 @@ interface CollectionPageProps {
 
 export function CollectionPage(props: CollectionPageProps) {
   const {route} = useLocation();
-  const [query, setQuery] = useState('');
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   usePageTitle(props.collection ? `Content: ${props.collection}` : 'Content');
 
@@ -65,41 +62,26 @@ export function CollectionPage(props: CollectionPageProps) {
 
   return (
     <Layout>
-      <SplitPanel className="CollectionPage" localStorageId="CollectionPage">
-        <SplitPanel.Item className="CollectionPage__side">
-          <div className="CollectionPage__side__title">Content</div>
-          <div className="CollectionPage__side__search">
-            <input
-              type="text"
-              placeholder="Search"
-              onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
-            />
-          </div>
-          <div className="CollectionPage__side__collections">
+      <div className="CollectionPage">
+        <div className="CollectionPage__layout">
+          <div className="CollectionPage__side">
+            {/* <div className="CollectionPage__side__title">Content</div> */}
             <CollectionTree
               collections={collections}
               activeCollectionId={props.collection}
-              query={query}
               projectId={projectId}
             />
           </div>
-        </SplitPanel.Item>
-        <SplitPanel.Item className="CollectionPage__main" fluid>
-          {props.collection ? (
-            <CollectionPage.Collection
-              key={props.collection}
-              collection={props.collection}
-            />
-          ) : (
-            <div className="CollectionPage__main__unselected">
-              <IconArrowRoundaboutRight size={24} strokeWidth={1.75} />
-              <div className="CollectionPage__main__unselected__title">
-                Select a collection to get started.
-              </div>
-            </div>
-          )}
-        </SplitPanel.Item>
-      </SplitPanel>
+          <div className="CollectionPage__main">
+            {props.collection && (
+              <CollectionPage.Collection
+                key={props.collection}
+                collection={props.collection}
+              />
+            )}
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 }
@@ -116,6 +98,10 @@ CollectionPage.Collection = (props: CollectionProps) => {
   const [orderBy, setOrderBy] = useLocalStorage<string>(
     `root::CollectionPage:${props.collection}:orderBy`,
     'modifiedAt'
+  );
+  const [showArchived, setShowArchived] = useLocalStorage<boolean>(
+    `root::CollectionPage:${props.collection}:showArchived`,
+    false
   );
   const [newDocModalOpen, setNewDocModalOpen] = useState(false);
 
@@ -137,7 +123,10 @@ CollectionPage.Collection = (props: CollectionProps) => {
     })) || []),
   ];
 
-  const [loading, listDocs, docs] = useDocsList(props.collection, {orderBy});
+  const [loading, listDocs, docs] = useDocsList(props.collection, {
+    orderBy,
+    includeArchived: showArchived,
+  });
 
   return (
     <>
@@ -147,99 +136,93 @@ CollectionPage.Collection = (props: CollectionProps) => {
         onClose={() => setNewDocModalOpen(false)}
       />
       <div className="CollectionPage__collection">
-        <div className="CollectionPage__collection__header">
-          <div className="CollectionPage__collection__header__title">
-            {collection.name}
-          </div>
-          {collection.description && (
-            <Markdown
-              className="CollectionPage__collection__header__description"
-              code={collection.description}
-            />
-          )}
-        </div>
-        <Tabs className="CollectionPage__collection__tabs" active={1}>
-          <Tabs.Tab label="Docs">
-            <div className="CollectionPage__collection__docsTab">
-              {!loading && docs.length > 0 && (
-                <div className="CollectionPage__collection__docsTab__header">
-                  <Heading className="CollectionPage__collection__docsTab__header__title">
-                    {collection.name || props.collection}
-                  </Heading>
-                  <div className="CollectionPage__collection__docsTab__controls">
-                    <div className="CollectionPage__collection__docsTab__controls__sort">
-                      <div className="CollectionPage__collection__docsTab__controls__sort__label">
-                        Sort:
-                      </div>
-                      <Select
-                        size="xs"
-                        value={orderBy}
-                        onChange={(value: any) =>
-                          setOrderBy(value || 'modifiedAt')
-                        }
-                        data={sortOptions}
-                      />
-                    </div>
-                    <div className="CollectionPage__collection__docsTab__controls__newDoc">
-                      <ConditionalTooltip
-                        label="You don't have access to create new documents"
-                        condition={!canEdit}
-                      >
-                        <Button
-                          color="dark"
-                          size="xs"
-                          leftIcon={<IconCirclePlus size={16} />}
-                          onClick={() => setNewDocModalOpen(true)}
-                          disabled={!canEdit}
-                        >
-                          New
-                        </Button>
-                      </ConditionalTooltip>
-                    </div>
-                  </div>
-                </div>
-              )}
-              <div className="CollectionPage__collection__docsTab__content">
-                {loading ? (
-                  <div className="CollectionPage__collection__docsTab__content__loading">
-                    <Loader color="gray" size="xl" />
-                  </div>
-                ) : docs.length === 0 ? (
-                  <div class="CollectionPage__collection__docsEmpty">
-                    <div class="CollectionPage__collection__docsEmpty__icon">
-                      <EmptyDocsImage />
-                    </div>
-                    <div class="CollectionPage__collection__docsEmpty__title">
-                      Collection is empty.
-                    </div>
-                    <div class="CollectionPage__collection__docsEmpty__button">
-                      <ConditionalTooltip
-                        label="You don't have access to create new documents"
-                        condition={!canEdit}
-                      >
-                        <Button
-                          color="dark"
-                          size="xs"
-                          leftIcon={<IconCirclePlus size={16} />}
-                          onClick={() => setNewDocModalOpen(true)}
-                          disabled={!canEdit}
-                        >
-                          New
-                        </Button>
-                      </ConditionalTooltip>
-                    </div>
-                  </div>
-                ) : (
-                  <CollectionPage.DocsList
-                    collection={props.collection}
-                    docs={docs}
-                    reloadDocs={() => listDocs()}
+        <div className="CollectionPage__collection__docsTab">
+          {!loading && (
+            <div className="CollectionPage__collection__docsTab__header">
+              <div className="CollectionPage__collection__docsTab__header__title">
+                {collection.name || props.collection}
+              </div>
+              <div className="CollectionPage__collection__docsTab__controls">
+                <div className="CollectionPage__collection__docsTab__controls__showArchived">
+                  <Switch
+                    size="sm"
+                    color="dark"
+                    label="Show archived:"
+                    checked={showArchived}
+                    onChange={(e: any) =>
+                      setShowArchived(Boolean(e.currentTarget.checked))
+                    }
                   />
-                )}
+                </div>
+                <div className="CollectionPage__collection__docsTab__controls__sort">
+                  <div className="CollectionPage__collection__docsTab__controls__sort__label">
+                    Sort:
+                  </div>
+                  <Select
+                    size="xs"
+                    value={orderBy}
+                    onChange={(value: any) => setOrderBy(value || 'modifiedAt')}
+                    data={sortOptions}
+                  />
+                </div>
+                <div className="CollectionPage__collection__docsTab__controls__newDoc">
+                  <ConditionalTooltip
+                    label="You don't have access to create new documents"
+                    condition={!canEdit}
+                  >
+                    <Button
+                      color="dark"
+                      size="xs"
+                      leftIcon={<IconCirclePlus size={16} />}
+                      onClick={() => setNewDocModalOpen(true)}
+                      disabled={!canEdit}
+                    >
+                      New
+                    </Button>
+                  </ConditionalTooltip>
+                </div>
               </div>
             </div>
-          </Tabs.Tab>
-        </Tabs>
+          )}
+          <Surface className="CollectionPage__collection__docsTab__content">
+            {loading ? (
+              <div className="CollectionPage__collection__docsTab__content__loading">
+                <Loader color="gray" size="xl" />
+              </div>
+            ) : docs.length === 0 ? (
+              <div class="CollectionPage__collection__docsEmpty">
+                <div class="CollectionPage__collection__docsEmpty__icon">
+                  <EmptyDocsImage />
+                </div>
+                <div class="CollectionPage__collection__docsEmpty__title">
+                  Collection is empty.
+                </div>
+                <div class="CollectionPage__collection__docsEmpty__button">
+                  <ConditionalTooltip
+                    label="You don't have access to create new documents"
+                    condition={!canEdit}
+                  >
+                    <Button
+                      color="dark"
+                      size="xs"
+                      leftIcon={<IconCirclePlus size={16} />}
+                      onClick={() => setNewDocModalOpen(true)}
+                      disabled={!canEdit}
+                    >
+                      New
+                    </Button>
+                  </ConditionalTooltip>
+                </div>
+              </div>
+            ) : (
+              <CollectionPage.DocsList
+                collection={props.collection}
+                docs={docs}
+                reloadDocs={() => listDocs()}
+              />
+            )}
+          </Surface>
+        </div>
       </div>
     </>
   );
@@ -320,6 +303,8 @@ CollectionPage.DocsList = (props: {
                 data={doc}
                 onAction={(e) => {
                   if (
+                    e.action === 'archive' ||
+                    e.action === 'unarchive' ||
                     e.action === 'delete' ||
                     e.action === 'unpublish' ||
                     e.action === 'locked' ||

--- a/packages/root-cms/ui/pages/DataPage/DataPage.css
+++ b/packages/root-cms/ui/pages/DataPage/DataPage.css
@@ -1,5 +1,6 @@
 .DataPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .DataPage__header {
@@ -16,12 +17,12 @@
 }
 
 .DataPage__DataSourcesTable table {
-  border: 1px solid #dee2e6;
+  border: none;
 }
 
 .DataPage__DataSourcesTable th:not(:first-child),
 .DataPage__DataSourcesTable td:not(:first-child) {
-  border-left: 1px solid #dee2e6;
+  border-left: 1px solid var(--color-border);
 }
 
 .DataPage__DataSourcesTable th,

--- a/packages/root-cms/ui/pages/DataPage/DataPage.tsx
+++ b/packages/root-cms/ui/pages/DataPage/DataPage.tsx
@@ -6,6 +6,7 @@ import {useEffect, useState} from 'preact/hooks';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {DataSourceStatusButton} from '../../components/DataSourceStatusButton/DataSourceStatusButton.js';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
@@ -69,7 +70,7 @@ DataPage.DataSourcesTable = () => {
   }, []);
 
   return (
-    <div className="DataPage__DataSourcesTable">
+    <Surface className="DataPage__DataSourcesTable">
       {loading && <Loader color="gray" size="xl" />}
       {tableData.length > 0 && (
         <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
@@ -138,6 +139,6 @@ DataPage.DataSourcesTable = () => {
           </tbody>
         </Table>
       )}
-    </div>
+    </Surface>
   );
 };

--- a/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.css
+++ b/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.css
@@ -1,6 +1,6 @@
 .DataSourcePage {
-  padding: 60px;
-  padding-top: 48px;
+  background: var(--page-background);
+  padding: 48px var(--page-padding-lg) var(--page-padding-lg);
 }
 
 .DataSourcePage__header {
@@ -45,8 +45,12 @@
   margin-bottom: 16px;
 }
 
-.DataSourcePage__SyncStatus table {
+.DataSourcePage__SyncStatus__content {
   max-width: 400px;
+}
+
+.DataSourcePage__SyncStatus__content table {
+  border: none;
 }
 
 .DataSourcePage__DataSection {
@@ -71,4 +75,8 @@
   max-width: 400px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.DataSourcePage__DataTable__table {
+  border: none;
 }

--- a/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
@@ -13,6 +13,7 @@ import {ComponentChildren} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {DataSourceStatusButton} from '../../components/DataSourceStatusButton/DataSourceStatusButton.js';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
@@ -102,35 +103,37 @@ DataSourcePage.SyncStatus = (props: {
   return (
     <div className="DataSourcePage__SyncStatus">
       <Heading size="h2">Status</Heading>
-      <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
-        <thead>
-          <tr>
-            <th>last synced</th>
-            <th>last published</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <DataSourceStatusButton
-                dataSource={dataSource}
-                action="sync"
-                onAction={() => {
-                  if (props.onAction) {
-                    props.onAction('sync');
-                  }
-                }}
-              />
-            </td>
-            <td>
-              <DataSourceStatusButton
-                dataSource={dataSource}
-                action="publish"
-              />
-            </td>
-          </tr>
-        </tbody>
-      </Table>
+      <Surface className="DataSourcePage__SyncStatus__content">
+        <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
+          <thead>
+            <tr>
+              <th>last synced</th>
+              <th>last published</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <DataSourceStatusButton
+                  dataSource={dataSource}
+                  action="sync"
+                  onAction={() => {
+                    if (props.onAction) {
+                      props.onAction('sync');
+                    }
+                  }}
+                />
+              </td>
+              <td>
+                <DataSourceStatusButton
+                  dataSource={dataSource}
+                  action="publish"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </Surface>
     </div>
   );
 };
@@ -227,7 +230,9 @@ DataSourcePage.DataSectionWrap = (props: {
           )}
         </div>
       </div>
-      {props.children}
+      <Surface className="DataSourcePage__DataSection__content">
+        {props.children}
+      </Surface>
     </div>
   );
 };

--- a/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.css
+++ b/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.css
@@ -1,5 +1,6 @@
 .EditDataSourcePage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .EditDataSourcePage__header {
@@ -40,4 +41,9 @@
 
 .EditDataSourcePage__header__controls a {
   display: flex;
+}
+
+.EditDataSourcePage__form {
+  max-width: 690px;
+  padding: 20px;
 }

--- a/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/EditDataSourcePage/EditDataSourcePage.tsx
@@ -5,6 +5,7 @@ import {IconTrashFilled} from '@tabler/icons-preact';
 import {useLocation} from 'preact-iso';
 import {DataSourceForm} from '../../components/DataSourceForm/DataSourceForm.js';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
@@ -76,7 +77,9 @@ export function EditDataSourcePage(props: {id: string}) {
             </div>
           </div>
         </div>
-        <DataSourceForm dataSourceId={props.id} />
+        <Surface className="EditDataSourcePage__form">
+          <DataSourceForm dataSourceId={props.id} />
+        </Surface>
       </div>
     </Layout>
   );

--- a/packages/root-cms/ui/pages/LogsPage/LogsPage.css
+++ b/packages/root-cms/ui/pages/LogsPage/LogsPage.css
@@ -1,5 +1,6 @@
 .LogsPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .LogsPage__header {

--- a/packages/root-cms/ui/pages/ProjectPage/ProjectPage.css
+++ b/packages/root-cms/ui/pages/ProjectPage/ProjectPage.css
@@ -1,47 +1,28 @@
 .ProjectPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding);
 }
 
-.ProjectPage__headline {
-  margin-bottom: 60px;
+.ProjectPage__section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  max-width: 1280px;
 }
 
-.ProjectPage__body {
-  margin-top: 16px;
-  max-width: 70ch;
+.ProjectPage__sectionTitle {
+  font-size: 14px;
+  line-height: 1.2;
+  font-weight: 600;
 }
 
-.ProjectPage__section + .ProjectPage__section {
-  margin-top: 80px;
-}
-
-.ProjectPage__section__title {
-  margin-bottom: 20px;
-}
-
-.ProjectPage__section__title--flex {
-  display: flex;
+.ProjectPage__actionLogs__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
-  gap: 12px;
+  margin-bottom: 12px;
 }
 
-.ProjectPage__collectionTree {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  max-width: 580px;
-}
-
-.ProjectPage__collectionTree .mantine-Accordion-control {
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.ProjectPage__collectionTree .CollectionTree__accordion__children {
-  gap: 12px;
-}
-
-.ProjectPage__collectionTree .CollectionTree__collection {
-  border: 2px solid black;
-  border-radius: 8px;
+.ProjectPage__actionLogs .ActionLogsCompact__table .mantine-Accordion-item:last-child {
+  border-bottom: none;
 }

--- a/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
+++ b/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
@@ -1,62 +1,67 @@
-import {Button} from '@mantine/core';
-import {ActionLogs} from '../../components/ActionLogs/ActionLogs.js';
-import {CollectionTree} from '../../components/CollectionTree/CollectionTree.js';
-import {Heading} from '../../components/Heading/Heading.js';
-import {usePageTitle} from '../../hooks/usePageTitle.js';
-import {Layout} from '../../layout/Layout.js';
 import './ProjectPage.css';
 
+import {Button} from '@mantine/core';
+import {ComponentChildren} from 'preact';
+import {ActionLogs} from '../../components/ActionLogs/ActionLogs.js';
+import {CollectionTree} from '../../components/CollectionTree/CollectionTree.js';
+import {Surface} from '../../components/Surface/Surface.js';
+import {usePageTitle} from '../../hooks/usePageTitle.js';
+import {Layout} from '../../layout/Layout.js';
+
 export function ProjectPage() {
-  const projectName = window.__ROOT_CTX.rootConfig.projectName || 'Root CMS';
+  // const projectName = window.__ROOT_CTX.rootConfig.projectName || 'Root CMS';
   usePageTitle('Home');
   return (
     <Layout>
       <div className="ProjectPage">
-        <div className="ProjectPage__headline">
-          <Heading className="ProjectPage__title" size="h1">
-            {projectName}
-          </Heading>
-        </div>
-
         <div className="ProjectPage__section">
-          <Heading className="ProjectPage__section__title" size="h2">
-            Content
-          </Heading>
-          <ProjectPage.CollectionList />
-        </div>
-
-        <div className="ProjectPage__section">
-          <Heading
-            className="ProjectPage__section__title ProjectPage__section__title--flex"
-            size="h2"
-          >
-            <div>Recent actions</div>
-            <div>
-              <Button
-                component="a"
-                variant="default"
-                size="xs"
-                compact
-                href="/cms/logs"
-              >
-                Show all
-              </Button>
-            </div>
-          </Heading>
-          <ActionLogs limit={20} compact />
+          <ProjectPage.Collections />
+          <ProjectPage.ActionLogs />
         </div>
       </div>
     </Layout>
   );
 }
 
-ProjectPage.CollectionList = () => {
+interface SectionTitleProps {
+  className?: string;
+  children?: ComponentChildren;
+}
+
+ProjectPage.SectionTitle = (props: SectionTitleProps) => {
+  return <div className="ProjectPage__sectionTitle">{props.children}</div>;
+};
+
+ProjectPage.Collections = () => {
   const collections = window.__ROOT_CTX.collections;
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
 
   return (
-    <div className="ProjectPage__collectionTree">
+    <div className="ProjectPage__collections">
+      {/* <ProjectPage.SectionTitle>Content</ProjectPage.SectionTitle> */}
       <CollectionTree collections={collections} projectId={projectId} />
+    </div>
+  );
+};
+
+ProjectPage.ActionLogs = () => {
+  return (
+    <div className="ProjectPage__actionLogs">
+      <div className="ProjectPage__actionLogs__header">
+        <ProjectPage.SectionTitle>Recent actions</ProjectPage.SectionTitle>
+        <Button
+          component="a"
+          variant="default"
+          size="xs"
+          compact
+          href="/cms/logs"
+        >
+          Show all
+        </Button>
+      </div>
+      <Surface>
+        <ActionLogs limit={10} compact />
+      </Surface>
     </div>
   );
 };

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
@@ -1,6 +1,6 @@
 .ReleasePage {
-  padding: 60px;
-  padding-top: 48px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .ReleasePage__header {
@@ -54,6 +54,10 @@
   gap: 8px;
 }
 
+.ReleasePage__PublishStatus__table {
+  border: none;
+}
+
 .ReleasePage__DocsList {
   margin-top: 40px;
   max-width: 800px;
@@ -66,11 +70,7 @@
   margin-bottom: 20px;
 }
 
-.ReleasePage__DocsList__cards {
-  border-bottom: 1px solid var(--color-border);
-}
-
-.ReleasePage__DocsList__card {
+.ReleasePage__DocsList__card + .ReleasePage__DocsList__card {
   border-top: 1px solid var(--color-border);
 }
 

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
@@ -17,6 +17,7 @@ import {DocPreviewCard} from '../../components/DocPreviewCard/DocPreviewCard.js'
 import {Heading} from '../../components/Heading/Heading.js';
 import {ReleaseStatusBadge} from '../../components/ReleaseStatusBadge/ReleaseStatusBadge.js';
 import {useScheduleReleaseModal} from '../../components/ScheduleReleaseModal/ScheduleReleaseModal.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
@@ -209,52 +210,33 @@ ReleasePage.PublishStatus = (props: {
   return (
     <div className="ReleasePage__PublishStatus">
       <Heading size="h2">Status</Heading>
-      <Table verticalSpacing="xs" striped fontSize="xs">
-        <thead>
-          <tr>
-            <th>status</th>
-            <th>actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <ReleaseStatusBadge release={release} />
-            </td>
-            <td>
-              <div className="ReleasePage__PublishStatus__actions">
-                {!release.archivedAt && !release.scheduledAt && (
-                  <ConditionalTooltip
-                    label="You don't have access to publish this release"
-                    condition={!canPublish}
-                  >
-                    <Tooltip
-                      label="Publish the release immediately"
-                      position="bottom"
-                      withArrow
-                      disabled={!canPublish}
-                    >
-                      <Button
-                        variant="default"
-                        size="xs"
-                        compact
-                        onClick={() => onPublishClicked()}
-                        loading={publishLoading}
-                        disabled={!canPublish}
-                      >
-                        {release.publishedAt ? 'Re-publish' : 'Publish'}
-                      </Button>
-                    </Tooltip>
-                  </ConditionalTooltip>
-                )}
-                {!release.archivedAt &&
-                  (release.scheduledAt ? (
+      <Surface>
+        <Table
+          className="ReleasePage__PublishStatus__table"
+          verticalSpacing="xs"
+          striped
+          fontSize="xs"
+        >
+          <thead>
+            <tr>
+              <th>status</th>
+              <th>actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <ReleaseStatusBadge release={release} />
+              </td>
+              <td>
+                <div className="ReleasePage__PublishStatus__actions">
+                  {!release.archivedAt && !release.scheduledAt && (
                     <ConditionalTooltip
-                      label="You don't have access to manage scheduled releases"
+                      label="You don't have access to publish this release"
                       condition={!canPublish}
                     >
                       <Tooltip
-                        label="Cancel the scheduled release"
+                        label="Publish the release immediately"
                         position="bottom"
                         withArrow
                         disabled={!canPublish}
@@ -263,43 +245,69 @@ ReleasePage.PublishStatus = (props: {
                           variant="default"
                           size="xs"
                           compact
-                          onClick={() => onCancelScheduleClicked()}
+                          onClick={() => onPublishClicked()}
+                          loading={publishLoading}
                           disabled={!canPublish}
                         >
-                          Cancel Schedule
+                          {release.publishedAt ? 'Re-publish' : 'Publish'}
                         </Button>
                       </Tooltip>
                     </ConditionalTooltip>
-                  ) : (
-                    <ConditionalTooltip
-                      label="You don't have access to manage scheduled releases"
-                      condition={!canPublish}
-                    >
-                      <Tooltip
-                        label="Schedule the release to be published at a future date"
-                        position="bottom"
-                        withArrow
-                        wrapLines
-                        width={180}
-                        disabled={!canPublish}
+                  )}
+                  {!release.archivedAt &&
+                    (release.scheduledAt ? (
+                      <ConditionalTooltip
+                        label="You don't have access to manage scheduled releases"
+                        condition={!canPublish}
                       >
-                        <Button
-                          variant="default"
-                          size="xs"
-                          compact
-                          onClick={() => onScheduleClicked()}
+                        <Tooltip
+                          label="Cancel the scheduled release"
+                          position="bottom"
+                          withArrow
                           disabled={!canPublish}
                         >
-                          Schedule
-                        </Button>
-                      </Tooltip>
-                    </ConditionalTooltip>
-                  ))}
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </Table>
+                          <Button
+                            variant="default"
+                            size="xs"
+                            compact
+                            onClick={() => onCancelScheduleClicked()}
+                            disabled={!canPublish}
+                          >
+                            Cancel Schedule
+                          </Button>
+                        </Tooltip>
+                      </ConditionalTooltip>
+                    ) : (
+                      <ConditionalTooltip
+                        label="You don't have access to manage scheduled releases"
+                        condition={!canPublish}
+                      >
+                        <Tooltip
+                          label="Schedule the release to be published at a future date"
+                          position="bottom"
+                          withArrow
+                          wrapLines
+                          width={180}
+                          disabled={!canPublish}
+                        >
+                          <Button
+                            variant="default"
+                            size="xs"
+                            compact
+                            onClick={() => onScheduleClicked()}
+                            disabled={!canPublish}
+                          >
+                            Schedule
+                          </Button>
+                        </Tooltip>
+                      </ConditionalTooltip>
+                    ))}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </Surface>
     </div>
   );
 };
@@ -321,7 +329,7 @@ ReleasePage.DocsList = (props: {release: Release}) => {
           Edit
         </Button>
       </div>
-      <div className="ReleasePage__DocsList__cards">
+      <Surface className="ReleasePage__DocsList__cards">
         {docIds.map((docId) => (
           <div key={docId} className="ReleasePage__DocsList__card">
             <a href={`/cms/content/${docId}`}>
@@ -329,7 +337,7 @@ ReleasePage.DocsList = (props: {release: Release}) => {
             </a>
           </div>
         ))}
-      </div>
+      </Surface>
     </div>
   );
 };

--- a/packages/root-cms/ui/pages/ReleasesPage/ReleasesPage.css
+++ b/packages/root-cms/ui/pages/ReleasesPage/ReleasesPage.css
@@ -1,5 +1,6 @@
 .ReleasesPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .ReleasesPage__header {
@@ -33,4 +34,8 @@
   display: flex;
   justify-content: flex-end;
   margin-bottom: 20px;
+}
+
+.ReleasesPage__ReleasesTable__table {
+  border: none;
 }

--- a/packages/root-cms/ui/pages/ReleasesPage/ReleasesPage.tsx
+++ b/packages/root-cms/ui/pages/ReleasesPage/ReleasesPage.tsx
@@ -5,6 +5,7 @@ import {useEffect, useMemo, useState} from 'preact/hooks';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {ReleaseStatusBadge} from '../../components/ReleaseStatusBadge/ReleaseStatusBadge.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
@@ -26,7 +27,9 @@ export function ReleasesPage() {
         <div className="ReleasesPage__header">
           <Heading size="h1">Releases</Heading>
           <Text as="p">
-            Create a release for publishing content in a batch.
+            Bundle one or more documents and publish them together. Schedule a
+            release to go live at a specific time, or publish manually when
+            you're ready.
           </Text>
           <div className="ReleasesPage__header__buttons">
             <ConditionalTooltip
@@ -103,38 +106,46 @@ ReleasesPage.ReleasesTable = () => {
             />
           </div>
           {filteredReleases.length > 0 && (
-            <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
-              <thead>
-                <tr>
-                  <th>id</th>
-                  <th>description</th>
-                  <th>content</th>
-                  <th>status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredReleases.map((release) => (
-                  <tr key={release.id}>
-                    <td>
-                      <a href={`/cms/releases/${release.id}`}>{release.id}</a>
-                    </td>
-                    <td>{release.description || ''}</td>
-                    <td>
-                      {(release.docIds || []).map((docId) => (
-                        <div key={docId}>
-                          <a href={`/cms/content/${docId}`}>{docId}</a>
-                        </div>
-                      ))}
-                    </td>
-                    <td>
-                      <div className="ReleasesPage__ReleasesTable__publishStatus">
-                        <ReleaseStatusBadge release={release} />
-                      </div>
-                    </td>
+            <Surface>
+              <Table
+                className="ReleasesPage__ReleasesTable__table"
+                verticalSpacing="xs"
+                striped
+                highlightOnHover
+                fontSize="xs"
+              >
+                <thead>
+                  <tr>
+                    <th>id</th>
+                    <th>description</th>
+                    <th>content</th>
+                    <th>status</th>
                   </tr>
-                ))}
-              </tbody>
-            </Table>
+                </thead>
+                <tbody>
+                  {filteredReleases.map((release) => (
+                    <tr key={release.id}>
+                      <td>
+                        <a href={`/cms/releases/${release.id}`}>{release.id}</a>
+                      </td>
+                      <td>{release.description || ''}</td>
+                      <td>
+                        {(release.docIds || []).map((docId) => (
+                          <div key={docId}>
+                            <a href={`/cms/content/${docId}`}>{docId}</a>
+                          </div>
+                        ))}
+                      </td>
+                      <td>
+                        <div className="ReleasesPage__ReleasesTable__publishStatus">
+                          <ReleaseStatusBadge release={release} />
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Surface>
           )}
           {filteredReleases.length === 0 && (
             <Text as="p">No releases found for this filter.</Text>

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
@@ -1,11 +1,13 @@
 .SettingsPage {
-  padding: 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg);
 }
 
 .SettingsPage__section {
   display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 60px;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--page-padding-lg);
+  max-width: 1280px;
 }
 
 .SettingsPage__section__left__title {
@@ -16,22 +18,28 @@
   margin-bottom: 12px;
 }
 
+.SettingsPage__section__right {
+  padding: 20px;
+}
+
 .SettingsPage__section + .SettingsPage__section {
-  margin-top: 100px;
+  margin-top: var(--page-padding-lg);
 }
 
 .SettingsPage__section__setting {
-  max-width: 420px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.SettingsPage__section__setting + .SettingsPage__section__setting {
+  margin-top: 24px;
 }
 
 .SettingsPage__section__userPref {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 20px;
-  max-width: 420px;
 }
 
 .SettingsPage__section__userPref__description__body {

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -2,6 +2,7 @@ import './SettingsPage.css';
 import {Switch, Textarea} from '@mantine/core';
 import {Heading} from '../../components/Heading/Heading.js';
 import {ShareBox} from '../../components/ShareBox/ShareBox.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {SITE_SETTINGS, useSiteSettings} from '../../hooks/useSiteSettings.js';
@@ -38,12 +39,12 @@ export function SettingsPage() {
               </ul>
             </Text>
           </div>
-          <div className="SettingsPage__section__right">
+          <Surface className="SettingsPage__section__right">
             <Heading className="SettingsPage__section__right__title" size="h3">
               Users
             </Heading>
             <ShareBox className="SettingsPage__section__users__sharebox" />
-          </div>
+          </Surface>
         </div>
         <div className="SettingsPage__section">
           <div className="SettingsPage__section__left">
@@ -62,7 +63,7 @@ export function SettingsPage() {
               </p>
             </Text>
           </div>
-          <div className="SettingsPage__section__right">
+          <Surface className="SettingsPage__section__right">
             {SITE_SETTINGS.map((setting) => (
               <div className="SettingsPage__section__setting" key={setting.key}>
                 <Text size="body" weight="semi-bold">
@@ -89,7 +90,7 @@ export function SettingsPage() {
                 )}
               </div>
             ))}
-          </div>
+          </Surface>
         </div>
         <div className="SettingsPage__section">
           <div className="SettingsPage__section__left">
@@ -105,7 +106,7 @@ export function SettingsPage() {
               <p>These settings are for you only.</p>
             </Text>
           </div>
-          <div className="SettingsPage__section__right">
+          <Surface className="SettingsPage__section__right">
             <div className="SettingsPage__section__userPref">
               <div className="SettingsPage__section__userPref__description">
                 <Text
@@ -154,7 +155,7 @@ export function SettingsPage() {
                 />
               </div>
             </div>
-          </div>
+          </Surface>
         </div>
       </div>
     </Layout>

--- a/packages/root-cms/ui/pages/TranslationsPage/TranslationsPage.css
+++ b/packages/root-cms/ui/pages/TranslationsPage/TranslationsPage.css
@@ -1,5 +1,6 @@
 .TranslationsPage {
-  padding: 60px 60px 20px 60px;
+  background: var(--page-background);
+  padding: var(--page-padding-lg) var(--page-padding-lg) 20px;
 }
 
 .TranslationsPage__header {
@@ -7,6 +8,10 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 40px;
+}
+
+.TranslationsPage__content {
+  padding: 16px;
 }
 
 .TranslationsPage__TranslationsTable table {

--- a/packages/root-cms/ui/pages/TranslationsPage/TranslationsPage.tsx
+++ b/packages/root-cms/ui/pages/TranslationsPage/TranslationsPage.tsx
@@ -2,6 +2,7 @@ import './TranslationsPage.css';
 
 import {Button} from '@mantine/core';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Surface} from '../../components/Surface/Surface.js';
 import {TranslationsTable} from '../../components/TranslationsTable/TranslationsTable.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
@@ -24,7 +25,9 @@ export function TranslationsPage() {
             </Button>
           </div>
         </div>
-        <TranslationsTable />
+        <Surface className="TranslationsPage__content">
+          <TranslationsTable />
+        </Surface>
       </div>
     </Layout>
   );

--- a/packages/root-cms/ui/styles/global.css
+++ b/packages/root-cms/ui/styles/global.css
@@ -4,9 +4,20 @@
   --color-text-default: #333333;
   --color-text-dark: #333333;
   --color-text-gray: #6b7280;
-  --color-border: #EFEFEF;
-  --button-background-hover: #F5F5F5;
-  --button-background-active: #E5E5E5;
+  /* --color-border: #efefef; */
+  --color-border: #e4e4e1;
+  --button-background-hover: #f5f5f5;
+  --button-background-active: #e5e5e5;
+  --page-background: #fbfbf9;
+  --page-padding: 30px;
+  --page-padding-lg: 60px;
+  --surface-background: #fff;
+  --surface-background-hover: rgb(248, 249, 250);
+  --surface-background-active: rgb(248, 249, 250);
+  --surface-border-radius: 8px;
+  --chip-background: #efefef;
+  --chip-text-color: #000;
+  --header-height: 48px;
 }
 
 html {

--- a/packages/root-cms/ui/utils/collection-tree.ts
+++ b/packages/root-cms/ui/utils/collection-tree.ts
@@ -52,7 +52,7 @@ export function buildCollectionTree(
   // Second pass: organize into tree structure.
   Object.entries(collections).forEach(([id, collection]) => {
     const node = nodes[id];
-    const groupId = collection.group;
+    const groupId = collection.group || 'Content';
 
     if (groupId) {
       // Create group if it doesn't exist.
@@ -76,8 +76,8 @@ export function buildCollectionTree(
   const hasGroups = Object.keys(groups).length > 0;
   if (hasGroups && roots.length > 0) {
     const defaultGroup: CollectionNode = {
-      id: 'group:Default',
-      name: 'Default',
+      id: 'group:Content',
+      name: 'Content',
       isGroup: true,
       children: roots,
     };


### PR DESCRIPTION
Note: The main project page looks a little bare without the "create task" onebox, I'll tackle the task manager stuff in a separate PR. This is primarily to get a few pages onto the new layout designs and color schemes.

### Mock from Claude Design:

<img width="2168" height="1402" alt="Screenshot 2026-04-22 at 8 27 00 AM" src="https://github.com/user-attachments/assets/25887713-faa0-4bf1-a131-e898c6b4d1a4" />

### Screenshots:

<img width="2168" height="1402" alt="Screenshot 2026-04-22 at 7 31 51 AM" src="https://github.com/user-attachments/assets/853ceb04-50a1-4a02-a0ce-8d799db0a49d" />

<img width="2168" height="1402" alt="Screenshot 2026-04-22 at 7 31 56 AM" src="https://github.com/user-attachments/assets/774fbc80-bd1f-4b12-a9c1-c47709050193" />