### PR TITLE
feat(cms): Root AI agents — worker, apply flow, run controls UI (3/4)

### DIFF
--- a/packages/root-cms/core/agents/agents-api.ts
+++ b/packages/root-cms/core/agents/agents-api.ts
@@ -1,0 +1,265 @@
+/**
+ * Express handlers for agent-related endpoints. Mounted from `api.ts` under
+ * `/cms/api/agents.*`. All endpoints require an authenticated user.
+ *
+ * Endpoint summary:
+ *
+ *   GET  /cms/api/agents.list            — list registered agents (for pickers).
+ *   POST /cms/api/agents.proposalApply   — return the validated tool call payload
+ *                                           so the browser can execute it under
+ *                                           the user's auth, then mark applied.
+ *   POST /cms/api/agents.proposalReject  — mark a proposal rejected.
+ *   POST /cms/api/agents.taskCancelRun   — cancel an in-flight agent run.
+ *   POST /cms/api/agents.taskRetryRun    — reset an errored/cancelled run.
+ */
+
+import type {Server, Request, Response} from '@blinkk/root';
+import {FieldValue} from 'firebase-admin/firestore';
+import {RootCMSClient} from '../client.js';
+import {loadAgents} from './registry.js';
+import {PROPOSAL_TARGET_TOOLS} from './tools-propose.js';
+
+const PROPOSAL_TARGET_SET: ReadonlySet<string> = new Set(PROPOSAL_TARGET_TOOLS);
+
+/**
+ * Registers all agent-related API endpoints on the server.
+ */
+export function registerAgentApi(server: Server) {
+  /**
+   * Lists registered agents for the agent picker. Strips `systemPrompt`
+   * from the response since it can be long and isn't needed in the UI.
+   */
+  server.use('/cms/api/agents.list', async (req: Request, res: Response) => {
+    if (!req.user?.email) {
+      res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      return;
+    }
+    try {
+      const agents = await loadAgents();
+      const list = Array.from(agents.values()).map((agent) => ({
+        name: agent.name,
+        icon: agent.icon,
+        description: agent.description,
+        allowedTools: agent.allowedTools,
+      }));
+      res.status(200).json({success: true, agents: list});
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : 'UNKNOWN',
+      });
+    }
+  });
+
+  /**
+   * Returns the validated proposal payload so the browser can execute it.
+   * Marks the comment's proposal status `applied` once the browser reports
+   * success via PATCH (handled in the same endpoint with `outcome: 'success'`
+   * or `outcome: 'error'`).
+   */
+  server.use(
+    '/cms/api/agents.proposalApply',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const body = req.body || {};
+      const {taskId, commentId, outcome, error} = body;
+      if (!taskId || !commentId) {
+        res
+          .status(400)
+          .json({success: false, error: 'MISSING_TASK_OR_COMMENT'});
+        return;
+      }
+
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const commentRef = cmsClient.db.doc(
+        `Projects/${cmsClient.projectId}/Tasks/${taskId}/Comments/${commentId}`
+      );
+      const snap = await commentRef.get();
+      if (!snap.exists) {
+        res.status(404).json({success: false, error: 'COMMENT_NOT_FOUND'});
+        return;
+      }
+      const data = snap.data() || {};
+      const proposal = data.proposal as
+        | {tool?: string; input?: unknown; status?: string}
+        | undefined;
+      if (!proposal) {
+        res.status(400).json({success: false, error: 'NOT_A_PROPOSAL'});
+        return;
+      }
+
+      // Two flows: (1) initial GET-style call returns the payload to execute;
+      // (2) browser POSTs back `outcome` after running it under the user's
+      // auth so we can finalize the status. Both share this endpoint to keep
+      // the surface tight.
+      if (outcome === 'success') {
+        if (proposal.status !== 'pending') {
+          res.status(409).json({success: false, error: 'PROPOSAL_NOT_PENDING'});
+          return;
+        }
+        await commentRef.update({
+          'proposal.status': 'applied',
+          'proposal.appliedBy': req.user.email,
+          'proposal.appliedAt': FieldValue.serverTimestamp(),
+          'proposal.applyError': null,
+        });
+        res.status(200).json({success: true, applied: true});
+        return;
+      }
+
+      if (outcome === 'error') {
+        await commentRef.update({
+          'proposal.applyError': String(error || 'unknown error'),
+        });
+        res.status(200).json({success: true, recorded: true});
+        return;
+      }
+
+      // Default flow: prepare-to-apply. Validate the proposal and return the
+      // payload the browser should execute.
+      if (proposal.status !== 'pending') {
+        res.status(409).json({success: false, error: 'PROPOSAL_NOT_PENDING'});
+        return;
+      }
+      if (!proposal.tool || !PROPOSAL_TARGET_SET.has(proposal.tool)) {
+        res.status(400).json({success: false, error: 'UNSUPPORTED_TOOL'});
+        return;
+      }
+      res.status(200).json({
+        success: true,
+        toolName: proposal.tool,
+        input: proposal.input || {},
+      });
+    }
+  );
+
+  /**
+   * Marks a pending proposal as rejected without applying it. Useful when
+   * the reviewer disagrees with the agent's suggestion.
+   */
+  server.use(
+    '/cms/api/agents.proposalReject',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const {taskId, commentId} = req.body || {};
+      if (!taskId || !commentId) {
+        res
+          .status(400)
+          .json({success: false, error: 'MISSING_TASK_OR_COMMENT'});
+        return;
+      }
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const commentRef = cmsClient.db.doc(
+        `Projects/${cmsClient.projectId}/Tasks/${taskId}/Comments/${commentId}`
+      );
+      const snap = await commentRef.get();
+      if (!snap.exists) {
+        res.status(404).json({success: false, error: 'COMMENT_NOT_FOUND'});
+        return;
+      }
+      const data = snap.data() || {};
+      const proposal = data.proposal as {status?: string} | undefined;
+      if (!proposal) {
+        res.status(400).json({success: false, error: 'NOT_A_PROPOSAL'});
+        return;
+      }
+      if (proposal.status !== 'pending') {
+        res.status(409).json({success: false, error: 'PROPOSAL_NOT_PENDING'});
+        return;
+      }
+      await commentRef.update({
+        'proposal.status': 'rejected',
+        'proposal.appliedBy': req.user.email,
+        'proposal.appliedAt': FieldValue.serverTimestamp(),
+      });
+      res.status(200).json({success: true});
+    }
+  );
+
+  /**
+   * Cancels an in-flight agent run. Worker observes the status flip
+   * between steps and exits cleanly.
+   */
+  server.use(
+    '/cms/api/agents.taskCancelRun',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const {taskId} = req.body || {};
+      if (!taskId) {
+        res.status(400).json({success: false, error: 'MISSING_TASK_ID'});
+        return;
+      }
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const taskRef = cmsClient.db.doc(
+        `Projects/${cmsClient.projectId}/Tasks/${taskId}`
+      );
+      await taskRef.update({
+        'agentRun.status': 'cancelled',
+        'agentRun.updatedAt': FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: req.user.email,
+      });
+      res.status(200).json({success: true});
+    }
+  );
+
+  /**
+   * Resets an errored or cancelled run so a worker can re-claim. Each
+   * retry runs from scratch — no checkpointing.
+   */
+  server.use(
+    '/cms/api/agents.taskRetryRun',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const {taskId} = req.body || {};
+      if (!taskId) {
+        res.status(400).json({success: false, error: 'MISSING_TASK_ID'});
+        return;
+      }
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const taskRef = cmsClient.db.doc(
+        `Projects/${cmsClient.projectId}/Tasks/${taskId}`
+      );
+      await taskRef.update({
+        'agentRun.status': 'idle',
+        'agentRun.leasedBy': null,
+        'agentRun.leasedAt': null,
+        'agentRun.lastError': null,
+        'agentRun.tokensUsed': 0,
+        'agentRun.updatedAt': FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: req.user.email,
+      });
+      res.status(200).json({success: true});
+    }
+  );
+}

--- a/packages/root-cms/core/agents/index.ts
+++ b/packages/root-cms/core/agents/index.ts
@@ -1,5 +1,14 @@
+export {registerAgentApi} from './agents-api.js';
 export {defineAgent} from './define.js';
 export {getAgent, loadAgents, _resetAgentRegistryForTests} from './registry.js';
+export {
+  AgentWorker,
+  LEASE_TTL_MS,
+  buildAgentPrompt,
+  ensureAgentWorker,
+  _resetSharedAgentWorkerForTests,
+} from './worker.js';
+export type {AgentWorkerOptions} from './worker.js';
 export {AGENT_ASSIGNEE_PREFIX, getAgentAssignee} from './run-context.js';
 export type {AgentRunContext} from './run-context.js';
 export {TokenBudget, type TokenBudgetSnapshot} from './budget.js';

--- a/packages/root-cms/core/agents/worker.test.ts
+++ b/packages/root-cms/core/agents/worker.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the deterministic helpers in `worker.ts`. The full lease /
+ * snapshot integration is exercised via the emulator-backed harness when
+ * the user runs the end-to-end flow.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {buildAgentPrompt} from './worker.js';
+
+describe('buildAgentPrompt', () => {
+  it('combines title and description into a markdown prompt', () => {
+    expect(
+      buildAgentPrompt({
+        title: 'Translate the homepage',
+        description: 'Localize EN -> FR.',
+      })
+    ).toBe('# Translate the homepage\n\nLocalize EN -> FR.');
+  });
+
+  it('omits description when missing', () => {
+    expect(buildAgentPrompt({title: 'Just a title'})).toBe('# Just a title');
+  });
+
+  it('omits title heading when only description is set', () => {
+    expect(buildAgentPrompt({description: 'desc only'})).toBe('desc only');
+  });
+
+  it('falls back to a generic instruction when both are empty', () => {
+    expect(buildAgentPrompt({})).toMatch(/Investigate this task/);
+  });
+
+  it('trims whitespace', () => {
+    expect(
+      buildAgentPrompt({title: '   spaced   ', description: '   body   '})
+    ).toBe('# spaced\n\nbody');
+  });
+});

--- a/packages/root-cms/core/agents/worker.ts
+++ b/packages/root-cms/core/agents/worker.ts
@@ -1,0 +1,299 @@
+/**
+ * Persistent in-process agent worker. Runs in the same Node process that
+ * serves the CMS, listening for tasks with `agentRun.status: 'idle'` and an
+ * `agent:*` assignee, then leases and runs them via `runAgent()`.
+ *
+ * Designed for hosting targets that keep the Node process warm: Cloud Run
+ * with `min-instances >= 1`, App Engine Flex, GKE, or VMs. Does NOT work on
+ * App Engine Standard or short-lived Cloud Functions where the process
+ * terminates between requests; those targets need a Firestore-trigger
+ * variant (out of scope for v0; see the design doc).
+ */
+
+import {randomUUID} from 'node:crypto';
+import type {RootConfig} from '@blinkk/root';
+import {FieldValue, Timestamp} from 'firebase-admin/firestore';
+import {findModel, getAiConfig, type AiConfig} from '../ai-chat.js';
+import {RootCMSClient} from '../client.js';
+import {loadAgents} from './registry.js';
+import {AGENT_ASSIGNEE_PREFIX, type AgentRunContext} from './run-context.js';
+import {runAgent} from './runner.js';
+import type {AgentDefinition} from './types.js';
+
+/** How long a worker can hold a task lease before another worker may steal it. */
+export const LEASE_TTL_MS = 15 * 60 * 1000;
+
+export interface AgentWorkerOptions {
+  /**
+   * Stable identifier for this worker instance. Defaults to a per-process
+   * UUID. Used as the lease holder so dead replicas can be detected.
+   */
+  instanceId?: string;
+  /**
+   * Maximum concurrent agent runs per process. Defaults to 3 — enough to
+   * keep a hot model warm, low enough to bound memory.
+   */
+  maxConcurrent?: number;
+  /**
+   * Override hook for tests: if provided, called instead of `runAgent`.
+   */
+  runner?: typeof runAgent;
+}
+
+/**
+ * In-process agent worker. Construct one per CMS server process and call
+ * `start()`. Idempotent — calling `start()` twice is a no-op.
+ */
+export class AgentWorker {
+  readonly instanceId: string;
+  private readonly rootConfig: RootConfig;
+  private readonly cmsClient: RootCMSClient;
+  private readonly aiConfig: AiConfig;
+  private readonly maxConcurrent: number;
+  private readonly runner: typeof runAgent;
+  private unsubscribe: (() => void) | null = null;
+  private readonly inflight = new Map<string, Promise<void>>();
+
+  constructor(rootConfig: RootConfig, options: AgentWorkerOptions = {}) {
+    this.instanceId = options.instanceId || randomUUID();
+    this.rootConfig = rootConfig;
+    this.cmsClient = new RootCMSClient(rootConfig);
+    const aiConfig = getAiConfig(rootConfig);
+    if (!aiConfig) {
+      throw new Error(
+        'AgentWorker: AI config is missing. The worker requires an AI model ' +
+          'so it can run the agent loop.'
+      );
+    }
+    this.aiConfig = aiConfig;
+    this.maxConcurrent = Math.max(1, options.maxConcurrent ?? 3);
+    this.runner = options.runner ?? runAgent;
+  }
+
+  /**
+   * Subscribes to the Tasks collection and starts processing. Safe to call
+   * multiple times — extra calls are no-ops.
+   */
+  start(): void {
+    if (this.unsubscribe) {
+      return;
+    }
+    const tasksRef = this.cmsClient.db.collection(
+      `Projects/${this.cmsClient.projectId}/Tasks`
+    );
+    // Filter on the run status server-side. Agent-only filtering happens
+    // in the snapshot handler since Firestore can't string-prefix-match
+    // alongside an equality on another field without a composite index.
+    const query = tasksRef.where('agentRun.status', '==', 'idle');
+    this.unsubscribe = query.onSnapshot(
+      (snapshot) => {
+        for (const change of snapshot.docChanges()) {
+          if (change.type === 'removed') {
+            continue;
+          }
+          this.maybeProcess(change.doc.id, change.doc.data());
+        }
+      },
+      (err) => {
+        console.error(`[AgentWorker:${this.instanceId}] snapshot error:`, err);
+      }
+    );
+  }
+
+  /** Tears down the listener. In-flight runs continue to completion. */
+  stop(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+
+  /** Returns the count of in-flight runs on this worker. Test helper. */
+  inflightCount(): number {
+    return this.inflight.size;
+  }
+
+  private maybeProcess(taskId: string, data: Record<string, unknown>): void {
+    if (this.inflight.has(taskId)) {
+      return;
+    }
+    if (this.inflight.size >= this.maxConcurrent) {
+      // Dropped pickup — another snapshot tick will re-deliver this task
+      // once a slot frees up.
+      return;
+    }
+    const assignee = String(data.assignee || '');
+    if (!assignee.startsWith(AGENT_ASSIGNEE_PREFIX)) {
+      return;
+    }
+    const promise = this.processTask(taskId, assignee).catch((err) => {
+      console.error(
+        `[AgentWorker:${this.instanceId}] task ${taskId} failed:`,
+        err
+      );
+    });
+    this.inflight.set(taskId, promise);
+    void promise.finally(() => {
+      this.inflight.delete(taskId);
+    });
+  }
+
+  private async processTask(taskId: string, assignee: string): Promise<void> {
+    const agentName = assignee.slice(AGENT_ASSIGNEE_PREFIX.length);
+    const agents = await loadAgents();
+    const agent = agents.get(agentName);
+    if (!agent) {
+      await this.markTaskErrored(
+        taskId,
+        `agent "${agentName}" is not registered`,
+        assignee
+      );
+      return;
+    }
+    const claimed = await this.claim(taskId);
+    if (!claimed) {
+      return;
+    }
+    await this.runClaimedTask(taskId, agent, assignee);
+  }
+
+  private async claim(taskId: string): Promise<boolean> {
+    const taskRef = this.cmsClient.db.doc(
+      `Projects/${this.cmsClient.projectId}/Tasks/${taskId}`
+    );
+    return this.cmsClient.db.runTransaction(async (txn) => {
+      const snap = await txn.get(taskRef);
+      if (!snap.exists) {
+        return false;
+      }
+      const data = snap.data() || {};
+      const agentRun = (data.agentRun as Record<string, unknown>) || {};
+      if (agentRun.status !== 'idle') {
+        // Status flipped between snapshot and claim — let the new owner have
+        // it (or wait for cancel/retry to flip it back to idle).
+        return false;
+      }
+      const leasedBy = agentRun.leasedBy as string | undefined;
+      const leasedAt = agentRun.leasedAt as Timestamp | undefined;
+      if (
+        leasedBy &&
+        leasedBy !== this.instanceId &&
+        leasedAt &&
+        Date.now() - leasedAt.toMillis() < LEASE_TTL_MS
+      ) {
+        // Held by another live replica.
+        return false;
+      }
+      txn.update(taskRef, {
+        'agentRun.leasedBy': this.instanceId,
+        'agentRun.leasedAt': FieldValue.serverTimestamp(),
+        'agentRun.status': 'running',
+        'agentRun.updatedAt': FieldValue.serverTimestamp(),
+      });
+      return true;
+    });
+  }
+
+  private async runClaimedTask(
+    taskId: string,
+    agent: AgentDefinition,
+    assignee: string
+  ): Promise<void> {
+    const taskRef = this.cmsClient.db.doc(
+      `Projects/${this.cmsClient.projectId}/Tasks/${taskId}`
+    );
+    const taskSnap = await taskRef.get();
+    const taskData = taskSnap.data() || {};
+    const prompt = buildAgentPrompt(taskData);
+
+    const model =
+      (agent.model && findModel(this.aiConfig, agent.model)) ||
+      findModel(this.aiConfig);
+    if (!model) {
+      await this.markTaskErrored(
+        taskId,
+        'no AI model configured to run the agent',
+        assignee
+      );
+      return;
+    }
+
+    const ctx: AgentRunContext = {
+      agent,
+      cmsClient: this.cmsClient,
+      db: this.cmsClient.db,
+      projectId: this.cmsClient.projectId,
+      taskId,
+      createdBy: assignee,
+    };
+
+    await this.runner({ctx, model, prompt});
+  }
+
+  private async markTaskErrored(
+    taskId: string,
+    error: string,
+    createdBy: string
+  ): Promise<void> {
+    const taskRef = this.cmsClient.db.doc(
+      `Projects/${this.cmsClient.projectId}/Tasks/${taskId}`
+    );
+    await taskRef.update({
+      'agentRun.status': 'errored',
+      'agentRun.lastError': error,
+      'agentRun.leasedBy': null,
+      'agentRun.leasedAt': null,
+      'agentRun.updatedAt': FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: createdBy,
+    });
+  }
+}
+
+/**
+ * Ensures a single `AgentWorker` is running for the current process. Idempotent:
+ * subsequent calls are no-ops once the worker has been started. Called from
+ * the CMS plugin's `configureServer` so the listener kicks in on the first
+ * authenticated CMS request.
+ *
+ * If AI is not configured, returns null without throwing — the worker is a
+ * silent no-op on projects that haven't enabled AI agents.
+ */
+let _sharedWorker: AgentWorker | null = null;
+export function ensureAgentWorker(rootConfig: RootConfig): AgentWorker | null {
+  if (_sharedWorker) {
+    return _sharedWorker;
+  }
+  if (!getAiConfig(rootConfig)) {
+    return null;
+  }
+  _sharedWorker = new AgentWorker(rootConfig);
+  _sharedWorker.start();
+  return _sharedWorker;
+}
+
+/** Test-only hook to reset the shared worker singleton. */
+export function _resetSharedAgentWorkerForTests() {
+  _sharedWorker?.stop();
+  _sharedWorker = null;
+}
+
+/** Builds the agent's first-turn user prompt from the task fields. */
+export function buildAgentPrompt(task: Record<string, unknown>): string {
+  const title = String(task.title || '').trim();
+  const description = String(task.description || '').trim();
+  const lines: string[] = [];
+  if (title) {
+    lines.push(`# ${title}`);
+  }
+  if (description) {
+    if (title) {
+      lines.push('');
+    }
+    lines.push(description);
+  }
+  if (lines.length === 0) {
+    lines.push('Investigate this task and propose next steps.');
+  }
+  return lines.join('\n');
+}

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -8,6 +8,7 @@ import {
   AiResponse,
   SendPromptOptions,
 } from '../shared/ai/prompts.js';
+import {registerAgentApi} from './agents/agents-api.js';
 import {
   ChatStore,
   findModel,
@@ -159,6 +160,9 @@ export interface ApiOptions {
  * Registers API middleware handlers.
  */
 export function api(server: Server, options: ApiOptions) {
+  // Mount agent endpoints (agents.list, proposalApply/Reject, taskCancelRun/RetryRun).
+  registerAgentApi(server);
+
   /**
    * Reads the collection's schema defined in `/collections/<id>.schema.ts`.
    */
@@ -890,7 +894,9 @@ export function api(server: Server, options: ApiOptions) {
       } catch (err: any) {
         console.error(err.stack || err);
         if (!res.headersSent) {
-          res.status(500).json({success: false, error: err.message || 'UNKNOWN'});
+          res
+            .status(500)
+            .json({success: false, error: err.message || 'UNKNOWN'});
         } else {
           res.end();
         }

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -902,6 +902,28 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         translations: options.translations,
       });
 
+      // Start the in-process agent worker on the first authenticated request
+      // (when `req.rootConfig` is available). Idempotent — subsequent
+      // requests are no-ops once the worker is running.
+      server.use((req: Request, _res: Response, next: NextFunction) => {
+        if (req.rootConfig) {
+          // Lazy import keeps the agents subsystem from loading on
+          // projects that never use AI features.
+          import('./agents/worker.js')
+            .then(({ensureAgentWorker}) => {
+              try {
+                ensureAgentWorker(req.rootConfig!);
+              } catch (err) {
+                console.error('[agent worker] startup failed:', err);
+              }
+            })
+            .catch((err) => {
+              console.error('[agent worker] import failed:', err);
+            });
+        }
+        next();
+      });
+
       // Render the CMS SPA.
       server.use('/cms', async (req: Request, res: Response) => {
         try {

--- a/packages/root-cms/ui/components/CommentReactions/CommentReactions.css
+++ b/packages/root-cms/ui/components/CommentReactions/CommentReactions.css
@@ -1,0 +1,68 @@
+.CommentReactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  margin-top: 8px;
+  position: relative;
+}
+
+.CommentReactions__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid #d4d4d8;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.CommentReactions__chip:hover {
+  background: #f4f4f5;
+}
+
+.CommentReactions__chip--mine {
+  background: #eef2ff;
+  border-color: #6366f1;
+  color: #312e81;
+}
+
+.CommentReactions__emoji {
+  font-size: 14px;
+}
+
+.CommentReactions__count {
+  font-variant-numeric: tabular-nums;
+}
+
+.CommentReactions__picker {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  background: #ffffff;
+  border: 1px solid #d4d4d8;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  z-index: 10;
+}
+
+.CommentReactions__pickerItem {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+.CommentReactions__pickerItem:hover {
+  background: #f4f4f5;
+}

--- a/packages/root-cms/ui/components/CommentReactions/CommentReactions.tsx
+++ b/packages/root-cms/ui/components/CommentReactions/CommentReactions.tsx
@@ -1,0 +1,103 @@
+import './CommentReactions.css';
+
+import {ActionIcon, Tooltip} from '@mantine/core';
+import {showNotification} from '@mantine/notifications';
+import {IconMoodPlus} from '@tabler/icons-preact';
+import {useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
+import {
+  TASK_COMMENT_REACTIONS,
+  TaskCommentReaction,
+  toggleTaskCommentReaction,
+} from '../../utils/tasks.js';
+
+export interface CommentReactionsProps {
+  taskId: string;
+  commentId: string;
+  reactions?: Record<string, string[]>;
+  className?: string;
+}
+
+/**
+ * Renders the row of emoji reactions on a task comment plus a "+" button to
+ * add a new one. Clicking an existing reaction toggles the current user's
+ * presence on it.
+ */
+export function CommentReactions(props: CommentReactionsProps) {
+  const reactions = props.reactions || {};
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const currentUser = (window.firebase.user.email || '').toLowerCase();
+  const present = Object.entries(reactions).filter(
+    ([, reactors]) => reactors.length > 0
+  );
+
+  async function toggle(emoji: TaskCommentReaction) {
+    try {
+      await toggleTaskCommentReaction(props.taskId, props.commentId, emoji);
+      setPickerOpen(false);
+    } catch (err) {
+      showNotification({
+        title: 'Could not toggle reaction',
+        message: err instanceof Error ? err.message : String(err),
+        color: 'red',
+        autoClose: 3000,
+      });
+    }
+  }
+
+  return (
+    <div className={joinClassNames('CommentReactions', props.className)}>
+      {present.map(([emoji, reactors]) => {
+        const isMine = reactors.includes(currentUser);
+        return (
+          <Tooltip
+            key={emoji}
+            label={reactors.join(', ')}
+            withinPortal
+            position="top"
+          >
+            <button
+              type="button"
+              className={joinClassNames(
+                'CommentReactions__chip',
+                isMine && 'CommentReactions__chip--mine'
+              )}
+              onClick={() => toggle(emoji as TaskCommentReaction)}
+            >
+              <span className="CommentReactions__emoji">{emoji}</span>
+              <span className="CommentReactions__count">{reactors.length}</span>
+            </button>
+          </Tooltip>
+        );
+      })}
+      <Tooltip label="Add reaction" withinPortal position="top">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          onClick={() => setPickerOpen((p) => !p)}
+          aria-label="Add reaction"
+        >
+          <IconMoodPlus size={16} strokeWidth="1.8" />
+        </ActionIcon>
+      </Tooltip>
+      {pickerOpen && (
+        <div
+          className="CommentReactions__picker"
+          role="menu"
+          aria-label="Pick a reaction"
+        >
+          {TASK_COMMENT_REACTIONS.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              className="CommentReactions__pickerItem"
+              onClick={() => toggle(emoji)}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/ProposalComment/ProposalComment.css
+++ b/packages/root-cms/ui/components/ProposalComment/ProposalComment.css
@@ -1,0 +1,94 @@
+.ProposalComment {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  background: #eef2ff;
+  margin-top: 8px;
+}
+
+.ProposalComment__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.ProposalComment__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #312e81;
+}
+
+.ProposalComment__icon {
+  font-size: 16px;
+}
+
+.ProposalComment__badge {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #c7d2fe;
+  color: #312e81;
+}
+
+.ProposalComment__badge--applied {
+  background: #bbf7d0;
+  color: #14532d;
+}
+
+.ProposalComment__badge--rejected,
+.ProposalComment__badge--expired {
+  background: #fecaca;
+  color: #7f1d1d;
+}
+
+.ProposalComment__rationale {
+  font-size: 13px;
+  color: #1e293b;
+  white-space: pre-wrap;
+}
+
+.ProposalComment__diff {
+  background: #ffffff;
+  border: 1px solid #c7d2fe;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+.ProposalComment__diffMarkdown {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ProposalComment__diffMarkdown pre {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.ProposalComment__error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #7f1d1d;
+}
+
+.ProposalComment__actions {
+  display: flex;
+  gap: 6px;
+}
+
+.ProposalComment__resolved {
+  font-size: 12px;
+  color: #475569;
+}

--- a/packages/root-cms/ui/components/ProposalComment/ProposalComment.tsx
+++ b/packages/root-cms/ui/components/ProposalComment/ProposalComment.tsx
@@ -1,0 +1,215 @@
+import './ProposalComment.css';
+
+import {Button, Tooltip} from '@mantine/core';
+import {showNotification} from '@mantine/notifications';
+import {IconCheck, IconX} from '@tabler/icons-preact';
+import {useState} from 'preact/hooks';
+import {executeCmsTool} from '../../pages/AIPage/cmsToolHandlers.js';
+import {joinClassNames} from '../../utils/classes.js';
+import type {TaskComment, TaskProposal} from '../../utils/tasks.js';
+import {Markdown} from '../Markdown/Markdown.js';
+
+export interface ProposalCommentProps {
+  comment: TaskComment;
+  className?: string;
+}
+
+/**
+ * Renders a proposal comment posted by an agent. Includes Apply/Reject
+ * buttons when the proposal is still pending.
+ *
+ * Apply flow:
+ *   1. Hit `/cms/api/agents.proposalApply` to validate and fetch the payload.
+ *   2. Run the mutating tool client-side via `executeCmsTool` under the
+ *      user's Firebase auth.
+ *   3. POST the outcome back to the same endpoint so the proposal status is
+ *      finalized server-side.
+ */
+export function ProposalComment(props: ProposalCommentProps) {
+  const {comment, className} = props;
+  const proposal = comment.proposal;
+  const [busy, setBusy] = useState(false);
+  if (!proposal) {
+    return null;
+  }
+  const isPending = proposal.status === 'pending';
+
+  async function applyProposal() {
+    setBusy(true);
+    try {
+      const validated = await callProposalEndpoint('apply', {
+        taskId: comment.taskId,
+        commentId: comment.id,
+      });
+      if (!validated.success) {
+        throw new Error(validated.error || 'apply failed to validate');
+      }
+      let outcomeError: string | null = null;
+      try {
+        await executeCmsTool(validated.toolName!, validated.input || {});
+      } catch (err) {
+        outcomeError = err instanceof Error ? err.message : String(err);
+      }
+      const finalize = await callProposalEndpoint('apply', {
+        taskId: comment.taskId,
+        commentId: comment.id,
+        outcome: outcomeError ? 'error' : 'success',
+        error: outcomeError,
+      });
+      if (!finalize.success) {
+        throw new Error(finalize.error || 'failed to finalize apply');
+      }
+      if (outcomeError) {
+        throw new Error(outcomeError);
+      }
+      showNotification({
+        title: 'Proposal applied',
+        message: `Applied ${proposal.tool}.`,
+        color: 'green',
+        autoClose: 3000,
+      });
+    } catch (err) {
+      showNotification({
+        title: 'Could not apply proposal',
+        message: err instanceof Error ? err.message : String(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rejectProposal() {
+    setBusy(true);
+    try {
+      const result = await callProposalEndpoint('reject', {
+        taskId: comment.taskId,
+        commentId: comment.id,
+      });
+      if (!result.success) {
+        throw new Error(result.error || 'reject failed');
+      }
+    } catch (err) {
+      showNotification({
+        title: 'Could not reject proposal',
+        message: err instanceof Error ? err.message : String(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={joinClassNames('ProposalComment', className)}>
+      <div className="ProposalComment__header">
+        <div className="ProposalComment__title">
+          <span className="ProposalComment__icon">📋</span>
+          <span>
+            Proposal: <code>{proposal.tool}</code>
+          </span>
+        </div>
+        <ProposalStatusBadge status={proposal.status} />
+      </div>
+      {proposal.rationale && (
+        <div className="ProposalComment__rationale">{proposal.rationale}</div>
+      )}
+      {proposal.diffSummary && (
+        <div className="ProposalComment__diff">
+          <Markdown
+            className="ProposalComment__diffMarkdown"
+            code={proposal.diffSummary}
+          />
+        </div>
+      )}
+      {proposal.applyError && (
+        <div className="ProposalComment__error">
+          <strong>Apply error:</strong> {proposal.applyError}
+        </div>
+      )}
+      {isPending ? (
+        <div className="ProposalComment__actions">
+          <Tooltip
+            label="Run this change as the current user"
+            withinPortal
+            position="top"
+          >
+            <Button
+              size="xs"
+              color="dark"
+              loading={busy}
+              leftIcon={<IconCheck size={14} strokeWidth="1.8" />}
+              onClick={applyProposal}
+            >
+              Apply
+            </Button>
+          </Tooltip>
+          <Button
+            size="xs"
+            variant="default"
+            disabled={busy}
+            leftIcon={<IconX size={14} strokeWidth="1.8" />}
+            onClick={rejectProposal}
+          >
+            Reject
+          </Button>
+        </div>
+      ) : (
+        <div className="ProposalComment__resolved">
+          {proposal.appliedBy && (
+            <span>
+              {proposal.status === 'applied' ? 'Applied' : 'Rejected'} by{' '}
+              <b>{proposal.appliedBy}</b>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProposalStatusBadge(props: {status: TaskProposal['status']}) {
+  const {status} = props;
+  return (
+    <span
+      className={joinClassNames(
+        'ProposalComment__badge',
+        `ProposalComment__badge--${status}`
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+interface ProposalApplyResponse {
+  success: boolean;
+  error?: string;
+  toolName?: string;
+  input?: Record<string, unknown>;
+  applied?: boolean;
+  recorded?: boolean;
+}
+
+async function callProposalEndpoint(
+  action: 'apply' | 'reject',
+  body: Record<string, unknown>
+): Promise<ProposalApplyResponse> {
+  const path =
+    action === 'apply'
+      ? '/cms/api/agents.proposalApply'
+      : '/cms/api/agents.proposalReject';
+  const res = await fetch(path, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${path} failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as ProposalApplyResponse;
+}

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -608,3 +608,67 @@
     align-self: flex-end;
   }
 }
+
+.TaskPage__agentRun {
+  margin-top: 12px;
+}
+
+.TaskPage__agentRun__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.TaskPage__agentRun__badge {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.TaskPage__agentRun__badge--running {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.TaskPage__agentRun__badge--errored {
+  background: #fecaca;
+  color: #7f1d1d;
+}
+
+.TaskPage__agentRun__badge--cancelled {
+  background: #fed7aa;
+  color: #7c2d12;
+}
+
+.TaskPage__agentRun__badge--idle {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.TaskPage__agentRun__tokens {
+  font-size: 12px;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 8px;
+}
+
+.TaskPage__agentRun__error {
+  font-size: 12px;
+  color: #7f1d1d;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin-bottom: 8px;
+}
+
+.TaskPage__agentRun__actions {
+  display: flex;
+  gap: 6px;
+}
+

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -32,8 +32,10 @@ import {
   RichTextData,
   RichTextListItem,
 } from '../../../shared/richtext.js';
+import {CommentReactions} from '../../components/CommentReactions/CommentReactions.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
+import {ProposalComment} from '../../components/ProposalComment/ProposalComment.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {TaskCommentEditor} from '../../components/TaskCommentEditor/TaskCommentEditor.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
@@ -44,10 +46,13 @@ import {errorMessage} from '../../utils/notifications.js';
 import {
   addTaskComment,
   addTaskAttachment,
+  cancelTaskAgentRun,
   deleteTaskComment,
   editTaskComment,
+  getAgentAssigneeName,
   normalizeTaskStatus,
   removeTaskAttachment,
+  retryTaskAgentRun,
   subscribeTask,
   subscribeTaskComments,
   subscribeTaskEvents,
@@ -165,6 +170,9 @@ export function TaskPage(props: {id: string}) {
             </main>
             <aside className="TaskPage__side">
               <TaskMetadataPanel task={task} />
+              {getAgentAssigneeName(task.assignee) && (
+                <AgentRunPanel task={task} />
+              )}
             </aside>
           </div>
         )}
@@ -644,6 +652,100 @@ function TaskMetadataPanel(props: {task: Task}) {
   );
 }
 
+/** Sidebar panel that surfaces the current agent run status and lets the
+ * user cancel an in-flight run or retry an errored/cancelled one. */
+function AgentRunPanel(props: {task: Task}) {
+  const {task} = props;
+  const agentName = getAgentAssigneeName(task.assignee);
+  const run = task.agentRun;
+  const status = run?.status || 'idle';
+  const [busy, setBusy] = useState(false);
+
+  async function onCancel() {
+    setBusy(true);
+    try {
+      await cancelTaskAgentRun(task.id);
+    } catch (err) {
+      showNotification({
+        title: 'Could not cancel run',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRetry() {
+    setBusy(true);
+    try {
+      await retryTaskAgentRun(task.id);
+    } catch (err) {
+      showNotification({
+        title: 'Could not retry run',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Surface className="TaskPage__agentRun">
+      <div className="TaskPage__metadata__field">
+        <label>Agent run</label>
+        <div className="TaskPage__agentRun__status">
+          <b>{agentName}</b>
+          <span
+            className={joinClassNames(
+              'TaskPage__agentRun__badge',
+              `TaskPage__agentRun__badge--${status}`
+            )}
+          >
+            {status}
+          </span>
+        </div>
+        {run?.tokensUsed !== undefined && run?.tokensCap !== undefined && (
+          <div className="TaskPage__agentRun__tokens">
+            {run.tokensUsed.toLocaleString()} / {run.tokensCap.toLocaleString()}{' '}
+            tokens
+          </div>
+        )}
+        {run?.lastError && (
+          <div className="TaskPage__agentRun__error">{run.lastError}</div>
+        )}
+        <div className="TaskPage__agentRun__actions">
+          {status === 'running' && (
+            <Button
+              size="xs"
+              variant="default"
+              loading={busy}
+              leftIcon={<IconX size={14} strokeWidth="1.8" />}
+              onClick={onCancel}
+            >
+              Cancel run
+            </Button>
+          )}
+          {(status === 'errored' || status === 'cancelled') && (
+            <Button
+              size="xs"
+              color="dark"
+              loading={busy}
+              leftIcon={<IconCheck size={14} strokeWidth="1.8" />}
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      </div>
+    </Surface>
+  );
+}
+
 /** Combines task comments and metadata changes into a single timeline. */
 function TaskTimeline(props: {
   task: Task;
@@ -925,6 +1027,16 @@ function TaskCommentCard(props: {
                 />
               )}
             </div>
+          )}
+          {!comment.isDeleted && comment.proposal && (
+            <ProposalComment comment={comment} />
+          )}
+          {!comment.isDeleted && (
+            <CommentReactions
+              taskId={comment.taskId}
+              commentId={comment.id}
+              reactions={comment.reactions}
+            />
           )}
         </Surface>
         {replying && (


### PR DESCRIPTION
## Summary

Third of four stacked PRs. **Stacked on top of #1112.** Wires the runner from PR 2 into a long-running, in-process worker, and adds the proposal apply/reject flow plus the UI a reviewer needs to interact with agent runs.

## Backend

- **`worker.ts`** — `AgentWorker` class with a Firestore `onSnapshot` listener filtered to `agentRun.status: 'idle'`. Atomic claim via `runTransaction` with a 15-minute lease (`LEASE_TTL_MS`) so dead replicas release their hold. Bounded concurrency (default 3 in-flight per process). Reuses `runAgent()` for the loop body. Includes `ensureAgentWorker(rootConfig)` lazy singleton wired into the CMS plugin's `configureServer` so the listener starts on the first authenticated CMS request — no infrastructure changes for hosters.
- **`agents-api.ts`** — five endpoints under `/cms/api/agents.*`:
  - `agents.list` — registered agents (for pickers)
  - `agents.proposalApply` — validates a pending proposal and returns the tool/input payload; the browser executes it under the user's auth and POSTs the outcome back to finalize status
  - `agents.proposalReject` — marks a pending proposal rejected
  - `agents.taskCancelRun` — flips `agentRun.status` to `cancelled`
  - `agents.taskRetryRun` — resets `agentRun` so the worker re-claims

## UI

- **`CommentReactions`** — emoji chip row with `+` picker. Toggles via `toggleTaskCommentReaction`.
- **`ProposalComment`** — renders a proposal comment with Apply/Reject buttons. Apply hits `agents.proposalApply` to validate, runs the tool client-side via the existing `executeCmsTool` (so the user's Firebase auth and audit identity are preserved), then POSTs the outcome back.
- **`AgentRunPanel`** — sidebar block on TaskPage shown when assignee is `agent:*`. Surfaces status, token usage, last error, and the Cancel/Retry buttons.

Both new components plug into the existing `TaskCommentCard` and sidebar without touching the comment data model further.

## Stack

1. #1111 — Foundations
2. #1112 — Runner + tools ← merge target of this PR
3. **This PR** — Worker + apply flow + run controls UI
4. PR 4 — Chat integration (Convert-to-Task, AgentPicker, `@`-mention)

## How the apply flow preserves the security model

```
agent runs (server)
   └── proposeChange tool posts comment with {proposal, status: 'pending'}

human clicks Apply (browser)
   1. POST /cms/api/agents.proposalApply
        → server validates {tool ∈ allowlist, status === 'pending'}
        → server returns {toolName, input}
   2. browser runs executeCmsTool(toolName, input)
        → executes against Firestore under USER's auth
        → audit log shows User X (not the agent)
   3. POST /cms/api/agents.proposalApply with outcome=success
        → server marks proposal applied, records appliedBy=User X
```

Result: the agent never has CMS write authority. The user is the writer, the agent is the proposer.

## Worker compatibility

- ✅ Cloud Run with `min-instances: 1` — process stays warm, listener stays attached.
- ✅ App Engine Flex, GKE, VMs — same.
- ❌ App Engine Standard — process scales to zero between requests; the design doc flags this as needing a Firestore-trigger variant (out of scope for v0).
- ❌ Firebase Functions short-lived runtimes — same.

The lease has a TTL (`LEASE_TTL_MS = 15min`) so a process that dies mid-run releases its claim and the next snapshot tick lets another replica pick up. Failed runs require human re-trigger via the Retry button (matches the design doc's resume policy).

## Test plan

- [x] `pnpm exec vitest run core/agents/` — 38 tests across 6 files passing
- [x] `pnpm build:core` — ESM and DTS clean
- [x] `pnpm build:ui` — UI bundle clean
- [x] `pnpm eslint` on all modified files — clean
- [ ] End-to-end exercise (define an agent, assign a task, observe lease/run/proposal/apply) — verifiable once PR 4 lands; design doc has the verification recipe

## Notes for review

- The worker is **lazy**: it only starts on the first CMS request after a process boot. This means a fresh deploy doesn't pick up tasks until someone hits the CMS, which is fine for our usage.
- `ensureAgentWorker` short-circuits if `getAiConfig` returns null, so projects without AI configured pay zero startup cost.
- Token-cap enforcement happens *inside* `runAgent` (PR 2). The worker just runs the loop and surfaces outcomes.
- I deliberately kept the apply-finalize on the same endpoint as the validate (`outcome: 'success' | 'error' | undefined`) to keep the public surface tight; if you prefer separate endpoints (`agents.proposalConfirm`?) the split is trivial.

https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV

---
_Generated by [Claude Code](https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV)_