### PR TITLE
feat(cms): Root AI agents foundations (1/4) — registry, schema, design doc

### DIFF
--- a/.changeset/agents-foundations.md
+++ b/.changeset/agents-foundations.md
@@ -1,0 +1,6 @@
+---
+'@blinkk/root-cms': minor
+'@blinkk/root': minor
+---
+
+feat: add Root AI agent registry foundations (`defineAgent`, `virtual:root/agents`, task schema additions)

--- a/packages/root-cms/core/agents/define.test.ts
+++ b/packages/root-cms/core/agents/define.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from 'vitest';
+import {defineAgent} from './define.js';
+
+describe('defineAgent', () => {
+  const validInput = {
+    name: 'content-manager',
+    icon: '📝',
+    description: 'Manages content updates.',
+    systemPrompt: 'You manage content.',
+  };
+
+  it('returns a normalized definition with default tool bundles', () => {
+    const def = defineAgent(validInput);
+    expect(def.name).toBe('content-manager');
+    expect(def.icon).toBe('📝');
+    expect(def.description).toBe('Manages content updates.');
+    expect(def.systemPrompt).toBe('You manage content.');
+    expect(def.allowedTools).toEqual(['read', 'propose']);
+    expect(def.model).toBeUndefined();
+    expect(def.maxTokensPerTask).toBeUndefined();
+  });
+
+  it('preserves explicit allowedTools and dedupes duplicates', () => {
+    const def = defineAgent({
+      ...validInput,
+      allowedTools: ['read', 'propose', 'subtask', 'read'],
+    });
+    expect(def.allowedTools).toEqual(['read', 'propose', 'subtask']);
+  });
+
+  it('trims whitespace from string fields', () => {
+    const def = defineAgent({
+      name: '  content-manager  ',
+      icon: ' 📝 ',
+      description: '  Manages content.  ',
+      systemPrompt: '  You manage content.  ',
+    });
+    expect(def.name).toBe('content-manager');
+    expect(def.icon).toBe('📝');
+    expect(def.description).toBe('Manages content.');
+    expect(def.systemPrompt).toBe('You manage content.');
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() => defineAgent({...validInput, name: ''})).toThrow(/name/);
+    expect(() => defineAgent({...validInput, icon: ''})).toThrow(/icon/);
+    expect(() => defineAgent({...validInput, description: ''})).toThrow(
+      /description/
+    );
+    expect(() => defineAgent({...validInput, systemPrompt: ''})).toThrow(
+      /systemPrompt/
+    );
+  });
+
+  it('rejects names that do not match the slug pattern', () => {
+    expect(() => defineAgent({...validInput, name: 'Content_Manager'})).toThrow(
+      /invalid name/
+    );
+    expect(() => defineAgent({...validInput, name: '-bad'})).toThrow(
+      /invalid name/
+    );
+    expect(() => defineAgent({...validInput, name: 'AGENT'})).toThrow(
+      /invalid name/
+    );
+  });
+
+  it('rejects unknown tool bundles', () => {
+    expect(() =>
+      defineAgent({
+        ...validInput,
+        // @ts-expect-error - testing runtime validation.
+        allowedTools: ['read', 'mutate'],
+      })
+    ).toThrow(/unknown tool bundle "mutate"/);
+  });
+
+  it('rejects non-array allowedTools', () => {
+    expect(() =>
+      defineAgent({
+        ...validInput,
+        // @ts-expect-error - testing runtime validation.
+        allowedTools: 'read',
+      })
+    ).toThrow(/allowedTools must be an array/);
+  });
+
+  it('rejects non-positive maxTokensPerTask', () => {
+    expect(() => defineAgent({...validInput, maxTokensPerTask: 0})).toThrow(
+      /maxTokensPerTask/
+    );
+    expect(() => defineAgent({...validInput, maxTokensPerTask: -100})).toThrow(
+      /maxTokensPerTask/
+    );
+    expect(() =>
+      // @ts-expect-error - testing runtime validation.
+      defineAgent({...validInput, maxTokensPerTask: NaN})
+    ).toThrow(/maxTokensPerTask/);
+  });
+
+  it('accepts optional model and maxTokensPerTask', () => {
+    const def = defineAgent({
+      ...validInput,
+      model: 'anthropic/claude-sonnet-4-6',
+      maxTokensPerTask: 100_000,
+    });
+    expect(def.model).toBe('anthropic/claude-sonnet-4-6');
+    expect(def.maxTokensPerTask).toBe(100_000);
+  });
+});

--- a/packages/root-cms/core/agents/define.ts
+++ b/packages/root-cms/core/agents/define.ts
@@ -1,0 +1,114 @@
+/**
+ * Public API for declaring a Root AI agent in a site's `agents/` directory.
+ *
+ * Example:
+ *   // agents/content-manager.ts
+ *   import {defineAgent} from '@blinkk/root-cms';
+ *   import systemPrompt from './content-manager.md?raw';
+ *
+ *   export default defineAgent({
+ *     name: 'content-manager',
+ *     icon: '📝',
+ *     description: 'Manages CMS content updates across collections.',
+ *     systemPrompt,
+ *     allowedTools: ['read', 'propose'],
+ *   });
+ */
+
+import type {
+  AgentDefinition,
+  AgentDefinitionInput,
+  AgentToolBundle,
+} from './types.js';
+
+const AGENT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const VALID_BUNDLES: ReadonlySet<AgentToolBundle> = new Set([
+  'read',
+  'propose',
+  'subtask',
+]);
+const DEFAULT_ALLOWED_TOOLS: AgentToolBundle[] = ['read', 'propose'];
+
+/**
+ * Validates and normalizes an agent definition. Throws on missing or
+ * malformed fields so configuration errors surface at module load time
+ * rather than mid-run.
+ */
+export function defineAgent(input: AgentDefinitionInput): AgentDefinition {
+  if (!input || typeof input !== 'object') {
+    throw new Error('defineAgent: missing config object');
+  }
+  const name = (input.name || '').trim();
+  if (!name) {
+    throw new Error('defineAgent: missing required field "name"');
+  }
+  if (!AGENT_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `defineAgent: invalid name "${name}" (must match ${AGENT_NAME_PATTERN})`
+    );
+  }
+  const icon = (input.icon || '').trim();
+  if (!icon) {
+    throw new Error(`defineAgent[${name}]: missing required field "icon"`);
+  }
+  const description = (input.description || '').trim();
+  if (!description) {
+    throw new Error(
+      `defineAgent[${name}]: missing required field "description"`
+    );
+  }
+  const systemPrompt = (input.systemPrompt || '').trim();
+  if (!systemPrompt) {
+    throw new Error(
+      `defineAgent[${name}]: missing required field "systemPrompt"`
+    );
+  }
+
+  const allowedTools = normalizeAllowedTools(name, input.allowedTools);
+
+  if (
+    input.maxTokensPerTask !== undefined &&
+    (!Number.isFinite(input.maxTokensPerTask) || input.maxTokensPerTask <= 0)
+  ) {
+    throw new Error(
+      `defineAgent[${name}]: maxTokensPerTask must be a positive number`
+    );
+  }
+
+  return {
+    name,
+    icon,
+    description,
+    systemPrompt,
+    allowedTools,
+    model: input.model?.trim() || undefined,
+    maxTokensPerTask: input.maxTokensPerTask,
+  };
+}
+
+function normalizeAllowedTools(
+  agentName: string,
+  bundles: AgentToolBundle[] | undefined
+): AgentToolBundle[] {
+  if (bundles === undefined) {
+    return [...DEFAULT_ALLOWED_TOOLS];
+  }
+  if (!Array.isArray(bundles)) {
+    throw new Error(`defineAgent[${agentName}]: allowedTools must be an array`);
+  }
+  const result: AgentToolBundle[] = [];
+  const seen = new Set<AgentToolBundle>();
+  for (const bundle of bundles) {
+    if (!VALID_BUNDLES.has(bundle)) {
+      throw new Error(
+        `defineAgent[${agentName}]: unknown tool bundle "${bundle}" ` +
+          `(expected one of: ${Array.from(VALID_BUNDLES).join(', ')})`
+      );
+    }
+    if (!seen.has(bundle)) {
+      seen.add(bundle);
+      result.push(bundle);
+    }
+  }
+  return result;
+}

--- a/packages/root-cms/core/agents/index.ts
+++ b/packages/root-cms/core/agents/index.ts
@@ -1,0 +1,7 @@
+export {defineAgent} from './define.js';
+export {getAgent, loadAgents, _resetAgentRegistryForTests} from './registry.js';
+export type {
+  AgentDefinition,
+  AgentDefinitionInput,
+  AgentToolBundle,
+} from './types.js';

--- a/packages/root-cms/core/agents/registry.test.ts
+++ b/packages/root-cms/core/agents/registry.test.ts
@@ -1,0 +1,141 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {defineAgent} from './define.js';
+import {_resetAgentRegistryForTests, getAgent, loadAgents} from './registry.js';
+
+const state = vi.hoisted(() => ({
+  modules: {} as Record<string, unknown>,
+}));
+
+vi.mock('virtual:root/agents', () => ({
+  get AGENT_MODULES() {
+    return state.modules;
+  },
+}));
+
+beforeEach(() => {
+  state.modules = {};
+  _resetAgentRegistryForTests();
+});
+
+describe('loadAgents', () => {
+  it('returns an empty map when no agents are declared', async () => {
+    const agents = await loadAgents();
+    expect(agents.size).toBe(0);
+  });
+
+  it('loads agents exported as default', async () => {
+    state.modules = {
+      '/agents/content-manager.ts': {
+        default: defineAgent({
+          name: 'content-manager',
+          icon: '📝',
+          description: 'Manages content.',
+          systemPrompt: 'You manage content.',
+        }),
+      },
+      '/agents/translator.ts': {
+        default: defineAgent({
+          name: 'translator',
+          icon: '🌐',
+          description: 'Translates copy.',
+          systemPrompt: 'You translate copy.',
+        }),
+      },
+    };
+    const agents = await loadAgents();
+    expect(agents.size).toBe(2);
+    expect(agents.get('content-manager')?.icon).toBe('📝');
+    expect(agents.get('translator')?.icon).toBe('🌐');
+  });
+
+  it('also accepts a named `agent` export', async () => {
+    state.modules = {
+      '/agents/content-manager.ts': {
+        agent: defineAgent({
+          name: 'content-manager',
+          icon: '📝',
+          description: 'Manages content.',
+          systemPrompt: 'You manage content.',
+        }),
+      },
+    };
+    const agents = await loadAgents();
+    expect(agents.get('content-manager')).toBeDefined();
+  });
+
+  it('throws on duplicate agent names', async () => {
+    state.modules = {
+      '/agents/a.ts': {
+        default: defineAgent({
+          name: 'duplicate',
+          icon: '📝',
+          description: 'A',
+          systemPrompt: 'A',
+        }),
+      },
+      '/agents/b.ts': {
+        default: defineAgent({
+          name: 'duplicate',
+          icon: '🌐',
+          description: 'B',
+          systemPrompt: 'B',
+        }),
+      },
+    };
+    await expect(loadAgents()).rejects.toThrow(/duplicate agent name/);
+  });
+
+  it('throws when an agent file is missing a default export', async () => {
+    state.modules = {
+      '/agents/oops.ts': {},
+    };
+    await expect(loadAgents()).rejects.toThrow(/does not export a default/);
+  });
+
+  it('throws when an export is not a valid agent definition', async () => {
+    state.modules = {
+      '/agents/oops.ts': {default: {name: 'incomplete'}},
+    };
+    await expect(loadAgents()).rejects.toThrow(/not a valid agent definition/);
+  });
+
+  it('caches across calls', async () => {
+    state.modules = {
+      '/agents/content-manager.ts': {
+        default: defineAgent({
+          name: 'content-manager',
+          icon: '📝',
+          description: 'Manages content.',
+          systemPrompt: 'You manage content.',
+        }),
+      },
+    };
+    const a = await loadAgents();
+    state.modules = {}; // Should be ignored due to caching.
+    const b = await loadAgents();
+    expect(a).toBe(b);
+    expect(b.has('content-manager')).toBe(true);
+  });
+});
+
+describe('getAgent', () => {
+  it('returns the agent by name', async () => {
+    state.modules = {
+      '/agents/content-manager.ts': {
+        default: defineAgent({
+          name: 'content-manager',
+          icon: '📝',
+          description: 'Manages content.',
+          systemPrompt: 'You manage content.',
+        }),
+      },
+    };
+    const agent = await getAgent('content-manager');
+    expect(agent?.name).toBe('content-manager');
+  });
+
+  it('returns null for unknown names', async () => {
+    const agent = await getAgent('does-not-exist');
+    expect(agent).toBeNull();
+  });
+});

--- a/packages/root-cms/core/agents/registry.ts
+++ b/packages/root-cms/core/agents/registry.ts
@@ -1,0 +1,109 @@
+/**
+ * Runtime registry that loads agents declared in a site's `agents/` directory
+ * via the `virtual:root/agents` Vite virtual module. Consumed by the agent
+ * runner, the API endpoints that serve the agent picker, and the worker.
+ *
+ * The virtual module exposes:
+ *
+ *   export const AGENT_MODULES: Record<string, {default?: AgentDefinition}>;
+ *
+ * keyed by the source path of each agent file. We dedupe by `name` and accept
+ * either a default export or a named `agent` export to keep authoring
+ * flexible.
+ */
+
+import type {AgentDefinition} from './types.js';
+
+interface AgentModuleExports {
+  default?: AgentDefinition;
+  agent?: AgentDefinition;
+}
+
+interface AgentModulesShape {
+  AGENT_MODULES?: Record<string, AgentModuleExports>;
+}
+
+let cache: ReadonlyMap<string, AgentDefinition> | null = null;
+
+/**
+ * Loads all agents declared in `<rootDir>/agents/`, returning a name-keyed map.
+ *
+ * Throws if duplicate agent names are encountered or an exported value is not
+ * a valid agent definition.
+ */
+export async function loadAgents(): Promise<
+  ReadonlyMap<string, AgentDefinition>
+> {
+  if (cache) {
+    return cache;
+  }
+
+  let mod: AgentModulesShape;
+  try {
+    // The virtual module is resolved by rootPodsVitePlugin when loaded
+    // through Vite's ssrLoadModule. Outside Vite (CLI, tests without the
+    // stub), it falls back to an empty registry.
+    // @ts-expect-error — virtual module provided by rootPodsVitePlugin.
+    mod = (await import('virtual:root/agents')) as AgentModulesShape;
+  } catch (err) {
+    cache = new Map();
+    return cache;
+  }
+
+  const entries = mod.AGENT_MODULES || {};
+  const byName = new Map<string, AgentDefinition>();
+  const seenAt = new Map<string, string>();
+  for (const [modulePath, exports] of Object.entries(entries)) {
+    const def = exports.default || exports.agent;
+    if (!def) {
+      throw new Error(
+        `agents: ${modulePath} does not export a default agent (use \`export default defineAgent({...})\`)`
+      );
+    }
+    if (!isAgentDefinition(def)) {
+      throw new Error(
+        `agents: ${modulePath} export is not a valid agent definition (did you forget to call defineAgent?)`
+      );
+    }
+    const existing = seenAt.get(def.name);
+    if (existing) {
+      throw new Error(
+        `agents: duplicate agent name "${def.name}" registered by ${existing} and ${modulePath}`
+      );
+    }
+    seenAt.set(def.name, modulePath);
+    byName.set(def.name, def);
+  }
+  cache = byName;
+  return cache;
+}
+
+/**
+ * Returns a single agent by name, or null if no such agent is registered.
+ */
+export async function getAgent(name: string): Promise<AgentDefinition | null> {
+  const agents = await loadAgents();
+  return agents.get(name) || null;
+}
+
+/**
+ * Resets the in-memory cache. Test-only; production code should rely on the
+ * one-shot lazy load.
+ */
+export function _resetAgentRegistryForTests() {
+  cache = null;
+}
+
+function isAgentDefinition(value: unknown): value is AgentDefinition {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.name === 'string' &&
+    typeof v.icon === 'string' &&
+    typeof v.description === 'string' &&
+    typeof v.systemPrompt === 'string' &&
+    Array.isArray(v.allowedTools)
+  );
+}

--- a/packages/root-cms/core/agents/types.ts
+++ b/packages/root-cms/core/agents/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared types for the Root AI agent registry. Definitions live in user code
+ * via `defineAgent()`; the runtime registry, runner, and worker all consume
+ * the resolved shape from this module.
+ */
+
+/**
+ * Capability bundles an agent may be granted. Bundles are coarse-grained on
+ * purpose so site authors don't accidentally hand agents dangerous tools and
+ * so the underlying tool surface can grow without breaking existing agents.
+ */
+export type AgentToolBundle = 'read' | 'propose' | 'subtask';
+
+/**
+ * Resolved agent definition shape. Returned by `defineAgent()` and registered
+ * in the agent registry.
+ */
+export interface AgentDefinition {
+  /**
+   * Unique identifier within a project. Must match `/^[a-z0-9][a-z0-9-]*$/`.
+   * The assignee form is `agent:<name>`.
+   */
+  name: string;
+  /** Single emoji or short string used as the agent's avatar in the UI. */
+  icon: string;
+  /** One-line description shown in pickers and lists. */
+  description: string;
+  /**
+   * Full system prompt for the agent. Typically authored as a sibling
+   * Markdown file imported via Vite's `?raw` query (e.g.
+   * `import sp from './content-manager.md?raw'`).
+   */
+  systemPrompt: string;
+  /** Granted capability bundles. Defaults to `['read', 'propose']`. */
+  allowedTools: AgentToolBundle[];
+  /**
+   * Optional model override of the form `<provider>/<model-id>` (e.g.
+   * `anthropic/claude-sonnet-4-6`). When omitted, the project default is used.
+   */
+  model?: string;
+  /**
+   * Optional per-task token cap. When the runner exceeds this across all steps
+   * (including subagents) the run halts and is marked errored. Defaults to the
+   * project default if unset.
+   */
+  maxTokensPerTask?: number;
+}
+
+/**
+ * Loose input shape accepted by `defineAgent()`. `allowedTools` is optional
+ * here and gets defaulted by the helper.
+ */
+export interface AgentDefinitionInput {
+  name: string;
+  icon: string;
+  description: string;
+  systemPrompt: string;
+  allowedTools?: AgentToolBundle[];
+  model?: string;
+  maxTokensPerTask?: number;
+}

--- a/packages/root-cms/core/core.ts
+++ b/packages/root-cms/core/core.ts
@@ -1,3 +1,4 @@
+export * from './agents/index.js';
 export * from './client.js';
 export * from './route.js';
 export * from './runtime.js';

--- a/packages/root-cms/docs/design/ai-agents.md
+++ b/packages/root-cms/docs/design/ai-agents.md
@@ -1,0 +1,260 @@
+# Root AI: Agents and Task Manager Integration
+
+Status: Draft.
+Targets: rootjs `alpha` channel (post v3.0).
+
+## Context
+
+Root v3 introduces two new surfaces in parallel:
+
+- **Root AI chat**, built on Vercel AI SDK v6 (`packages/root-cms/core/ai-chat.ts`), with browser-executed CMS tools so writes go through the user's Firebase auth.
+- **Task Manager** (`packages/root-cms/ui/components/TaskManager`, `ui/utils/tasks.ts`), introduced in #1065 / #1081 and recently moved to experimental in #1104, with tasks, comments, mentions, events, and assignees.
+
+Today these are disconnected. This design unifies them so Root CMS becomes the entrypoint for ideating and executing big website projects with clients: a chat session can graduate to a long-running Task, and Tasks can be assigned to AI agents defined per-site.
+
+The shape is deliberately narrow. Agents read and propose; humans approve and apply. Agents do not write code, do not have direct mutating authority over the CMS, and run only with the same project scope the site itself has.
+
+## Goals
+
+- A site-defined agent registry under `<root>/agents/`, discoverable by Root AI and the Task Manager.
+- Tasks can be assigned to agents (in addition to humans) and agents post comments, reactions, and proposals as they work.
+- Read-only operations auto-approve; mutating operations are posted as proposals that a human applies.
+- "Convert chat to task" hand-off from Root AI to the Task Manager.
+- Background workers run agent loops without introducing new third-party infrastructure to a Root deployment.
+
+## Non-goals
+
+- Autonomous code editing. Agents advise; engineers edit code.
+- Multi-day stateful workflows beyond simple subtask hand-offs.
+- New 3p infrastructure (Cloud Tasks, Pub/Sub, Redis, LangGraph runtime, etc.).
+- Service-account writes. Mutations always run under a human's Firebase auth via the Apply flow.
+
+## Architecture
+
+### Agent registry (`agents/`)
+
+Agents live next to other site code in `<root>/agents/`. Each agent is a TypeScript file that calls `defineAgent()`, optionally importing a co-located Markdown file as its system prompt:
+
+```ts
+// agents/content-manager.ts
+import {defineAgent} from '@blinkk/root-cms';
+import systemPrompt from './content-manager.md?raw';
+
+export default defineAgent({
+  name: 'content-manager',
+  icon: '📝',
+  description: 'Manages CMS content updates across collections.',
+  systemPrompt,
+  allowedTools: ['read', 'propose', 'subtask'],
+  model: 'anthropic/claude-sonnet-4-6', // Optional override.
+  maxTokensPerTask: 200_000,             // Optional override.
+});
+```
+
+Discovery uses a new Vite virtual module `virtual:root/agents`, modelled on the existing `virtual:root/schemas` plugin (`packages/root/src/node/pods-vite-plugin.ts:16-96`). The plugin walks `agents/`, generates a module that imports each definition, and exposes a typed registry to both server (worker, API) and client (UI).
+
+`allowedTools` uses *bundle keys* rather than individual tool names so site authors don't accidentally grant dangerous capabilities and the bundles can grow over time:
+
+| Bundle     | Purpose                                                      |
+| ---------- | ------------------------------------------------------------ |
+| `read`     | Search docs, list collections, get doc, schema introspection |
+| `propose`  | Post structured proposals as comments on the current task    |
+| `subtask`  | Create child tasks assigned to other agents or humans        |
+
+### Task data model additions
+
+The existing `Task` and `TaskComment` shapes (`packages/root-cms/ui/utils/tasks.ts:23-91`) need additive changes; nothing existing breaks.
+
+`Task`:
+- `assignee?: string` — already freeform. Agent assignees use `agent:<name>` (e.g. `agent:content-manager`).
+- `parentTaskId?: string` — new, links subtasks to their parent.
+- `sourceChatId?: string` — new, links a Task back to the chat it originated from.
+- `agentRun?: AgentRunMetadata` — new. Tracks `{leasedBy, leasedAt, tokensUsed, tokensCap, status: 'idle' | 'running' | 'errored', lastError?}`. Workers update via Firestore transaction.
+
+`TaskComment`:
+- `reactions?: {[emoji: string]: string[]}` — new. Tight emoji set: `👀 🤔 💬 ✅ ⚠️ ❌`. Keys are reactor identifiers (`createdBy` or `agent:<name>`).
+- `proposal?: TaskProposal` — new (only present on proposal comments). Shape: `{tool, input, rationale, diffSummary, status: 'pending' | 'applied' | 'rejected' | 'expired', appliedBy?, appliedAt?}`.
+
+Schema changes are purely additive. No migration required for existing tasks.
+
+### Server-side tool execution
+
+Today every tool call round-trips through the browser via `executeCmsTool` (`packages/root-cms/ui/pages/AIPage/cmsToolHandlers.ts:540`). For background agents the tab isn't open, so the *read* bundle gets a server-side execution layer.
+
+- `packages/root-cms/core/agents/tools-server.ts` — server execute functions for the read bundle, all routed through `RootCMSClient` so per-project access checks still apply.
+- The same tool *names* as the existing chat tools, just with server-side `execute` wired up. The agent code calls them identically.
+- The chat handler keeps the existing schema-only registration so user-driven mutations stay in the browser.
+
+The mutating tool surface is **not** ported. Agents never get a server-side `update_doc` or similar. Mutations exist only as proposals.
+
+### Proposal + apply flow
+
+When an agent wants to mutate the CMS, it calls a single tool:
+
+```
+proposeChange({
+  tool: 'update_doc',                         // The mutating tool to invoke.
+  input: { docId: '...', fields: {...} },     // Input to that tool.
+  rationale: 'Updated hero copy per brief.',
+  diffSummary: '...'                          // Human-readable diff for the comment.
+})
+```
+
+`proposeChange` posts a structured comment on the active task with `proposal: {...status: 'pending'}`. The agent never directly applies the change.
+
+When a human views the task and clicks **Apply**:
+
+1. UI hits `/cms/api/proposal.apply?commentId=<id>` with the user's Firebase auth.
+2. Server validates the proposal (status still `pending`, target doc still exists, optional staleness check on the source state).
+3. Server returns the proposal payload to the browser, which executes it via the existing `executeCmsTool` path under the user's auth.
+4. On success, server marks the comment `status: 'applied'`, records `appliedBy` / `appliedAt`, and writes a `TaskEvent`.
+5. Audit reads cleanly: *User X approved Agent Y's proposal Z, applied by User X*.
+
+Proposal comments render with a distinct affordance (icon + diff summary + Apply / Reject buttons), modelled in `ProposalComment.tsx`.
+
+### Worker
+
+The agent loop must run somewhere a browser isn't. The constraint is no new 3p infrastructure, but Root sites already deploy on Firebase / App Engine / Cloud Run, so platform-native triggers and listeners are fair game.
+
+Two implementations sit behind one `AgentWorker` interface:
+
+**Persistent worker** (Cloud Run with `min-instances: 1`, App Engine Flex, GKE, VMs):
+- In-process Firestore `onSnapshot` listener filtered to tasks with `assignee` matching `agent:*` and `agentRun.status: 'idle'`.
+- Claims tasks with a transactional lease (`leasedBy: <instanceId>`, `leasedAt: <ts>`). Lease expires after N minutes so a dead replica releases its claim.
+- Runs the agent loop to completion; updates tokens used; posts comments and reactions as it goes.
+
+**Triggered worker** (Firebase Functions, App Engine Standard):
+- Firestore-trigger 2nd-gen Cloud Function on `Projects/{p}/Tasks/{t}` writes.
+- Wakes when a task's `agentRun.status` flips to `idle` with an agent assignee.
+- Runs the agent loop within the function's timeout (9 min for v2 background functions).
+- If the run exceeds the timeout, the task is marked `errored` and a human re-trigger is required.
+
+Both implementations share the same loop body in `packages/root-cms/core/agents/runner.ts` (a thin wrapper around `ToolLoopAgent`). The harness is selected by `root.config` (`agents.worker: 'persistent' | 'triggered' | 'auto'`); `auto` detects the platform.
+
+For v0 we ship the **persistent** worker only. Triggered worker is a later add.
+
+### Resume policy
+
+Failed runs require **human re-trigger** (option (c)). No checkpointing.
+
+If a worker dies mid-run:
+- Lease expires after the lease TTL.
+- Task surfaces with `agentRun.status: 'errored'` and `lastError` set.
+- UI shows a "Retry" button on the task; clicking it resets `status` to `idle` so the worker re-claims.
+- Each retry runs from scratch. Already-posted proposals remain visible.
+
+### Subagents within a run vs. subtasks across runs
+
+Two patterns, kept separate to avoid coupling:
+
+- **Tool-call subagent** (in-run): The active agent invokes another agent via a tool whose `execute` calls a child `ToolLoopAgent`. ai-sdk v6's subagent pattern with `toModelOutput` for context isolation. No new task is created; the subagent's work is reflected in the parent's transcript only as a summary.
+- **Subtask** (cross-run): The active agent calls `createSubtask({title, description, assignee, ...})` to file a new `Task` with `parentTaskId` set. **Fire-and-forget** — the parent agent does not wait. The child task wakes the worker on its own. Parents post a "Filed subtask: ..." comment on themselves so the human can follow the thread.
+
+The rule of thumb: if a human needs to see or approve the intermediate step, it's a subtask. Otherwise it's a tool-call subagent.
+
+### Reactions
+
+Tight emoji set used by agents to communicate progress without flooding the comment thread:
+
+| Emoji | Meaning                                   |
+| ----- | ----------------------------------------- |
+| 👀    | Acknowledged, starting work.              |
+| 🤔    | Working / mid-research.                   |
+| 💬    | Posted a proposal or substantive comment. |
+| ✅    | Done.                                     |
+| ⚠️    | Needs human input (e.g., ambiguous).      |
+| ❌    | Errored / cannot complete.                |
+
+Stored as `Comment.reactions[emoji]: string[]`. The first comment in an agent run gets the `👀`; subsequent reactions are added to existing comments rather than spawning new ones where possible, to keep the thread terse.
+
+### Token budget + kill switch
+
+- Per-agent default `maxTokensPerTask` set in `defineAgent`. Per-task override allowed.
+- Worker tracks cumulative input + output tokens across all steps and subagents in the current run.
+- Exceeding the cap halts the run, posts a `❌ Token budget exceeded` reaction, and marks `agentRun.status: 'errored'`.
+- Kill switch on the task UI: a **Cancel run** button sets `agentRun.status: 'cancelled'`. Worker checks this between steps and exits cleanly.
+
+### Chat → Task conversion
+
+A "Convert to Task" button in `ChatPanel.tsx`:
+
+1. Calls `/cms/api/chat.convertToTask` with the active chat ID.
+2. Server creates a new Task. The chat's first user message becomes the task title (truncated). The full conversation is rendered as the seed comment (markdown, with tool calls collapsed).
+3. The user is offered an assignee picker (humans + available agents) on conversion. If an agent is selected, the task starts with `agentRun.status: 'idle'` and the worker picks it up.
+4. The original chat is preserved with `Task.sourceChatId` linking back to it.
+
+### `@`-mentions and agent visibility in chat
+
+Agents are first-class mention targets in the chat input alongside humans. `TaskCommentInput`'s mention parser (`extractMentions.ts`) extends to recognize `@<agent-name>`.
+
+For discoverability, the chat header shows an **Agents** button that opens a popover listing every agent in the project (icon + name + description). Selecting one inserts an `@`-mention. This both teaches the user what agents exist and provides a mouse-driven path; `@` autocomplete remains the keyboard path.
+
+`@`-mentioning an agent in the chat does **not** start an agent run on its own — the chat is still a synchronous, browser-executed session. It does pre-select the agent as the suggested assignee for "Convert to Task."
+
+## File-level changes
+
+New:
+- `packages/root-cms/core/agents/types.ts` — types for `Agent`, `AgentRunMetadata`, `TaskProposal`, `ToolBundle`.
+- `packages/root-cms/core/agents/define.ts` — `defineAgent()` API.
+- `packages/root-cms/core/agents/registry.ts` — virtual module loader and runtime registry.
+- `packages/root-cms/core/agents/runner.ts` — agent loop using `ToolLoopAgent`.
+- `packages/root-cms/core/agents/tools-server.ts` — server-side `execute` for read bundle.
+- `packages/root-cms/core/agents/tools-propose.ts` — `proposeChange`, `createSubtask` definitions.
+- `packages/root-cms/core/agents/worker-persistent.ts` — in-process listener implementation.
+- `packages/root-cms/core/agents/budget.ts` — token tracking and cap enforcement.
+- `packages/root/src/node/agents-vite-plugin.ts` — `virtual:root/agents`.
+- `packages/root-cms/ui/components/AgentPicker/` — list/select agents.
+- `packages/root-cms/ui/components/AgentMention/` — `@` autocomplete extension.
+- `packages/root-cms/ui/components/ProposalComment/` — proposal renderer + Apply / Reject.
+- `packages/root-cms/ui/components/CommentReactions/` — emoji reactions row.
+
+Modified:
+- `packages/root-cms/ui/utils/tasks.ts` — schema additions (`reactions`, `proposal`, `parentTaskId`, `sourceChatId`, `agentRun`).
+- `packages/root-cms/core/api.ts` — endpoints: `chat.convertToTask`, `proposal.apply`, `proposal.reject`, `task.cancelRun`, `task.retryRun`.
+- `packages/root-cms/core/ai-tools.ts` — split server vs schema-only registrations for the read bundle.
+- `packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx` — Convert to Task button, agent picker integration.
+- `packages/root-cms/ui/pages/TaskPage/TaskPage.tsx` — agent assignee rendering, kill switch, retry button, proposal comment rendering.
+- `packages/root-cms/ui/components/TaskCommentInput/extractMentions.ts` — agent name recognition.
+
+## Verification
+
+- E2E: convert a chat to a task with `agent:content-manager` assigned. Observe `👀` reaction, then a `proposeChange` comment with diff. Click Apply; verify the doc is updated and the comment marks `status: 'applied'` with the user as `appliedBy`.
+- Unit: `tools-server.test.ts` covers read bundle execute paths against a mocked `RootCMSClient`. `runner.test.ts` covers loop control, budget enforcement, and lease handling.
+- Integration: stand up the persistent worker against a Firestore emulator; assign a task; assert the lease is taken, comments accumulate, and on completion `agentRun.status: 'idle'`.
+- Permissions: an agent attempting a mutation directly (rather than via `proposeChange`) is rejected at the tool layer because mutating tools have no server-side `execute`.
+- Token cap: configure `maxTokensPerTask: 1_000`; assert the run halts and `❌ Token budget exceeded` reaction appears.
+
+## Migration / rollout
+
+- Behind `experimental.aiAgents` flag in `root.config`.
+- Schema additions are all optional — existing tasks and comments work unchanged.
+- Worker starts only when the flag is on and at least one agent is registered.
+- Existing chat sessions and existing tasks are unaffected.
+
+## Open questions / future work
+
+Out of scope for v0:
+- Triggered (Firebase Functions) worker implementation.
+- Multi-step proposals that apply atomically (transactional batch).
+- Agent learning / feedback loop from approved vs. rejected proposals.
+- Cross-project agent sharing.
+- Voice / audio input on tasks.
+
+## Resolved decisions
+
+| Question                                  | Decision                                            |
+| ----------------------------------------- | --------------------------------------------------- |
+| Agents write code?                        | No. Agents advise; engineers edit code.             |
+| Read-only auto-approves?                  | Yes.                                                |
+| Mutating ops?                             | Posted as proposals; humans apply under their auth. |
+| Where does the worker run?                | In-process listener for v0; trigger function later. |
+| Resume policy on worker death?            | Human re-trigger; no automatic resume.              |
+| Reaction set?                             | `👀 🤔 💬 ✅ ⚠️ ❌`.                              |
+| Agent definition format?                  | TS file + Markdown body imported as `?raw`.         |
+| Tool surface granularity?                 | Bundles (`read`, `propose`, `subtask`).             |
+| Subtask blocking?                         | Fire-and-forget. Parents do not wait.               |
+| `@`-mention?                              | Yes, plus an agent list popover in the chat header. |
+| Token cap?                                | Per-task, configurable in `defineAgent`.            |
+| Kill switch?                              | Cancel-run button on the task UI.                   |
+| Configured by whom?                       | Repo developers only. No CMS-managed agents in v0.  |
+| Project scope?                            | Scoped per project (one CMS per site).              |

--- a/packages/root-cms/ui/utils/tasks.ts
+++ b/packages/root-cms/ui/utils/tasks.ts
@@ -33,10 +33,93 @@ export interface Task {
   createdBy: string;
   updatedAt?: Timestamp;
   updatedBy?: string;
+  /** Optional link to a parent task; set when this task was filed by an agent as a subtask. */
+  parentTaskId?: string | null;
+  /** Optional link to the AI chat session that this task was converted from. */
+  sourceChatId?: string | null;
+  /** Agent run state, present when the assignee is `agent:<name>`. */
+  agentRun?: AgentRunMetadata;
 }
 
 export type TaskPriority = 'high' | 'medium' | 'normal';
 export type TaskUnsubscribe = () => void;
+
+/**
+ * Agent assignees use the form `agent:<name>` (e.g. `agent:content-manager`)
+ * to distinguish them from human assignees, which are emails.
+ */
+export const AGENT_ASSIGNEE_PREFIX = 'agent:';
+
+/**
+ * Returns the agent name for an `agent:<name>` assignee, or null for humans.
+ */
+export function getAgentAssigneeName(assignee?: string | null): string | null {
+  if (!assignee || !assignee.startsWith(AGENT_ASSIGNEE_PREFIX)) {
+    return null;
+  }
+  return assignee.slice(AGENT_ASSIGNEE_PREFIX.length) || null;
+}
+
+/**
+ * Tracks the lifecycle of a single agent run on a task. Workers update this via
+ * Firestore transactions; the UI reads it to render run status and surface
+ * cancel/retry affordances.
+ */
+export interface AgentRunMetadata {
+  /** Run lifecycle state. */
+  status: 'idle' | 'running' | 'errored' | 'cancelled';
+  /** Worker instance that holds the lease, or null when idle. */
+  leasedBy?: string | null;
+  /** Lease acquisition timestamp; consumers may treat stale leases as expired. */
+  leasedAt?: Timestamp | null;
+  /** Cumulative tokens consumed across all steps in the current run. */
+  tokensUsed?: number;
+  /** Per-task token budget; the run halts when `tokensUsed` exceeds this. */
+  tokensCap?: number;
+  /** Last error message when status is `errored`. */
+  lastError?: string | null;
+  /** Timestamp the run last transitioned state. */
+  updatedAt?: Timestamp | null;
+}
+
+/**
+ * Tight emoji set used for reactions on task comments. Agents post reactions
+ * to communicate progress without spawning new comments.
+ */
+export const TASK_COMMENT_REACTIONS = [
+  '👀',
+  '🤔',
+  '💬',
+  '✅',
+  '⚠️',
+  '❌',
+] as const;
+
+export type TaskCommentReaction = (typeof TASK_COMMENT_REACTIONS)[number];
+
+/**
+ * A structured proposal posted by an agent. Proposals carry the intended
+ * mutating tool call; the actual mutation runs only after a human clicks
+ * "Apply" and the call is executed under their Firebase auth.
+ */
+export interface TaskProposal {
+  /** The mutating tool the agent wants to invoke (e.g. `update_doc`). */
+  tool: string;
+  /** Input that will be passed to the tool when applied. */
+  input: Record<string, unknown>;
+  /** Human-readable explanation surfaced in the proposal comment. */
+  rationale?: string;
+  /** Pre-rendered diff summary (markdown) shown to reviewers. */
+  diffSummary?: string;
+  /** Lifecycle state; transitions one-way from `pending`. */
+  status: 'pending' | 'applied' | 'rejected' | 'expired';
+  /** Email of the human who applied or rejected the proposal. */
+  appliedBy?: string;
+  /** Timestamp the proposal was applied or rejected. */
+  appliedAt?: Timestamp;
+  /** Optional error message recorded if Apply failed. */
+  applyError?: string | null;
+}
 
 export interface TaskAttachment extends UploadedFile {
   id: string;
@@ -70,6 +153,16 @@ export interface TaskComment {
   deletedBy?: string;
   isDeleted?: boolean;
   history?: TaskCommentHistoryEntry[];
+  /**
+   * Emoji reactions keyed by emoji; values are the reactor identifiers
+   * (lower-cased emails for humans, `agent:<name>` for agents).
+   */
+  reactions?: Record<string, string[]>;
+  /**
+   * Present on proposal comments posted by agents. The mutation only runs
+   * after a human applies the proposal under their Firebase auth.
+   */
+  proposal?: TaskProposal;
 }
 
 export type TaskMetadataField =
@@ -798,4 +891,92 @@ export async function deleteTaskComment(taskId: string, commentId: string) {
   logAction('tasks.comment.delete', {
     metadata: {taskId, commentId},
   });
+}
+
+/**
+ * Toggles a reaction on a task comment for the current user. Adds the user as
+ * a reactor if absent; removes them if already present.
+ */
+export async function toggleTaskCommentReaction(
+  taskId: string,
+  commentId: string,
+  emoji: TaskCommentReaction
+) {
+  if (!taskId || !commentId) {
+    throw new Error('missing task or comment id');
+  }
+  const reactor = (window.firebase.user.email || '').toLowerCase();
+  if (!reactor) {
+    throw new Error('missing user');
+  }
+
+  const db = window.firebase.db;
+  const commentRef = taskCommentDocRef(taskId, commentId);
+  await runTransaction(db, async (transaction) => {
+    const snapshot = await transaction.get(commentRef);
+    if (!snapshot.exists()) {
+      throw new Error('comment not found');
+    }
+    const data = snapshot.data() as TaskComment;
+    const reactions = {...(data.reactions || {})};
+    const reactors = new Set<string>(reactions[emoji] || []);
+    if (reactors.has(reactor)) {
+      reactors.delete(reactor);
+    } else {
+      reactors.add(reactor);
+    }
+    if (reactors.size === 0) {
+      delete reactions[emoji];
+    } else {
+      reactions[emoji] = Array.from(reactors);
+    }
+    transaction.update(commentRef, {reactions});
+  });
+
+  logAction('tasks.comment.reaction', {
+    metadata: {taskId, commentId, emoji},
+  });
+}
+
+/**
+ * Cancels an in-flight agent run on a task. The worker observes the status
+ * change between steps and exits cleanly. Failed cancels (no run in flight)
+ * are a no-op.
+ */
+export async function cancelTaskAgentRun(taskId: string) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const taskRef = taskDocRef(taskId);
+  const userEmail = window.firebase.user.email || '';
+  await updateDoc(taskRef, {
+    'agentRun.status': 'cancelled',
+    'agentRun.updatedAt': serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    updatedBy: userEmail,
+  });
+  logAction('tasks.agentRun.cancel', {metadata: {taskId}});
+}
+
+/**
+ * Resets an errored or cancelled agent run so a worker can re-claim the task.
+ * Used by the "Retry" button on the task UI.
+ */
+export async function retryTaskAgentRun(taskId: string) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const taskRef = taskDocRef(taskId);
+  const userEmail = window.firebase.user.email || '';
+  await updateDoc(taskRef, {
+    'agentRun.status': 'idle',
+    'agentRun.leasedBy': null,
+    'agentRun.leasedAt': null,
+    'agentRun.lastError': null,
+    'agentRun.tokensUsed': 0,
+    'agentRun.updatedAt': serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    updatedBy: userEmail,
+  });
+  logAction('tasks.agentRun.retry', {metadata: {taskId}});
 }

--- a/packages/root-cms/vitest.config.ts
+++ b/packages/root-cms/vitest.config.ts
@@ -6,11 +6,15 @@ function stubVirtualModules(): Plugin {
     name: 'stub-virtual-modules',
     resolveId(id) {
       if (id === 'virtual:root/schemas') return '\0virtual:root/schemas';
+      if (id === 'virtual:root/agents') return '\0virtual:root/agents';
       return null;
     },
     load(id) {
       if (id === '\0virtual:root/schemas') {
         return 'export const SCHEMA_MODULES = {};';
+      }
+      if (id === '\0virtual:root/agents') {
+        return 'export const AGENT_MODULES = {};';
       }
       return null;
     },

--- a/packages/root/src/node/pods-vite-plugin.ts
+++ b/packages/root/src/node/pods-vite-plugin.ts
@@ -8,10 +8,12 @@ import {collectPods, invalidatePodCache, ResolvedPod} from './pod-collector.js';
 export const VIRTUAL_ROUTES_ID = 'virtual:root/routes';
 export const VIRTUAL_SCHEMAS_ID = 'virtual:root/schemas';
 export const VIRTUAL_TRANSLATIONS_ID = 'virtual:root/translations';
+export const VIRTUAL_AGENTS_ID = 'virtual:root/agents';
 
 const RESOLVED_VIRTUAL_ROUTES = '\0' + VIRTUAL_ROUTES_ID;
 const RESOLVED_VIRTUAL_SCHEMAS = '\0' + VIRTUAL_SCHEMAS_ID;
 const RESOLVED_VIRTUAL_TRANSLATIONS = '\0' + VIRTUAL_TRANSLATIONS_ID;
+const RESOLVED_VIRTUAL_AGENTS = '\0' + VIRTUAL_AGENTS_ID;
 
 export function rootPodsVitePlugin(rootConfig: RootConfig): VitePlugin {
   let podsPromise: Promise<ResolvedPod[]> | null = null;
@@ -31,6 +33,7 @@ export function rootPodsVitePlugin(rootConfig: RootConfig): VitePlugin {
       if (id === VIRTUAL_ROUTES_ID) return RESOLVED_VIRTUAL_ROUTES;
       if (id === VIRTUAL_SCHEMAS_ID) return RESOLVED_VIRTUAL_SCHEMAS;
       if (id === VIRTUAL_TRANSLATIONS_ID) return RESOLVED_VIRTUAL_TRANSLATIONS;
+      if (id === VIRTUAL_AGENTS_ID) return RESOLVED_VIRTUAL_AGENTS;
       return null;
     },
 
@@ -44,11 +47,16 @@ export function rootPodsVitePlugin(rootConfig: RootConfig): VitePlugin {
       if (id === RESOLVED_VIRTUAL_TRANSLATIONS) {
         return buildTranslationsModule(rootConfig, await getPods());
       }
+      if (id === RESOLVED_VIRTUAL_AGENTS) {
+        return buildAgentsModule(rootConfig);
+      }
       return null;
     },
 
     configureServer(server) {
       const watchDirs: string[] = [];
+      const userAgentsDir = path.join(rootConfig.rootDir, 'agents');
+      watchDirs.push(userAgentsDir);
       getPods().then((pods) => {
         for (const pod of pods) {
           if (pod.routesDir) watchDirs.push(pod.routesDir);
@@ -71,6 +79,7 @@ export function rootPodsVitePlugin(rootConfig: RootConfig): VitePlugin {
           RESOLVED_VIRTUAL_ROUTES,
           RESOLVED_VIRTUAL_SCHEMAS,
           RESOLVED_VIRTUAL_TRANSLATIONS,
+          RESOLVED_VIRTUAL_AGENTS,
         ];
         for (const modId of mods) {
           const mod = server.moduleGraph.getModuleById(modId);
@@ -225,6 +234,43 @@ async function scanRootSchemaFiles(rootDir: string): Promise<string[]> {
     const normalized = file.replace(/\\/g, '/');
     return !excludeDirs.some((dir) => normalized.startsWith(dir + '/'));
   });
+}
+
+async function buildAgentsModule(rootConfig: RootConfig): Promise<string> {
+  const rootDir = rootConfig.rootDir;
+  const imports: string[] = [];
+  const entries: string[] = [];
+  let idx = 0;
+
+  const agentsDir = path.join(rootDir, 'agents');
+  if (await isDirectory(agentsDir)) {
+    const files = await glob('**/*.{ts,tsx,js,jsx,mjs}', {cwd: agentsDir});
+    for (const file of files) {
+      const parts = path.parse(file);
+      // Skip test files, type-declaration files, and underscore-prefixed
+      // module names (the established convention for "private" modules).
+      if (
+        parts.name.startsWith('_') ||
+        parts.name.endsWith('.test') ||
+        parts.name.endsWith('.spec') ||
+        parts.name.endsWith('.d')
+      ) {
+        continue;
+      }
+      const modulePath = `/agents/${file.replace(/\\/g, '/')}`;
+      const varName = `_a${idx++}`;
+      imports.push(`import * as ${varName} from '${modulePath}';`);
+      entries.push(`  '${modulePath}': ${varName},`);
+    }
+  }
+
+  return [
+    ...imports,
+    '',
+    'export const AGENT_MODULES = {',
+    ...entries,
+    '};',
+  ].join('\n');
 }
 
 async function buildTranslationsModule(


### PR DESCRIPTION
## Summary

First of four stacked PRs delivering a unified Root AI ↔ Task Manager flow where site-defined agents pick up tasks, post proposals, and humans apply them under their own auth. Full design at [`packages/root-cms/docs/design/ai-agents.md`](../blob/claude/ai-agents-01-foundations/packages/root-cms/docs/design/ai-agents.md).

This PR is **scaffolding only** — no user-visible behavior changes. Adds:

- **`defineAgent()`** API exported from `@blinkk/root-cms`. Validates and normalizes site-authored agent declarations.
- **`virtual:root/agents`** Vite virtual module discovering `<rootDir>/agents/*.{ts,tsx,js,jsx,mjs}` (parallels the existing `virtual:root/schemas`).
- **Agent registry** (`loadAgents`, `getAgent`) for server-side consumers (runner, API endpoints, worker).
- **Task data model additions**, all optional and additive:
  - `Task.parentTaskId`, `Task.sourceChatId`, `Task.agentRun` (lifecycle metadata)
  - `TaskComment.reactions` (tight emoji set: 👀 🤔 💬 ✅ ⚠️ ❌)
  - `TaskComment.proposal` (structured payload for human Apply flow)
- **Helpers** for reaction toggling and agent-run cancel/retry in `ui/utils/tasks.ts`.
- **Design doc** at `packages/root-cms/docs/design/ai-agents.md` covering the full rollout plan.

## Stack

1. **This PR** — Foundations
2. PR 2 — Server-side read tools, propose/subtask tools, runner + budget
3. PR 3 — Persistent worker, apply/reject/cancel/retry endpoints, ProposalComment + reactions UI, kill switch
4. PR 4 — Chat integration: Convert-to-Task button, AgentPicker, `@`-mention extension

## Non-goals (called out in design doc)

- Agents do **not** write code. Engineers edit code; agents advise.
- Mutations are posted as proposals; humans apply under their Firebase auth. No agent service accounts, no server-side write authority.
- No new third-party infrastructure. Worker (PR 3) runs in-process via Firestore listener.

## Test plan

- [x] `pnpm exec vitest run core/agents/` — 18 tests passing across `define.test.ts` and `registry.test.ts`
- [x] `pnpm build:core` — ESM and DTS builds clean
- [x] `pnpm build:ui` — UI bundle clean (`tasks.ts` schema additions compile)
- [x] `pnpm eslint` on all modified files — clean (the 2 errors on `pods-vite-plugin.ts` are pre-existing on alpha)
- [ ] End-to-end exercise comes in PR 4 once the full flow is wired

## Notes for review

- The `virtual:root/agents` plugin uses `// @ts-expect-error` on the dynamic import, mirroring the existing pattern in `core/project.ts` for `virtual:root/schemas`.
- vitest config stubs both virtual modules; `tsup.config.ts` already excludes `/^virtual:/` so no build config change was needed.
- `AgentRunMetadata.status` includes `'cancelled'` so the kill switch (PR 3) can transition without a separate field.

https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV

---
_Generated by [Claude Code](https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV)_