### PR TITLE
chore: move taskManager to experimental

### DIFF
--- a/.changeset/taskmanager-experimental-flag.md
+++ b/.changeset/taskmanager-experimental-flag.md
@@ -1,0 +1,10 @@
+---
+'@blinkk/root-cms': patch
+---
+
+chore: gate task manager behind `experiments.taskManager` opt-in
+
+The task manager is now an opt-in experimental feature. To enable it, set
+`experiments: {taskManager: true}` in the CMS plugin config. The previous
+mechanism of hiding `'tasks'` via `sidebar.hiddenBuiltInTools` no longer
+applies.

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -62,7 +62,6 @@ export type {
 export type CMSBuiltInSidebarTool =
   | 'home'
   | 'content'
-  | 'tasks'
   | 'releases'
   | 'data'
   | 'assets'
@@ -277,8 +276,7 @@ export type CMSPluginOptions = {
 
     /**
      * Hide specific built-in sidebar tools. Hiding a tool also removes its
-     * surfaces from the CMS home page (e.g. hiding `'tasks'` removes the task
-     * manager card from the home page). The underlying routes remain
+     * surfaces from the CMS home page. The underlying routes remain
      * accessible via direct URL.
      */
     hiddenBuiltInTools?: CMSBuiltInSidebarTool[];
@@ -366,6 +364,12 @@ export type CMSPluginOptions = {
      * Enables the v2 `TranslationsManager`.
      */
     v2TranslationsManager?: boolean;
+
+    /**
+     * Enables the task manager (sidebar entry, home page card, and
+     * `/cms/tasks` routes).
+     */
+    taskManager?: boolean;
   };
 
   /**

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -130,7 +130,7 @@ Layout.Side = () => {
           </Layout.SideButton>
         )}
 
-        {!isBuiltInHidden('tasks') && (
+        {experiments.taskManager && (
           <Layout.SideButton
             label="Tasks"
             url="/cms/tasks"

--- a/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
+++ b/packages/root-cms/ui/pages/ProjectPage/ProjectPage.tsx
@@ -12,9 +12,7 @@ import {Layout} from '../../layout/Layout.js';
 export function ProjectPage() {
   // const projectName = window.__ROOT_CTX.rootConfig.projectName || 'Root CMS';
   usePageTitle('Home');
-  const hiddenBuiltInTools =
-    window.__ROOT_CTX.sidebar?.hiddenBuiltInTools || [];
-  const showTaskManager = !hiddenBuiltInTools.includes('tasks');
+  const showTaskManager = !!window.__ROOT_CTX.experiments?.taskManager;
   return (
     <Layout>
       <div className="ProjectPage">

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -186,6 +186,7 @@ declare global {
       };
       experiments?: {
         ai?: boolean | {endpoint?: string};
+        taskManager?: boolean;
       };
       ai?: {
         defaultModel?: string;


### PR DESCRIPTION
## Summary
The task manager is now an opt-in experimental feature that must be explicitly enabled via configuration, rather than being hidden through the `sidebar.hiddenBuiltInTools` mechanism.

## Key Changes
- Removed `'tasks'` from the `CMSBuiltInSidebarTool` type, as it's no longer a standard built-in tool
- Added `taskManager?: boolean` to the `experiments` configuration object in `CMSPluginOptions`
- Updated `ProjectPage.tsx` to check `experiments.taskManager` instead of checking if `'tasks'` is in `hiddenBuiltInTools`
- Updated `Layout.tsx` sidebar rendering to conditionally show the Tasks button based on `experiments.taskManager`
- Updated the global `__ROOT_CTX` type declaration to include `taskManager` in the experiments object
- Updated documentation in `hiddenBuiltInTools` to remove the specific reference to tasks

## Implementation Details
- To enable the task manager, users must now set `experiments: {taskManager: true}` in their CMS plugin configuration
- The previous approach of hiding tasks via `sidebar.hiddenBuiltInTools` no longer applies
- The underlying `/cms/tasks` routes remain accessible via direct URL regardless of the flag setting

https://claude.ai/code/session_01F7z7g1bnD53PXjucSHvLrK