### PR TITLE
feat: add picker variant + presets to schema.oneOf()

### DIFF
--- a/.changeset/honest-teachers-notice.md
+++ b/.changeset/honest-teachers-notice.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add picker variant + presets to schema.oneOf() (#1084)

--- a/docs/collections/Pages.schema.ts
+++ b/docs/collections/Pages.schema.ts
@@ -50,6 +50,7 @@ export default schema.collection({
           help: 'Compose the page by adding one or more modules.',
           of: schema.oneOf({
             types: schema.glob('/templates/*/*.schema.ts'),
+            variant: 'picker',
           }),
           preview: [
             'm{_index:02}: {description} (#{id})',

--- a/docs/root-cms.d.ts
+++ b/docs/root-cms.d.ts
@@ -92,6 +92,7 @@ export interface ButtonFields {
   href?: string;
 }
 
+/** Generated from `/blocks/ButtonsBlock/ButtonsBlock.schema.ts`. */
 export interface ButtonsBlockFields {
   /** Block Options */
   options?: string[];
@@ -108,6 +109,7 @@ export interface ButtonsBlockFields {
   }[];
 }
 
+/** Generated from `/blocks/CodeBlock/CodeBlock.schema.ts`. */
 export interface CodeBlockFields {
   /** ID. Used for deep linking, tracking, etc. */
   id?: string;
@@ -119,6 +121,7 @@ export interface CodeBlockFields {
   code?: string;
 }
 
+/** Generated from `/blocks/CopyBlock/CopyBlock.schema.ts`. */
 export interface CopyBlockFields {
   /** ID. Used for deep linking, tracking, etc. */
   id?: string;
@@ -189,6 +192,7 @@ export interface GuideFields {
 /** Generated from `/collections/Guide.schema.ts`. */
 export type GuideDoc = RootCMSDoc<GuideFields>;
 
+/** Generated from `/blocks/ImageBlock/ImageBlock.schema.ts`. */
 export interface ImageBlockFields {
   /** ID. Used for deep linking, tracking, etc. */
   id?: string;

--- a/docs/templates/Template50x50/Template50x50.schema.ts
+++ b/docs/templates/Template50x50/Template50x50.schema.ts
@@ -2,6 +2,43 @@ import {schema} from '@blinkk/root-cms';
 
 export default schema.define({
   name: 'Template50x50',
+  label: '50/50 Section',
+  description: 'Two-column section with independent left and right blocks.',
+  presets: [
+    schema.preset({
+      id: 'copyImage',
+      label: 'Copy + Image',
+      description: 'Copy on the left, image on the right.',
+      data: {
+        leftSection: {
+          _type: 'CopyBlock',
+          eyebrow: 'Highlight',
+          title: 'A short, descriptive title',
+          titleSize: 'h2',
+        },
+        rightSection: {
+          _type: 'ImageBlock',
+        },
+      },
+    }),
+    schema.preset({
+      id: 'imageCopy',
+      label: 'Image + Copy',
+      description: 'Image on the left, copy on the right.',
+      data: {
+        options: ['layout:mobile-reverse'],
+        leftSection: {
+          _type: 'ImageBlock',
+        },
+        rightSection: {
+          _type: 'CopyBlock',
+          eyebrow: 'Highlight',
+          title: 'A short, descriptive title',
+          titleSize: 'h2',
+        },
+      },
+    }),
+  ],
   fields: [
     schema.string({
       id: 'id',

--- a/docs/templates/TemplateHeadline/TemplateHeadline.schema.ts
+++ b/docs/templates/TemplateHeadline/TemplateHeadline.schema.ts
@@ -3,9 +3,46 @@ import ButtonSchema from '@/components/Button/Button.schema.js';
 
 export default schema.define({
   name: 'TemplateHeadline',
+  label: 'Headline',
+  description: 'Title block with optional eyebrow, body and buttons.',
   preview: {
     title: ['m{_index:02}: {title}'],
   },
+  presets: [
+    schema.preset({
+      id: 'hero',
+      label: 'Hero headline',
+      description: 'Eyebrow, large title, body, and a primary CTA button.',
+      data: {
+        options: ['title:h1'],
+        eyebrow: 'Announcing',
+        title: 'A bold new headline',
+        buttons: [
+          {options: ['variant:primary'], label: 'Get started', href: '/start'},
+        ],
+      },
+    }),
+    schema.preset({
+      id: 'section',
+      label: 'Section heading',
+      description: 'Compact section title with supporting body copy.',
+      data: {
+        title: 'Section title',
+      },
+    }),
+    schema.preset({
+      id: 'cta',
+      label: 'CTA pair',
+      description: 'Title plus two buttons (primary and secondary).',
+      data: {
+        title: 'Ready to dive in?',
+        buttons: [
+          {options: ['variant:primary'], label: 'Get started', href: '/start'},
+          {options: ['variant:outline'], label: 'Learn more', href: '/docs'},
+        ],
+      },
+    }),
+  ],
   fields: [
     schema.string({
       id: 'id',

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -521,3 +521,60 @@ test('glob can be used for self-referencing container schemas', () => {
   expect(pattern._schemaPattern).toBe(true);
   expect(pattern.pattern).toBe('/templates/*/*.schema.ts');
 });
+
+test('oneOf accepts variant: picker', () => {
+  const field = schema.oneOf({
+    id: 'asset',
+    variant: 'picker',
+    types: [],
+  });
+  expect(field.type).toBe('oneof');
+  expect(field.variant).toBe('picker');
+});
+
+test('oneOf without variant defaults to undefined (dropdown)', () => {
+  const field = schema.oneOf({id: 'asset', types: []});
+  expect(field.variant).toBeUndefined();
+});
+
+test('schema.define accepts image and presets', () => {
+  const Hero = schema.define({
+    name: 'Hero',
+    label: 'Hero block',
+    description: 'A page hero',
+    image: '/thumbnails/hero.png',
+    presets: [
+      {
+        id: 'big',
+        label: 'Big hero',
+        description: 'Full-bleed hero with overlay',
+        image: '/thumbnails/hero-big.png',
+        data: {
+          title: 'Welcome',
+          cta: {text: 'Get started'},
+        },
+      },
+      {
+        id: 'small',
+        label: 'Compact hero',
+        data: {title: 'Hi'},
+      },
+    ],
+    fields: [
+      schema.string({id: 'title'}),
+      schema.object({
+        id: 'cta',
+        fields: [schema.string({id: 'text'}), schema.string({id: 'href'})],
+      }),
+    ],
+  });
+
+  expect(Hero.image).toBe('/thumbnails/hero.png');
+  expect(Hero.presets).toHaveLength(2);
+  expect(Hero.presets![0].id).toBe('big');
+  expect(Hero.presets![0].label).toBe('Big hero');
+  expect(Hero.presets![0].image).toBe('/thumbnails/hero-big.png');
+  expect(Hero.presets![0].data?.title).toBe('Welcome');
+  expect(Hero.presets![0].data?.cta?.text).toBe('Get started');
+  expect(Hero.presets![1].id).toBe('small');
+});

--- a/packages/root-cms/core/schema.test.ts
+++ b/packages/root-cms/core/schema.test.ts
@@ -578,3 +578,49 @@ test('schema.define accepts image and presets', () => {
   expect(Hero.presets![0].data?.cta?.text).toBe('Get started');
   expect(Hero.presets![1].id).toBe('small');
 });
+
+test('definePreset returns the preset object', () => {
+  const preset = schema.definePreset({
+    id: 'hero',
+    label: 'Hero',
+    data: {title: 'Welcome'},
+  });
+  expect(preset.id).toBe('hero');
+  expect(preset.label).toBe('Hero');
+  expect(preset.data?.title).toBe('Welcome');
+});
+
+test('preset is an alias for definePreset', () => {
+  expect(schema.preset).toBe(schema.definePreset);
+});
+
+test('definePreset accepts a generic type for data', () => {
+  interface HeroFields {
+    title?: string;
+    subtitle?: string;
+  }
+  const preset = schema.definePreset<HeroFields>({
+    id: 'hero',
+    data: {title: 'Welcome', subtitle: 'Hi'},
+  });
+  expect(preset.data?.title).toBe('Welcome');
+  expect(preset.data?.subtitle).toBe('Hi');
+});
+
+test('definePreset can be used inside schema.define presets array', () => {
+  const Hero = schema.define({
+    name: 'Hero',
+    presets: [
+      schema.definePreset({
+        id: 'big',
+        label: 'Big',
+        data: {title: 'Welcome'},
+      }),
+      schema.preset({id: 'small', data: {title: 'Hi'}}),
+    ],
+    fields: [schema.string({id: 'title'})],
+  });
+  expect(Hero.presets).toHaveLength(2);
+  expect(Hero.presets![0].id).toBe('big');
+  expect(Hero.presets![1].id).toBe('small');
+});

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -358,9 +358,6 @@ export interface SchemaPreset {
    * Field values to prefill. Deep-merged into the schema's default value
    * (preset values override defaults). `_type` is set automatically. The
    * preset id is NOT persisted — presets are purely a prefill mechanism.
-   *
-   * For `array` fields, use the array-map shape
-   * `{_array: ['k1'], k1: {...}}` so the array UI renders correctly.
    */
   data?: Record<string, any>;
 }
@@ -425,6 +422,30 @@ export function defineSchema(schema: Schema): Schema {
 
 /** Defines the schema for a collection or reusable component. */
 export const define = defineSchema;
+
+/**
+ * Defines a preset for use within `schema.define({presets: [...]})`. The
+ * optional generic parameter `T` constrains the shape of the preset's `data`
+ * field. Pass an auto-generated fields type to enable type-safety:
+ *
+ * ```ts
+ * import type {HeroFields} from './generated/types.d.ts';
+ *
+ * schema.definePreset<HeroFields>({
+ *   id: 'big',
+ *   label: 'Big hero',
+ *   data: {title: 'Welcome'},
+ * });
+ * ```
+ */
+export function definePreset<T = any>(
+  preset: Omit<SchemaPreset, 'data'> & {data?: T}
+): SchemaPreset {
+  return preset as SchemaPreset;
+}
+
+/** Alias for {@link definePreset}. */
+export const preset = definePreset;
 
 export type Collection = SchemaWithTypes & {
   /**

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -345,7 +345,7 @@ export type ObjectLikeField =
   | OneOfField
   | ReferenceField;
 
-export interface SchemaPreset {
+export interface SchemaPreset<T = Record<string, any>> {
   /** Unique identifier for the preset within the schema. */
   id: string;
   /** Display title for the preset. Defaults to the preset id. */
@@ -358,8 +358,11 @@ export interface SchemaPreset {
    * Field values to prefill. Deep-merged into the schema's default value
    * (preset values override defaults). `_type` is set automatically. The
    * preset id is NOT persisted — presets are purely a prefill mechanism.
+   *
+   * Pass a generated fields type as the generic parameter `T` to
+   * type-check the keys against the schema's fields.
    */
-  data?: Record<string, any>;
+  data?: T;
 }
 
 export interface Schema {
@@ -381,7 +384,7 @@ export interface Schema {
    * the schema's "blank" card. Selecting a preset sets `_type` to the schema's
    * `name` and merges `data` over the schema's default field values.
    */
-  presets?: SchemaPreset[];
+  presets?: SchemaPreset<any>[];
   /** Fields describe the structure of the content. */
   fields: FieldWithId[];
   /** Defines the preview displayed within the CMS UI. Overrides the `preview` definition for the `array` field. */
@@ -438,10 +441,10 @@ export const define = defineSchema;
  * });
  * ```
  */
-export function definePreset<T = any>(
-  preset: Omit<SchemaPreset, 'data'> & {data?: T}
-): SchemaPreset {
-  return preset as SchemaPreset;
+export function definePreset<T = Record<string, any>>(
+  preset: SchemaPreset<T>
+): SchemaPreset<T> {
+  return preset;
 }
 
 /** Alias for {@link definePreset}. */

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -246,6 +246,13 @@ export interface SchemaPattern {
 export type OneOfField = CommonFieldProps & {
   type: 'oneof';
   /**
+   * UI variant for the oneOf field.
+   * - `dropdown` (default): A `Select` dropdown for choosing the type.
+   * - `picker`: A `Button` that opens a modal with searchable cards. Use this
+   *   variant when types declare presets or thumbnail images.
+   */
+  variant?: 'dropdown' | 'picker';
+  /**
    * Schema types to include in the oneOf field. Can be:
    * - An array of Schema objects
    * - An array of string names (resolved at runtime)
@@ -338,6 +345,26 @@ export type ObjectLikeField =
   | OneOfField
   | ReferenceField;
 
+export interface SchemaPreset {
+  /** Unique identifier for the preset within the schema. */
+  id: string;
+  /** Display title for the preset. Defaults to the preset id. */
+  label?: string;
+  /** Description shown below the title in the picker. */
+  description?: string;
+  /** Thumbnail image (URL or absolute /-path) for the picker. */
+  image?: string;
+  /**
+   * Field values to prefill. Deep-merged into the schema's default value
+   * (preset values override defaults). `_type` is set automatically. The
+   * preset id is NOT persisted — presets are purely a prefill mechanism.
+   *
+   * For `array` fields, use the array-map shape
+   * `{_array: ['k1'], k1: {...}}` so the array UI renders correctly.
+   */
+  data?: Record<string, any>;
+}
+
 export interface Schema {
   /** The name of the content type. Used as the field key. */
   name: string;
@@ -345,6 +372,19 @@ export interface Schema {
   label?: string;
   /** The description of the content type. Appears in CMS menus. */
   description?: string;
+  /**
+   * Optional thumbnail image (URL or absolute /-path) used to represent this
+   * schema in the picker UI for `oneof` fields with `variant: 'picker'`.
+   */
+  image?: string;
+  /**
+   * Optional preset prefill configurations for use in the picker UI.
+   *
+   * Each preset appears in the picker as a separate selectable card alongside
+   * the schema's "blank" card. Selecting a preset sets `_type` to the schema's
+   * `name` and merges `data` over the schema's default field values.
+   */
+  presets?: SchemaPreset[];
   /** Fields describe the structure of the content. */
   fields: FieldWithId[];
   /** Defines the preview displayed within the CMS UI. Overrides the `preview` definition for the `array` field. */

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
@@ -166,3 +166,7 @@
   display: flex;
   justify-content: flex-start;
 }
+
+.ComponentPickerModal__controls__layout .mantine-SegmentedControl-label {
+  display: flex;
+}

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
@@ -1,0 +1,99 @@
+.ComponentPickerModal {
+  padding-right: 20px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.ComponentPickerModal__controls {
+  position: sticky;
+  top: 0;
+  background: white;
+  z-index: 1;
+  padding-bottom: 12px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ComponentPickerModal__controls__search {
+  width: 100%;
+}
+
+.ComponentPickerModal__cards {
+  display: flex;
+  flex-direction: column;
+}
+
+.ComponentPickerModal__Card {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  padding: 12px 8px 12px 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  font-family: inherit;
+  color: inherit;
+  transition: background-color 0.1s ease;
+}
+
+.ComponentPickerModal__Card:first-child {
+  border-top: none;
+}
+
+.ComponentPickerModal__Card:hover,
+.ComponentPickerModal__Card:focus-visible {
+  background: #f5f6f7;
+  outline: none;
+}
+
+.ComponentPickerModal__Card__image {
+  border: 1px solid var(--color-border);
+  flex-shrink: 0;
+  width: 120px;
+  height: 90px;
+  overflow: hidden;
+}
+
+.ComponentPickerModal__Card__content {
+  display: flex;
+  flex-direction: column;
+  padding: 0 12px;
+  flex: 1;
+  gap: 4px;
+  justify-content: center;
+}
+
+.ComponentPickerModal__Card__content__subtitle {
+  font-size: 11px;
+  font-weight: 500;
+  color: #777;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ComponentPickerModal__Card__content__title {
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.ComponentPickerModal__Card__content__description {
+  font-size: 13px;
+  color: #555;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.ComponentPickerModal__empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: #999;
+  font-size: 14px;
+}

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
@@ -13,15 +13,36 @@
   padding-bottom: 12px;
   margin-bottom: 8px;
   border-bottom: 1px solid var(--color-border);
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .ComponentPickerModal__controls__search {
-  width: 100%;
+  flex: 1;
+}
+
+.ComponentPickerModal__controls__layout {
+  flex-shrink: 0;
+}
+
+.ComponentPickerModal__controls__layout__option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 14px;
 }
 
 .ComponentPickerModal__cards {
   display: flex;
   flex-direction: column;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  padding: 8px 0;
 }
 
 .ComponentPickerModal__Card {
@@ -45,9 +66,23 @@
 }
 
 .ComponentPickerModal__Card:hover,
-.ComponentPickerModal__Card:focus-visible {
+.ComponentPickerModal__Card:focus-visible,
+.ComponentPickerModal__Card--focused {
   background: #f5f6f7;
   outline: none;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__Card {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__Card:first-child {
+  border-top: 1px solid var(--color-border);
 }
 
 .ComponentPickerModal__Card__image {
@@ -58,6 +93,15 @@
   overflow: hidden;
 }
 
+.ComponentPickerModal--grid .ComponentPickerModal__Card__image {
+  width: 100%;
+  height: 120px;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__Card__image > * {
+  width: 100% !important;
+}
+
 .ComponentPickerModal__Card__content {
   display: flex;
   flex-direction: column;
@@ -65,6 +109,11 @@
   flex: 1;
   gap: 4px;
   justify-content: center;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__Card__content {
+  padding: 0 4px 4px;
+  justify-content: flex-start;
 }
 
 .ComponentPickerModal__Card__content__subtitle {
@@ -81,6 +130,10 @@
   line-height: 1.3;
 }
 
+.ComponentPickerModal--grid .ComponentPickerModal__Card__content__title {
+  font-size: 14px;
+}
+
 .ComponentPickerModal__Card__content__description {
   font-size: 13px;
   color: #555;
@@ -89,6 +142,11 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;
+}
+
+.ComponentPickerModal--grid .ComponentPickerModal__Card__content__description {
+  font-size: 12px;
+  -webkit-line-clamp: 2;
 }
 
 .ComponentPickerModal__empty {

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.css
@@ -97,3 +97,14 @@
   color: #999;
   font-size: 14px;
 }
+
+.ComponentPickerModal__footer {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  border-top: 1px solid var(--color-border);
+  padding: 12px 0;
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-start;
+}

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
@@ -38,10 +38,11 @@ export interface ComponentPickerModalProps {
   /** Invoked when the user clicks a card. The caller is responsible for closing. */
   onSelect: (option: ComponentPickerOption) => void;
   /**
-   * Optional handler invoked when the user clicks the "Remove component"
-   * button in the footer. When omitted, the button is not rendered. The
-   * button is also hidden while the user has an active search query. The
-   * caller is responsible for closing the modal.
+   * Optional handler invoked when the user clicks the "Clear selection"
+   * button in the footer. When omitted, the button is not rendered, so
+   * callers should pass it only when there's an existing value to clear.
+   * The button is also hidden while the user has an active search query.
+   * The caller is responsible for closing the modal.
    */
   onRemove?: () => void;
 }
@@ -227,7 +228,7 @@ export function ComponentPickerModal(
             leftIcon={<IconTrash size={14} />}
             onClick={() => props.onRemove?.()}
           >
-            Remove component
+            Clear selection
           </Button>
         </div>
       )}

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
@@ -1,14 +1,30 @@
 import './ComponentPickerModal.css';
 
-import {Button, Image, TextInput} from '@mantine/core';
+import {Button, Image, SegmentedControl, TextInput} from '@mantine/core';
 import {ContextModalProps, useModals} from '@mantine/modals';
-import {IconSearch, IconTrash} from '@tabler/icons-preact';
-import {useMemo, useState} from 'preact/hooks';
+import {
+  IconLayoutGrid,
+  IconLayoutList,
+  IconSearch,
+  IconTrash,
+} from '@tabler/icons-preact';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
 
 import * as schema from '../../../core/schema.js';
+import {useLocalStorage} from '../../hooks/useLocalStorage.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 
 const MODAL_ID = 'ComponentPickerModal';
+const LAYOUT_STORAGE_KEY = 'root::ComponentPickerModal:layout';
+const GRID_COLUMNS = 3;
+
+export type ComponentPickerLayout = 'list' | 'grid';
 
 export interface ComponentPickerOption {
   /** Stable key for reconciliation. */
@@ -60,6 +76,13 @@ export function ComponentPickerModal(
 ) {
   const {innerProps: props} = modalProps;
   const [searchQuery, setSearchQuery] = useState('');
+  const [layout, setLayout] = useLocalStorage<ComponentPickerLayout>(
+    LAYOUT_STORAGE_KEY,
+    'list'
+  );
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const cardsContainerRef = useRef<HTMLDivElement | null>(null);
 
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -82,19 +105,110 @@ export function ComponentPickerModal(
     });
   }, [props.options, searchQuery]);
 
+  // Reset focus to the first card whenever the filtered list changes.
+  useEffect(() => {
+    setFocusedIndex(filtered.length > 0 ? 0 : -1);
+  }, [filtered]);
+
+  // Imperatively focus the search input on mount. Mantine modals can swallow
+  // the native `autoFocus` prop depending on portal/overlay timing.
+  useLayoutEffect(() => {
+    const input = searchInputRef.current;
+    if (input) {
+      input.focus();
+    }
+  }, []);
+
+  // Scroll the focused card into view as the user navigates with the keyboard.
+  useEffect(() => {
+    if (focusedIndex < 0 || !cardsContainerRef.current) {
+      return;
+    }
+    const cards = cardsContainerRef.current.querySelectorAll<HTMLElement>(
+      '.ComponentPickerModal__Card'
+    );
+    cards[focusedIndex]?.scrollIntoView({block: 'nearest'});
+  }, [focusedIndex]);
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (filtered.length === 0) {
+      return;
+    }
+    const cols = layout === 'grid' ? GRID_COLUMNS : 1;
+    const last = filtered.length - 1;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(last, Math.max(0, i) + cols));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(0, i - cols));
+    } else if (e.key === 'ArrowRight' && layout === 'grid') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(last, Math.max(0, i) + 1));
+    } else if (e.key === 'ArrowLeft' && layout === 'grid') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter' && focusedIndex >= 0) {
+      const opt = filtered[focusedIndex];
+      if (opt) {
+        e.preventDefault();
+        props.onSelect(opt);
+      }
+    }
+  }
+
   const showRemoveButton = !!props.onRemove && !searchQuery.trim();
+  const layoutClass =
+    layout === 'grid'
+      ? 'ComponentPickerModal--grid'
+      : 'ComponentPickerModal--list';
 
   return (
-    <div className="ComponentPickerModal">
+    <div
+      className={`ComponentPickerModal ${layoutClass}`}
+      onKeyDown={handleKeyDown}
+    >
       <div className="ComponentPickerModal__controls">
         <TextInput
+          ref={searchInputRef}
           placeholder={props.searchPlaceholder || 'Search components...'}
           value={searchQuery}
           onChange={(e: any) => setSearchQuery(e.target.value)}
           icon={<IconSearch size={16} />}
           size="xs"
-          autoFocus
           className="ComponentPickerModal__controls__search"
+        />
+        <SegmentedControl
+          className="ComponentPickerModal__controls__layout"
+          size="xs"
+          value={layout}
+          onChange={(value: ComponentPickerLayout) => setLayout(value)}
+          data={[
+            {
+              value: 'list',
+              label: (
+                <span
+                  className="ComponentPickerModal__controls__layout__option"
+                  aria-label="List layout"
+                  title="List layout"
+                >
+                  <IconLayoutList size={14} />
+                </span>
+              ),
+            },
+            {
+              value: 'grid',
+              label: (
+                <span
+                  className="ComponentPickerModal__controls__layout__option"
+                  aria-label="Grid layout"
+                  title="Grid layout"
+                >
+                  <IconLayoutGrid size={14} />
+                </span>
+              ),
+            },
+          ]}
         />
       </div>
       {filtered.length === 0 ? (
@@ -104,11 +218,14 @@ export function ComponentPickerModal(
             : 'No components match your search.'}
         </div>
       ) : (
-        <div className="ComponentPickerModal__cards">
-          {filtered.map((opt) => (
+        <div className="ComponentPickerModal__cards" ref={cardsContainerRef}>
+          {filtered.map((opt, i) => (
             <ComponentPickerModal.Card
               key={opt.key}
               option={opt}
+              layout={layout}
+              focused={i === focusedIndex}
+              onMouseEnter={() => setFocusedIndex(i)}
               onSelect={() => props.onSelect(opt)}
             />
           ))}
@@ -133,7 +250,10 @@ export function ComponentPickerModal(
 
 ComponentPickerModal.Card = (props: {
   option: ComponentPickerOption;
+  layout: ComponentPickerLayout;
+  focused?: boolean;
   onSelect: () => void;
+  onMouseEnter?: () => void;
 }) => {
   const {schema: s, preset} = props.option;
   const title = preset?.label || preset?.id || s.label || s.name;
@@ -143,17 +263,29 @@ ComponentPickerModal.Card = (props: {
   // editor can tell which component the preset belongs to.
   const subtitle = preset ? s.label || s.name : '';
 
+  const dim = props.layout === 'grid' ? 180 : 120;
+  const imgWidth = dim;
+  const imgHeight = props.layout === 'grid' ? 120 : 90;
+
+  const className = [
+    'ComponentPickerModal__Card',
+    props.focused ? 'ComponentPickerModal__Card--focused' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <button
       type="button"
-      className="ComponentPickerModal__Card"
+      className={className}
       onClick={props.onSelect}
+      onMouseEnter={props.onMouseEnter}
     >
       <div className="ComponentPickerModal__Card__image">
         <Image
           src={image}
-          width={120}
-          height={90}
+          width={imgWidth}
+          height={imgHeight}
           withPlaceholder={!image}
           alt={title}
         />

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
@@ -1,8 +1,8 @@
 import './ComponentPickerModal.css';
 
-import {Image, TextInput} from '@mantine/core';
+import {Button, Image, TextInput} from '@mantine/core';
 import {ContextModalProps, useModals} from '@mantine/modals';
-import {IconSearch} from '@tabler/icons-preact';
+import {IconSearch, IconTrash} from '@tabler/icons-preact';
 import {useMemo, useState} from 'preact/hooks';
 
 import * as schema from '../../../core/schema.js';
@@ -27,6 +27,13 @@ export interface ComponentPickerModalProps {
   searchPlaceholder?: string;
   /** Invoked when the user clicks a card. The caller is responsible for closing. */
   onSelect: (option: ComponentPickerOption) => void;
+  /**
+   * Optional handler invoked when the user clicks the "Remove component"
+   * button in the footer. When omitted, the button is not rendered. The
+   * button is also hidden while the user has an active search query. The
+   * caller is responsible for closing the modal.
+   */
+  onRemove?: () => void;
 }
 
 export function useComponentPickerModal() {
@@ -75,6 +82,8 @@ export function ComponentPickerModal(
     });
   }, [props.options, searchQuery]);
 
+  const showRemoveButton = !!props.onRemove && !searchQuery.trim();
+
   return (
     <div className="ComponentPickerModal">
       <div className="ComponentPickerModal__controls">
@@ -103,6 +112,19 @@ export function ComponentPickerModal(
               onSelect={() => props.onSelect(opt)}
             />
           ))}
+        </div>
+      )}
+      {showRemoveButton && (
+        <div className="ComponentPickerModal__footer">
+          <Button
+            variant="subtle"
+            color="red"
+            size="xs"
+            leftIcon={<IconTrash size={14} />}
+            onClick={() => props.onRemove?.()}
+          >
+            Remove component
+          </Button>
         </div>
       )}
     </div>

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
@@ -1,0 +1,158 @@
+import './ComponentPickerModal.css';
+
+import {Image, TextInput} from '@mantine/core';
+import {ContextModalProps, useModals} from '@mantine/modals';
+import {IconSearch} from '@tabler/icons-preact';
+import {useMemo, useState} from 'preact/hooks';
+
+import * as schema from '../../../core/schema.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
+
+const MODAL_ID = 'ComponentPickerModal';
+
+export interface ComponentPickerOption {
+  /** Stable key for reconciliation. */
+  key: string;
+  /** Schema this option uses to compute defaults / `_type`. */
+  schema: schema.Schema;
+  /** Optional preset; when omitted, this is the schema's "blank" card. */
+  preset?: schema.SchemaPreset;
+}
+
+export interface ComponentPickerModalProps {
+  [key: string]: unknown;
+  /** Cards to render. The caller assembles these from `field.types` + presets. */
+  options: ComponentPickerOption[];
+  /** Optional placeholder text for the search input. */
+  searchPlaceholder?: string;
+  /** Invoked when the user clicks a card. The caller is responsible for closing. */
+  onSelect: (option: ComponentPickerOption) => void;
+}
+
+export function useComponentPickerModal() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  return {
+    open: (props: ComponentPickerModalProps) => {
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        innerProps: props,
+        size: '720px',
+        overflow: 'inside',
+        title: 'Select a component',
+      });
+    },
+    close: () => {
+      modals.closeModal(MODAL_ID);
+    },
+  };
+}
+
+export function ComponentPickerModal(
+  modalProps: ContextModalProps<ComponentPickerModalProps>
+) {
+  const {innerProps: props} = modalProps;
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) {
+      return props.options;
+    }
+    return props.options.filter((opt) => {
+      const haystack = [
+        opt.schema.name,
+        opt.schema.label,
+        opt.schema.description,
+        opt.preset?.id,
+        opt.preset?.label,
+        opt.preset?.description,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [props.options, searchQuery]);
+
+  return (
+    <div className="ComponentPickerModal">
+      <div className="ComponentPickerModal__controls">
+        <TextInput
+          placeholder={props.searchPlaceholder || 'Search components...'}
+          value={searchQuery}
+          onChange={(e: any) => setSearchQuery(e.target.value)}
+          icon={<IconSearch size={16} />}
+          size="xs"
+          autoFocus
+          className="ComponentPickerModal__controls__search"
+        />
+      </div>
+      {filtered.length === 0 ? (
+        <div className="ComponentPickerModal__empty">
+          {props.options.length === 0
+            ? 'No component types available.'
+            : 'No components match your search.'}
+        </div>
+      ) : (
+        <div className="ComponentPickerModal__cards">
+          {filtered.map((opt) => (
+            <ComponentPickerModal.Card
+              key={opt.key}
+              option={opt}
+              onSelect={() => props.onSelect(opt)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ComponentPickerModal.Card = (props: {
+  option: ComponentPickerOption;
+  onSelect: () => void;
+}) => {
+  const {schema: s, preset} = props.option;
+  const title = preset?.label || preset?.id || s.label || s.name;
+  const description = preset?.description ?? s.description ?? '';
+  const image = preset?.image || s.image;
+  // Show the schema name as a small subtitle when displaying a preset, so the
+  // editor can tell which component the preset belongs to.
+  const subtitle = preset ? s.label || s.name : '';
+
+  return (
+    <button
+      type="button"
+      className="ComponentPickerModal__Card"
+      onClick={props.onSelect}
+    >
+      <div className="ComponentPickerModal__Card__image">
+        <Image
+          src={image}
+          width={120}
+          height={90}
+          withPlaceholder={!image}
+          alt={title}
+        />
+      </div>
+      <div className="ComponentPickerModal__Card__content">
+        {subtitle && (
+          <div className="ComponentPickerModal__Card__content__subtitle">
+            {subtitle}
+          </div>
+        )}
+        <div className="ComponentPickerModal__Card__content__title">
+          {title}
+        </div>
+        {description && (
+          <div className="ComponentPickerModal__Card__content__description">
+            {description}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+};
+
+ComponentPickerModal.id = MODAL_ID;

--- a/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
+++ b/packages/root-cms/ui/components/ComponentPickerModal/ComponentPickerModal.tsx
@@ -8,13 +8,7 @@ import {
   IconSearch,
   IconTrash,
 } from '@tabler/icons-preact';
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
 
 import * as schema from '../../../core/schema.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
@@ -81,7 +75,6 @@ export function ComponentPickerModal(
     'list'
   );
   const [focusedIndex, setFocusedIndex] = useState(0);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const cardsContainerRef = useRef<HTMLDivElement | null>(null);
 
   const filtered = useMemo(() => {
@@ -109,15 +102,6 @@ export function ComponentPickerModal(
   useEffect(() => {
     setFocusedIndex(filtered.length > 0 ? 0 : -1);
   }, [filtered]);
-
-  // Imperatively focus the search input on mount. Mantine modals can swallow
-  // the native `autoFocus` prop depending on portal/overlay timing.
-  useLayoutEffect(() => {
-    const input = searchInputRef.current;
-    if (input) {
-      input.focus();
-    }
-  }, []);
 
   // Scroll the focused card into view as the user navigates with the keyboard.
   useEffect(() => {
@@ -170,7 +154,10 @@ export function ComponentPickerModal(
     >
       <div className="ComponentPickerModal__controls">
         <TextInput
-          ref={searchInputRef}
+          // `data-autofocus` cooperates with Mantine's modal focus trap, which
+          // runs in setTimeout(0) and would otherwise override any imperative
+          // focus call we made on mount.
+          data-autofocus
           placeholder={props.searchPlaceholder || 'Search components...'}
           value={searchQuery}
           onChange={(e: any) => setSearchQuery(e.target.value)}

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -444,6 +444,17 @@
   gap: 24px;
 }
 
+.DocEditor__OneOfField--picker .DocEditor__OneOfField__pickerButton {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.DocEditor__OneOfField__pickerButton .mantine-Button-root {
+  font-weight: 500;
+}
+
 .DocEditor__DateTimeField input {
   display: block;
   width: 100%;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1797,6 +1797,13 @@ DocEditor.OneOfField = (props: FieldProps) => {
         await applyType(opt.schema.name, opt.preset?.data);
         componentPickerModal.close();
       },
+      // Only allow removal when a component is currently selected.
+      onRemove: selectedType
+        ? async () => {
+            await applyType('');
+            componentPickerModal.close();
+          }
+        : undefined,
     });
   }
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -82,12 +82,17 @@ import {
 import {extractField} from '../../utils/extract.js';
 import {getDefaultFieldValue} from '../../utils/fields.js';
 import {requestHighlightNode} from '../../utils/iframe-preview.js';
+import {deepMerge} from '../../utils/objects.js';
 import {testCanPublish} from '../../utils/permissions.js';
 import {autokey} from '../../utils/rand.js';
 import {buildPreviewValue} from '../../utils/schema-previews.js';
 import {testFieldEmpty} from '../../utils/test-field-empty.js';
 import {formatDateTime} from '../../utils/time.js';
 import {useAiEditModal} from '../AiEditModal/AiEditModal.js';
+import {
+  ComponentPickerOption,
+  useComponentPickerModal,
+} from '../ComponentPickerModal/ComponentPickerModal.js';
 import {ConditionalTooltip} from '../ConditionalTooltip/ConditionalTooltip.js';
 import {
   DocActionEvent,
@@ -1685,45 +1690,67 @@ DocEditor.ArrayFieldPreview = (props: ArrayFieldPreviewProps) => {
 
 DocEditor.OneOfField = (props: FieldProps) => {
   const field = props.field as schema.OneOfField;
+  const variant = field.variant || 'dropdown';
   const [type, setType] = useState('');
   const collectionTypes = useCollectionSchemaTypes();
   const typesMap: Record<string, schema.Schema> = {};
+  const orderedSchemas: schema.Schema[] = [];
   const dropdownValues: Array<{value: string; label: string}> = [
     {value: '', label: field.placeholder || 'Select type'},
   ];
   field.types.forEach((typedef) => {
+    let resolved: schema.Schema | undefined;
+    let name = '';
     if (typeof typedef === 'string') {
-      typesMap[typedef] = collectionTypes[typedef];
-      dropdownValues.push({value: typedef, label: typedef});
+      resolved = collectionTypes[typedef];
+      name = typedef;
     } else {
-      typesMap[typedef.name] = typedef;
-      dropdownValues.push({value: typedef.name, label: typedef.name});
+      resolved = typedef;
+      name = typedef.name;
     }
+    if (!name) {
+      return;
+    }
+    if (resolved) {
+      typesMap[name] = resolved;
+      orderedSchemas.push(resolved);
+    }
+    dropdownValues.push({value: name, label: name});
   });
   const selectedType = typesMap[type || ''];
   const draft = useDraftDoc().controller;
+  const componentPickerModal = useComponentPickerModal();
 
   const cachedValues = useMemo<any>(() => {
     return {};
   }, []);
 
-  async function onTypeChange(newType: string) {
+  async function applyType(newType: string, prefill?: Record<string, any>) {
     const newValue: any = {};
     if (newType) {
-      if (newType in cachedValues) {
+      if (prefill) {
+        // Preset path: deep-merge prefill over schema defaults so nested
+        // objects merge instead of clobbering each other.
+        const defaults = typesMap[newType]
+          ? getDefaultFieldValue(typesMap[newType])
+          : {};
+        Object.assign(newValue, deepMerge(defaults, prefill));
+      } else if (newType in cachedValues) {
         // When swapping to a previously selected type, reset to the previous
         // value.
-        const cachedValue = cachedValues[newType];
-        Object.assign(newValue, cachedValue);
+        Object.assign(newValue, cachedValues[newType]);
       } else if (newType in typesMap) {
-        const defaultValue = getDefaultFieldValue(typesMap[newType]);
-        Object.assign(newValue, defaultValue);
+        Object.assign(newValue, getDefaultFieldValue(typesMap[newType]));
       }
     }
     newValue._type = newType;
 
     await draft.updateKey(props.deepKey, newValue);
     setType(newType);
+  }
+
+  async function onTypeChange(newType: string) {
+    await applyType(newType);
   }
 
   useDraftDocField(props.deepKey, (newValue: any) => {
@@ -1740,6 +1767,85 @@ DocEditor.OneOfField = (props: FieldProps) => {
     if (target && target.select) {
       target.select();
     }
+  }
+
+  function buildPickerOptions(): ComponentPickerOption[] {
+    const options: ComponentPickerOption[] = [];
+    orderedSchemas.forEach((s) => {
+      options.push({key: `${s.name}::__blank__`, schema: s});
+      (s.presets || []).forEach((preset) => {
+        options.push({
+          key: `${s.name}::${preset.id}`,
+          schema: s,
+          preset,
+        });
+      });
+    });
+    return options;
+  }
+
+  function openPicker() {
+    componentPickerModal.open({
+      options: buildPickerOptions(),
+      onSelect: async (opt) => {
+        await applyType(opt.schema.name, opt.preset?.data);
+        componentPickerModal.close();
+      },
+    });
+  }
+
+  const fieldsBlock = selectedType && (
+    <div className="DocEditor__OneOfField__fields">
+      {selectedType.fields.map((subField) => (
+        <DocEditor.Field
+          key={`${type}::${subField.id}`}
+          field={subField}
+          deepKey={`${props.deepKey}.${subField.id!}`}
+          onBlur={() => {
+            requestHighlightNode(null);
+          }}
+          onFocus={() => {
+            requestHighlightNode(`${props.deepKey}.${subField.id!}`, {
+              scroll: true,
+            });
+          }}
+        />
+      ))}
+    </div>
+  );
+
+  if (variant === 'picker') {
+    const buttonLabel = selectedType
+      ? selectedType.label || selectedType.name
+      : field.placeholder || 'Select component';
+    return (
+      <div className="DocEditor__OneOfField DocEditor__OneOfField--picker">
+        <div className="DocEditor__OneOfField__pickerButton">
+          <div className="DocEditor__OneOfField__select__label">Type:</div>
+          <Button
+            variant="default"
+            color="dark"
+            size="xs"
+            radius={0}
+            onClick={openPicker}
+          >
+            {buttonLabel}
+          </Button>
+          {selectedType && (
+            <Button
+              variant="subtle"
+              color="gray"
+              size="xs"
+              compact
+              onClick={() => onTypeChange('')}
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+        {fieldsBlock}
+      </div>
+    );
   }
 
   return (
@@ -1759,25 +1865,7 @@ DocEditor.OneOfField = (props: FieldProps) => {
           dropdownComponent="div"
         />
       </div>
-      {selectedType && (
-        <div className="DocEditor__OneOfField__fields">
-          {selectedType.fields.map((field) => (
-            <DocEditor.Field
-              key={`${type}::${field.id}`}
-              field={field}
-              deepKey={`${props.deepKey}.${field.id!}`}
-              onBlur={() => {
-                requestHighlightNode(null);
-              }}
-              onFocus={() => {
-                requestHighlightNode(`${props.deepKey}.${field.id!}`, {
-                  scroll: true,
-                });
-              }}
-            />
-          ))}
-        </div>
-      )}
+      {fieldsBlock}
     </div>
   );
 };

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -80,7 +80,7 @@ import {
   testPublishingLocked,
 } from '../../utils/doc.js';
 import {extractField} from '../../utils/extract.js';
-import {getDefaultFieldValue} from '../../utils/fields.js';
+import {getDefaultFieldValue, normalizePresetData} from '../../utils/fields.js';
 import {requestHighlightNode} from '../../utils/iframe-preview.js';
 import {deepMerge} from '../../utils/objects.js';
 import {testCanPublish} from '../../utils/permissions.js';
@@ -1728,19 +1728,25 @@ DocEditor.OneOfField = (props: FieldProps) => {
   async function applyType(newType: string, prefill?: Record<string, any>) {
     const newValue: any = {};
     if (newType) {
-      if (prefill) {
-        // Preset path: deep-merge prefill over schema defaults so nested
-        // objects merge instead of clobbering each other.
-        const defaults = typesMap[newType]
-          ? getDefaultFieldValue(typesMap[newType])
-          : {};
-        Object.assign(newValue, deepMerge(defaults, prefill));
+      const typeSchema = typesMap[newType];
+      if (prefill && typeSchema) {
+        // Preset path: normalize prefill so any plain `[]` arrays in the
+        // preset's data become array-maps for proper CMS rendering, then
+        // deep-merge over schema defaults so nested objects merge instead of
+        // clobbering each other.
+        const defaults = getDefaultFieldValue(typeSchema);
+        const normalized = normalizePresetData(
+          typeSchema,
+          prefill,
+          collectionTypes
+        );
+        Object.assign(newValue, deepMerge(defaults, normalized));
       } else if (newType in cachedValues) {
         // When swapping to a previously selected type, reset to the previous
         // value.
         Object.assign(newValue, cachedValues[newType]);
-      } else if (newType in typesMap) {
-        Object.assign(newValue, getDefaultFieldValue(typesMap[newType]));
+      } else if (typeSchema) {
+        Object.assign(newValue, getDefaultFieldValue(typeSchema));
       }
     }
     newValue._type = newType;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1830,7 +1830,7 @@ DocEditor.OneOfField = (props: FieldProps) => {
   if (variant === 'picker') {
     const buttonLabel = selectedType
       ? selectedType.label || selectedType.name
-      : field.placeholder || 'Select component';
+      : field.placeholder || 'Select type';
     return (
       <div className="DocEditor__OneOfField DocEditor__OneOfField--picker">
         <div className="DocEditor__OneOfField__pickerButton">

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1826,22 +1826,11 @@ DocEditor.OneOfField = (props: FieldProps) => {
             variant="default"
             color="dark"
             size="xs"
-            radius={0}
             onClick={openPicker}
+            rightIcon={<IconChevronDown size={16} />}
           >
             {buttonLabel}
           </Button>
-          {selectedType && (
-            <Button
-              variant="subtle"
-              color="gray"
-              size="xs"
-              compact
-              onClick={() => onTypeChange('')}
-            >
-              Clear
-            </Button>
-          )}
         </div>
         {fieldsBlock}
       </div>

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -19,6 +19,7 @@ import type {CMSBuiltInSidebarTool} from '../core/plugin.js';
 import {Collection} from '../core/schema.js';
 import {AddToReleaseModal} from './components/AddToReleaseModal/AddToReleaseModal.js';
 import {AiEditModal} from './components/AiEditModal/AiEditModal.js';
+import {ComponentPickerModal} from './components/ComponentPickerModal/ComponentPickerModal.js';
 import {CopyDocModal} from './components/CopyDocModal/CopyDocModal.js';
 import {DataSourceSelectModal} from './components/DataSourceSelectModal/DataSourceSelectModal.js';
 import {DocPickerModal} from './components/DocPickerModal/DocPickerModal.js';
@@ -227,6 +228,7 @@ function App() {
                     modals={{
                       [AddToReleaseModal.id]: AddToReleaseModal,
                       [AiEditModal.id]: AiEditModal,
+                      [ComponentPickerModal.id]: ComponentPickerModal,
                       [CopyDocModal.id]: CopyDocModal,
                       [DocPickerModal.id]: DocPickerModal,
                       [DataSourceSelectModal.id]: DataSourceSelectModal,

--- a/packages/root-cms/ui/utils/fields.test.ts
+++ b/packages/root-cms/ui/utils/fields.test.ts
@@ -1,0 +1,188 @@
+import {describe, it, expect} from 'vitest';
+import * as schema from '../../core/schema.js';
+import {getDefaultFieldValue, normalizePresetData} from './fields.js';
+
+describe('normalizePresetData', () => {
+  it('returns data unchanged when there are no array/object fields', () => {
+    const Hero = schema.define({
+      name: 'Hero',
+      fields: [schema.string({id: 'title'}), schema.string({id: 'subtitle'})],
+    });
+    const result = normalizePresetData(Hero, {
+      title: 'Welcome',
+      subtitle: 'Hi',
+    });
+    expect(result).toEqual({title: 'Welcome', subtitle: 'Hi'});
+  });
+
+  it('converts plain arrays at array-field positions to array-maps', () => {
+    const CardGrid = schema.define({
+      name: 'CardGrid',
+      fields: [
+        schema.array({
+          id: 'cards',
+          of: schema.object({
+            fields: [schema.string({id: 'title'})],
+          }),
+        }),
+      ],
+    });
+    const result = normalizePresetData(CardGrid, {
+      cards: [{title: 'A'}, {title: 'B'}],
+    });
+    expect(Array.isArray(result.cards)).toBe(false);
+    expect(Array.isArray(result.cards._array)).toBe(true);
+    expect(result.cards._array).toHaveLength(2);
+    const [k1, k2] = result.cards._array;
+    expect(result.cards[k1]).toEqual({title: 'A'});
+    expect(result.cards[k2]).toEqual({title: 'B'});
+  });
+
+  it('leaves array-maps untouched if the author already wrote one', () => {
+    const CardGrid = schema.define({
+      name: 'CardGrid',
+      fields: [
+        schema.array({
+          id: 'cards',
+          of: schema.object({
+            fields: [schema.string({id: 'title'})],
+          }),
+        }),
+      ],
+    });
+    const arrayMap = {_array: ['x'], x: {title: 'A'}};
+    const result = normalizePresetData(CardGrid, {cards: arrayMap});
+    expect(result.cards).toEqual(arrayMap);
+  });
+
+  it('recurses into object fields and normalizes their nested arrays', () => {
+    const Page = schema.define({
+      name: 'Page',
+      fields: [
+        schema.object({
+          id: 'meta',
+          fields: [
+            schema.array({
+              id: 'tags',
+              of: schema.object({fields: [schema.string({id: 'label'})]}),
+            }),
+          ],
+        }),
+      ],
+    });
+    const result = normalizePresetData(Page, {
+      meta: {tags: [{label: 'a'}, {label: 'b'}]},
+    });
+    expect(Array.isArray(result.meta.tags._array)).toBe(true);
+    expect(result.meta.tags._array).toHaveLength(2);
+  });
+
+  it('recurses into items of an array of objects', () => {
+    const Doc = schema.define({
+      name: 'Doc',
+      fields: [
+        schema.array({
+          id: 'sections',
+          of: schema.object({
+            fields: [
+              schema.array({
+                id: 'paragraphs',
+                of: schema.object({
+                  fields: [schema.string({id: 'text'})],
+                }),
+              }),
+            ],
+          }),
+        }),
+      ],
+    });
+    const result = normalizePresetData(Doc, {
+      sections: [
+        {
+          paragraphs: [{text: 'p1'}, {text: 'p2'}],
+        },
+      ],
+    });
+    const [sectionKey] = result.sections._array;
+    const section = result.sections[sectionKey];
+    expect(Array.isArray(section.paragraphs._array)).toBe(true);
+    expect(section.paragraphs._array).toHaveLength(2);
+  });
+
+  it('handles oneof items in arrays via the types map', () => {
+    const ImageBlock = schema.define({
+      name: 'ImageBlock',
+      fields: [
+        schema.array({
+          id: 'tags',
+          of: schema.object({fields: [schema.string({id: 'label'})]}),
+        }),
+      ],
+    });
+    const types = {ImageBlock};
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.array({
+          id: 'children',
+          of: schema.oneOf({types: ['ImageBlock']}),
+        }),
+      ],
+    });
+    const result = normalizePresetData(
+      Container,
+      {
+        children: [{_type: 'ImageBlock', tags: [{label: 'a'}]}],
+      },
+      types
+    );
+    const [childKey] = result.children._array;
+    const child = result.children[childKey];
+    expect(child._type).toBe('ImageBlock');
+    expect(Array.isArray(child.tags._array)).toBe(true);
+    expect(child.tags._array).toHaveLength(1);
+  });
+
+  it('skips fields that are not in the data', () => {
+    const Hero = schema.define({
+      name: 'Hero',
+      fields: [schema.string({id: 'title'}), schema.string({id: 'subtitle'})],
+    });
+    const result = normalizePresetData(Hero, {title: 'Welcome'});
+    expect(result).toEqual({title: 'Welcome'});
+    expect('subtitle' in result).toBe(false);
+  });
+
+  it('preserves _type on the data root', () => {
+    const Hero = schema.define({
+      name: 'Hero',
+      fields: [schema.string({id: 'title'})],
+    });
+    const result = normalizePresetData(Hero, {
+      _type: 'Hero',
+      title: 'Welcome',
+    });
+    expect(result._type).toBe('Hero');
+  });
+});
+
+describe('getDefaultFieldValue', () => {
+  it('returns an empty object when no defaults are set', () => {
+    const Hero = schema.define({
+      name: 'Hero',
+      fields: [schema.string({id: 'title'})],
+    });
+    expect(getDefaultFieldValue(Hero)).toEqual({});
+  });
+
+  it('uses field defaults when set', () => {
+    const Hero = schema.define({
+      name: 'Hero',
+      fields: [
+        schema.string({id: 'title', default: 'Default title'}),
+        schema.string({id: 'subtitle'}),
+      ],
+    });
+    expect(getDefaultFieldValue(Hero)).toEqual({title: 'Default title'});
+  });
+});

--- a/packages/root-cms/ui/utils/fields.ts
+++ b/packages/root-cms/ui/utils/fields.ts
@@ -1,5 +1,11 @@
-import {Collection, ObjectField, Schema} from '../../core/schema.js';
+import {
+  Collection,
+  ObjectField,
+  ObjectLikeField,
+  Schema,
+} from '../../core/schema.js';
 import {toArrayMap} from './array-map.js';
+import {isObject} from './objects.js';
 
 /**
  * Returns the default field values for a collection or object field. Used for
@@ -25,4 +31,70 @@ export function getDefaultFieldValue(field: Collection | ObjectField | Schema) {
     }
   });
   return defaultValue;
+}
+
+/**
+ * Normalizes a preset's `data` payload so it can be stored in the draft doc.
+ * In particular, plain `[]` arrays at `array`-field positions are converted to
+ * the internal array-map shape (`{_array: ['k1'], k1: {...}}`) used by the CMS
+ * array UI. Authors can write natural-looking arrays in their presets without
+ * worrying about this implementation detail.
+ *
+ * Recurses into `object` and `oneof` fields. For arrays of objects/oneOfs,
+ * each item is normalized in turn.
+ */
+export function normalizePresetData(
+  schemaOrField: Collection | ObjectField | Schema,
+  data: Record<string, any>,
+  types?: Record<string, Schema>
+): Record<string, any> {
+  const result: Record<string, any> = {...data};
+  schemaOrField.fields.forEach((field) => {
+    if (!field.id) {
+      return;
+    }
+    const value = result[field.id];
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (field.type === 'array' && Array.isArray(value)) {
+      const items = value.map((item) =>
+        normalizeArrayItem(field.of, item, types)
+      );
+      result[field.id] = toArrayMap(items);
+    } else if (field.type === 'object' && isObject(value)) {
+      result[field.id] = normalizePresetData(field, value, types);
+    } else if (
+      field.type === 'oneof' &&
+      isObject(value) &&
+      typeof value._type === 'string' &&
+      types
+    ) {
+      const sub = types[value._type];
+      if (sub) {
+        result[field.id] = normalizePresetData(sub, value, types);
+      }
+    }
+  });
+  return result;
+}
+
+function normalizeArrayItem(
+  itemField: ObjectLikeField,
+  item: any,
+  types?: Record<string, Schema>
+): any {
+  if (!isObject(item)) {
+    return item;
+  }
+  if (itemField.type === 'object') {
+    return normalizePresetData(itemField, item, types);
+  }
+  if (itemField.type === 'oneof' && typeof item._type === 'string' && types) {
+    const sub = types[item._type];
+    if (sub) {
+      return normalizePresetData(sub, item, types);
+    }
+  }
+  return item;
 }

--- a/packages/root-cms/ui/utils/objects.test.ts
+++ b/packages/root-cms/ui/utils/objects.test.ts
@@ -152,4 +152,16 @@ describe('deepMerge', () => {
     expect(target).toEqual({a: {x: 1}});
     expect(source).toEqual({a: {y: 2}});
   });
+
+  it('replaces array-maps wholesale instead of merging them', () => {
+    const target: Record<string, any> = {
+      items: {_array: ['a'], a: {title: 'old'}},
+    };
+    const source: Record<string, any> = {
+      items: {_array: ['b', 'c'], b: {title: 'new1'}, c: {title: 'new2'}},
+    };
+    expect(deepMerge(target, source)).toEqual({
+      items: {_array: ['b', 'c'], b: {title: 'new1'}, c: {title: 'new2'}},
+    });
+  });
 });

--- a/packages/root-cms/ui/utils/objects.test.ts
+++ b/packages/root-cms/ui/utils/objects.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect} from 'vitest';
 import {
+  deepMerge,
   getNestedValue,
   sortObjectKeysDeep,
   stableJsonStringify,
@@ -110,5 +111,45 @@ describe('stableJsonStringify', () => {
     };
 
     expect(stableJsonStringify(before)).toBe(stableJsonStringify(after));
+  });
+});
+
+describe('deepMerge', () => {
+  it('merges shallow keys, source overrides target', () => {
+    const target: Record<string, any> = {a: 1, b: 2};
+    const source: Record<string, any> = {b: 99, c: 3};
+    expect(deepMerge(target, source)).toEqual({a: 1, b: 99, c: 3});
+  });
+
+  it('recursively merges nested objects', () => {
+    const target: Record<string, any> = {a: {x: 1, y: 2}};
+    const source: Record<string, any> = {a: {y: 99, z: 3}};
+    expect(deepMerge(target, source)).toEqual({a: {x: 1, y: 99, z: 3}});
+  });
+
+  it('replaces arrays wholesale', () => {
+    const target: Record<string, any> = {tags: ['a', 'b']};
+    const source: Record<string, any> = {tags: ['c']};
+    expect(deepMerge(target, source)).toEqual({tags: ['c']});
+  });
+
+  it('ignores undefined source values', () => {
+    const target: Record<string, any> = {a: 1};
+    const source: Record<string, any> = {a: undefined};
+    expect(deepMerge(target, source)).toEqual({a: 1});
+  });
+
+  it('allows null to override target values', () => {
+    const target: Record<string, any> = {a: 1};
+    const source: Record<string, any> = {a: null};
+    expect(deepMerge(target, source)).toEqual({a: null});
+  });
+
+  it('does not mutate the inputs', () => {
+    const target: Record<string, any> = {a: {x: 1}};
+    const source: Record<string, any> = {a: {y: 2}};
+    deepMerge(target, source);
+    expect(target).toEqual({a: {x: 1}});
+    expect(source).toEqual({a: {y: 2}});
   });
 });

--- a/packages/root-cms/ui/utils/objects.ts
+++ b/packages/root-cms/ui/utils/objects.ts
@@ -222,9 +222,20 @@ export function stableJsonStringify(data: unknown, space = 2): string {
 }
 
 /**
+ * Returns true if `value` is an array-map (an object containing an `_array`
+ * field listing string keys for ordered child entries). The array-map shape is
+ * used by the CMS to persist ordered arrays of objects in Firestore.
+ */
+function isArrayMap(value: any): boolean {
+  return isObject(value) && Array.isArray((value as any)._array);
+}
+
+/**
  * Recursively merges plain objects. `source` values override `target` values.
  * Arrays and primitives are replaced wholesale (no array concatenation).
- * `undefined` source values are skipped; `null` overrides.
+ * Array-maps (`{_array: [...]}`) are also replaced wholesale to avoid
+ * corrupting the ordering. `undefined` source values are skipped; `null`
+ * overrides.
  */
 export function deepMerge<T extends Record<string, any>>(
   target: T,
@@ -234,7 +245,7 @@ export function deepMerge<T extends Record<string, any>>(
   for (const key in source) {
     const sv = source[key];
     const tv = result[key];
-    if (isObject(sv) && isObject(tv)) {
+    if (isObject(sv) && isObject(tv) && !isArrayMap(sv) && !isArrayMap(tv)) {
       result[key] = deepMerge(tv, sv as any);
     } else if (sv !== undefined) {
       result[key] = sv;

--- a/packages/root-cms/ui/utils/objects.ts
+++ b/packages/root-cms/ui/utils/objects.ts
@@ -220,3 +220,25 @@ export function sortObjectKeysDeep<T>(data: T): T {
 export function stableJsonStringify(data: unknown, space = 2): string {
   return JSON.stringify(sortObjectKeysDeep(data), null, space);
 }
+
+/**
+ * Recursively merges plain objects. `source` values override `target` values.
+ * Arrays and primitives are replaced wholesale (no array concatenation).
+ * `undefined` source values are skipped; `null` overrides.
+ */
+export function deepMerge<T extends Record<string, any>>(
+  target: T,
+  source: Partial<T>
+): T {
+  const result: Record<string, any> = {...target};
+  for (const key in source) {
+    const sv = source[key];
+    const tv = result[key];
+    if (isObject(sv) && isObject(tv)) {
+      result[key] = deepMerge(tv, sv as any);
+    } else if (sv !== undefined) {
+      result[key] = sv;
+    }
+  }
+  return result as T;
+}


### PR DESCRIPTION
## Summary
Introduces a new `ComponentPickerModal` component and adds support for schema presets, enabling a visual picker UI for `oneOf` fields as an alternative to the dropdown variant.

## Key Changes

- **New ComponentPickerModal component**: A searchable modal that displays component options as cards with thumbnails, titles, descriptions, and optional preset variants
  - Supports filtering by schema name, label, description, preset id, and preset label/description
  - Displays empty state when no options match the search
  - Integrates with Mantine's modal system via `useComponentPickerModal` hook

- **Schema preset support**: Added `SchemaPreset` interface and `presets` array to `Schema`
  - Presets include id, label, description, image, and prefill data
  - Schemas can now have an optional `image` field for thumbnail representation
  - Presets appear as separate cards in the picker alongside the schema's blank card

- **OneOfField picker variant**: Added `variant` option to `OneOfField` ('dropdown' or 'picker')
  - When `variant: 'picker'`, displays a button that opens the component picker modal
  - Supports clearing the selected type
  - Preset data is deep-merged over schema defaults to preserve nested object structure

- **Deep merge utility**: Implemented `deepMerge` function for recursively merging objects
  - Handles nested object merging while replacing arrays wholesale
  - Skips undefined source values but allows null to override
  - Non-mutating implementation

- **UI improvements**: Added styling for the picker button layout and modal cards with hover states

## Implementation Details

- The picker modal uses `useMemo` to efficiently filter options based on search query
- Preset data is applied via a new `applyType` function that deep-merges prefill data over schema defaults
- The component picker modal is registered with Mantine's modal system using a stable `MODAL_ID`
- Card rendering extracts subtitle (schema name) when displaying presets to provide context
- Comprehensive test coverage for preset functionality and deep merge behavior

## Screenshots

<img width="2168" height="1402" alt="Screenshot 2026-05-04 at 7 41 50 AM" src="https://github.com/user-attachments/assets/de79798f-80c6-461f-924a-08012a9a5aeb" />

## References

Fixes #1068 

https://claude.ai/code/session_01JTWi28i8Eztd7bjQYvvLEg