### PR TITLE
feat: add include/exclude filters for search indexer 

### DIFF
--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -121,6 +121,42 @@ export interface CMSAIConfig {
   model?: RootAiModel;
 }
 
+/**
+ * Filters applied to the spotlight / global search indexer. By default every
+ * collection and every doc is indexed. Use these options to scope the index to
+ * a subset of the project's content.
+ *
+ * Doc ids use the `<collectionId>/<slug>` format (e.g. `Pages/about`), which
+ * matches the format used elsewhere in the CMS.
+ */
+export interface CMSSearchIndexConfig {
+  /**
+   * Collections to include in the search index. If specified, only these
+   * collections are indexed. If unset, all collections are indexed (subject to
+   * `excludeCollections`).
+   */
+  includeCollections?: string[];
+
+  /**
+   * Collections to exclude from the search index. Applied after
+   * `includeCollections`.
+   */
+  excludeCollections?: string[];
+
+  /**
+   * Doc ids to include in the search index. If specified, only these docs are
+   * indexed (within collections that pass the collection filter). Format:
+   * `<collectionId>/<slug>`.
+   */
+  includeDocIds?: string[];
+
+  /**
+   * Doc ids to exclude from the search index. Applied after `includeDocIds`.
+   * Format: `<collectionId>/<slug>`.
+   */
+  excludeDocIds?: string[];
+}
+
 export interface CMSSidebarTool {
   /** URL for the sidebar icon image. */
   icon?: string;
@@ -360,6 +396,12 @@ export type CMSPluginOptions = {
    * ```
    */
   notifications?: CMSNotificationService[];
+
+  /**
+   * Configuration for the spotlight / global search indexer. Use this to
+   * include or exclude specific collections or docs from being indexed.
+   */
+  searchIndex?: CMSSearchIndexConfig;
 };
 
 export type CMSPlugin = Plugin & {

--- a/packages/root-cms/core/search-index.test.ts
+++ b/packages/root-cms/core/search-index.test.ts
@@ -10,9 +10,93 @@ import * as schema from './schema.js';
 import {extractDocRecords} from './search-extract.js';
 import {
   SearchIndexService,
+  isCollectionIndexable,
+  isDocIndexable,
   isTitleyDeepKey,
+  resolveSearchIndexFilters,
   withWeight,
 } from './search-index.js';
+
+describe('search index filters', () => {
+  it('treats unset/empty config as "index everything"', () => {
+    const filters = resolveSearchIndexFilters(undefined);
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+    expect(isCollectionIndexable(filters, 'Posts')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+  });
+
+  it('treats empty arrays as unset (does not exclude everything)', () => {
+    const filters = resolveSearchIndexFilters({
+      includeCollections: [],
+      includeDocIds: [],
+    });
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+  });
+
+  it('respects includeCollections allowlist', () => {
+    const filters = resolveSearchIndexFilters({
+      includeCollections: ['Pages'],
+    });
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+    expect(isCollectionIndexable(filters, 'Posts')).toBe(false);
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+    expect(isDocIndexable(filters, 'Posts/hello')).toBe(false);
+  });
+
+  it('respects excludeCollections denylist', () => {
+    const filters = resolveSearchIndexFilters({
+      excludeCollections: ['Drafts'],
+    });
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+    expect(isCollectionIndexable(filters, 'Drafts')).toBe(false);
+    expect(isDocIndexable(filters, 'Drafts/foo')).toBe(false);
+  });
+
+  it('applies excludeCollections after includeCollections', () => {
+    const filters = resolveSearchIndexFilters({
+      includeCollections: ['Pages', 'Posts'],
+      excludeCollections: ['Posts'],
+    });
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+    expect(isCollectionIndexable(filters, 'Posts')).toBe(false);
+    expect(isCollectionIndexable(filters, 'Other')).toBe(false);
+  });
+
+  it('respects includeDocIds allowlist', () => {
+    const filters = resolveSearchIndexFilters({
+      includeDocIds: ['Pages/home', 'Pages/about'],
+    });
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/about')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/contact')).toBe(false);
+    // Collections are still indexable; only the doc-level filter narrows.
+    expect(isCollectionIndexable(filters, 'Pages')).toBe(true);
+  });
+
+  it('respects excludeDocIds denylist', () => {
+    const filters = resolveSearchIndexFilters({
+      excludeDocIds: ['Pages/secret'],
+    });
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/secret')).toBe(false);
+  });
+
+  it('combines collection and doc-id filters', () => {
+    const filters = resolveSearchIndexFilters({
+      includeCollections: ['Pages'],
+      excludeDocIds: ['Pages/secret'],
+    });
+    expect(isDocIndexable(filters, 'Pages/home')).toBe(true);
+    expect(isDocIndexable(filters, 'Pages/secret')).toBe(false);
+    expect(isDocIndexable(filters, 'Posts/hello')).toBe(false);
+  });
+
+  it('rejects malformed doc ids (no slash)', () => {
+    const filters = resolveSearchIndexFilters(undefined);
+    expect(isDocIndexable(filters, 'no-slash')).toBe(false);
+  });
+});
 
 describe('isTitleyDeepKey', () => {
   it('matches title-like terminal segments case-insensitively', () => {

--- a/packages/root-cms/core/search-index.ts
+++ b/packages/root-cms/core/search-index.ts
@@ -25,6 +25,7 @@ import {Firestore, Query, Timestamp} from 'firebase-admin/firestore';
 import MiniSearch from 'minisearch';
 import glob from 'tiny-glob';
 import {getCmsPlugin} from './client.js';
+import type {CMSSearchIndexConfig} from './plugin.js';
 import type {Schema} from './schema.js';
 import {extractDocRecords, ExtractedRecord} from './search-extract.js';
 
@@ -122,6 +123,73 @@ interface CmsCollectionDoc {
 
 type DocMap = Record<string, string[]>;
 
+/**
+ * Normalized form of `CMSSearchIndexConfig`. Empty arrays are treated as
+ * "unset" so the user can defensively pass an empty list without accidentally
+ * excluding everything via `includeCollections: []`.
+ */
+interface ResolvedFilters {
+  includeCollections: Set<string> | null;
+  excludeCollections: Set<string> | null;
+  includeDocIds: Set<string> | null;
+  excludeDocIds: Set<string> | null;
+}
+
+function toSetOrNull(values: string[] | undefined): Set<string> | null {
+  if (!values || values.length === 0) {
+    return null;
+  }
+  return new Set(values);
+}
+
+export function resolveSearchIndexFilters(
+  config?: CMSSearchIndexConfig
+): ResolvedFilters {
+  return {
+    includeCollections: toSetOrNull(config?.includeCollections),
+    excludeCollections: toSetOrNull(config?.excludeCollections),
+    includeDocIds: toSetOrNull(config?.includeDocIds),
+    excludeDocIds: toSetOrNull(config?.excludeDocIds),
+  };
+}
+
+export function isCollectionIndexable(
+  filters: ResolvedFilters,
+  collectionId: string
+): boolean {
+  if (
+    filters.includeCollections &&
+    !filters.includeCollections.has(collectionId)
+  ) {
+    return false;
+  }
+  if (filters.excludeCollections?.has(collectionId)) {
+    return false;
+  }
+  return true;
+}
+
+export function isDocIndexable(
+  filters: ResolvedFilters,
+  docId: string
+): boolean {
+  const slashIndex = docId.indexOf('/');
+  if (slashIndex < 0) {
+    return false;
+  }
+  const collectionId = docId.slice(0, slashIndex);
+  if (!isCollectionIndexable(filters, collectionId)) {
+    return false;
+  }
+  if (filters.includeDocIds && !filters.includeDocIds.has(docId)) {
+    return false;
+  }
+  if (filters.excludeDocIds?.has(docId)) {
+    return false;
+  }
+  return true;
+}
+
 interface CachedIndex {
   index: MiniSearch;
   meta: SearchIndexMeta;
@@ -148,9 +216,14 @@ export class SearchIndexService {
   private readonly projectId: string;
   private readonly db: Firestore;
   private readonly loadSchema: LoadSchemaFn;
+  private readonly filters: ResolvedFilters;
   private cached: CachedIndex | null = null;
 
-  constructor(rootConfig: RootConfig, loadSchema?: LoadSchemaFn) {
+  constructor(
+    rootConfig: RootConfig,
+    loadSchema?: LoadSchemaFn,
+    filtersOverride?: CMSSearchIndexConfig
+  ) {
     this.rootConfig = rootConfig;
     const cmsPlugin = getCmsPlugin(rootConfig);
     const cmsPluginOptions = cmsPlugin.getConfig();
@@ -158,6 +231,22 @@ export class SearchIndexService {
     this.db = cmsPlugin.getFirestore();
     this.loadSchema =
       loadSchema || ((id) => this.loadCollectionSchemaFromDist(id));
+    this.filters = resolveSearchIndexFilters(
+      filtersOverride ?? cmsPluginOptions.searchIndex
+    );
+  }
+
+  /** Returns true if the given collection passes the include/exclude filter. */
+  isCollectionIndexable(collectionId: string): boolean {
+    return isCollectionIndexable(this.filters, collectionId);
+  }
+
+  /**
+   * Returns true if the given doc id passes the include/exclude filter (and
+   * its collection is itself indexable). Doc ids are `<collectionId>/<slug>`.
+   */
+  isDocIndexable(docId: string): boolean {
+    return isDocIndexable(this.filters, docId);
   }
 
   /** Returns the MiniSearch options used by both writers and readers. */
@@ -173,14 +262,19 @@ export class SearchIndexService {
     return `Projects/${this.projectId}/${SEARCH_INDEX_SUBCOLLECTION}`;
   }
 
-  /** Lists collection ids by globbing `<rootDir>/collections/*.schema.ts`. */
+  /**
+   * Lists collection ids by globbing `<rootDir>/collections/*.schema.ts`,
+   * filtered by the include/exclude config.
+   */
   async listCollectionIds(): Promise<string[]> {
     const collectionsDir = path.join(this.rootConfig.rootDir, 'collections');
     if (!fs.existsSync(collectionsDir)) {
       return [];
     }
     const fileNames = await glob('*.schema.ts', {cwd: collectionsDir});
-    return fileNames.map((f) => f.slice(0, -10));
+    return fileNames
+      .map((f) => f.slice(0, -10))
+      .filter((id) => this.isCollectionIndexable(id));
   }
 
   /**
@@ -313,7 +407,10 @@ export class SearchIndexService {
     await batch.commit();
   }
 
-  /** Lists the full set of live (collection, slug, doc) tuples for `Drafts`. */
+  /**
+   * Lists the full set of live (collection, slug, doc) tuples for `Drafts`,
+   * filtered by the include/exclude config.
+   */
   private async listAllDocs(
     collectionIds: string[]
   ): Promise<CmsCollectionDoc[]> {
@@ -322,17 +419,24 @@ export class SearchIndexService {
       const path = `Projects/${this.projectId}/Collections/${collectionId}/Drafts`;
       const snap = await this.db.collection(path).get();
       snap.forEach((d) => {
+        const docId = `${collectionId}/${d.id}`;
+        if (!this.isDocIndexable(docId)) {
+          return;
+        }
         const data = (d.data() || {}) as CmsCollectionDoc;
         if (!data.collection) data.collection = collectionId;
         if (!data.slug) data.slug = d.id;
-        if (!data.id) data.id = `${collectionId}/${d.id}`;
+        if (!data.id) data.id = docId;
         all.push(data);
       });
     }
     return all;
   }
 
-  /** Lists docs modified since `lastRun` across every collection. */
+  /**
+   * Lists docs modified since `lastRun` across every collection, filtered by
+   * the include/exclude config.
+   */
   private async listChangedDocs(
     collectionIds: string[],
     lastRun: Timestamp
@@ -345,10 +449,14 @@ export class SearchIndexService {
         .where('sys.modifiedAt', '>=', lastRun);
       const snap = await q.get();
       snap.forEach((d) => {
+        const docId = `${collectionId}/${d.id}`;
+        if (!this.isDocIndexable(docId)) {
+          return;
+        }
         const data = (d.data() || {}) as CmsCollectionDoc;
         if (!data.collection) data.collection = collectionId;
         if (!data.slug) data.slug = d.id;
-        if (!data.id) data.id = `${collectionId}/${d.id}`;
+        if (!data.id) data.id = docId;
         all.push(data);
       });
     }
@@ -386,7 +494,12 @@ export class SearchIndexService {
     for (const collectionId of collectionIds) {
       const path = `Projects/${this.projectId}/Collections/${collectionId}/Drafts`;
       const snap = await this.db.collection(path).select().get();
-      snap.forEach((d) => liveIds.add(`${collectionId}/${d.id}`));
+      snap.forEach((d) => {
+        const docId = `${collectionId}/${d.id}`;
+        if (this.isDocIndexable(docId)) {
+          liveIds.add(docId);
+        }
+      });
     }
     for (const id of knownIds) {
       if (!liveIds.has(id)) {
@@ -460,6 +573,9 @@ export class SearchIndexService {
       snap.forEach((d) => {
         const data = (d.data() || {}) as CmsCollectionDoc;
         const slug = data.slug || d.id;
+        if (!this.isDocIndexable(`${collectionId}/${slug}`)) {
+          return;
+        }
         const records = extractDocRecords(schema, {
           collection: collectionId,
           slug,
@@ -540,12 +656,18 @@ export class SearchIndexService {
     }
 
     // Reconcile deletions: drop records for docs in _docMap that no longer
-    // exist in any collection.
+    // exist in any collection — or that have been newly excluded by the
+    // include/exclude config (treated as a logical deletion).
     const liveIds = new Set<string>();
     for (const collectionId of collectionIds) {
       const path = `Projects/${this.projectId}/Collections/${collectionId}/Drafts`;
       const snap = await this.db.collection(path).select().get();
-      snap.forEach((d) => liveIds.add(`${collectionId}/${d.id}`));
+      snap.forEach((d) => {
+        const docId = `${collectionId}/${d.id}`;
+        if (this.isDocIndexable(docId)) {
+          liveIds.add(docId);
+        }
+      });
     }
     let deletions = 0;
     for (const docId of Object.keys(docMap)) {


### PR DESCRIPTION
## Summary
This PR adds support for filtering which collections and documents are included in the CMS search index. Users can now configure include/exclude lists at both the collection and document level to scope the spotlight/global search indexer to a subset of their content.

## Key Changes
- **New `CMSSearchIndexConfig` interface** in `plugin.ts` with four filter options:
  - `includeCollections` / `excludeCollections` for collection-level filtering
  - `includeDocIds` / `excludeDocIds` for document-level filtering (format: `<collectionId>/<slug>`)

- **Filter resolution and checking functions** in `search-index.ts`:
  - `resolveSearchIndexFilters()` converts config arrays to Sets, treating empty arrays as "unset" to prevent accidental exclusion of all content
  - `isCollectionIndexable()` and `isDocIndexable()` check if a collection/doc passes the filters
  - Filters are applied in order: include allowlist → exclude denylist

- **Integration into `SearchIndexService`**:
  - Constructor now accepts optional `filtersOverride` parameter and reads `searchIndex` config from CMS plugin options
  - Filter checks added to all document enumeration paths: `listCollectionIds()`, `listAllDocs()`, `listChangedDocs()`, and deletion reconciliation logic
  - Public methods `isCollectionIndexable()` and `isDocIndexable()` expose filter checking

- **Comprehensive test coverage** in `search-index.test.ts`:
  - Tests for unset/empty config behavior (indexes everything by default)
  - Tests for include/exclude allowlists and denylists
  - Tests for filter combination and precedence
  - Tests for malformed doc ids

## Implementation Details
- Empty arrays in config are treated as `null` (unset) rather than excluding everything, allowing defensive empty list passing
- Doc id validation requires the `<collectionId>/<slug>` format with a slash separator
- Exclude filters are applied after include filters, allowing fine-grained control (e.g., include a collection but exclude specific docs)
- Filter checks are applied consistently across all code paths that enumerate documents for indexing

https://claude.ai/code/session_015aERpGRrNS8yxu38n3QWsy