### PR TITLE
feat: add streaming AI chat for array-item "Edit with AI" modal

### DIFF
--- a/packages/root-cms/core/ai-chat.ts
+++ b/packages/root-cms/core/ai-chat.ts
@@ -23,7 +23,7 @@ import {
   UIMessage,
 } from 'ai';
 import {Timestamp} from 'firebase-admin/firestore';
-import {createCmsTools} from './ai-tools.js';
+import {createCmsTools, createReadOnlyCmsTools} from './ai-tools.js';
 import {RootCMSClient} from './client.js';
 
 /** Filename of the project-level instructions file loaded into the AI prompt. */
@@ -468,6 +468,127 @@ export async function runChatStream(
       }
     },
   });
+}
+
+export interface RunEditObjectStreamOptions {
+  rootConfig: RootConfig;
+  config: AiConfig;
+  model: AiModelConfig;
+  messages: UIMessage[];
+  /** The JSON object the user is editing. Injected as context for the model. */
+  editData: unknown;
+}
+
+/**
+ * Streaming variant used by the array-item "Edit with AI" diff-viewer flow.
+ *
+ * Differences from `runChatStream`:
+ *
+ * - Uses an edit-specific system prompt that injects the JSON the user is
+ *   editing and the project's `root-cms.d.ts` types, and instructs the model
+ *   to end every response with a fenced ```json block containing the
+ *   complete proposed new JSON. The client extracts that block to populate
+ *   the diff viewer.
+ * - Tools are filtered to read-only (see `createReadOnlyCmsTools`). The user
+ *   approves changes via the modal's "Save" button, so the model must not
+ *   mutate Firestore directly.
+ * - No Firestore persistence — edit sessions are ephemeral and don't show up
+ *   in the user's chat history.
+ */
+export async function runEditObjectStream(
+  options: RunEditObjectStreamOptions
+): Promise<Response> {
+  const {rootConfig, model, config, messages, editData} = options;
+  const languageModel = resolveLanguageModel(model);
+  const tools: ToolSet =
+    model.capabilities?.tools === false ? {} : createReadOnlyCmsTools();
+
+  const editPromptText = (await import('../shared/ai/prompts/edit.txt'))
+    .default;
+  // Strip the legacy `{"data": ..., "message": ...}` output spec from the
+  // bundled prompt — for the streaming flow we replace it with explicit
+  // instructions to emit a fenced ```json code block instead.
+  const promptParts: string[] = [
+    stripLegacyEditOutputSpec(editPromptText),
+    '',
+    'Output format:',
+    '- Begin with a brief 1-2 sentence message describing what you changed.',
+    '- Then emit a single fenced code block tagged ```json containing the',
+    '  COMPLETE proposed new JSON object (including any unmodified fields).',
+    '- The code block must be the LAST content in your response. The CMS UI',
+    '  parses it and shows the result in a diff viewer for the user to',
+    '  approve before saving.',
+    '',
+    'Tool policy:',
+    '- The available tools are READ-ONLY. Use them only when you need extra',
+    '  context (e.g. inspecting the schema or referencing other CMS docs).',
+    '- You MUST NOT attempt to call write tools (e.g. doc_set, doc_create,',
+    '  doc_updateField). The user approves and saves changes manually via',
+    '  the modal\'s Save button.',
+  ];
+
+  // Append the project's root-cms.d.ts type definitions if present so the
+  // model can validate its output against the actual schema.
+  try {
+    const rootCmsDefsPath = path.join(rootConfig.rootDir, 'root-cms.d.ts');
+    const rootCmsDefs = await fs.readFile(rootCmsDefsPath, 'utf8');
+    if (rootCmsDefs.trim()) {
+      promptParts.push(
+        '',
+        'Here is the `root-cms.d.ts` file for this project:',
+        '```',
+        rootCmsDefs,
+        '```'
+      );
+    }
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.error('failed to read root-cms.d.ts:', err);
+    }
+  }
+
+  // Inject the JSON being edited at the end of the system prompt.
+  promptParts.push(
+    '',
+    'The JSON you must edit is:',
+    '```json',
+    JSON.stringify(editData ?? {}, null, 2),
+    '```'
+  );
+
+  const basePrompt = promptParts.join('\n');
+  const rootMd = await readRootMd(rootConfig.rootDir);
+  const systemPrompt = buildSystemPrompt(basePrompt, rootMd);
+
+  const modelMessages = await convertToModelMessages(messages, {tools});
+  const result = streamText({
+    model: languageModel,
+    system: systemPrompt,
+    messages: modelMessages,
+    tools,
+    stopWhen: stepCountIs(config.maxSteps ?? 10),
+  });
+
+  return result.toUIMessageStreamResponse({
+    sendReasoning: model.capabilities?.reasoning ?? false,
+    originalMessages: messages,
+  });
+}
+
+/**
+ * Removes the trailing legacy output specification block from `edit.txt`
+ * (the `{"data": ..., "message": ...}` JSON envelope used by the Genkit-era
+ * chat). The streaming flow uses fenced code blocks instead, which we
+ * append after this function returns.
+ */
+function stripLegacyEditOutputSpec(prompt: string): string {
+  const marker =
+    'Finally, when you provide your response, it MUST be structured';
+  const idx = prompt.indexOf(marker);
+  if (idx === -1) {
+    return prompt;
+  }
+  return prompt.slice(0, idx).trimEnd();
 }
 
 /**

--- a/packages/root-cms/core/ai-tools.ts
+++ b/packages/root-cms/core/ai-tools.ts
@@ -43,6 +43,37 @@ export const CMS_TOOL_NAMES = [
 export type CmsToolName = (typeof CMS_TOOL_NAMES)[number];
 
 /**
+ * Subset of CMS tools that perform reads only. Used by flows where the user
+ * approves changes via UI (e.g. the array-item "Edit with AI" diff viewer)
+ * and the model must not write to Firestore directly.
+ */
+export const READ_ONLY_CMS_TOOL_NAMES: readonly CmsToolName[] = [
+  'collections_list',
+  'docs_list',
+  'docs_search',
+  'doc_get',
+  'doc_getVersion',
+  'doc_listVersions',
+  'schema_get',
+] as const;
+
+/**
+ * Returns a `ToolSet` filtered to only the read-only CMS tools. Use this in
+ * flows where the AI assists with proposing changes that the user reviews
+ * and saves manually (so the model can read context but cannot mutate data).
+ */
+export function createReadOnlyCmsTools(): ToolSet {
+  const all = createCmsTools();
+  const out: ToolSet = {};
+  for (const name of READ_ONLY_CMS_TOOL_NAMES) {
+    if (all[name]) {
+      out[name] = all[name];
+    }
+  }
+  return out;
+}
+
+/**
  * Schema-only tool definitions. The server passes these to `streamText` so
  * the model knows the contract; the browser provides the actual `execute`.
  *

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -13,6 +13,7 @@ import {
   findModel,
   getAiConfig,
   runChatStream,
+  runEditObjectStream,
   serializeAiConfig,
 } from './ai-chat.js';
 import {ChatClient, RootAiModel, summarizeDiff} from './ai.js';
@@ -833,6 +834,69 @@ export function api(server: Server, options: ApiOptions) {
       }
     }
   });
+
+  /**
+   * Streams an LLM response for the array-item "Edit with AI" diff-viewer
+   * flow. Like `ai.v2.chat`, the server proxies the model's UI message stream
+   * directly to the browser. Differences:
+   *
+   * - The available tool set is restricted to read-only CMS tools — the user
+   *   approves and saves changes manually via the modal's Save button, so
+   *   the model must not write to Firestore directly.
+   * - Conversation state is ephemeral — edit sessions are not persisted to
+   *   Firestore and don't appear in the user's chat history.
+   * - The system prompt instructs the model to emit its proposed JSON in a
+   *   fenced ```json code block which the client extracts to populate the
+   *   diff viewer.
+   */
+  server.use(
+    '/cms/api/ai.v2.editObject',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const aiConfig = getAiConfig(req.rootConfig!);
+      if (!aiConfig) {
+        res.status(404).json({success: false, error: 'AI_NOT_CONFIGURED'});
+        return;
+      }
+
+      const body = req.body || {};
+      const messages = (body.messages as UIMessage[]) || [];
+      if (!Array.isArray(messages) || messages.length === 0) {
+        res.status(400).json({success: false, error: 'MISSING_MESSAGES'});
+        return;
+      }
+      const model = findModel(aiConfig, body.modelId);
+      if (!model) {
+        res.status(400).json({success: false, error: 'UNKNOWN_MODEL'});
+        return;
+      }
+
+      try {
+        const streamResponse = await runEditObjectStream({
+          rootConfig: req.rootConfig!,
+          config: aiConfig,
+          model,
+          messages,
+          editData: body.editData,
+        });
+        await pipeWebResponse(streamResponse, res);
+      } catch (err: any) {
+        console.error(err.stack || err);
+        if (!res.headersSent) {
+          res.status(500).json({success: false, error: err.message || 'UNKNOWN'});
+        } else {
+          res.end();
+        }
+      }
+    }
+  );
 
   /** Lists the current user's recent chats. */
   server.use(

--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
@@ -37,9 +37,321 @@
 
 .AiEditModal__SplitPanel__ChatPanel {
   height: 100%;
-  overflow: auto;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+
+.AiEditModal__ChatPanel__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.AiEditModal__ChatPanel__notConfigured {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+  padding: 24px;
+  height: 100%;
+  color: rgb(73, 80, 87);
+}
+
+.AiEditModal__ChatPanel__notConfigured__icon {
+  color: rgb(134, 142, 150);
+}
+
+.AiEditModal__ChatPanel__notConfigured__title {
+  font-weight: 600;
+}
+
+.AiEditModal__ChatPanel__notConfigured__error {
+  margin-top: 8px;
+  background: rgb(248, 249, 250);
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  text-align: left;
+  width: 100%;
+}
+
+.AiEditModal__ChatPanel__transcript {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px 4px;
+}
+
+.AiEditModal__ChatPanel__transcript--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.AiEditModal__ChatPanel__transcript__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.AiEditModal__ChatPanel__welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  padding: 24px;
+  color: rgb(73, 80, 87);
+}
+
+.AiEditModal__ChatPanel__welcome__icon {
+  color: rgb(134, 142, 150);
+}
+
+.AiEditModal__ChatPanel__welcome__title {
+  font-weight: 600;
+}
+
+.AiEditModal__ChatPanel__welcome__body {
+  font-size: 0.875rem;
+}
+
+.AiEditModal__ChatPanel__welcome__body p {
+  margin: 0 0 8px;
+}
+
+.AiEditModal__ChatPanel__streamingIndicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  color: rgb(134, 142, 150);
+}
+
+.AiEditModal__ChatPanel__error {
+  margin: 8px 0;
+  padding: 8px 12px;
+  background: rgb(255, 245, 245);
+  border: 1px solid rgb(255, 201, 201);
+  border-radius: 4px;
+  color: rgb(201, 42, 42);
+  font-size: 0.875rem;
+}
+
+.AiEditModal__ChatPanel__message {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.AiEditModal__ChatPanel__message__avatar {
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgb(241, 243, 245);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: rgb(73, 80, 87);
+}
+
+.AiEditModal__ChatPanel__message__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.AiEditModal__ChatPanel__message__body {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.AiEditModal__ChatPanel__message__username {
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: rgb(73, 80, 87);
+  margin-bottom: 2px;
+}
+
+.AiEditModal__ChatPanel__message__parts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.AiEditModal__ChatPanel__textPart {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.AiEditModal__ChatPanel__textPart p {
+  margin: 0 0 6px;
+}
+
+.AiEditModal__ChatPanel__textPart p:last-child {
+  margin-bottom: 0;
+}
+
+.AiEditModal__ChatPanel__reasoning {
+  font-size: 0.8125rem;
+  border-left: 2px solid rgb(222, 226, 230);
+  padding-left: 8px;
+  color: rgb(73, 80, 87);
+}
+
+.AiEditModal__ChatPanel__reasoning__toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: rgb(134, 142, 150);
+  font-weight: 500;
+}
+
+.AiEditModal__ChatPanel__reasoning__body {
+  margin-top: 4px;
+}
+
+.AiEditModal__ChatPanel__filePart img {
+  max-width: 200px;
+  border-radius: 4px;
+}
+
+.AiEditModal__ChatPanel__filePart--link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8125rem;
+  color: rgb(34, 139, 230);
+}
+
+.AiEditModal__ChatPanel__tool {
+  border: 1px solid rgb(222, 226, 230);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  background: rgb(248, 249, 250);
+}
+
+.AiEditModal__ChatPanel__tool__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.AiEditModal__ChatPanel__tool__state {
+  color: rgb(134, 142, 150);
+  font-size: 0.75rem;
+}
+
+.AiEditModal__ChatPanel__tool__body {
+  padding: 6px 8px;
+  border-top: 1px solid rgb(222, 226, 230);
+}
+
+.AiEditModal__ChatPanel__tool__body pre {
+  font-size: 0.75rem;
+  background: white;
+  padding: 6px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow: auto;
+  margin: 4px 0 0;
+}
+
+.AiEditModal__ChatPanel__tool__error {
+  color: rgb(201, 42, 42);
+  margin-top: 4px;
+}
+
+.AiEditModal__ChatPanel__composer {
+  border-top: 1px solid rgb(222, 226, 230);
+  padding: 8px 4px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.AiEditModal__ChatPanel__composer__attachments {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.AiEditModal__ChatPanel__composer__attachment {
+  position: relative;
+}
+
+.AiEditModal__ChatPanel__composer__attachment img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.AiEditModal__ChatPanel__composer__attachment__remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: rgb(33, 37, 41);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.AiEditModal__ChatPanel__composer__row {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.AiEditModal__ChatPanel__composer__textarea {
+  flex: 1 1 0;
+  resize: none;
+  border: 1px solid rgb(222, 226, 230);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  outline: none;
+  min-height: 32px;
+  max-height: 200px;
+}
+
+.AiEditModal__ChatPanel__composer__textarea:focus {
+  border-color: rgb(134, 142, 150);
+}
+
+.AiEditModal__ChatPanel__composer__disclaimer {
+  font-size: 0.6875rem;
+  color: rgb(134, 142, 150);
+  text-align: center;
 }
 
 .AiEditModal__Tabs {

--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
@@ -6,7 +6,7 @@
 }
 
 .AiEditModal__JsonInput .mantine-JsonInput-input {
-  font-size: 0.875rem;
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -110,15 +110,29 @@
 }
 
 .AiEditModal__ChatPanel__welcome__icon {
-  color: rgb(134, 142, 150);
+  width: 48px;
+  padding: 8px;
+  border-radius: 50%;
+  border: 1px solid #dedede;
+}
+
+.AiEditModal__ChatPanel__welcome__icon svg {
+  width: 100%;
 }
 
 .AiEditModal__ChatPanel__welcome__title {
-  font-weight: 600;
+  color: var(--color-text-dark, #000);
+  font-size: 28px;
+  line-height: 1.2;
+  font-weight: 700;
 }
 
 .AiEditModal__ChatPanel__welcome__body {
-  font-size: 0.875rem;
+  font-size: 16px;
+  line-height: 1.5;
+  text-align: center;
+  max-width: 600px;
+  padding: 0 24px;
 }
 
 .AiEditModal__ChatPanel__welcome__body p {

--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
@@ -283,75 +283,121 @@
 }
 
 .AiEditModal__ChatPanel__composer {
-  border-top: 1px solid rgb(222, 226, 230);
-  padding: 8px 4px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.AiEditModal__ChatPanel__composer__attachments {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.AiEditModal__ChatPanel__composer__attachment {
+  flex-shrink: 0;
+  padding: 12px 8px 0;
   position: relative;
+  z-index: 10;
 }
 
-.AiEditModal__ChatPanel__composer__attachment img {
-  width: 48px;
-  height: 48px;
-  object-fit: cover;
-  border-radius: 4px;
+.AiEditModal__ChatPanel__composer__prompt {
+  --image-preview-size: 64px;
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
-.AiEditModal__ChatPanel__composer__attachment__remove {
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  background: rgb(33, 37, 41);
-  color: white;
-  border: none;
-  border-radius: 50%;
-  width: 18px;
-  height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  padding: 0;
-}
-
-.AiEditModal__ChatPanel__composer__row {
-  display: flex;
-  align-items: flex-end;
-  gap: 6px;
-}
-
-.AiEditModal__ChatPanel__composer__textarea {
-  flex: 1 1 0;
+.AiEditModal__ChatPanel__composer__textInput {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
   resize: none;
+  padding: 12px 48px;
+  border-radius: 24px;
   border: 1px solid rgb(222, 226, 230);
-  border-radius: 4px;
-  padding: 6px 8px;
-  font: inherit;
-  font-size: 0.875rem;
-  line-height: 1.4;
-  outline: none;
-  min-height: 32px;
+  background: white;
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: 400;
+  font-family: inherit;
+  transition: box-shadow 0.3s ease;
   max-height: 200px;
 }
 
-.AiEditModal__ChatPanel__composer__textarea:focus {
-  border-color: rgb(134, 142, 150);
+.AiEditModal__ChatPanel__composer__prompt--hasImage
+  .AiEditModal__ChatPanel__composer__textInput {
+  padding-bottom: calc(var(--image-preview-size) + 24px);
+}
+
+.AiEditModal__ChatPanel__composer__textInput:focus {
+  border: 1px solid rgb(173, 181, 189);
+  outline: none;
+  box-shadow: rgba(0, 0, 0, 0.05) 0 2px 6px;
+}
+
+.AiEditModal__ChatPanel__composer__imageUpload {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+}
+
+.AiEditModal__ChatPanel__composer__imageUpload__input {
+  display: none;
+}
+
+.AiEditModal__ChatPanel__composer__attachments {
+  position: absolute;
+  left: 44px;
+  bottom: 8px;
+  display: flex;
+  gap: 6px;
+}
+
+.AiEditModal__ChatPanel__composer__attachment {
+  width: var(--image-preview-size);
+  height: var(--image-preview-size);
+  padding: 4px;
+  background: rgb(239, 239, 239);
+  border: 1px solid rgb(222, 226, 230);
+  border-radius: 8px;
+  position: relative;
+  cursor: pointer;
+}
+
+.AiEditModal__ChatPanel__composer__attachment img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+}
+
+.AiEditModal__ChatPanel__composer__attachment__name {
+  display: block;
+  font-size: 0.6875rem;
+  text-align: center;
+  word-break: break-word;
+}
+
+.AiEditModal__ChatPanel__composer__attachment__close {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  background: rgba(0, 0, 0, 0.75);
+  border-radius: 50%;
+  padding: 2px;
+  transition: opacity 0.24s ease;
+}
+
+.AiEditModal__ChatPanel__composer__attachment:hover
+  .AiEditModal__ChatPanel__composer__attachment__close {
+  opacity: 1;
+}
+
+.AiEditModal__ChatPanel__composer__submit {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
 }
 
 .AiEditModal__ChatPanel__composer__disclaimer {
-  font-size: 0.6875rem;
-  color: rgb(134, 142, 150);
+  margin-top: 12px;
   text-align: center;
+  padding: 0 20px;
+  font-size: 12px;
+  color: dimgray;
+  text-wrap: balance;
 }
 
 .AiEditModal__Tabs {

--- a/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
@@ -29,6 +29,7 @@ import {AiResponse} from '../../../shared/ai/prompts.js';
 import {executeCmsTool} from '../../pages/AIPage/cmsToolHandlers.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
+import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {Markdown} from '../Markdown/Markdown.js';
 
 interface ModelInfo {
@@ -276,10 +277,10 @@ function ChatTranscript(props: {
       >
         <div className="AiEditModal__ChatPanel__welcome">
           <div className="AiEditModal__ChatPanel__welcome__icon">
-            <IconRobot size={32} />
+            <IconRootAI />
           </div>
           <div className="AiEditModal__ChatPanel__welcome__title">
-            Root AI is ready
+            Edit with Root AI
           </div>
           {props.welcome && (
             <div className="AiEditModal__ChatPanel__welcome__body">

--- a/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
@@ -577,56 +577,37 @@ function ChatComposer(props: {
 
   return (
     <div className="AiEditModal__ChatPanel__composer">
-      {attachments.length > 0 && (
-        <div className="AiEditModal__ChatPanel__composer__attachments">
-          {attachments.map((a, i) => (
-            <div
-              key={i}
-              className="AiEditModal__ChatPanel__composer__attachment"
-            >
-              {a.mediaType.startsWith('image/') ? (
-                <img src={a.url} alt={a.filename} />
-              ) : (
-                <span className="AiEditModal__ChatPanel__composer__attachment__name">
-                  {a.filename}
-                </span>
-              )}
-              <button
-                type="button"
-                className="AiEditModal__ChatPanel__composer__attachment__remove"
-                onClick={() =>
-                  setAttachments((prev) => prev.filter((_, idx) => idx !== i))
-                }
-              >
-                <IconX size={12} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-      <div className="AiEditModal__ChatPanel__composer__row">
+      <div
+        className={joinClassNames(
+          'AiEditModal__ChatPanel__composer__prompt',
+          (uploading || attachments.length > 0) &&
+            'AiEditModal__ChatPanel__composer__prompt--hasImage'
+        )}
+      >
         {props.canAttach && (
-          <Tooltip label="Attach file">
-            <ActionIcon
-              component="label"
-              radius="xl"
-              className="AiEditModal__ChatPanel__composer__attach"
-            >
-              {uploading ? <Loader size="xs" /> : <IconPaperclip size={18} />}
-              <input
-                ref={fileRef}
-                type="file"
-                accept="image/png,image/jpeg,image/webp"
-                style={{display: 'none'}}
-                onChange={onFileChange}
-              />
-            </ActionIcon>
-          </Tooltip>
+          <label className="AiEditModal__ChatPanel__composer__imageUpload">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              className="AiEditModal__ChatPanel__composer__imageUpload__input"
+              onChange={onFileChange}
+            />
+            <Tooltip label="Upload image">
+              <ActionIcon
+                component="div"
+                className="AiEditModal__ChatPanel__composer__imageUpload__icon"
+                radius="xl"
+              >
+                <IconPaperclip size={18} />
+              </ActionIcon>
+            </Tooltip>
+          </label>
         )}
         <textarea
           ref={textareaRef}
-          className="AiEditModal__ChatPanel__composer__textarea"
-          placeholder="Tell me what you want to change…"
+          className="AiEditModal__ChatPanel__composer__textInput"
+          placeholder="Tell me what you want to change..."
           value={text}
           rows={1}
           autofocus
@@ -644,11 +625,44 @@ function ChatComposer(props: {
             }
           }}
         />
+        {(uploading || attachments.length > 0) && (
+          <div className="AiEditModal__ChatPanel__composer__attachments">
+            {uploading && <Loader size="sm" />}
+            {attachments.map((a, i) => (
+              <Tooltip
+                key={i}
+                label={a.filename}
+                transition="pop"
+                position="top"
+                withArrow
+              >
+                <button
+                  className="AiEditModal__ChatPanel__composer__attachment"
+                  onClick={() =>
+                    setAttachments((prev) => prev.filter((_, idx) => idx !== i))
+                  }
+                >
+                  {a.mediaType.startsWith('image/') ? (
+                    <img src={a.url} alt={a.filename} />
+                  ) : (
+                    <span className="AiEditModal__ChatPanel__composer__attachment__name">
+                      {a.filename}
+                    </span>
+                  )}
+                  <div className="AiEditModal__ChatPanel__composer__attachment__close">
+                    <IconX size={20} color="white" />
+                  </div>
+                </button>
+              </Tooltip>
+            ))}
+          </div>
+        )}
         {props.isStreaming ? (
           <ActionIcon
-            radius="xl"
-            color="dark"
+            className="AiEditModal__ChatPanel__composer__submit"
             variant="filled"
+            color="dark"
+            radius="xl"
             onClick={props.onStop}
             title="Stop"
           >
@@ -656,9 +670,10 @@ function ChatComposer(props: {
           </ActionIcon>
         ) : (
           <ActionIcon
-            radius="xl"
-            color="dark"
+            className="AiEditModal__ChatPanel__composer__submit"
             variant="filled"
+            color="dark"
+            radius="xl"
             disabled={uploading || (!text && attachments.length === 0)}
             onClick={submit}
             title="Send"

--- a/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
@@ -1,25 +1,746 @@
-import {ChatBar} from '../ChatBar/ChatBar.js';
-import {useLegacyChat} from '../ChatBar/legacyChat.js';
-import {ChatWindow} from '../ChatBar/LegacyChatView.js';
+/**
+ * Chat panel used inside the array-item "Edit with AI" modal. Built on top of
+ * the Vercel AI SDK (`ai`, `@ai-sdk/react`) and streams responses from
+ * `/cms/api/ai.v2.editObject`.
+ *
+ * The endpoint exposes a READ-ONLY tool subset — the model can inspect CMS
+ * docs and schemas for context but cannot mutate Firestore. Edits are
+ * proposed as a fenced ```json code block in the assistant's message; this
+ * component extracts it and forwards it to the modal so it can populate the
+ * diff viewer for the user to approve and save.
+ */
+import {useChat} from '@ai-sdk/react';
+import {ActionIcon, Loader, Tooltip} from '@mantine/core';
+import {
+  IconChevronDown,
+  IconPaperclip,
+  IconRobot,
+  IconSend2,
+  IconTool,
+  IconX,
+} from '@tabler/icons-preact';
+import type {UIMessage} from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from 'ai';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
+import {AiResponse} from '../../../shared/ai/prompts.js';
+import {executeCmsTool} from '../../pages/AIPage/cmsToolHandlers.js';
+import {joinClassNames} from '../../utils/classes.js';
+import {uploadFileToGCS} from '../../utils/gcs.js';
+import {Markdown} from '../Markdown/Markdown.js';
+
+interface ModelInfo {
+  id: string;
+  label: string;
+  description?: string;
+  provider: string;
+  capabilities: {
+    tools: boolean;
+    reasoning: boolean;
+    attachments: boolean;
+  };
+}
+
+interface AiConfigResponse {
+  enabled: boolean;
+  defaultModel?: string;
+  models?: ModelInfo[];
+}
+
+interface AttachmentPreview {
+  url: string;
+  filename: string;
+  mediaType: string;
+  width?: number;
+  height?: number;
+}
 
 interface ChatPanelProps {
   children?: preact.ComponentChildren;
-  /** Data supplied for the ChatBar to run in "edit mode". Typically this will be the JSON of the data being edited. */
-  editModeData?: Record<string, any>;
-  /** Callback for handling the response from "edit mode" requests from the ChatBar. */
-  onEditModeResponse?: (data: any) => void;
+  /** JSON of the array item being edited. Sent to the model as context. */
+  editModeData?: Record<string, any> | null;
+  /** Called whenever the model emits a new proposed JSON value. */
+  onEditModeResponse?: (data: AiResponse) => void;
 }
 
 export function ChatPanel(props: ChatPanelProps) {
-  const chat = useLegacyChat();
+  const [config, setConfig] = useState<AiConfigResponse | null>(null);
+  const [configError, setConfigError] = useState<string>('');
+
+  useEffect(() => {
+    let active = true;
+    fetch('/cms/api/ai.v2.config', {credentials: 'include'})
+      .then(async (res) => {
+        const data = (await res.json()) as AiConfigResponse;
+        if (active) {
+          setConfig(data);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setConfigError(String(err));
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!config && !configError) {
+    return (
+      <div className="AiEditModal__ChatPanel__loading">
+        <Loader size="sm" color="gray" />
+      </div>
+    );
+  }
+
+  const isEnabled = !!config?.enabled && (config.models?.length || 0) > 0;
+  if (!isEnabled) {
+    return (
+      <div className="AiEditModal__ChatPanel__notConfigured">
+        <div className="AiEditModal__ChatPanel__notConfigured__icon">
+          <IconRobot size={32} />
+        </div>
+        <div className="AiEditModal__ChatPanel__notConfigured__title">
+          Root AI is not configured for this project.
+        </div>
+        <div className="AiEditModal__ChatPanel__notConfigured__body">
+          Add an <code>ai.models</code> entry to <code>cmsPlugin()</code> in{' '}
+          <code>root.config.ts</code>.
+        </div>
+        {configError && (
+          <pre className="AiEditModal__ChatPanel__notConfigured__error">
+            {configError}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  const defaultModel =
+    config!.models!.find((m) => m.id === config!.defaultModel) ||
+    config!.models![0];
+  return (
+    <ChatPanelInner
+      model={defaultModel}
+      editModeData={props.editModeData}
+      onEditModeResponse={props.onEditModeResponse}
+      welcome={props.children}
+    />
+  );
+}
+
+function ChatPanelInner(props: {
+  model: ModelInfo;
+  editModeData?: Record<string, any> | null;
+  onEditModeResponse?: (data: AiResponse) => void;
+  welcome?: preact.ComponentChildren;
+}) {
+  // Latest editModeData is sent on every request so the model always edits
+  // against the user's current JSON (including any manual tweaks made
+  // mid-conversation in the JSON tab).
+  const editDataRef = useRef(props.editModeData);
+  editDataRef.current = props.editModeData;
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport<UIMessage>({
+        api: '/cms/api/ai.v2.editObject',
+        credentials: 'include',
+        prepareSendMessagesRequest: ({messages}) => ({
+          body: {
+            messages,
+            modelId: props.model.id,
+            editData: editDataRef.current,
+          },
+        }),
+      }),
+    [props.model.id]
+  );
+
+  const onResponseRef = useRef(props.onEditModeResponse);
+  onResponseRef.current = props.onEditModeResponse;
+  // Tracks the JSON snippet emitted for each assistant message id so we
+  // don't re-fire onEditModeResponse on every streaming token.
+  const lastEmittedRef = useRef<Map<string, string>>(new Map());
+
+  const {messages, sendMessage, status, error, stop, addToolOutput} = useChat({
+    transport,
+    // Auto-resubmit once all tool calls in the latest assistant message have
+    // results, so the model can finish its turn after consulting tools.
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    // Tools execute in the browser using the signed-in user's Firebase
+    // credentials; the result is fed back to the model on the next round.
+    // The server tool list is read-only, so only read handlers run here.
+    onToolCall: async ({toolCall}) => {
+      const output = await executeCmsTool(toolCall.toolName, toolCall.input);
+      addToolOutput({
+        tool: toolCall.toolName as any,
+        toolCallId: toolCall.toolCallId,
+        output,
+      });
+    },
+  });
+
+  const isStreaming = status === 'streaming' || status === 'submitted';
+
+  // Whenever the latest assistant message changes, try to extract a
+  // proposed JSON object from its text and bubble it up to the modal.
+  useEffect(() => {
+    const onResponse = onResponseRef.current;
+    if (!onResponse) {
+      return;
+    }
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.role !== 'assistant') {
+        continue;
+      }
+      const text = collectAssistantText(m);
+      const json = extractLastJsonBlock(text);
+      if (!json) {
+        return;
+      }
+      const last = lastEmittedRef.current.get(m.id);
+      if (last === json) {
+        return;
+      }
+      try {
+        const parsed = JSON.parse(json);
+        if (parsed && typeof parsed === 'object') {
+          lastEmittedRef.current.set(m.id, json);
+          onResponse({message: '', data: parsed});
+        }
+      } catch {
+        // Incomplete JSON during streaming — wait for more tokens.
+      }
+      return;
+    }
+  }, [messages]);
+
   return (
     <>
-      <ChatWindow chat={chat} children={props.children} />
-      <ChatBar
-        chat={chat}
-        options={{mode: 'edit', editData: props.editModeData}}
-        onData={props.onEditModeResponse}
+      <ChatTranscript
+        messages={messages}
+        isStreaming={isStreaming}
+        welcome={props.welcome}
+      />
+      {error && (
+        <div className="AiEditModal__ChatPanel__error">
+          <strong>Error:</strong> {error.message}
+        </div>
+      )}
+      <ChatComposer
+        canAttach={props.model.capabilities.attachments}
+        isStreaming={isStreaming}
+        onStop={stop}
+        onSend={(text, attachments) => {
+          if (!text && attachments.length === 0) {
+            return;
+          }
+          sendMessage({
+            text,
+            files: attachments.map((a) => ({
+              type: 'file',
+              mediaType: a.mediaType,
+              url: a.url,
+              filename: a.filename,
+            })),
+          });
+        }}
       />
     </>
   );
+}
+
+function ChatTranscript(props: {
+  messages: UIMessage[];
+  isStreaming: boolean;
+  welcome?: preact.ComponentChildren;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [props.messages]);
+
+  if (props.messages.length === 0) {
+    return (
+      <div
+        className="AiEditModal__ChatPanel__transcript AiEditModal__ChatPanel__transcript--empty"
+        ref={ref}
+      >
+        <div className="AiEditModal__ChatPanel__welcome">
+          <div className="AiEditModal__ChatPanel__welcome__icon">
+            <IconRobot size={32} />
+          </div>
+          <div className="AiEditModal__ChatPanel__welcome__title">
+            Root AI is ready
+          </div>
+          {props.welcome && (
+            <div className="AiEditModal__ChatPanel__welcome__body">
+              {props.welcome}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="AiEditModal__ChatPanel__transcript" ref={ref}>
+      <div className="AiEditModal__ChatPanel__transcript__inner">
+        {props.messages.map((m) => (
+          <MessageView key={m.id} message={m} />
+        ))}
+        {props.isStreaming && (
+          <div className="AiEditModal__ChatPanel__streamingIndicator">
+            <Loader size="xs" color="gray" />
+            <span>Thinking…</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MessageView(props: {message: UIMessage}) {
+  const message = props.message;
+  const isUser = message.role === 'user';
+  const username = isUser ? 'You' : 'Root AI';
+  const photoURL = isUser ? window.firebase.user?.photoURL : null;
+  return (
+    <div
+      className={joinClassNames(
+        'AiEditModal__ChatPanel__message',
+        `AiEditModal__ChatPanel__message--${message.role}`
+      )}
+    >
+      <div className="AiEditModal__ChatPanel__message__avatar">
+        {photoURL ? (
+          <img src={photoURL} alt={username} />
+        ) : (
+          <IconRobot size={18} />
+        )}
+      </div>
+      <div className="AiEditModal__ChatPanel__message__body">
+        <div className="AiEditModal__ChatPanel__message__username">
+          {username}
+        </div>
+        <div className="AiEditModal__ChatPanel__message__parts">
+          {(message.parts || []).map((part, i) => (
+            <PartView key={i} part={part} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PartView(props: {part: any}) {
+  const part = props.part;
+  if (part.type === 'text') {
+    if (!part.text) {
+      return null;
+    }
+    // Hide the trailing fenced ```json block from the chat UI — it's already
+    // applied to the JSON editor and shown in the diff tab.
+    const visibleText = stripLastJsonBlock(part.text);
+    if (!visibleText) {
+      return null;
+    }
+    return (
+      <div className="AiEditModal__ChatPanel__textPart">
+        <Markdown code={visibleText} />
+      </div>
+    );
+  }
+  if (part.type === 'reasoning') {
+    return <ReasoningPartView text={part.text} />;
+  }
+  if (part.type === 'file') {
+    return <FilePartView part={part} />;
+  }
+  if (typeof part.type === 'string' && part.type.startsWith('tool-')) {
+    return <ToolPartView part={part} />;
+  }
+  if (part.type === 'dynamic-tool') {
+    return <ToolPartView part={part} />;
+  }
+  if (part.type === 'step-start') {
+    return null;
+  }
+  return null;
+}
+
+function ReasoningPartView(props: {text: string}) {
+  const [open, setOpen] = useState(false);
+  if (!props.text) {
+    return null;
+  }
+  return (
+    <div
+      className={joinClassNames(
+        'AiEditModal__ChatPanel__reasoning',
+        open && 'AiEditModal__ChatPanel__reasoning--open'
+      )}
+    >
+      <button
+        type="button"
+        className="AiEditModal__ChatPanel__reasoning__toggle"
+        onClick={() => setOpen(!open)}
+      >
+        <IconChevronDown
+          size={14}
+          style={{transform: open ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+        />
+        <span>Thinking</span>
+      </button>
+      {open && (
+        <div className="AiEditModal__ChatPanel__reasoning__body">
+          <Markdown code={props.text} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilePartView(props: {part: any}) {
+  const part = props.part;
+  if (part.mediaType?.startsWith('image/')) {
+    return (
+      <div className="AiEditModal__ChatPanel__filePart">
+        <img src={part.url} alt={part.filename || 'attachment'} />
+      </div>
+    );
+  }
+  return (
+    <a
+      className="AiEditModal__ChatPanel__filePart AiEditModal__ChatPanel__filePart--link"
+      href={part.url}
+      target="_blank"
+    >
+      <IconPaperclip size={14} />
+      <span>{part.filename || part.url}</span>
+    </a>
+  );
+}
+
+function ToolPartView(props: {part: any}) {
+  const part = props.part;
+  const toolName: string =
+    typeof part.type === 'string' && part.type.startsWith('tool-')
+      ? part.type.slice('tool-'.length)
+      : part.toolName || 'tool';
+  const state: string = part.state || '';
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="AiEditModal__ChatPanel__tool">
+      <button
+        type="button"
+        className="AiEditModal__ChatPanel__tool__header"
+        onClick={() => setOpen(!open)}
+      >
+        <IconTool size={14} />
+        <code>{toolName}</code>
+        <span className="AiEditModal__ChatPanel__tool__state">
+          {prettyToolState(state)}
+        </span>
+        <IconChevronDown
+          size={14}
+          style={{
+            marginLeft: 'auto',
+            transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+          }}
+        />
+      </button>
+      {open && (
+        <div className="AiEditModal__ChatPanel__tool__body">
+          {part.input && (
+            <details open>
+              <summary>Input</summary>
+              <pre>{JSON.stringify(part.input, null, 2)}</pre>
+            </details>
+          )}
+          {part.output && (
+            <details open>
+              <summary>Output</summary>
+              <pre>{JSON.stringify(part.output, null, 2)}</pre>
+            </details>
+          )}
+          {part.errorText && (
+            <div className="AiEditModal__ChatPanel__tool__error">
+              {part.errorText}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function prettyToolState(state: string): string {
+  switch (state) {
+    case 'input-streaming':
+      return 'preparing…';
+    case 'input-available':
+      return 'running…';
+    case 'output-available':
+      return 'done';
+    case 'output-error':
+      return 'error';
+    default:
+      return state;
+  }
+}
+
+function ChatComposer(props: {
+  canAttach: boolean;
+  isStreaming: boolean;
+  onSend: (text: string, attachments: AttachmentPreview[]) => void;
+  onStop: () => void;
+}) {
+  const [text, setText] = useState('');
+  const [attachments, setAttachments] = useState<AttachmentPreview[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const fitTextarea = () => {
+    window.requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) {
+        return;
+      }
+      el.style.height = 'auto';
+      el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+    });
+  };
+
+  useEffect(fitTextarea, [text, attachments]);
+
+  const submit = useCallback(() => {
+    if (props.isStreaming) {
+      return;
+    }
+    if (!text && attachments.length === 0) {
+      return;
+    }
+    props.onSend(text, attachments);
+    setText('');
+    setAttachments([]);
+    if (fileRef.current) {
+      fileRef.current.value = '';
+    }
+  }, [text, attachments, props.isStreaming]);
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const uploadFile = async (file: File) => {
+    setUploading(true);
+    try {
+      const data: any = await uploadFileToGCS(file, {disableGci: true});
+      setAttachments((prev) => [
+        ...prev,
+        {
+          url: data.src,
+          filename: data.filename || file.name,
+          mediaType: file.type || guessMimeType(file.name),
+          width: data.width,
+          height: data.height,
+        },
+      ]);
+    } catch (err) {
+      console.error('upload failed', err);
+    } finally {
+      setUploading(false);
+      if (fileRef.current) {
+        fileRef.current.value = '';
+      }
+    }
+  };
+
+  const onFileChange = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    const files = Array.from(input.files || []);
+    files.forEach(uploadFile);
+  };
+
+  return (
+    <div className="AiEditModal__ChatPanel__composer">
+      {attachments.length > 0 && (
+        <div className="AiEditModal__ChatPanel__composer__attachments">
+          {attachments.map((a, i) => (
+            <div
+              key={i}
+              className="AiEditModal__ChatPanel__composer__attachment"
+            >
+              {a.mediaType.startsWith('image/') ? (
+                <img src={a.url} alt={a.filename} />
+              ) : (
+                <span className="AiEditModal__ChatPanel__composer__attachment__name">
+                  {a.filename}
+                </span>
+              )}
+              <button
+                type="button"
+                className="AiEditModal__ChatPanel__composer__attachment__remove"
+                onClick={() =>
+                  setAttachments((prev) => prev.filter((_, idx) => idx !== i))
+                }
+              >
+                <IconX size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="AiEditModal__ChatPanel__composer__row">
+        {props.canAttach && (
+          <Tooltip label="Attach file">
+            <ActionIcon
+              component="label"
+              radius="xl"
+              className="AiEditModal__ChatPanel__composer__attach"
+            >
+              {uploading ? <Loader size="xs" /> : <IconPaperclip size={18} />}
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                style={{display: 'none'}}
+                onChange={onFileChange}
+              />
+            </ActionIcon>
+          </Tooltip>
+        )}
+        <textarea
+          ref={textareaRef}
+          className="AiEditModal__ChatPanel__composer__textarea"
+          placeholder="Tell me what you want to change…"
+          value={text}
+          rows={1}
+          autofocus
+          onKeyDown={onKeyDown}
+          onChange={(e) => setText((e.target as HTMLTextAreaElement).value)}
+          onPaste={(e) => {
+            const items = e.clipboardData?.items || [];
+            for (const item of items) {
+              if (item.kind === 'file' && item.type.startsWith('image/')) {
+                const file = item.getAsFile();
+                if (file && props.canAttach) {
+                  uploadFile(file);
+                }
+              }
+            }
+          }}
+        />
+        {props.isStreaming ? (
+          <ActionIcon
+            radius="xl"
+            color="dark"
+            variant="filled"
+            onClick={props.onStop}
+            title="Stop"
+          >
+            <IconX size={18} />
+          </ActionIcon>
+        ) : (
+          <ActionIcon
+            radius="xl"
+            color="dark"
+            variant="filled"
+            disabled={uploading || (!text && attachments.length === 0)}
+            onClick={submit}
+            title="Send"
+          >
+            <IconSend2 size={18} />
+          </ActionIcon>
+        )}
+      </div>
+      <div className="AiEditModal__ChatPanel__composer__disclaimer">
+        Root AI is experimental and makes mistakes. Check all info.
+      </div>
+    </div>
+  );
+}
+
+function guessMimeType(filename: string): string {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  return 'image/jpeg';
+}
+
+/** Concatenates all `text` parts of an assistant message. */
+function collectAssistantText(message: UIMessage): string {
+  return (message.parts || [])
+    .filter((p: any) => p.type === 'text' && typeof p.text === 'string')
+    .map((p: any) => p.text)
+    .join('');
+}
+
+/**
+ * Returns the contents of the LAST fenced ```json (or untagged ```) block in
+ * `text`, or `null` if none is found. Used to extract the model's proposed
+ * edit while ignoring earlier illustrative snippets it may have included
+ * mid-explanation.
+ */
+function extractLastJsonBlock(text: string): string | null {
+  if (!text) {
+    return null;
+  }
+  // Match fenced ```json ... ``` blocks first; fall back to plain ``` blocks.
+  const pattern = /```(?:json)?\s*\n([\s\S]*?)```/gi;
+  let match: RegExpExecArray | null;
+  let last: string | null = null;
+  while ((match = pattern.exec(text)) !== null) {
+    last = match[1].trim();
+  }
+  return last;
+}
+
+/**
+ * Strips the trailing fenced JSON block from an assistant message's text so
+ * the chat UI doesn't duplicate what the diff viewer already displays. Also
+ * strips an in-flight (un-closed) ```json fence during streaming.
+ */
+function stripLastJsonBlock(text: string): string {
+  if (!text) {
+    return text;
+  }
+  // Find every complete fenced block; if the LAST one is at the tail of the
+  // message (only whitespace after it), strip it.
+  const fenced = /```(?:json)?\s*\n[\s\S]*?```/gi;
+  const matches = Array.from(text.matchAll(fenced));
+  let out = text;
+  if (matches.length > 0) {
+    const last = matches[matches.length - 1];
+    const start = last.index ?? -1;
+    const end = start + last[0].length;
+    if (start !== -1 && /^\s*$/.test(out.slice(end))) {
+      out = out.slice(0, start);
+    }
+  }
+  // Streaming case: if the remaining text contains an odd number of
+  // triple-backtick fences, the last one is an opener that hasn't been
+  // closed yet — strip from it onward so the partial JSON stays out of
+  // the chat transcript.
+  const fenceCount = (out.match(/```/g) || []).length;
+  if (fenceCount % 2 === 1) {
+    const lastIdx = out.lastIndexOf('```');
+    if (lastIdx !== -1) {
+      out = out.slice(0, lastIdx);
+    }
+  }
+  return out.trim();
 }

--- a/packages/root-cms/ui/components/ChatBar/ChatBar.tsx
+++ b/packages/root-cms/ui/components/ChatBar/ChatBar.tsx
@@ -259,7 +259,7 @@ export function ChatBar(props: {
         </ActionIcon>
       </div>
       <div className="AIPage__ChatBar__disclaimer">
-        Root AI is experimental and makes mistakes. Check all info.
+        Root AI is experimental and can make mistakes. Use with caution.
       </div>
     </div>
   );

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -104,6 +104,7 @@ import {
 } from '../DocStatusBadges/DocStatusBadges.js';
 import {useEditJsonModal} from '../EditJsonModal/EditJsonModal.js';
 import {useEditTranslationsModal} from '../EditTranslationsModal/EditTranslationsModal.js';
+import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Viewers} from '../Viewers/Viewers.js';
@@ -1574,12 +1575,10 @@ DocEditor.ArrayField = (props: FieldProps) => {
                                 {experiments.ai && (
                                   <Menu.Item
                                     className="DocEditor__ArrayField__menu__item"
-                                    icon={
-                                      <IconSparkles size={18} stroke="1.75" />
-                                    }
+                                    icon={<IconRootAI size={16} />}
                                     onClick={() => aiEdit(i)}
                                   >
-                                    Edit with AI
+                                    Edit with Root AI
                                   </Menu.Item>
                                 )}
                                 <Menu.Label>REMOVE</Menu.Label>

--- a/packages/root-cms/ui/components/IconRootAI/IconRootAI.tsx
+++ b/packages/root-cms/ui/components/IconRootAI/IconRootAI.tsx
@@ -1,0 +1,10 @@
+import {IconRobot} from '@tabler/icons-preact';
+
+export interface IconRootAIProps {
+  className?: string;
+  size?: number;
+}
+
+export function IconRootAI(props: IconRootAIProps) {
+  return <IconRobot className={props.className} size={props.size} />;
+}


### PR DESCRIPTION
## Summary

Replaces the legacy chat implementation in the array-item "Edit with AI" modal with a new streaming-based chat panel built on the Vercel AI SDK. The new implementation streams responses from a dedicated `/cms/api/ai.v2.editObject` endpoint, extracts proposed JSON edits from fenced code blocks, and forwards them to the diff viewer for user approval.

## Key Changes

- **ChatPanel component rewrite**: Replaced legacy `ChatBar`/`LegacyChatView` imports with a new implementation using `@ai-sdk/react`'s `useChat` hook and `DefaultChatTransport`
  - Fetches AI model configuration from `/cms/api/ai.v2.config`
  - Displays loading/not-configured states with helpful guidance
  - Streams messages and tool calls in real-time

- **New chat UI components**:
  - `ChatTranscript`: Renders message history with auto-scroll, welcome state, and streaming indicator
  - `MessageView`: Displays user/assistant messages with avatars and usernames
  - `PartView`: Handles different message part types (text, reasoning, files, tool calls)
  - `ChatComposer`: Text input with file attachment support, auto-sizing textarea, and send/stop controls
  - `ReasoningPartView`, `FilePartView`, `ToolPartView`: Specialized renderers for extended message types

- **JSON extraction logic**:
  - `extractLastJsonBlock()`: Extracts the final fenced ```json block from assistant responses (ignoring earlier illustrative snippets)
  - `stripLastJsonBlock()`: Removes trailing JSON blocks from chat display to avoid duplication with diff viewer
  - `collectAssistantText()`: Concatenates all text parts from assistant messages

- **Server-side streaming endpoint** (`/cms/api/ai.v2.editObject`):
  - New `runEditObjectStream()` function in `ai-chat.ts` that uses read-only CMS tools only
  - Injects the edited JSON and `root-cms.d.ts` types into the system prompt
  - Instructs the model to emit proposed changes as a fenced code block
  - No Firestore persistence — edit sessions are ephemeral

- **Read-only tool subset**:
  - New `createReadOnlyCmsTools()` function in `ai-tools.ts`
  - Filters to 7 read-only tools: `collections_list`, `docs_list`, `docs_search`, `doc_get`, `doc_getVersion`, `doc_listVersions`, `schema_get`
  - Prevents the model from mutating Firestore directly (user approves via modal)

- **Styling**: Comprehensive CSS for chat transcript, messages, composer, tool displays, reasoning blocks, and error states

## Notable Implementation Details

- Tool calls execute in the browser using the signed-in user's Firebase credentials; results are fed back to the model via `addToolOutput()`
- Auto-resubmit on tool completion using `lastAssistantMessageIsCompleteWithToolCalls` predicate
- File attachments support image paste, drag-drop, and GCS upload with preview thumbnails
- Streaming JSON extraction uses a ref to avoid re-firing `onEditModeResponse` on every token
- Graceful handling of incomplete JSON during streaming (waits for more tokens before parsing)

https://claude.ai/code/session_015mE34NKvYRuA962CcgnwYH