### PR TITLE
ci: update gcloud functions CLI flag from --gen2 to --v2

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -35,7 +35,7 @@ jobs:
           set -euo pipefail
 
           gcloud functions list \
-            --gen2 \
+            --v2 \
             --project rootjs-dev \
             --format=json > /tmp/rootjs-preview-functions.json
 
@@ -78,7 +78,7 @@ jobs:
           while IFS=$'\t' read -r function_name region updated_at; do
             echo "Deleting ${function_name} in ${region}, last updated ${updated_at}."
             gcloud functions delete "$function_name" \
-              --gen2 \
+              --v2 \
               --region "$region" \
               --project rootjs-dev \
               --quiet


### PR DESCRIPTION
## Summary
Updates the gcloud CLI commands in the docs preview cleanup workflow to use the current `--v2` flag instead of the deprecated `--gen2` flag for Cloud Functions operations.

## Changes
- Replaced `--gen2` with `--v2` flag in the `gcloud functions list` command
- Replaced `--gen2` with `--v2` flag in the `gcloud functions delete` command

## Details
The `--gen2` flag has been superseded by `--v2` in the gcloud CLI. This change ensures the workflow uses the current, supported flag syntax for Cloud Functions v2 operations in the docs preview cleanup automation.

https://claude.ai/code/session_017GXSn5pBnoGkux6caRg9tw