### PR TITLE
chore: add open doc button to copied doc notification

### DIFF
--- a/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.css
+++ b/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.css
@@ -23,6 +23,10 @@
   border-radius: 4px;
 }
 
+.CopyDocModal__notificationButton {
+  margin-top: 8px;
+}
+
 .CopyDocModal__buttons {
   margin-top: 24px;
   display: flex;

--- a/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
+++ b/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
@@ -110,11 +110,12 @@ export function CopyDocModal(modalProps: ContextModalProps<CopyDocModalProps>) {
           <div>
             <div>{`Successfully copied ${sourceLabel} to ${toDocId}.`}</div>
             <Button
+              className="CopyDocModal__notificationButton"
               component="a"
               href={docUrl}
               size="xs"
+              compact
               variant="default"
-              style={{marginTop: '8px'}}
             >
               Open doc
             </Button>

--- a/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
+++ b/packages/root-cms/ui/components/CopyDocModal/CopyDocModal.tsx
@@ -103,10 +103,24 @@ export function CopyDocModal(modalProps: ContextModalProps<CopyDocModalProps>) {
       }
 
       context.closeModal(id);
+      const docUrl = `/cms/content/${toCollectionId}/${cleanSlug}`;
       showNotification({
         title: 'Copied!',
-        message: `Succesfully copied ${sourceLabel} to ${toDocId}.`,
-        autoClose: 5000,
+        message: (
+          <div>
+            <div>{`Successfully copied ${sourceLabel} to ${toDocId}.`}</div>
+            <Button
+              component="a"
+              href={docUrl}
+              size="xs"
+              variant="default"
+              style={{marginTop: '8px'}}
+            >
+              Open doc
+            </Button>
+          </div>
+        ),
+        autoClose: 10000,
       });
       if (props.onSuccess) {
         props.onSuccess(toDocId);


### PR DESCRIPTION
## Summary
- Add an Open doc link button to the copied doc success notification.
- Keep the copied doc URL available from the notification and fix the success message spelling.

## Testing
- pnpm --filter @blinkk/root-cms build:ui