### PR TITLE
fix: propagate context to RichText inline components

### DIFF
--- a/.changeset/olive-timers-trade.md
+++ b/.changeset/olive-timers-trade.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: propagate context to RichText inline components (#1060)

--- a/packages/root-cms/core/richtext.test.tsx
+++ b/packages/root-cms/core/richtext.test.tsx
@@ -1,0 +1,53 @@
+import {render, cleanup} from '@testing-library/preact';
+import {createContext} from 'preact';
+import {useContext} from 'preact/hooks';
+import {afterEach, expect, test} from 'vitest';
+import {RichText, RichTextData} from './richtext.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Regression test: inline components rendered via `renderToString` previously
+ * lost the surrounding Preact context (so e.g. `useTranslations()` couldn't
+ * find the `I18nContext`). The fix captures the parent's full context tree
+ * via a class component and threads it through `renderToString`, so any
+ * `useContext()` call inside an inline component sees the providers above
+ * `<RichText>`.
+ */
+test('inline component sees context providers from the parent render tree', () => {
+  const NameContext = createContext<string>('default');
+
+  function NameInline() {
+    const name = useContext(NameContext);
+    return <span data-testid="name">{name}</span>;
+  }
+
+  const data: RichTextData = {
+    blocks: [
+      {
+        type: 'paragraph',
+        data: {
+          text: 'Hello, {NameInline:abc}!',
+          components: {
+            abc: {type: 'NameInline', data: {}},
+          },
+        },
+      },
+    ],
+  };
+
+  const {container} = render(
+    <NameContext.Provider value="Alice">
+      <RichText data={data} components={{NameInline}} />
+    </NameContext.Provider>
+  );
+
+  // Marker was substituted, the inline span was rendered with the provider's
+  // value (not the context default).
+  expect(container.innerHTML).not.toContain('{NameInline:abc}');
+  expect(container.innerHTML).not.toContain('default');
+  expect(container.innerHTML).toContain('Alice');
+  expect(container.innerHTML).toContain('Hello,');
+});

--- a/packages/root-cms/core/richtext.tsx
+++ b/packages/root-cms/core/richtext.tsx
@@ -1,5 +1,5 @@
 import {StringParamsProvider, useTranslations} from '@blinkk/root';
-import {FunctionalComponent, createContext} from 'preact';
+import {Component, FunctionalComponent, createContext} from 'preact';
 import {useContext} from 'preact/hooks';
 import {renderToString} from 'preact-render-to-string';
 
@@ -94,21 +94,50 @@ RichText.Block = (props: RichTextBlock) => {
     return null;
   }
   const componentMap = useRichTextContextComponentMap();
-  const Component = componentMap[blockType];
-  if (!Component) {
+  const BlockComponent = componentMap[blockType];
+  if (!BlockComponent) {
     console.warn(`[RichText] ignoring unknown richtext type: "${blockType}"`);
     return null;
   }
-  const stringParams = collectInlineComponentParams(block, componentMap);
-  if (stringParams) {
-    return (
-      <StringParamsProvider value={stringParams}>
-        <Component {...block} />
-      </StringParamsProvider>
-    );
-  }
-  return <Component {...block} />;
+  return (
+    <InlineComponentRenderer
+      block={block}
+      componentMap={componentMap}
+      BlockComponent={BlockComponent}
+    />
+  );
 };
+
+interface InlineComponentRendererProps {
+  block: RichTextBlock;
+  componentMap: RichTextComponentMap;
+  BlockComponent: RichTextBlockComponent;
+}
+
+/**
+ * Class component used to capture the parent's full Preact context tree (via
+ * `this.context`) so that inline components rendered through `renderToString`
+ * have access to the same providers (e.g. I18nContext for `useTranslations`,
+ * any custom user contexts, etc.) as the surrounding render.
+ */
+class InlineComponentRenderer extends Component<InlineComponentRendererProps> {
+  render() {
+    const {block, componentMap, BlockComponent} = this.props;
+    const stringParams = collectInlineComponentParams(
+      block,
+      componentMap,
+      this.context
+    );
+    if (stringParams) {
+      return (
+        <StringParamsProvider value={stringParams}>
+          <BlockComponent {...block} />
+        </StringParamsProvider>
+      );
+    }
+    return <BlockComponent {...block} />;
+  }
+}
 
 export interface RichTextParagraphBlockProps {
   type: 'paragraph';
@@ -305,10 +334,15 @@ export function testContent(data: RichTextData) {
  * Collects inline component data from all blocks and renders them into a string
  * params map. Keys use the `{ComponentType:componentId}` format that matches
  * the markers in the rich text content.
+ *
+ * `renderContext` is the raw Preact context object captured from the calling
+ * component's render tree, so the inline components can read context providers
+ * (e.g. `useTranslations`, custom user contexts) just like any other component.
  */
 function collectInlineComponentParams(
   block: RichTextBlock,
-  componentMap: RichTextComponentMap
+  componentMap: RichTextComponentMap,
+  renderContext?: any
 ): Record<string, string> | null {
   const components: Record<string, any> = block?.data?.components || {};
   if (Object.keys(components).length === 0) {
@@ -320,7 +354,10 @@ function collectInlineComponentParams(
     const Component = componentMap[component.type];
     if (Component) {
       const key = `${component.type}:${componentId}`;
-      params[key] = renderToString(<Component {...component.data} />);
+      params[key] = renderToString(
+        <Component {...component.data} />,
+        renderContext
+      );
     } else {
       console.warn(
         `[RichText] could not find inline component for type: "${component.type}"`


### PR DESCRIPTION
## Summary
Fixed a bug where inline components rendered within RichText blocks lost access to Preact context providers (such as `I18nContext` for `useTranslations()`). The issue occurred because inline components were rendered via `renderToString()` without the parent's context tree.

## Key Changes
- Converted the `RichText.Block` functional component logic into a new `InlineComponentRenderer` class component that captures the full Preact context tree via `this.context`
- Updated `collectInlineComponentParams()` to accept and pass through the captured `renderContext` to `renderToString()`, enabling inline components to access parent providers
- Added comprehensive regression test verifying that inline components can now access context providers from the parent render tree

## Implementation Details
The fix leverages Preact's class component `this.context` property to capture the entire context tree at render time. This context object is then threaded through to `renderToString()`, which uses it to initialize the context for inline component rendering. This ensures inline components have the same access to providers (I18nContext, custom user contexts, etc.) as any other component in the tree.

https://claude.ai/code/session_01KUyfMWPzNCjVfYHEvCz41r