### PR TITLE
feat: add defaultOpen option to ArrayField

### DIFF
--- a/.changeset/khaki-boxes-greet.md
+++ b/.changeset/khaki-boxes-greet.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add defaultOpen option to ArrayField (#1061)

--- a/docs/collections/BlogPosts.schema.ts
+++ b/docs/collections/BlogPosts.schema.ts
@@ -85,6 +85,7 @@ export default schema.collection({
           id: 'blocks',
           label: 'Content blocks',
           help: 'Add blocks to embed various content types to the blog.',
+          defaultOpen: true,
           of: schema.oneOf({
             types: schema.glob('/blocks/*/*.schema.ts'),
           }),

--- a/docs/collections/Guide.schema.ts
+++ b/docs/collections/Guide.schema.ts
@@ -99,6 +99,7 @@ export default schema.collection({
                 id: 'blocks',
                 label: 'Section: Blocks',
                 help: 'Add blocks to embed various content types to the section.',
+                defaultOpen: true,
                 of: schema.oneOf({
                   types: schema.glob('/blocks/*/*.schema.ts'),
                 }),

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -221,6 +221,11 @@ export type ArrayField = CommonFieldProps & {
    * Label to use for the "add item" button. Defaults to `Add`.
    */
   buttonLabel?: string;
+  /**
+   * Whether array items should be open (expanded) by default. Defaults to
+   * `false`, meaning items start collapsed.
+   */
+  defaultOpen?: boolean;
 };
 
 export function array(field: Omit<ArrayField, 'type'>): ArrayField {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1448,7 +1448,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
                         <details
                           className="DocEditor__ArrayField__item"
                           key={key}
-                          open={newlyAdded.includes(key) || itemInDeeplink(key)}
+                          open={newlyAdded.includes(key) || itemInDeeplink(key) || !!field.defaultOpen}
                           onToggle={(e) => {
                             if ((e.target as HTMLDetailsElement).open) {
                               requestHighlightNode(


### PR DESCRIPTION
## Summary
Added a new `defaultOpen` configuration option to array fields that allows array items to be expanded by default instead of starting in a collapsed state.

## Changes
- **Schema**: Added `defaultOpen?: boolean` property to the `ArrayField` type in `schema.ts`, with documentation indicating it defaults to `false` (items start collapsed)
- **UI**: Updated the `DocEditor.ArrayField` component to respect the `defaultOpen` setting when determining the initial open state of array item details elements

## Implementation Details
The `defaultOpen` option is integrated into the existing logic that determines whether array items should be open. Items will now be expanded by default if:
- They were newly added, OR
- They are referenced in a deeplink, OR
- The `defaultOpen` option is set to `true`

This provides users with fine-grained control over the initial presentation of array fields in the document editor.

https://claude.ai/code/session_01BMnPc4pHhm9rkny3e45VnE