### PR TITLE
Ignore Chrome DevTools well-known path in dev server 404 logs

### DIFF
--- a/packages/root/src/cli/dev.ts
+++ b/packages/root/src/cli/dev.ts
@@ -31,6 +31,9 @@ import {getSessionCookieSecret} from '../utils/rand.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 type RenderModule = typeof import('../render/render.js');
+const DEV_SERVER_404_LOG_IGNORE_PATHS = new Set([
+  '/.well-known/appspecific/com.chrome.devtools.json',
+]);
 
 export interface DevOptions {
   host?: string;
@@ -320,7 +323,9 @@ function rootDevServerMiddleware() {
 
 function rootDevServer404Middleware() {
   return async (req: Request, res: Response) => {
-    console.error(`❓ 404 ${req.originalUrl}`);
+    if (!DEV_SERVER_404_LOG_IGNORE_PATHS.has(req.path)) {
+      console.error(`❓ 404 ${req.originalUrl}`);
+    }
     if (req.renderer) {
       const url = req.path;
       const ext = path.extname(url);


### PR DESCRIPTION
### Motivation
- Reduce noisy 404 logging for automated browser requests to the `/.well-known/appspecific/com.chrome.devtools.json` path during development.

### Description
- Introduce `DEV_SERVER_404_LOG_IGNORE_PATHS` with `/.well-known/appspecific/com.chrome.devtools.json` and skip emitting the 404 log in `rootDevServer404Middleware` when `req.path` is in the set.

### Testing
- No automated tests were added or run for this small logging change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f7600dac8323abb10bfe4aaf731c)