### PR TITLE
feat: add global search bar to top right of CMS UI

### DIFF
--- a/.changeset/swift-clouds-search.md
+++ b/.changeset/swift-clouds-search.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add global search bar to top right of CMS UI

--- a/packages/root-cms/ui/components/SearchBar/SearchBar.css
+++ b/packages/root-cms/ui/components/SearchBar/SearchBar.css
@@ -1,0 +1,53 @@
+.SearchBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 240px;
+  height: 32px;
+  padding: 0 8px 0 12px;
+  background: var(--surface-background, #fff);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--color-text-gray, #6b7280);
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+
+.SearchBar:hover {
+  background-color: var(--button-background-hover);
+}
+
+.SearchBar:focus-visible {
+  outline: 2px solid var(--mantine-color-blue-5, #339af0);
+  outline-offset: 2px;
+}
+
+.SearchBar__icon {
+  flex: 0 0 auto;
+  color: var(--color-text-gray, #6b7280);
+}
+
+.SearchBar__placeholder {
+  flex: 1 1 auto;
+  text-align: left;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text-gray, #6b7280);
+}
+
+.SearchBar__shortcut {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  padding: 0 8px;
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-gray, #6b7280);
+  background: var(--chip-background, #efefef);
+  border-radius: 6px;
+  white-space: nowrap;
+}

--- a/packages/root-cms/ui/components/SearchBar/SearchBar.css
+++ b/packages/root-cms/ui/components/SearchBar/SearchBar.css
@@ -7,7 +7,7 @@
   padding: 0 8px 0 12px;
   background: var(--surface-background, #fff);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 4px;
   cursor: pointer;
   font-family: inherit;
   color: var(--color-text-gray, #6b7280);

--- a/packages/root-cms/ui/components/SearchBar/SearchBar.tsx
+++ b/packages/root-cms/ui/components/SearchBar/SearchBar.tsx
@@ -1,0 +1,44 @@
+import './SearchBar.css';
+import {openSpotlight} from '@mantine/spotlight';
+import {IconSearch} from '@tabler/icons-preact';
+import {useEffect, useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
+
+interface SearchBarProps {
+  className?: string;
+}
+
+/**
+ * A button styled like a search input that opens the global Spotlight search
+ * when clicked. Displays the platform-appropriate keyboard shortcut hint
+ * (`⌘ + K` on macOS, `Ctrl + K` elsewhere) on the right.
+ */
+export function SearchBar(props: SearchBarProps) {
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    // Detect macOS so we can render `⌘` instead of `Ctrl`.
+    const platform =
+      (navigator as any).userAgentData?.platform ?? navigator.platform;
+    setIsMac(/mac/i.test(platform || ''));
+  }, []);
+
+  const onClick = () => {
+    openSpotlight();
+  };
+
+  return (
+    <button
+      type="button"
+      className={joinClassNames('SearchBar', props.className)}
+      onClick={onClick}
+      aria-label="Open search"
+    >
+      <IconSearch className="SearchBar__icon" size={16} stroke={1.5} />
+      <span className="SearchBar__placeholder">Search</span>
+      <span className="SearchBar__shortcut" aria-hidden="true">
+        {isMac ? '⌘ + K' : 'Ctrl + K'}
+      </span>
+    </button>
+  );
+}

--- a/packages/root-cms/ui/layout/Layout.css
+++ b/packages/root-cms/ui/layout/Layout.css
@@ -50,6 +50,10 @@
   margin-left: auto;
 }
 
+.Layout__top__search {
+  margin-left: auto;
+}
+
 .Layout__top__logo:hover {
   background-color: var(--button-background-hover);
 }

--- a/packages/root-cms/ui/layout/Layout.css
+++ b/packages/root-cms/ui/layout/Layout.css
@@ -52,6 +52,7 @@
 
 .Layout__top__search {
   margin-left: auto;
+  padding-right: 8px;
 }
 
 .Layout__top__logo:hover {

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -24,6 +24,7 @@ import {useLocation} from 'preact-iso';
 import type {CMSBuiltInSidebarTool} from '../../core/plugin.js';
 import packageJson from '../../package.json' assert {type: 'json'};
 import {RootCMSLogo} from '../components/RootCMSLogo/RootCMSLogo.js';
+import {SearchBar} from '../components/SearchBar/SearchBar.js';
 import {joinClassNames} from '../utils/classes.js';
 import './Layout.css';
 
@@ -45,10 +46,23 @@ export function Layout(props: LayoutProps) {
   );
 }
 
+/**
+ * Returns true when the current URL is the document editor page
+ * (`/cms/content/:collection/:slug`), which has its own custom search and
+ * should therefore hide the global search bar.
+ */
+function isDocumentEditorUrl(url: string): boolean {
+  const path = url.split('?')[0].replace(/\/+$/g, '');
+  const parts = path.split('/').filter(Boolean);
+  return parts.length === 4 && parts[0] === 'cms' && parts[1] === 'content';
+}
+
 Layout.Top = () => {
   const rootConfig = window.__ROOT_CTX.rootConfig;
   const projectName = rootConfig.projectName || rootConfig.projectId;
   const minimalBranding = rootConfig.minimalBranding;
+  const {url} = useLocation();
+  const showSearchBar = !isDocumentEditorUrl(url);
   return (
     <div className="Layout__top">
       {!minimalBranding ? (
@@ -66,6 +80,11 @@ Layout.Top = () => {
           </a>
           <div className="Layout__top__version">v{packageJson.version}</div>
         </>
+      )}
+      {showSearchBar && (
+        <div className="Layout__top__search">
+          <SearchBar />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
This PR adds a global search bar component to the top navigation of the CMS UI, providing quick access to the Spotlight search functionality from anywhere in the application.

## Key Changes
- **New SearchBar component** (`SearchBar.tsx` + `SearchBar.css`): A styled button that opens the global Spotlight search when clicked, displaying the platform-appropriate keyboard shortcut hint (⌘ + K on macOS, Ctrl + K elsewhere)
- **Layout integration**: Added the SearchBar to the top navigation bar in `Layout.tsx`, positioned on the right side
- **Smart visibility**: The search bar is hidden on the document editor page (`/cms/content/:collection/:slug`) which has its own custom search interface
- **Platform detection**: Automatically detects macOS to display the correct keyboard shortcut symbol

## Implementation Details
- The SearchBar component uses Mantine's `openSpotlight()` function to trigger the search modal
- Platform detection is performed on component mount using `navigator.userAgentData` with a fallback to `navigator.platform`
- The component includes proper accessibility attributes (`aria-label` and `aria-hidden`)
- Styling uses CSS custom properties for theming consistency with the rest of the CMS UI
- The `isDocumentEditorUrl()` helper function parses the current URL to determine if the search bar should be displayed

## Screenshots

<img width="1896" height="1382" alt="Screenshot 2026-05-04 at 12 38 00 PM" src="https://github.com/user-attachments/assets/22a78297-46f8-458e-adc2-3b82871e150b" />

## References

https://claude.ai/code/session_01DEv2rpHxoCR6ZNwBUkBqPb