### PR TITLE
feat: expand cmd+k search to jump to cms objects and recent views

### DIFF
--- a/.changeset/four-files-obey.md
+++ b/.changeset/four-files-obey.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: expand cmd+k search to jump to cms objects and recent views

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
@@ -53,6 +53,87 @@
   border-radius: 2px;
 }
 
+.GlobalSearchAction__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.GlobalSearchAction__icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--mantine-color-gray-2, #e9ecef);
+  color: var(--mantine-color-dark-7, #343a40);
+}
+
+.GlobalSearchAction__icon--muted {
+  background: var(--mantine-color-gray-1, #f1f3f5);
+  color: var(--mantine-color-gray-6, #868e96);
+}
+
+.GlobalSearchAction__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.GlobalSearchAction__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--mantine-color-dark-9, #25262b);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.GlobalSearchAction__sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--mantine-color-gray-6, #868e96);
+  margin-top: 2px;
+}
+
+.GlobalSearchAction__subText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.GlobalSearchAction__subIcon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--mantine-color-gray-5, #adb5bd);
+}
+
+.GlobalSearchAction__tag {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: var(--mantine-color-gray-2, #e9ecef);
+  color: var(--mantine-color-gray-7, #495057);
+}
+
+.GlobalSearchAction--header {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--mantine-color-gray-6, #868e96);
+  padding: 8px 16px 4px;
+  background: transparent;
+  cursor: default;
+}
+
 .GlobalSearchAction--footer {
   font-size: 11px;
   color: var(--mantine-color-gray-6, #868e96);

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
@@ -2,14 +2,27 @@ import './GlobalSearch.css';
 import {SpotlightProvider, SpotlightAction} from '@mantine/spotlight';
 import {IconSearch} from '@tabler/icons-preact';
 import {ComponentChildren} from 'preact';
-import {useMemo, useState} from 'preact/hooks';
+import {useEffect, useMemo, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {
+  DocSlugHit,
   GlobalSearchHit,
   GlobalSearchStatus,
+  useDocSlugSearch,
   useGlobalSearch,
 } from '../../hooks/useGlobalSearch.js';
-import {GlobalSearchAction} from './GlobalSearchAction.js';
+import {usePendingReleases} from '../../hooks/usePendingReleases.js';
+import {DataSource, listDataSources} from '../../utils/data-source.js';
+import {
+  RecentView,
+  recentViewFromUrl,
+  recordRecentView,
+  useRecentViews,
+} from '../../utils/recent-views.js';
+import {
+  GlobalSearchAction,
+  GlobalSearchActionMeta,
+} from './GlobalSearchAction.js';
 
 function formatLastIndexed(status: GlobalSearchStatus | null): string | null {
   if (!status?.lastRun) {
@@ -28,18 +41,179 @@ function formatLastIndexed(status: GlobalSearchStatus | null): string | null {
   return `${Math.floor(ms / (24 * 60 * 60_000))}d ago`;
 }
 
-function buildAction(
+interface CollectionTarget {
+  kind: 'collection';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+interface DataSourceTarget {
+  kind: 'data-source';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+interface ReleaseTarget {
+  kind: 'release';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+type StaticTarget = CollectionTarget | DataSourceTarget | ReleaseTarget;
+
+function buildCollectionTargets(): CollectionTarget[] {
+  const collections = window.__ROOT_CTX?.collections || {};
+  return Object.entries(collections)
+    .map(([id, meta]) => {
+      const label = meta?.name || id;
+      const description = meta?.description;
+      return {
+        kind: 'collection' as const,
+        id,
+        url: `/cms/content/${id}`,
+        label,
+        description,
+        haystack: [id, label, description].filter(Boolean).join(' ').toLowerCase(),
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function buildDataSourceTargets(dataSources: DataSource[]): DataSourceTarget[] {
+  return dataSources.map((ds) => ({
+    kind: 'data-source' as const,
+    id: ds.id,
+    url: `/cms/data/${ds.id}`,
+    label: ds.id,
+    description: ds.description,
+    haystack: [ds.id, ds.description].filter(Boolean).join(' ').toLowerCase(),
+  }));
+}
+
+function buildReleaseTargets(
+  releases: {id: string; description?: string}[]
+): ReleaseTarget[] {
+  return releases.map((r) => ({
+    kind: 'release' as const,
+    id: r.id,
+    url: `/cms/releases/${r.id}`,
+    label: r.id,
+    description: r.description,
+    haystack: [r.id, r.description].filter(Boolean).join(' ').toLowerCase(),
+  }));
+}
+
+function filterStaticTargets(
+  targets: StaticTarget[],
+  query: string
+): StaticTarget[] {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return [];
+  }
+  // Prefer prefix matches; fall back to substring matches.
+  const prefix: StaticTarget[] = [];
+  const substr: StaticTarget[] = [];
+  for (const t of targets) {
+    if (t.id.toLowerCase().startsWith(q) || t.label.toLowerCase().startsWith(q)) {
+      prefix.push(t);
+    } else if (t.haystack.includes(q)) {
+      substr.push(t);
+    }
+  }
+  return [...prefix, ...substr];
+}
+
+function buildFieldHitAction(
   hit: GlobalSearchHit,
   onTrigger: () => void
 ): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'field', hit};
   return {
-    id: hit.id,
+    id: `field:${hit.id}`,
     title: hit.text || hit.fieldLabel,
     description: `${hit.collection} · ${hit.slug} · ${hit.fieldLabel}`,
     keywords: [hit.collection, hit.slug, hit.fieldLabel],
     onTrigger,
-    // Pass-through fields consumed by GlobalSearchAction.
-    hit,
+    meta,
+  };
+}
+
+function buildDocSlugAction(
+  hit: DocSlugHit,
+  onTrigger: () => void
+): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'doc', hit};
+  return {
+    id: `doc:${hit.docId}`,
+    title: hit.slug,
+    description: hit.collection,
+    keywords: [hit.collection, hit.slug, hit.docId],
+    onTrigger,
+    meta,
+  };
+}
+
+function buildStaticAction(
+  target: StaticTarget,
+  onTrigger: () => void
+): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'target', target};
+  return {
+    id: `${target.kind}:${target.id}`,
+    title: target.label,
+    description: target.description || target.id,
+    keywords: [target.id, target.label, target.description || ''],
+    onTrigger,
+    meta,
+  };
+}
+
+function buildRecentAction(
+  view: RecentView,
+  onTrigger: () => void
+): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'recent', view};
+  return {
+    id: `recent:${view.url}`,
+    title: view.label,
+    description: view.description || '',
+    keywords: [view.label, view.description || '', view.url],
+    onTrigger,
+    meta,
+  };
+}
+
+function buildHeader(id: string, label: string): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'header', label};
+  return {
+    id: `header:${id}`,
+    title: label,
+    description: '',
+    keywords: '__internal__',
+    onTrigger: () => {},
+    meta,
+  };
+}
+
+function buildFooter(lastIndexed: string): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'footer', lastIndexed};
+  return {
+    id: '__last-indexed__',
+    title: '',
+    description: '',
+    keywords: '__internal__',
+    onTrigger: () => {},
+    meta,
   };
 }
 
@@ -50,61 +224,134 @@ function GlobalSearchInner(props: {
 }) {
   const {query, onQueryChange} = props;
   const location = useLocation();
-  const {hits, loading, error, status} = useGlobalSearch(query);
+  const trimmedQuery = query.trim();
+  const {hits: fieldHits, loading: fieldLoading, status} =
+    useGlobalSearch(query);
+  const {hits: docSlugHits, loading: slugLoading} = useDocSlugSearch(query);
+
+  const recentViews = useRecentViews();
+
+  // Lazy-fetch data sources once when the spotlight provider mounts. Failures
+  // just leave the data source list empty — they shouldn't break search.
+  const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    listDataSources()
+      .then((list) => {
+        if (!cancelled) {
+          setDataSources(list);
+        }
+      })
+      .catch((err) => {
+        console.error('failed to list data sources:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const {releases: pendingReleases} = usePendingReleases();
+
+  // Static spotlight targets: collections (always present), data sources, and
+  // active releases (pending = not published, not archived).
+  const staticTargets = useMemo<StaticTarget[]>(() => {
+    return [
+      ...buildCollectionTargets(),
+      ...buildDataSourceTargets(dataSources),
+      ...buildReleaseTargets(pendingReleases),
+    ];
+  }, [dataSources, pendingReleases]);
+
+  // Track route changes and record CMS object views so they show up as
+  // recent results in the spotlight.
+  useEffect(() => {
+    const view = recentViewFromUrl(location.url);
+    if (view) {
+      recordRecentView(view);
+    }
+  }, [location.url]);
+
+  const navigate = (url: string) => location.route(url);
+
+  // When the query is empty, surface recent views; when populated, compose
+  // matches across static targets, doc slug lookups, and field text hits.
+  const actions: SpotlightAction[] = useMemo(() => {
+    if (!trimmedQuery) {
+      if (recentViews.length === 0) {
+        return [];
+      }
+      return [
+        buildHeader('recent', 'Recently viewed'),
+        ...recentViews.map((view) =>
+          buildRecentAction(view, () => navigate(view.url))
+        ),
+      ];
+    }
+
+    const result: SpotlightAction[] = [];
+    const matchedStatic = filterStaticTargets(staticTargets, trimmedQuery);
+    if (matchedStatic.length > 0) {
+      result.push(buildHeader('static', 'Jump to'));
+      for (const target of matchedStatic) {
+        result.push(buildStaticAction(target, () => navigate(target.url)));
+      }
+    }
+
+    if (docSlugHits.length > 0) {
+      result.push(buildHeader('docs', 'Documents'));
+      for (const hit of docSlugHits) {
+        const url = `/cms/content/${hit.collection}/${encodeURIComponent(
+          hit.slug
+        )}`;
+        result.push(buildDocSlugAction(hit, () => navigate(url)));
+      }
+    }
+
+    if (fieldHits.length > 0) {
+      result.push(buildHeader('fields', 'Field matches'));
+      for (const hit of fieldHits) {
+        const url = `/cms/content/${hit.collection}/${encodeURIComponent(
+          hit.slug
+        )}?deeplink=${encodeURIComponent(hit.deepKey)}`;
+        result.push(buildFieldHitAction(hit, () => navigate(url)));
+      }
+    }
+    return result;
+  }, [
+    trimmedQuery,
+    fieldHits,
+    docSlugHits,
+    staticTargets,
+    recentViews,
+    location,
+  ]);
 
   const lastIndexed = formatLastIndexed(status);
-
-  // Build SpotlightActions whenever results change. The onTrigger closure
-  // captures the current `route` so navigation works as expected.
-  const actions: SpotlightAction[] = useMemo(() => {
-    return hits.map((hit) => {
-      const url = `/cms/content/${hit.collection}/${encodeURIComponent(
-        hit.slug
-      )}?deeplink=${encodeURIComponent(hit.deepKey)}`;
-      return buildAction(hit, () => {
-        location.route(url);
-      });
-    });
-  }, [hits, location]);
+  const augmented = useMemo(() => {
+    // The "last indexed" footer is only meaningful while the user is actively
+    // querying the index. When the query is empty (recent views) or there are
+    // no results, we suppress it so the surface stays clean.
+    if (!lastIndexed || !trimmedQuery || actions.length === 0) {
+      return actions;
+    }
+    return [...actions, buildFooter(lastIndexed)];
+  }, [actions, lastIndexed, trimmedQuery]);
 
   // Compose the "nothing found" message based on state.
+  const loading = fieldLoading || slugLoading;
   const nothingFoundMessage = useMemo(() => {
     if (loading) {
       return 'Searching…';
     }
-    if (error) {
-      return `Search failed: ${error}`;
-    }
-    if (!query.trim()) {
-      return 'Type to search docs.';
+    if (!trimmedQuery) {
+      return 'Type to search docs, collections, releases…';
     }
     return 'No results.';
-  }, [loading, error, query]);
+  }, [loading, trimmedQuery]);
 
-  // Append a footer-like action that's never triggerable to surface the
-  // last-indexed timestamp at the bottom of the spotlight.
-  const augmented = useMemo(() => {
-    if (!lastIndexed) {
-      return actions;
-    }
-    return [
-      ...actions,
-      {
-        id: '__last-indexed__',
-        title: '',
-        description: '',
-        keywords: '__internal__',
-        // No-op: clicking does nothing.
-        onTrigger: () => {},
-        // Marker consumed by GlobalSearchAction to render footer styling.
-        __footer: true,
-        lastIndexed,
-      } as SpotlightAction,
-    ];
-  }, [actions, lastIndexed]);
-
-  // Pass-through filter: server already ranks/filters; we don't want the
-  // built-in title/description filter to drop our results.
+  // Pass-through filter: server already ranks/filters and our static-target
+  // filter is computed above; we don't want Spotlight's built-in title/
+  // description filter to drop our results.
   const filterAll = (_q: string, list: SpotlightAction[]) => list;
 
   return (
@@ -112,7 +359,7 @@ function GlobalSearchInner(props: {
       actions={augmented}
       shortcut={['mod + K']}
       onQueryChange={onQueryChange}
-      searchPlaceholder="Search docs and fields…"
+      searchPlaceholder="Search docs, collections, releases…"
       searchIcon={<IconSearch size={18} />}
       nothingFoundMessage={nothingFoundMessage}
       filter={filterAll}
@@ -127,9 +374,11 @@ function GlobalSearchInner(props: {
 }
 
 /**
- * Wraps children in a Mantine Spotlight bound to `mod + K`. Renders search
- * results that, when clicked, navigate the doc editor with a `?deeplink=…`
- * query param (handled by `useDeeplink`).
+ * Wraps children in a Mantine Spotlight bound to `mod + K`. Surfaces:
+ *  - Recently viewed CMS objects (when the query is empty)
+ *  - Collections, data sources, and active releases by name
+ *  - Documents by slug or `<collection>/<slug>` id
+ *  - Field text hits from the server-side MiniSearch index
  */
 export function GlobalSearch(props: {children: ComponentChildren}) {
   const [query, setQuery] = useState('');
@@ -139,3 +388,4 @@ export function GlobalSearch(props: {children: ComponentChildren}) {
     </GlobalSearchInner>
   );
 }
+

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
@@ -1,9 +1,66 @@
 import {SpotlightActionProps} from '@mantine/spotlight';
-import {IconChevronRight} from '@tabler/icons-preact';
-import type {GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
+import {
+  IconChevronRight,
+  IconClock,
+  IconDatabase,
+  IconFile,
+  IconFolder,
+  IconRocket,
+} from '@tabler/icons-preact';
+import {ComponentChild} from 'preact';
+import type {
+  DocSlugHit,
+  GlobalSearchHit,
+} from '../../hooks/useGlobalSearch.js';
+import type {RecentView, RecentViewKind} from '../../utils/recent-views.js';
 
 const SNIPPET_BEFORE = 60;
 const SNIPPET_AFTER = 120;
+
+interface CollectionTargetMeta {
+  kind: 'collection';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+interface DataSourceTargetMeta {
+  kind: 'data-source';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+interface ReleaseTargetMeta {
+  kind: 'release';
+  id: string;
+  url: string;
+  label: string;
+  description?: string;
+  haystack: string;
+}
+
+type StaticTargetMeta =
+  | CollectionTargetMeta
+  | DataSourceTargetMeta
+  | ReleaseTargetMeta;
+
+/**
+ * Discriminated payload attached to each SpotlightAction. The Mantine
+ * SpotlightAction type is open-ended, so we stash everything we need on a
+ * single `meta` field and let this component render the appropriate row.
+ */
+export type GlobalSearchActionMeta =
+  | {kind: 'field'; hit: GlobalSearchHit}
+  | {kind: 'doc'; hit: DocSlugHit}
+  | {kind: 'target'; target: StaticTargetMeta}
+  | {kind: 'recent'; view: RecentView}
+  | {kind: 'header'; label: string}
+  | {kind: 'footer'; lastIndexed: string};
 
 /**
  * Returns the highlighted text + surrounding context for a search hit.
@@ -52,50 +109,184 @@ function buildSnippet(hit: GlobalSearchHit): {
   return {pre, mark, post};
 }
 
-export function GlobalSearchAction(props: SpotlightActionProps) {
-  const action = props.action as any;
-
-  // Footer pseudo-action: render a non-interactive timestamp row.
-  if (action?.__footer && action?.lastIndexed) {
-    return (
-      <div className="GlobalSearchAction GlobalSearchAction--footer">
-        Last indexed {action.lastIndexed}
-      </div>
-    );
+function targetIcon(kind: StaticTargetMeta['kind']): ComponentChild {
+  if (kind === 'collection') {
+    return <IconFolder size={16} />;
   }
-
-  const hit = action?.hit as GlobalSearchHit | undefined;
-  if (!hit) {
-    return null;
+  if (kind === 'data-source') {
+    return <IconDatabase size={16} />;
   }
-  const snippet = buildSnippet(hit);
+  return <IconRocket size={16} />;
+}
+
+function recentIcon(kind: RecentViewKind): ComponentChild {
+  if (kind === 'collection') {
+    return <IconFolder size={16} />;
+  }
+  if (kind === 'data-source') {
+    return <IconDatabase size={16} />;
+  }
+  if (kind === 'release') {
+    return <IconRocket size={16} />;
+  }
+  return <IconFile size={16} />;
+}
+
+function targetLabel(kind: StaticTargetMeta['kind']): string {
+  if (kind === 'collection') return 'Collection';
+  if (kind === 'data-source') return 'Data source';
+  return 'Release';
+}
+
+function recentKindLabel(kind: RecentViewKind): string {
+  if (kind === 'collection') return 'Collection';
+  if (kind === 'data-source') return 'Data source';
+  if (kind === 'release') return 'Release';
+  return 'Doc';
+}
+
+interface RowProps {
+  hovered: boolean;
+  onTrigger: () => void;
+  className?: string;
+  children: ComponentChild;
+}
+
+function Row(props: RowProps) {
+  const className = [
+    'GlobalSearchAction',
+    props.className || '',
+    props.hovered ? 'GlobalSearchAction--hovered' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
   return (
     <button
       type="button"
-      className={
-        'GlobalSearchAction' +
-        (props.hovered ? ' GlobalSearchAction--hovered' : '')
-      }
+      className={className}
       onMouseDown={(e) => {
         // mousedown so the click registers before Spotlight closes the modal.
         e.preventDefault();
         props.onTrigger();
       }}
     >
-      <div className="GlobalSearchAction__crumbs">
-        <span className="GlobalSearchAction__docId">{hit.docId}</span>
-        <span className="GlobalSearchAction__sep">
-          <IconChevronRight size={16} />
-        </span>
-        <span className="GlobalSearchAction__field">{hit.fieldLabel}</span>
-      </div>
-      <div className="GlobalSearchAction__snippet">
-        <span>{snippet.pre}</span>
-        {snippet.mark && (
-          <mark className="GlobalSearchAction__mark">{snippet.mark}</mark>
-        )}
-        <span>{snippet.post}</span>
-      </div>
+      {props.children}
     </button>
   );
+}
+
+export function GlobalSearchAction(props: SpotlightActionProps) {
+  const meta = (props.action as any)?.meta as GlobalSearchActionMeta | undefined;
+  if (!meta) {
+    return null;
+  }
+
+  if (meta.kind === 'header') {
+    return (
+      <div className="GlobalSearchAction GlobalSearchAction--header">
+        {meta.label}
+      </div>
+    );
+  }
+
+  if (meta.kind === 'footer') {
+    return (
+      <div className="GlobalSearchAction GlobalSearchAction--footer">
+        Last indexed {meta.lastIndexed}
+      </div>
+    );
+  }
+
+  if (meta.kind === 'field') {
+    const hit = meta.hit;
+    const snippet = buildSnippet(hit);
+    return (
+      <Row hovered={props.hovered} onTrigger={props.onTrigger}>
+        <div className="GlobalSearchAction__crumbs">
+          <span className="GlobalSearchAction__docId">{hit.docId}</span>
+          <span className="GlobalSearchAction__sep">
+            <IconChevronRight size={16} />
+          </span>
+          <span className="GlobalSearchAction__field">{hit.fieldLabel}</span>
+        </div>
+        <div className="GlobalSearchAction__snippet">
+          <span>{snippet.pre}</span>
+          {snippet.mark && (
+            <mark className="GlobalSearchAction__mark">{snippet.mark}</mark>
+          )}
+          <span>{snippet.post}</span>
+        </div>
+      </Row>
+    );
+  }
+
+  if (meta.kind === 'doc') {
+    const hit = meta.hit;
+    return (
+      <Row hovered={props.hovered} onTrigger={props.onTrigger}>
+        <div className="GlobalSearchAction__row">
+          <div className="GlobalSearchAction__icon">
+            <IconFile size={16} />
+          </div>
+          <div className="GlobalSearchAction__body">
+            <div className="GlobalSearchAction__title">{hit.slug}</div>
+            <div className="GlobalSearchAction__sub">
+              <span className="GlobalSearchAction__tag">Doc</span>
+              <span className="GlobalSearchAction__subText">{hit.docId}</span>
+            </div>
+          </div>
+        </div>
+      </Row>
+    );
+  }
+
+  if (meta.kind === 'target') {
+    const t = meta.target;
+    return (
+      <Row hovered={props.hovered} onTrigger={props.onTrigger}>
+        <div className="GlobalSearchAction__row">
+          <div className="GlobalSearchAction__icon">{targetIcon(t.kind)}</div>
+          <div className="GlobalSearchAction__body">
+            <div className="GlobalSearchAction__title">{t.label}</div>
+            <div className="GlobalSearchAction__sub">
+              <span className="GlobalSearchAction__tag">
+                {targetLabel(t.kind)}
+              </span>
+              {t.description && (
+                <span className="GlobalSearchAction__subText">
+                  {t.description}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </Row>
+    );
+  }
+
+  if (meta.kind === 'recent') {
+    const view = meta.view;
+    return (
+      <Row hovered={props.hovered} onTrigger={props.onTrigger}>
+        <div className="GlobalSearchAction__row">
+          <div className="GlobalSearchAction__icon GlobalSearchAction__icon--muted">
+            <IconClock size={16} />
+          </div>
+          <div className="GlobalSearchAction__body">
+            <div className="GlobalSearchAction__title">{view.label}</div>
+            <div className="GlobalSearchAction__sub">
+              <span className="GlobalSearchAction__tag">
+                {recentKindLabel(view.kind)}
+              </span>
+              <span className="GlobalSearchAction__subIcon">
+                {recentIcon(view.kind)}
+              </span>
+            </div>
+          </div>
+        </div>
+      </Row>
+    );
+  }
+
+  return null;
 }

--- a/packages/root-cms/ui/hooks/useGlobalSearch.tsx
+++ b/packages/root-cms/ui/hooks/useGlobalSearch.tsx
@@ -1,3 +1,13 @@
+import {
+  collection,
+  documentId,
+  endAt,
+  getDocs,
+  limit as fbLimit,
+  orderBy,
+  query,
+  startAt,
+} from 'firebase/firestore';
 import {useCallback, useEffect, useRef, useState} from 'preact/hooks';
 
 export interface GlobalSearchHit {
@@ -152,4 +162,157 @@ export function useSearchIndexStatus(): SearchIndexAdminStatus & {
   }, [refresh]);
 
   return {...data, loading, refresh};
+}
+
+export interface DocSlugHit {
+  collection: string;
+  slug: string;
+  /** "<collection>/<slug>" */
+  docId: string;
+}
+
+export interface UseDocSlugSearchResult {
+  hits: DocSlugHit[];
+  loading: boolean;
+}
+
+const SLUG_DEBOUNCE_MS = 200;
+const PER_COLLECTION_LIMIT = 5;
+
+/**
+ * Looks up CMS docs by slug (or `<collection>/<slug>` doc id) prefix using
+ * Firestore range queries on each collection's `Drafts` subcollection.
+ *
+ * Slug-only queries (e.g. `home`) fan out across every registered collection;
+ * a `<collection>/<slug>` form (e.g. `Pages/home`) restricts the lookup to a
+ * single collection. Empty queries clear the result list.
+ */
+export function useDocSlugSearch(
+  rawQuery: string,
+  options: {limit?: number} = {}
+): UseDocSlugSearchResult {
+  const [hits, setHits] = useState<DocSlugHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const cancelRef = useRef<{aborted: boolean} | null>(null);
+  const totalLimit = options.limit ?? 10;
+
+  useEffect(() => {
+    const trimmed = rawQuery.trim();
+    if (!trimmed) {
+      if (cancelRef.current) {
+        cancelRef.current.aborted = true;
+      }
+      cancelRef.current = null;
+      setHits([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+
+    const handle = window.setTimeout(async () => {
+      if (cancelRef.current) {
+        cancelRef.current.aborted = true;
+      }
+      const ctrl = {aborted: false};
+      cancelRef.current = ctrl;
+
+      let collFilter: string | null = null;
+      let prefix = trimmed;
+      const slashIdx = trimmed.indexOf('/');
+      if (slashIdx >= 0) {
+        collFilter = trimmed.slice(0, slashIdx);
+        prefix = trimmed.slice(slashIdx + 1);
+      }
+
+      const projectId = window.__ROOT_CTX?.rootConfig?.projectId;
+      const db = window.firebase?.db;
+      if (!projectId || !db) {
+        setHits([]);
+        setLoading(false);
+        return;
+      }
+
+      const allColls = Object.keys(window.__ROOT_CTX.collections || {});
+      const colls = collFilter
+        ? allColls.filter(
+            (c) => c.toLowerCase() === collFilter!.toLowerCase()
+          )
+        : allColls;
+
+      // Inclusive Firestore range bounds for a prefix match. The
+      // `` character is a high private-use codepoint that sorts
+      // after any normal slug character.
+      const lower = prefix;
+      const upper = `${prefix}`;
+
+      try {
+        const queries = colls.map(async (collId) => {
+          const ref = collection(
+            db,
+            'Projects',
+            projectId,
+            'Collections',
+            collId,
+            'Drafts'
+          );
+          const q = query(
+            ref,
+            orderBy(documentId()),
+            startAt(lower),
+            endAt(upper),
+            fbLimit(PER_COLLECTION_LIMIT)
+          );
+          try {
+            const snap = await getDocs(q);
+            const out: DocSlugHit[] = [];
+            snap.forEach((d) => {
+              out.push({
+                collection: collId,
+                slug: d.id,
+                docId: `${collId}/${d.id}`,
+              });
+            });
+            return out;
+          } catch (err) {
+            // Some Firestore instances reject documentId range filters in
+            // narrow contexts; swallow per-collection failures rather than
+            // taking down the whole spotlight.
+            console.error(`docSlugSearch failed for ${collId}:`, err);
+            return [];
+          }
+        });
+        const results = (await Promise.all(queries)).flat();
+        if (ctrl.aborted) {
+          return;
+        }
+        // Rank exact slug or docId matches first, then prefix matches
+        // alphabetically so results are stable across renders.
+        const sorted = results.sort((a, b) => {
+          const aExact =
+            a.slug === prefix || a.docId === trimmed ? 0 : 1;
+          const bExact =
+            b.slug === prefix || b.docId === trimmed ? 0 : 1;
+          if (aExact !== bExact) {
+            return aExact - bExact;
+          }
+          return a.docId.localeCompare(b.docId);
+        });
+        setHits(sorted.slice(0, totalLimit));
+        setLoading(false);
+      } catch (err) {
+        if (ctrl.aborted) {
+          return;
+        }
+        console.error('docSlugSearch failed:', err);
+        setHits([]);
+        setLoading(false);
+      }
+    }, SLUG_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [rawQuery, totalLimit]);
+
+  return {hits, loading};
 }

--- a/packages/root-cms/ui/utils/recent-views.ts
+++ b/packages/root-cms/ui/utils/recent-views.ts
@@ -1,0 +1,167 @@
+import {useEffect, useState} from 'preact/hooks';
+
+const STORAGE_KEY = 'root::cms:recentViews';
+const MAX_RECENT = 5;
+const CHANGE_EVENT = 'rootcms:recentViewsChange';
+
+export type RecentViewKind = 'doc' | 'collection' | 'data-source' | 'release';
+
+export interface RecentView {
+  kind: RecentViewKind;
+  /** Stable key used for dedup; usually the destination URL. */
+  url: string;
+  /** Primary label (e.g. "Pages / home"). */
+  label: string;
+  /** Optional secondary text. */
+  description?: string;
+  /** ms epoch when the view was last recorded. */
+  viewedAt: number;
+}
+
+function read(): RecentView[] {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (v): v is RecentView =>
+        v &&
+        typeof v === 'object' &&
+        typeof v.url === 'string' &&
+        typeof v.label === 'string' &&
+        typeof v.kind === 'string'
+    );
+  } catch (_err) {
+    return [];
+  }
+}
+
+function write(views: RecentView[]) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(views));
+  } catch (err) {
+    console.error('failed to persist recent views:', err);
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+export function getRecentViews(): RecentView[] {
+  return read().sort((a, b) => b.viewedAt - a.viewedAt);
+}
+
+export function recordRecentView(view: Omit<RecentView, 'viewedAt'>): void {
+  if (!view.url) {
+    return;
+  }
+  const existing = read().filter((v) => v.url !== view.url);
+  const next: RecentView[] = [{...view, viewedAt: Date.now()}, ...existing]
+    .slice(0, MAX_RECENT);
+  write(next);
+}
+
+export function clearRecentViews() {
+  write([]);
+}
+
+/** Subscribes to recent-view changes (same-tab and cross-tab). */
+export function useRecentViews(): RecentView[] {
+  const [views, setViews] = useState<RecentView[]>(() => getRecentViews());
+  useEffect(() => {
+    const refresh = () => setViews(getRecentViews());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        refresh();
+      }
+    };
+    window.addEventListener(CHANGE_EVENT, refresh);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, refresh);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+  return views;
+}
+
+/**
+ * Inspects a CMS URL and returns the corresponding recent view, or null if
+ * the URL is not one of the trackable views (doc, collection, data source, or
+ * release).
+ */
+export function recentViewFromUrl(rawUrl: string): RecentView | null {
+  let pathname = rawUrl;
+  try {
+    pathname = new URL(rawUrl, window.location.origin).pathname;
+  } catch (_err) {
+    pathname = rawUrl.split('?')[0] || rawUrl;
+  }
+  pathname = pathname.replace(/\/+$/, '');
+  const segments = pathname.split('/').filter(Boolean);
+  // /cms/content/:collection/:slug
+  if (
+    segments.length === 4 &&
+    segments[0] === 'cms' &&
+    segments[1] === 'content'
+  ) {
+    const collection = decodeURIComponent(segments[2]);
+    const slug = decodeURIComponent(segments[3]);
+    return {
+      kind: 'doc',
+      url: `/cms/content/${segments[2]}/${segments[3]}`,
+      label: `${collection} / ${slug}`,
+      viewedAt: 0,
+    };
+  }
+  // /cms/content/:collection
+  if (
+    segments.length === 3 &&
+    segments[0] === 'cms' &&
+    segments[1] === 'content'
+  ) {
+    const collection = decodeURIComponent(segments[2]);
+    const meta = window.__ROOT_CTX?.collections?.[collection];
+    return {
+      kind: 'collection',
+      url: `/cms/content/${segments[2]}`,
+      label: meta?.name || collection,
+      description: meta?.description,
+      viewedAt: 0,
+    };
+  }
+  // /cms/data/:id (skip /cms/data/new and /cms/data/:id/edit)
+  if (
+    segments.length === 3 &&
+    segments[0] === 'cms' &&
+    segments[1] === 'data' &&
+    segments[2] !== 'new'
+  ) {
+    const id = decodeURIComponent(segments[2]);
+    return {
+      kind: 'data-source',
+      url: `/cms/data/${segments[2]}`,
+      label: id,
+      viewedAt: 0,
+    };
+  }
+  // /cms/releases/:id (skip /cms/releases/new and /cms/releases/:id/edit)
+  if (
+    segments.length === 3 &&
+    segments[0] === 'cms' &&
+    segments[1] === 'releases' &&
+    segments[2] !== 'new'
+  ) {
+    const id = decodeURIComponent(segments[2]);
+    return {
+      kind: 'release',
+      url: `/cms/releases/${segments[2]}`,
+      label: id,
+      viewedAt: 0,
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Significantly expands the global search (Cmd+K) functionality to surface more CMS objects and navigation patterns. The search now includes collections, data sources, active releases, document slugs, and recently viewed items—in addition to the existing field-text search.

## Key Changes

- **Recent Views Tracking**: Added `recent-views.ts` utility to track and persist recently viewed CMS objects (docs, collections, data sources, releases) in localStorage. The spotlight displays these when the query is empty.

- **Document Slug Search**: Implemented `useDocSlugSearch` hook that performs Firestore range queries across collections to find documents by slug or `<collection>/<slug>` format. Results are ranked with exact matches first, then alphabetically.

- **Static Target Navigation**: Added builders for collections (from `window.__ROOT_CTX`), data sources (fetched via `listDataSources`), and active releases (from `usePendingReleases`). These are searchable by name with prefix-match ranking.

- **Refactored Action Building**: Replaced single `buildAction` with specialized builders (`buildFieldHitAction`, `buildDocSlugAction`, `buildStaticAction`, `buildRecentAction`, `buildHeader`, `buildFooter`) and introduced `GlobalSearchActionMeta` discriminated union to cleanly route rendering logic.

- **Enhanced Result Organization**: Results are now grouped by type (Jump to, Documents, Field matches) with section headers. Recent views appear when query is empty; "last indexed" footer only shows when actively querying.

- **Updated GlobalSearchAction Component**: Refactored to handle multiple result types (field hits, doc slugs, static targets, recent views, headers, footers) with appropriate icons and metadata display. Added new CSS classes for icon containers, tags, and section headers.

- **Improved UX**: Updated search placeholder and empty-state messages to reflect expanded scope. Added visual distinction between result types with icons and category tags.

## Implementation Details

- Slug search uses Firestore `documentId()` range queries with high private-use codepoint (``) as upper bound for prefix matching
- Recent views limited to 5 items, deduplicated by URL, sorted by recency
- Static targets filtered with prefix-match preference, falling back to substring matches
- All async operations (data source fetch, slug search) include cancellation handling to prevent stale updates
- Footer timestamp only renders when there are results and an active query to keep UI clean

## Screenshots

<img width="2168" height="1402" alt="Screenshot 2026-05-03 at 9 46 48 AM" src="https://github.com/user-attachments/assets/5bcbfb85-3b11-4d08-8ae3-d2ea5c95e6d2" />
<img width="2168" height="1402" alt="Screenshot 2026-05-03 at 9 47 01 AM" src="https://github.com/user-attachments/assets/277c7da7-5941-4dcc-a3b0-332d4d40d7fc" />
<img width="2168" height="1402" alt="Screenshot 2026-05-03 at 9 49 12 AM" src="https://github.com/user-attachments/assets/d9945c17-15cc-49d9-8837-25d7c3ab4400" />
<img width="2168" height="1402" alt="Screenshot 2026-05-03 at 9 49 18 AM" src="https://github.com/user-attachments/assets/9e2236af-6465-4ee4-9c79-5f64b5d60778" />
<img width="2168" height="1402" alt="Screenshot 2026-05-03 at 9 49 38 AM" src="https://github.com/user-attachments/assets/b2b2033b-0288-4ce7-91d9-0e1a5d45a7c1" />

## AI

https://claude.ai/code/session_01AH8HSLuUKzAND44Moe1nVk