### PR TITLE
chore: link version badge to changelog

### DIFF
--- a/packages/root-cms/ui/layout/Layout.css
+++ b/packages/root-cms/ui/layout/Layout.css
@@ -37,6 +37,12 @@
   background-color: #efefef;
   padding: 0 8px;
   border-radius: 20px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.Layout__top__version:hover {
+  background-color: #e5e5e5;
 }
 
 .Layout__top__project {

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -70,7 +70,14 @@ Layout.Top = () => {
           <a className="Layout__top__logo" href="/cms">
             <RootCMSLogo />
           </a>
-          <div className="Layout__top__version">v{packageJson.version}</div>
+          <a
+            className="Layout__top__version"
+            href="https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            v{packageJson.version}
+          </a>
           <div className="Layout__top__project">{projectName}</div>
         </>
       ) : (
@@ -78,7 +85,14 @@ Layout.Top = () => {
           <a className="Layout__top__logo" href="/cms">
             {projectName}
           </a>
-          <div className="Layout__top__version">v{packageJson.version}</div>
+          <a
+            className="Layout__top__version"
+            href="https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            v{packageJson.version}
+          </a>
         </>
       )}
       {showSearchBar && (


### PR DESCRIPTION
## Summary
Updated the version display in the CMS layout header to be a clickable link that directs users to the Root CMS changelog on GitHub.

## Key Changes
- Converted the version display from a static `<div>` to an interactive `<a>` element in both layout variants (with and without logo)
- Added link to the Root CMS changelog: `https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md`
- Configured link to open in a new tab with `target="_blank"` and `rel="noreferrer noopener"`
- Updated styling to make the version element appear as a proper link:
  - Added `color: inherit` to maintain text color consistency
  - Added `text-decoration: none` to remove default link underline
  - Added `:hover` state with slightly darker background (`#e5e5e5`) for visual feedback

## Implementation Details
The change maintains the existing visual appearance while adding functionality. The version badge now provides users with quick access to release notes and changelog information directly from the CMS interface.

https://claude.ai/code/session_01DCKy5jDk8uCPfMY8WzSrSR