### PR TITLE
feat: add Google-style search query parsing and execution

### DIFF
--- a/packages/root-cms/core/search-index.ts
+++ b/packages/root-cms/core/search-index.ts
@@ -28,6 +28,7 @@ import {getCmsPlugin} from './client.js';
 import type {CMSSearchIndexConfig} from './plugin.js';
 import type {Schema} from './schema.js';
 import {extractDocRecords, ExtractedRecord} from './search-extract.js';
+import {executeQuery, parseQuery} from './search-query.js';
 
 /** Max chars per shard. Leaves headroom under the Firestore 1 MB doc cap. */
 const SHARD_MAX_CHARS = 500_000;
@@ -764,7 +765,7 @@ export class SearchIndexService {
     if (!cached || !q.trim()) {
       return {hits: [], meta: status};
     }
-    const raw = cached.index.search(q.trim());
+    const raw = executeQuery(cached.index, parseQuery(q));
     const hits: SearchHit[] = raw.slice(0, limit).map((r: any) => ({
       id: String(r.id || ''),
       docId: String(r.docId || ''),

--- a/packages/root-cms/core/search-query.test.ts
+++ b/packages/root-cms/core/search-query.test.ts
@@ -1,0 +1,305 @@
+import MiniSearch from 'minisearch';
+import {describe, it, expect} from 'vitest';
+import {SearchIndexService, withWeight} from './search-index.js';
+import {
+  containsPhrase,
+  executeQuery,
+  isEmptyQuery,
+  parseQuery,
+} from './search-query.js';
+
+describe('parseQuery', () => {
+  it('parses a single bare term', () => {
+    expect(parseQuery('foo')).toEqual({
+      phrases: [],
+      terms: ['foo'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('splits multiple bare terms on whitespace', () => {
+    expect(parseQuery('foo  bar\tbaz')).toEqual({
+      phrases: [],
+      terms: ['foo', 'bar', 'baz'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('extracts a quoted phrase', () => {
+    expect(parseQuery('"foo bar"')).toEqual({
+      phrases: ['foo bar'],
+      terms: [],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('mixes phrases and bare terms', () => {
+    expect(parseQuery('hero "foo bar" baz')).toEqual({
+      phrases: ['foo bar'],
+      terms: ['hero', 'baz'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('treats `-foo` as an exclusion', () => {
+    expect(parseQuery('foo -bar')).toEqual({
+      phrases: [],
+      terms: ['foo'],
+      excluded: ['bar'],
+      excludedPhrases: [],
+    });
+  });
+
+  it('treats `-"foo bar"` as an excluded phrase', () => {
+    expect(parseQuery('keep -"throw away"')).toEqual({
+      phrases: [],
+      terms: ['keep'],
+      excluded: [],
+      excludedPhrases: ['throw away'],
+    });
+  });
+
+  it('normalizes smart quotes to straight quotes', () => {
+    // U+201C / U+201D — the iOS / macOS "smart quote" defaults.
+    expect(parseQuery('“foo bar”')).toEqual({
+      phrases: ['foo bar'],
+      terms: [],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('treats an unclosed quote as a phrase to end-of-input', () => {
+    expect(parseQuery('"foo bar')).toEqual({
+      phrases: ['foo bar'],
+      terms: [],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('skips empty quotes', () => {
+    expect(parseQuery('foo "" "  " bar')).toEqual({
+      phrases: [],
+      terms: ['foo', 'bar'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('keeps an embedded dash inside a term', () => {
+    // `foo-bar` is a single token; only a leading `-` after whitespace excludes.
+    expect(parseQuery('foo-bar')).toEqual({
+      phrases: [],
+      terms: ['foo-bar'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('drops a standalone dash', () => {
+    expect(parseQuery('foo - bar')).toEqual({
+      phrases: [],
+      terms: ['foo', 'bar'],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+
+  it('handles empty / whitespace-only input', () => {
+    expect(parseQuery('')).toEqual({
+      phrases: [],
+      terms: [],
+      excluded: [],
+      excludedPhrases: [],
+    });
+    expect(parseQuery('   ')).toEqual({
+      phrases: [],
+      terms: [],
+      excluded: [],
+      excludedPhrases: [],
+    });
+  });
+});
+
+describe('isEmptyQuery', () => {
+  it('treats a parsed query without positive constraints as empty', () => {
+    expect(isEmptyQuery(parseQuery(''))).toBe(true);
+    expect(isEmptyQuery(parseQuery('   '))).toBe(true);
+    // Pure exclusions can't be answered without enumerating the index.
+    expect(isEmptyQuery(parseQuery('-foo'))).toBe(true);
+    expect(isEmptyQuery(parseQuery('foo'))).toBe(false);
+    expect(isEmptyQuery(parseQuery('"foo"'))).toBe(false);
+  });
+});
+
+describe('containsPhrase', () => {
+  it('matches a contiguous run of word tokens', () => {
+    expect(containsPhrase('the quick brown fox', 'quick brown')).toBe(true);
+    expect(containsPhrase('the quick brown fox', 'brown quick')).toBe(false);
+  });
+
+  it('ignores punctuation between tokens', () => {
+    expect(containsPhrase('quick. brown! fox?', 'quick brown fox')).toBe(true);
+  });
+
+  it('requires word boundaries (no substring matches)', () => {
+    expect(containsPhrase('foobar', 'foo bar')).toBe(false);
+    expect(containsPhrase('foobar', 'foo')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(containsPhrase('The Quick Brown Fox', 'quick BROWN fox')).toBe(true);
+  });
+
+  it('handles single-word phrases', () => {
+    expect(containsPhrase('foo bar baz', 'bar')).toBe(true);
+    expect(containsPhrase('foo bar baz', 'qux')).toBe(false);
+  });
+
+  it('returns true for empty phrases (vacuously true)', () => {
+    expect(containsPhrase('anything', '')).toBe(true);
+  });
+
+  it('returns false when the text is shorter than the phrase', () => {
+    expect(containsPhrase('foo', 'foo bar baz')).toBe(false);
+  });
+});
+
+describe('executeQuery', () => {
+  function buildIndex() {
+    const opts = SearchIndexService.getMiniSearchOptions();
+    const index = new MiniSearch(opts);
+    const records = [
+      {
+        id: 'A',
+        docId: 'Pages/a',
+        collection: 'Pages',
+        slug: 'a',
+        deepKey: 'fields.body',
+        fieldType: 'richtext',
+        fieldLabel: 'Body',
+        text: 'The quick brown fox jumps over the lazy dog',
+      },
+      {
+        id: 'B',
+        docId: 'Pages/b',
+        collection: 'Pages',
+        slug: 'b',
+        deepKey: 'fields.body',
+        fieldType: 'richtext',
+        fieldLabel: 'Body',
+        text: 'A brown bag full of quick snacks',
+      },
+      {
+        id: 'C',
+        docId: 'Pages/c',
+        collection: 'Pages',
+        slug: 'c',
+        deepKey: 'fields.title',
+        fieldType: 'string',
+        fieldLabel: 'Title',
+        text: 'Quick brown fox',
+      },
+      {
+        id: 'D',
+        docId: 'Pages/d',
+        collection: 'Pages',
+        slug: 'd',
+        deepKey: 'fields.body',
+        fieldType: 'richtext',
+        fieldLabel: 'Body',
+        text: 'Just a slow turtle',
+      },
+    ];
+    index.addAll(records.map(withWeight));
+    return index;
+  }
+
+  it('returns no hits for an empty query', () => {
+    const index = buildIndex();
+    expect(executeQuery(index, parseQuery(''))).toEqual([]);
+  });
+
+  it('AND-combines unquoted terms (narrows results)', () => {
+    const index = buildIndex();
+    // `lazy` only appears in A; `quick` is in A, B, C. With AND, only A
+    // satisfies both — under the prior OR default, B and C would also match.
+    const ids = executeQuery(index, parseQuery('quick lazy')).map((r) => r.id);
+    expect(ids).toEqual(['A']);
+  });
+
+  it('phrases require contiguous tokens', () => {
+    const index = buildIndex();
+    // `B` contains both `brown` and `quick`, but not as the phrase
+    // "quick brown" — only A and C do.
+    const ids = executeQuery(index, parseQuery('"quick brown"')).map(
+      (r) => r.id
+    );
+    expect(ids).toEqual(expect.arrayContaining(['A', 'C']));
+    expect(ids).not.toContain('B');
+    expect(ids).not.toContain('D');
+  });
+
+  it('phrases disable fuzzy/prefix matching', () => {
+    const index = buildIndex();
+    // `quic` would normally prefix-match `quick` and surface A/B/C, but a
+    // quoted phrase should require the literal token.
+    const looseIds = executeQuery(index, parseQuery('quic')).map((r) => r.id);
+    expect(looseIds.length).toBeGreaterThan(0);
+    const exactIds = executeQuery(index, parseQuery('"quic"')).map((r) => r.id);
+    expect(exactIds).toEqual([]);
+  });
+
+  it('combines phrases with bare terms (AND)', () => {
+    const index = buildIndex();
+    const ids = executeQuery(index, parseQuery('"quick brown" jumps')).map(
+      (r) => r.id
+    );
+    // Only A has both the phrase AND the term `jumps`.
+    expect(ids).toEqual(['A']);
+  });
+
+  it('excludes docs matching `-term`', () => {
+    const index = buildIndex();
+    const all = executeQuery(index, parseQuery('brown')).map((r) => r.id);
+    expect(all).toEqual(expect.arrayContaining(['A', 'B', 'C']));
+    const filtered = executeQuery(index, parseQuery('brown -lazy')).map(
+      (r) => r.id
+    );
+    expect(filtered).not.toContain('A');
+    expect(filtered).toEqual(expect.arrayContaining(['B', 'C']));
+  });
+
+  it('excludes docs matching `-"phrase"`', () => {
+    const index = buildIndex();
+    const filtered = executeQuery(
+      index,
+      parseQuery('brown -"quick brown"')
+    ).map((r) => r.id);
+    // A and C contain the phrase "quick brown" — they must be excluded.
+    expect(filtered).not.toContain('A');
+    expect(filtered).not.toContain('C');
+    expect(filtered).toContain('B');
+  });
+
+  it('returns no hits for queries with only exclusions', () => {
+    const index = buildIndex();
+    expect(executeQuery(index, parseQuery('-foo'))).toEqual([]);
+  });
+
+  it('returns both title and body matches for a phrase search', () => {
+    const index = buildIndex();
+    const ids = executeQuery(index, parseQuery('"quick brown"')).map(
+      (r) => r.id
+    );
+    // The phrase appears in A (body) and C (title); B has the words but
+    // out of order, so it must be excluded.
+    expect(ids).toEqual(expect.arrayContaining(['A', 'C']));
+    expect(ids).not.toContain('B');
+  });
+});

--- a/packages/root-cms/core/search-query.ts
+++ b/packages/root-cms/core/search-query.ts
@@ -1,0 +1,290 @@
+/**
+ * Google-style query parsing and execution for the CMS search index.
+ *
+ * The CMS spotlight passes raw user input straight through to MiniSearch, which
+ * means quotes, leading dashes, and multiple words all get tokenized the same
+ * way (fuzzy + prefix on every term, OR-combined). That produces noisy results
+ * — typing `homepage hero` returns every doc containing `homepage` *or* a
+ * fuzzy/prefix match for `hero`.
+ *
+ * This module preprocesses the query string into structured parts and runs
+ * each part with the appropriate MiniSearch options:
+ *
+ *   - `"exact phrase"`  — must appear verbatim (token-aligned) in the doc;
+ *                         fuzzy + prefix disabled.
+ *   - `bare term`       — fuzzy + prefix allowed (existing behavior).
+ *   - `-foo` / `-"x y"` — must NOT appear in matching docs.
+ *
+ * Multiple parts are AND-combined so adding more terms narrows results, just
+ * like Google.
+ */
+
+import MiniSearch, {SearchResult} from 'minisearch';
+
+/** Structured form of a user query string. */
+export interface ParsedQuery {
+  /** Quoted phrases that must appear verbatim (token-aligned). */
+  phrases: string[];
+  /** Free-form terms; fuzzy + prefix matching applies. */
+  terms: string[];
+  /** Bare terms that must NOT appear in matching docs. */
+  excluded: string[];
+  /** Quoted phrases that must NOT appear in matching docs. */
+  excludedPhrases: string[];
+}
+
+/**
+ * Curly / typographic quote characters that browsers (especially iOS / macOS
+ * with "smart quotes" enabled) substitute for plain `"`. We normalize them so
+ * users don't get confused when their pasted query stops working.
+ */
+const SMART_QUOTES = /[“”„«»]/g;
+
+/**
+ * Splits a Google-style query string into phrases / terms / exclusions.
+ *
+ * Examples:
+ *   `foo "bar baz" -qux`   ->  terms=[foo], phrases=[bar baz], excluded=[qux]
+ *   `"exact phrase only"`  ->  phrases=[exact phrase only]
+ *   `-"forbidden phrase"`  ->  excludedPhrases=[forbidden phrase]
+ *
+ * Notes:
+ *   - Smart quotes (U+201C / U+201D / etc.) are normalized to straight `"`.
+ *   - An unclosed quote is treated as if closed at end-of-input (matches
+ *     Google's behavior — the rest of the query becomes a single phrase).
+ *   - Empty or whitespace-only quotes (`""`, `"  "`) are skipped.
+ *   - A leading `-` only marks exclusion when followed by a non-whitespace
+ *     character; standalone `-` is dropped.
+ */
+export function parseQuery(input: string): ParsedQuery {
+  const out: ParsedQuery = {
+    phrases: [],
+    terms: [],
+    excluded: [],
+    excludedPhrases: [],
+  };
+  if (!input) {
+    return out;
+  }
+  const s = input.replace(SMART_QUOTES, '"');
+  let i = 0;
+  while (i < s.length) {
+    while (i < s.length && isSpace(s[i])) {
+      i++;
+    }
+    if (i >= s.length) {
+      break;
+    }
+    let negative = false;
+    if (s[i] === '-' && i + 1 < s.length && !isSpace(s[i + 1])) {
+      negative = true;
+      i++;
+    }
+    if (s[i] === '"') {
+      i++;
+      const start = i;
+      while (i < s.length && s[i] !== '"') {
+        i++;
+      }
+      const phrase = s.slice(start, i).trim();
+      if (i < s.length) {
+        i++;
+      }
+      if (phrase) {
+        if (negative) {
+          out.excludedPhrases.push(phrase);
+        } else {
+          out.phrases.push(phrase);
+        }
+      }
+    } else {
+      const start = i;
+      while (i < s.length && !isSpace(s[i]) && s[i] !== '"') {
+        i++;
+      }
+      const term = s.slice(start, i);
+      // Skip tokens that are just dashes (e.g. an isolated `-` between words).
+      if (term && term.replace(/^-+$/, '')) {
+        if (negative) {
+          out.excluded.push(term);
+        } else {
+          out.terms.push(term);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function isSpace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+}
+
+/**
+ * Splits text into lowercase word tokens, mirroring MiniSearch's default
+ * tokenizer (whitespace + Unicode punctuation). Used for token-aligned phrase
+ * matching so `"foo bar"` matches `foo. bar` but not `foobar`.
+ */
+function tokenize(s: string): string[] {
+  return s
+    .toLowerCase()
+    .split(/[\s\p{P}]+/u)
+    .filter(Boolean);
+}
+
+/**
+ * Returns true if `phrase` appears in `text` as a contiguous run of word
+ * tokens. Punctuation between tokens is ignored, but token boundaries are
+ * required (so `foo bar` does NOT match `foobar`).
+ */
+export function containsPhrase(text: string, phrase: string): boolean {
+  const phraseTokens = tokenize(phrase);
+  if (phraseTokens.length === 0) {
+    return true;
+  }
+  const textTokens = tokenize(text);
+  if (textTokens.length < phraseTokens.length) {
+    return false;
+  }
+  outer: for (let i = 0; i <= textTokens.length - phraseTokens.length; i++) {
+    for (let j = 0; j < phraseTokens.length; j++) {
+      if (textTokens[i + j] !== phraseTokens[j]) {
+        continue outer;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+/** True if this parsed query carries no positive constraints. */
+export function isEmptyQuery(parsed: ParsedQuery): boolean {
+  return parsed.phrases.length === 0 && parsed.terms.length === 0;
+}
+
+/** Per-record accumulator while AND-combining results from multiple parts. */
+interface AccEntry {
+  /** Sum of MiniSearch scores across each constraint that matched. */
+  score: number;
+  /** The first record we saw for this id; storeFields are identical. */
+  record: SearchResult;
+  /** Union of MiniSearch `terms` arrays across constraints. */
+  terms: Set<string>;
+}
+
+/**
+ * Runs a parsed query against a MiniSearch index using Google-style semantics:
+ *   - phrases match as exact contiguous word runs (no fuzzy / no prefix);
+ *   - free terms keep the index's default fuzzy + prefix behavior;
+ *   - all positive parts are AND-combined (a doc must satisfy each one);
+ *   - excluded terms / phrases remove docs from the result.
+ *
+ * Per-record scores from each part are summed, so a doc that matches more
+ * constraints ranks above one that matches fewer.
+ */
+export function executeQuery(
+  index: MiniSearch,
+  parsed: ParsedQuery
+): SearchResult[] {
+  if (isEmptyQuery(parsed)) {
+    return [];
+  }
+
+  let acc: Map<string, AccEntry> | null = null;
+
+  for (const phrase of parsed.phrases) {
+    const candidates = index.search(phrase, {
+      combineWith: 'AND',
+      fuzzy: false,
+      prefix: false,
+    });
+    const matched = candidates.filter(
+      (r) =>
+        containsPhrase(String((r as any).text || ''), phrase) ||
+        containsPhrase(String((r as any).fieldLabel || ''), phrase)
+    );
+    acc = mergeAnd(acc, matched);
+    if (acc.size === 0) {
+      return [];
+    }
+  }
+
+  if (parsed.terms.length > 0) {
+    const q = parsed.terms.join(' ');
+    const results = index.search(q, {combineWith: 'AND'});
+    acc = mergeAnd(acc, results);
+  }
+
+  if (!acc || acc.size === 0) {
+    return [];
+  }
+
+  for (const term of parsed.excluded) {
+    for (const r of index.search(term)) {
+      acc.delete(String(r.id));
+    }
+  }
+  for (const phrase of parsed.excludedPhrases) {
+    const candidates = index.search(phrase, {
+      combineWith: 'AND',
+      fuzzy: false,
+      prefix: false,
+    });
+    for (const r of candidates) {
+      if (
+        containsPhrase(String((r as any).text || ''), phrase) ||
+        containsPhrase(String((r as any).fieldLabel || ''), phrase)
+      ) {
+        acc.delete(String(r.id));
+      }
+    }
+  }
+
+  return Array.from(acc.values())
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => ({
+      ...entry.record,
+      score: entry.score,
+      terms: Array.from(entry.terms),
+    }));
+}
+
+function mergeAnd(
+  acc: Map<string, AccEntry> | null,
+  results: SearchResult[]
+): Map<string, AccEntry> {
+  if (acc === null) {
+    const next = new Map<string, AccEntry>();
+    for (const r of results) {
+      next.set(String(r.id), {
+        score: r.score,
+        record: r,
+        terms: new Set<string>(Array.isArray(r.terms) ? r.terms : []),
+      });
+    }
+    return next;
+  }
+  const byId = new Map<string, SearchResult>();
+  for (const r of results) {
+    byId.set(String(r.id), r);
+  }
+  const next = new Map<string, AccEntry>();
+  for (const [id, entry] of acc) {
+    const r = byId.get(id);
+    if (!r) {
+      continue;
+    }
+    const terms = new Set(entry.terms);
+    if (Array.isArray(r.terms)) {
+      for (const t of r.terms) {
+        terms.add(t);
+      }
+    }
+    next.set(id, {
+      score: entry.score + r.score,
+      record: entry.record,
+      terms,
+    });
+  }
+  return next;
+}

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
@@ -142,3 +142,37 @@
   border-top: 1px solid var(--mantine-color-gray-2, #e9ecef);
   background: var(--mantine-color-gray-0, #f8f9fa);
 }
+
+.GlobalSearchAction--tips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--mantine-color-gray-6, #868e96);
+  padding: 8px 16px;
+  border-top: 1px solid var(--mantine-color-gray-2, #e9ecef);
+  background: var(--mantine-color-gray-0, #f8f9fa);
+}
+
+.GlobalSearchAction__tipItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.GlobalSearchAction__tipSep {
+  color: var(--mantine-color-gray-4, #ced4da);
+}
+
+.GlobalSearchAction__kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--mantine-color-gray-2, #e9ecef);
+  color: var(--mantine-color-gray-8, #343a40);
+  border: 1px solid var(--mantine-color-gray-3, #dee2e6);
+  border-bottom-width: 2px;
+}

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
@@ -82,7 +82,10 @@ function buildCollectionTargets(): CollectionTarget[] {
         url: `/cms/content/${id}`,
         label,
         description,
-        haystack: [id, label, description].filter(Boolean).join(' ').toLowerCase(),
+        haystack: [id, label, description]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase(),
       };
     })
     .sort((a, b) => a.label.localeCompare(b.label));
@@ -124,7 +127,10 @@ function filterStaticTargets(
   const prefix: StaticTarget[] = [];
   const substr: StaticTarget[] = [];
   for (const t of targets) {
-    if (t.id.toLowerCase().startsWith(q) || t.label.toLowerCase().startsWith(q)) {
+    if (
+      t.id.toLowerCase().startsWith(q) ||
+      t.label.toLowerCase().startsWith(q)
+    ) {
       prefix.push(t);
     } else if (t.haystack.includes(q)) {
       substr.push(t);
@@ -217,6 +223,18 @@ function buildFooter(lastIndexed: string): SpotlightAction {
   };
 }
 
+function buildTipsRow(): SpotlightAction {
+  const meta: GlobalSearchActionMeta = {kind: 'tips'};
+  return {
+    id: '__syntax-tips__',
+    title: '',
+    description: '',
+    keywords: '__internal__',
+    onTrigger: () => {},
+    meta,
+  };
+}
+
 function GlobalSearchInner(props: {
   children: ComponentChildren;
   query: string;
@@ -225,8 +243,11 @@ function GlobalSearchInner(props: {
   const {query, onQueryChange} = props;
   const location = useLocation();
   const trimmedQuery = query.trim();
-  const {hits: fieldHits, loading: fieldLoading, status} =
-    useGlobalSearch(query);
+  const {
+    hits: fieldHits,
+    loading: fieldLoading,
+    status,
+  } = useGlobalSearch(query);
   const {hits: docSlugHits, loading: slugLoading} = useDocSlugSearch(query);
 
   const recentViews = useRecentViews();
@@ -328,13 +349,20 @@ function GlobalSearchInner(props: {
 
   const lastIndexed = formatLastIndexed(status);
   const augmented = useMemo(() => {
-    // The "last indexed" footer is only meaningful while the user is actively
-    // querying the index. When the query is empty (recent views) or there are
-    // no results, we suppress it so the surface stays clean.
-    if (!lastIndexed || !trimmedQuery || actions.length === 0) {
+    // Footers only render when there's at least one real action above them —
+    // otherwise Mantine would show them in place of the "nothing found"
+    // message and the surface would feel cluttered.
+    if (actions.length === 0) {
       return actions;
     }
-    return [...actions, buildFooter(lastIndexed)];
+    const out = [...actions];
+    if (trimmedQuery) {
+      out.push(buildTipsRow());
+    }
+    if (lastIndexed && trimmedQuery) {
+      out.push(buildFooter(lastIndexed));
+    }
+    return out;
   }, [actions, lastIndexed, trimmedQuery]);
 
   // Compose the "nothing found" message based on state.
@@ -344,9 +372,9 @@ function GlobalSearchInner(props: {
       return 'Searching…';
     }
     if (!trimmedQuery) {
-      return 'Type to search docs, collections, releases…';
+      return 'Type to search · "quotes" for exact match · -word to exclude';
     }
-    return 'No results.';
+    return 'No results. Try fewer words, or "quotes" for an exact phrase.';
   }, [loading, trimmedQuery]);
 
   // Pass-through filter: server already ranks/filters and our static-target
@@ -388,4 +416,3 @@ export function GlobalSearch(props: {children: ComponentChildren}) {
     </GlobalSearchInner>
   );
 }
-

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
@@ -8,14 +8,9 @@ import {
   IconRocket,
 } from '@tabler/icons-preact';
 import {ComponentChild} from 'preact';
-import type {
-  DocSlugHit,
-  GlobalSearchHit,
-} from '../../hooks/useGlobalSearch.js';
+import type {DocSlugHit, GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
 import type {RecentView, RecentViewKind} from '../../utils/recent-views.js';
-
-const SNIPPET_BEFORE = 60;
-const SNIPPET_AFTER = 120;
+import {buildSnippet} from './snippet.js';
 
 interface CollectionTargetMeta {
   kind: 'collection';
@@ -60,54 +55,8 @@ export type GlobalSearchActionMeta =
   | {kind: 'target'; target: StaticTargetMeta}
   | {kind: 'recent'; view: RecentView}
   | {kind: 'header'; label: string}
-  | {kind: 'footer'; lastIndexed: string};
-
-/**
- * Returns the highlighted text + surrounding context for a search hit.
- *
- * If any of the matched terms appears in `hit.text`, returns a snippet
- * windowed around the first occurrence with the term wrapped in <mark>. If
- * none of the terms match (e.g. fuzzy hit on the field label), returns the
- * full text with no highlighting.
- */
-function buildSnippet(hit: GlobalSearchHit): {
-  pre: string;
-  mark: string;
-  post: string;
-} {
-  const text = hit.text || '';
-  const terms = (hit.terms || [])
-    .filter(Boolean)
-    .sort((a, b) => b.length - a.length);
-  if (!terms.length || !text) {
-    return {pre: text, mark: '', post: ''};
-  }
-  const lower = text.toLowerCase();
-  let foundAt = -1;
-  let foundLen = 0;
-  for (const term of terms) {
-    const idx = lower.indexOf(term.toLowerCase());
-    if (idx !== -1) {
-      foundAt = idx;
-      foundLen = term.length;
-      break;
-    }
-  }
-  if (foundAt === -1) {
-    return {
-      pre: text.slice(0, SNIPPET_BEFORE + SNIPPET_AFTER),
-      mark: '',
-      post: '',
-    };
-  }
-  const start = Math.max(0, foundAt - SNIPPET_BEFORE);
-  const end = Math.min(text.length, foundAt + foundLen + SNIPPET_AFTER);
-  const pre = (start > 0 ? '… ' : '') + text.slice(start, foundAt);
-  const mark = text.slice(foundAt, foundAt + foundLen);
-  const post =
-    text.slice(foundAt + foundLen, end) + (end < text.length ? ' …' : '');
-  return {pre, mark, post};
-}
+  | {kind: 'footer'; lastIndexed: string}
+  | {kind: 'tips'};
 
 function targetIcon(kind: StaticTargetMeta['kind']): ComponentChild {
   if (kind === 'collection') {
@@ -176,7 +125,9 @@ function Row(props: RowProps) {
 }
 
 export function GlobalSearchAction(props: SpotlightActionProps) {
-  const meta = (props.action as any)?.meta as GlobalSearchActionMeta | undefined;
+  const meta = (props.action as any)?.meta as
+    | GlobalSearchActionMeta
+    | undefined;
   if (!meta) {
     return null;
   }
@@ -197,9 +148,30 @@ export function GlobalSearchAction(props: SpotlightActionProps) {
     );
   }
 
+  if (meta.kind === 'tips') {
+    return (
+      <div className="GlobalSearchAction GlobalSearchAction--tips">
+        <span className="GlobalSearchAction__tipItem">
+          <kbd className="GlobalSearchAction__kbd">"…"</kbd>
+          <span>exact phrase</span>
+        </span>
+        <span className="GlobalSearchAction__tipSep">·</span>
+        <span className="GlobalSearchAction__tipItem">
+          <kbd className="GlobalSearchAction__kbd">-word</kbd>
+          <span>exclude</span>
+        </span>
+        <span className="GlobalSearchAction__tipSep">·</span>
+        <span className="GlobalSearchAction__tipItem">
+          <kbd className="GlobalSearchAction__kbd">coll/slug</kbd>
+          <span>jump by id</span>
+        </span>
+      </div>
+    );
+  }
+
   if (meta.kind === 'field') {
     const hit = meta.hit;
-    const snippet = buildSnippet(hit);
+    const segments = buildSnippet(hit);
     return (
       <Row hovered={props.hovered} onTrigger={props.onTrigger}>
         <div className="GlobalSearchAction__crumbs">
@@ -210,11 +182,15 @@ export function GlobalSearchAction(props: SpotlightActionProps) {
           <span className="GlobalSearchAction__field">{hit.fieldLabel}</span>
         </div>
         <div className="GlobalSearchAction__snippet">
-          <span>{snippet.pre}</span>
-          {snippet.mark && (
-            <mark className="GlobalSearchAction__mark">{snippet.mark}</mark>
+          {segments.map((seg, i) =>
+            seg.kind === 'mark' ? (
+              <mark key={i} className="GlobalSearchAction__mark">
+                {seg.value}
+              </mark>
+            ) : (
+              <span key={i}>{seg.value}</span>
+            )
           )}
-          <span>{snippet.post}</span>
         </div>
       </Row>
     );

--- a/packages/root-cms/ui/components/GlobalSearch/snippet.test.ts
+++ b/packages/root-cms/ui/components/GlobalSearch/snippet.test.ts
@@ -1,0 +1,80 @@
+import {describe, it, expect} from 'vitest';
+import type {GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
+import {buildSnippet} from './snippet.js';
+
+function hit(text: string, terms: string[]): GlobalSearchHit {
+  return {
+    id: 'X',
+    docId: 'Pages/x',
+    collection: 'Pages',
+    slug: 'x',
+    deepKey: 'fields.body',
+    fieldLabel: 'Body',
+    fieldType: 'richtext',
+    text,
+    score: 1,
+    terms,
+  };
+}
+
+describe('buildSnippet', () => {
+  it('returns an empty list for empty text', () => {
+    expect(buildSnippet(hit('', ['foo']))).toEqual([]);
+  });
+
+  it('returns a single plain segment when no terms are present', () => {
+    expect(buildSnippet(hit('hello world', []))).toEqual([
+      {kind: 'text', value: 'hello world'},
+    ]);
+  });
+
+  it('returns a single plain segment when terms do not match the text', () => {
+    expect(buildSnippet(hit('hello world', ['xyz']))).toEqual([
+      {kind: 'text', value: 'hello world'},
+    ]);
+  });
+
+  it('marks every occurrence of a single term', () => {
+    const segs = buildSnippet(hit('foo bar foo bar foo', ['foo']));
+    const marks = segs.filter((s) => s.kind === 'mark').map((s) => s.value);
+    expect(marks).toEqual(['foo', 'foo', 'foo']);
+  });
+
+  it('marks all matches across multiple terms', () => {
+    const segs = buildSnippet(
+      hit('the quick brown fox jumps', ['quick', 'fox'])
+    );
+    const marks = segs.filter((s) => s.kind === 'mark').map((s) => s.value);
+    expect(marks).toEqual(['quick', 'fox']);
+  });
+
+  it('merges overlapping term ranges (no nested marks)', () => {
+    // Both `home` and `homepage` match within the word "homepage" — the
+    // result should be a single merged mark, not two overlapping ones.
+    const segs = buildSnippet(hit('the homepage hero', ['home', 'homepage']));
+    const marks = segs.filter((s) => s.kind === 'mark').map((s) => s.value);
+    expect(marks).toEqual(['homepage']);
+  });
+
+  it('preserves original casing in the marked text', () => {
+    const segs = buildSnippet(hit('The Quick Brown Fox', ['quick']));
+    const mark = segs.find((s) => s.kind === 'mark');
+    expect(mark?.value).toBe('Quick');
+  });
+
+  it('reconstructs the original window via concatenation', () => {
+    const text = 'the quick brown fox jumps over the lazy dog';
+    const segs = buildSnippet(hit(text, ['quick', 'lazy']));
+    expect(segs.map((s) => s.value).join('')).toBe(text);
+  });
+
+  it('windows around the first match for very long text', () => {
+    const long = `${'a '.repeat(200)}TARGET${'b '.repeat(200)}`;
+    const segs = buildSnippet(hit(long, ['target']));
+    const joined = segs.map((s) => s.value).join('');
+    expect(joined.startsWith('… ')).toBe(true);
+    expect(joined.endsWith(' …')).toBe(true);
+    expect(joined).toContain('TARGET');
+    expect(joined.length).toBeLessThan(long.length);
+  });
+});

--- a/packages/root-cms/ui/components/GlobalSearch/snippet.ts
+++ b/packages/root-cms/ui/components/GlobalSearch/snippet.ts
@@ -1,0 +1,90 @@
+import type {GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
+
+const SNIPPET_BEFORE = 60;
+const SNIPPET_AFTER = 120;
+
+export type SnippetSegment = {kind: 'text' | 'mark'; value: string};
+
+/**
+ * Returns a sequence of plain / highlighted segments for a search hit.
+ *
+ * The window is centered on the first occurrence of any matched term; every
+ * occurrence of every term that falls within the window is wrapped in a
+ * `mark` segment so users can see all the matches at a glance. When no term
+ * matches the indexed text (e.g. a fuzzy hit on the field label), returns
+ * the leading slice of the text as a single plain segment.
+ */
+export function buildSnippet(hit: GlobalSearchHit): SnippetSegment[] {
+  const text = hit.text || '';
+  const terms = (hit.terms || []).filter(Boolean);
+  if (!text) {
+    return [];
+  }
+  if (!terms.length) {
+    return [
+      {kind: 'text', value: text.slice(0, SNIPPET_BEFORE + SNIPPET_AFTER)},
+    ];
+  }
+
+  const lower = text.toLowerCase();
+  const matches: {start: number; end: number}[] = [];
+  for (const term of terms) {
+    const lowerTerm = term.toLowerCase();
+    if (!lowerTerm) {
+      continue;
+    }
+    let idx = 0;
+    while ((idx = lower.indexOf(lowerTerm, idx)) !== -1) {
+      matches.push({start: idx, end: idx + lowerTerm.length});
+      idx += lowerTerm.length;
+    }
+  }
+  if (matches.length === 0) {
+    return [
+      {kind: 'text', value: text.slice(0, SNIPPET_BEFORE + SNIPPET_AFTER)},
+    ];
+  }
+
+  // Merge overlapping ranges so an inner term doesn't split an outer one
+  // (e.g. searching `home` + `homepage` against the word `homepage`).
+  matches.sort((a, b) => a.start - b.start);
+  const merged: {start: number; end: number}[] = [];
+  for (const m of matches) {
+    const last = merged[merged.length - 1];
+    if (last && m.start <= last.end) {
+      last.end = Math.max(last.end, m.end);
+    } else {
+      merged.push({...m});
+    }
+  }
+
+  // Window around the first match.
+  const first = merged[0];
+  const start = Math.max(0, first.start - SNIPPET_BEFORE);
+  const end = Math.min(text.length, first.end + SNIPPET_AFTER);
+
+  const segments: SnippetSegment[] = [];
+  if (start > 0) {
+    segments.push({kind: 'text', value: '… '});
+  }
+  let cursor = start;
+  for (const m of merged) {
+    if (m.end <= start || m.start >= end) {
+      continue;
+    }
+    const matchStart = Math.max(m.start, start);
+    const matchEnd = Math.min(m.end, end);
+    if (matchStart > cursor) {
+      segments.push({kind: 'text', value: text.slice(cursor, matchStart)});
+    }
+    segments.push({kind: 'mark', value: text.slice(matchStart, matchEnd)});
+    cursor = matchEnd;
+  }
+  if (cursor < end) {
+    segments.push({kind: 'text', value: text.slice(cursor, end)});
+  }
+  if (end < text.length) {
+    segments.push({kind: 'text', value: ' …'});
+  }
+  return segments;
+}

--- a/packages/root-cms/ui/hooks/useGlobalSearch.tsx
+++ b/packages/root-cms/ui/hooks/useGlobalSearch.tsx
@@ -39,6 +39,9 @@ export interface UseGlobalSearchResult {
 
 const DEBOUNCE_MS = 200;
 const DEFAULT_LIMIT = 25;
+/** Minimum chars before we hit `/cms/api/search.query` (avoids noisy 1-letter
+ * matches that prefix-match nearly every doc). */
+const DEFAULT_MIN_QUERY_LENGTH = 2;
 
 /**
  * Debounced fetch hook for the global search endpoint.
@@ -50,7 +53,7 @@ const DEFAULT_LIMIT = 25;
  */
 export function useGlobalSearch(
   query: string,
-  options: {limit?: number} = {}
+  options: {limit?: number; minQueryLength?: number} = {}
 ): UseGlobalSearchResult {
   const [hits, setHits] = useState<GlobalSearchHit[]>([]);
   const [loading, setLoading] = useState(false);
@@ -58,10 +61,11 @@ export function useGlobalSearch(
   const [status, setStatus] = useState<GlobalSearchStatus | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const limit = options.limit ?? DEFAULT_LIMIT;
+  const minLen = options.minQueryLength ?? DEFAULT_MIN_QUERY_LENGTH;
 
   useEffect(() => {
     const trimmed = query.trim();
-    if (!trimmed) {
+    if (trimmed.length < minLen) {
       // Cancel anything in flight, clear state.
       abortRef.current?.abort();
       abortRef.current = null;
@@ -109,7 +113,7 @@ export function useGlobalSearch(
     return () => {
       window.clearTimeout(handle);
     };
-  }, [query, limit]);
+  }, [query, limit, minLen]);
 
   return {hits, loading, error, status};
 }
@@ -178,6 +182,7 @@ export interface UseDocSlugSearchResult {
 
 const SLUG_DEBOUNCE_MS = 200;
 const PER_COLLECTION_LIMIT = 5;
+const SLUG_MIN_QUERY_LENGTH = 2;
 
 /**
  * Looks up CMS docs by slug (or `<collection>/<slug>` doc id) prefix using
@@ -185,20 +190,27 @@ const PER_COLLECTION_LIMIT = 5;
  *
  * Slug-only queries (e.g. `home`) fan out across every registered collection;
  * a `<collection>/<slug>` form (e.g. `Pages/home`) restricts the lookup to a
- * single collection. Empty queries clear the result list.
+ * single collection. Queries shorter than `minQueryLength` (default 2) are
+ * skipped to avoid fanning out across every collection on a single keystroke.
  */
 export function useDocSlugSearch(
   rawQuery: string,
-  options: {limit?: number} = {}
+  options: {limit?: number; minQueryLength?: number} = {}
 ): UseDocSlugSearchResult {
   const [hits, setHits] = useState<DocSlugHit[]>([]);
   const [loading, setLoading] = useState(false);
   const cancelRef = useRef<{aborted: boolean} | null>(null);
   const totalLimit = options.limit ?? 10;
+  const minLen = options.minQueryLength ?? SLUG_MIN_QUERY_LENGTH;
 
   useEffect(() => {
     const trimmed = rawQuery.trim();
-    if (!trimmed) {
+    // For `<coll>/<slug>` queries the prefix is what's *after* the slash, so
+    // gate on that piece rather than the raw query length (otherwise typing
+    // `Pages/h` would be skipped at length 7).
+    const slashIdx = trimmed.indexOf('/');
+    const probe = slashIdx >= 0 ? trimmed.slice(slashIdx + 1) : trimmed;
+    if (probe.length < minLen) {
       if (cancelRef.current) {
         cancelRef.current.aborted = true;
       }
@@ -218,7 +230,6 @@ export function useDocSlugSearch(
 
       let collFilter: string | null = null;
       let prefix = trimmed;
-      const slashIdx = trimmed.indexOf('/');
       if (slashIdx >= 0) {
         collFilter = trimmed.slice(0, slashIdx);
         prefix = trimmed.slice(slashIdx + 1);
@@ -234,9 +245,7 @@ export function useDocSlugSearch(
 
       const allColls = Object.keys(window.__ROOT_CTX.collections || {});
       const colls = collFilter
-        ? allColls.filter(
-            (c) => c.toLowerCase() === collFilter!.toLowerCase()
-          )
+        ? allColls.filter((c) => c.toLowerCase() === collFilter!.toLowerCase())
         : allColls;
 
       // Inclusive Firestore range bounds for a prefix match. The
@@ -288,10 +297,8 @@ export function useDocSlugSearch(
         // Rank exact slug or docId matches first, then prefix matches
         // alphabetically so results are stable across renders.
         const sorted = results.sort((a, b) => {
-          const aExact =
-            a.slug === prefix || a.docId === trimmed ? 0 : 1;
-          const bExact =
-            b.slug === prefix || b.docId === trimmed ? 0 : 1;
+          const aExact = a.slug === prefix || a.docId === trimmed ? 0 : 1;
+          const bExact = b.slug === prefix || b.docId === trimmed ? 0 : 1;
           if (aExact !== bExact) {
             return aExact - bExact;
           }
@@ -312,7 +319,7 @@ export function useDocSlugSearch(
     return () => {
       window.clearTimeout(handle);
     };
-  }, [rawQuery, totalLimit]);
+  }, [rawQuery, totalLimit, minLen]);
 
   return {hits, loading};
 }


### PR DESCRIPTION
## Summary
Implements Google-style search query parsing and execution to improve search result relevance in the CMS. Instead of passing raw user input directly to MiniSearch (which OR-combines all terms with fuzzy/prefix matching), this change preprocesses queries into structured components and applies appropriate matching strategies to each.

## Key Changes
- **New `search-query.ts` module** with Google-style query semantics:
  - `parseQuery()` — Splits input into phrases (quoted), terms (bare), and exclusions (leading `-`)
  - `containsPhrase()` — Token-aligned phrase matching (respects word boundaries, ignores punctuation)
  - `executeQuery()` — AND-combines parsed components with appropriate MiniSearch options per part
  - `isEmptyQuery()` — Validates that a query has positive constraints

- **Query syntax support**:
  - `"exact phrase"` — Matches contiguous word tokens only (fuzzy/prefix disabled)
  - `bare term` — Fuzzy + prefix matching (existing MiniSearch behavior)
  - `-foo` / `-"phrase"` — Excludes matching documents
  - Smart quote normalization (U+201C/U+201D → `"`)
  - Unclosed quotes treated as phrase to end-of-input

- **Comprehensive test suite** (`search-query.test.ts`) covering:
  - Query parsing edge cases (empty input, mixed terms/phrases, exclusions, smart quotes)
  - Phrase matching with punctuation and case-insensitivity
  - AND-combination semantics with real index examples
  - Exclusion filtering for both terms and phrases

## Implementation Details
- Multiple query parts are AND-combined by intersecting result sets and summing scores, so adding more terms narrows results (Google-like behavior)
- Phrase matching uses a custom tokenizer mirroring MiniSearch's default (whitespace + Unicode punctuation)
- Exclusions are applied as a final filter after positive constraints are satisfied
- Per-record scores accumulate across matched constraints for ranking

https://claude.ai/code/session_018Y2odB6z76iRxgQDCQQZKJ