### PR TITLE
feat(cms): Root AI agents — chat→task, AgentPicker, mentions (4/4)

### DIFF
--- a/packages/root-cms/core/agents/agents-api.ts
+++ b/packages/root-cms/core/agents/agents-api.ts
@@ -4,19 +4,24 @@
  *
  * Endpoint summary:
  *
- *   GET  /cms/api/agents.list            — list registered agents (for pickers).
- *   POST /cms/api/agents.proposalApply   — return the validated tool call payload
- *                                           so the browser can execute it under
- *                                           the user's auth, then mark applied.
- *   POST /cms/api/agents.proposalReject  — mark a proposal rejected.
- *   POST /cms/api/agents.taskCancelRun   — cancel an in-flight agent run.
- *   POST /cms/api/agents.taskRetryRun    — reset an errored/cancelled run.
+ *   GET  /cms/api/agents.list             — list registered agents (for pickers).
+ *   POST /cms/api/agents.proposalApply    — return the validated tool call payload
+ *                                            so the browser can execute it under
+ *                                            the user's auth, then mark applied.
+ *   POST /cms/api/agents.proposalReject   — mark a proposal rejected.
+ *   POST /cms/api/agents.taskCancelRun    — cancel an in-flight agent run.
+ *   POST /cms/api/agents.taskRetryRun     — reset an errored/cancelled run.
+ *   POST /cms/api/agents.chatConvertToTask — turn an AI chat into a task,
+ *                                            optionally assigned to an agent.
  */
 
 import type {Server, Request, Response} from '@blinkk/root';
+import type {UIMessage} from 'ai';
 import {FieldValue} from 'firebase-admin/firestore';
+import {ChatStore} from '../ai-chat.js';
 import {RootCMSClient} from '../client.js';
 import {loadAgents} from './registry.js';
+import {AGENT_ASSIGNEE_PREFIX} from './run-context.js';
 import {PROPOSAL_TARGET_TOOLS} from './tools-propose.js';
 
 const PROPOSAL_TARGET_SET: ReadonlySet<string> = new Set(PROPOSAL_TARGET_TOOLS);
@@ -262,4 +267,215 @@ export function registerAgentApi(server: Server) {
       res.status(200).json({success: true});
     }
   );
+
+  /**
+   * Converts an AI chat session into a task. Renders the chat history as
+   * the task's seed comment and optionally assigns it to a registered
+   * agent. The chat itself is preserved; the task carries `sourceChatId`
+   * back to it.
+   */
+  server.use(
+    '/cms/api/agents.chatConvertToTask',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const {chatId, agentName, title} = req.body || {};
+      if (!chatId) {
+        res.status(400).json({success: false, error: 'MISSING_CHAT_ID'});
+        return;
+      }
+
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const store = new ChatStore(cmsClient, req.user.email);
+      const chat = await store.getChat(String(chatId));
+      if (!chat) {
+        res.status(404).json({success: false, error: 'CHAT_NOT_FOUND'});
+        return;
+      }
+
+      let assignee: string | null = null;
+      if (agentName) {
+        const agents = await loadAgents();
+        if (!agents.has(String(agentName))) {
+          res.status(400).json({success: false, error: 'UNKNOWN_AGENT'});
+          return;
+        }
+        assignee = `${AGENT_ASSIGNEE_PREFIX}${agentName}`;
+      }
+
+      try {
+        const taskId = await createTaskFromChat(cmsClient, {
+          chat,
+          title: title ? String(title) : undefined,
+          assignee,
+          createdBy: req.user.email,
+        });
+        res.status(200).json({success: true, taskId});
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({
+          success: false,
+          error: err instanceof Error ? err.message : 'UNKNOWN',
+        });
+      }
+    }
+  );
+}
+
+const TASK_COUNTER_ID = 'tasks';
+const TASK_ID_ALLOCATION_ATTEMPTS = 20;
+
+/**
+ * Allocates a fresh task id and writes the chat-derived task + seed comment
+ * in a single transaction. If `assignee` is `agent:*`, marks
+ * `agentRun.status: 'idle'` so the worker picks it up.
+ */
+async function createTaskFromChat(
+  cmsClient: RootCMSClient,
+  options: {
+    chat: {id: string; title?: string; messages: UIMessage[]};
+    title?: string;
+    assignee: string | null;
+    createdBy: string;
+  }
+): Promise<string> {
+  const {chat, createdBy, assignee} = options;
+  const counterRef = cmsClient.db.doc(
+    `Projects/${cmsClient.projectId}/Counters/${TASK_COUNTER_ID}`
+  );
+  const tasksCol = cmsClient.db.collection(
+    `Projects/${cmsClient.projectId}/Tasks`
+  );
+  const isAgentAssignee = (assignee || '').startsWith(AGENT_ASSIGNEE_PREFIX);
+  const seedContent = renderChatAsMarkdown(chat.messages);
+  const title =
+    options.title?.trim() || chat.title?.trim() || deriveTitle(chat.messages);
+
+  const taskId = await cmsClient.db.runTransaction(async (txn) => {
+    const counterSnap = await txn.get(counterRef);
+    const counterData = counterSnap.data() || {};
+    const lastTaskId =
+      typeof counterData.lastTaskId === 'number' ? counterData.lastTaskId : 0;
+    let nextTaskId = Math.floor(lastTaskId) + 1;
+
+    for (let i = 0; i < TASK_ID_ALLOCATION_ATTEMPTS; i++) {
+      const taskRef = tasksCol.doc(String(nextTaskId));
+      const taskSnap = await txn.get(taskRef);
+      if (!taskSnap.exists) {
+        txn.set(
+          counterRef,
+          {lastTaskId: nextTaskId, updatedAt: FieldValue.serverTimestamp()},
+          {merge: true}
+        );
+        txn.set(taskRef, {
+          id: String(nextTaskId),
+          title,
+          description: '',
+          assignee,
+          priority: 'normal',
+          status: 'new',
+          targetLaunchDate: null,
+          createdAt: FieldValue.serverTimestamp(),
+          createdBy,
+          updatedAt: FieldValue.serverTimestamp(),
+          updatedBy: createdBy,
+          sourceChatId: chat.id,
+          ...(isAgentAssignee
+            ? {
+                agentRun: {
+                  status: 'idle',
+                  tokensUsed: 0,
+                  updatedAt: FieldValue.serverTimestamp(),
+                },
+              }
+            : {}),
+        });
+        const commentRef = taskRef.collection('Comments').doc();
+        txn.set(commentRef, {
+          id: commentRef.id,
+          taskId: String(nextTaskId),
+          parentId: null,
+          content: seedContent,
+          body: null,
+          mentions: [],
+          createdAt: FieldValue.serverTimestamp(),
+          createdBy,
+          history: [],
+        });
+        return String(nextTaskId);
+      }
+      nextTaskId += 1;
+    }
+    throw new Error('chatConvertToTask: unable to allocate a task id');
+  });
+  return taskId;
+}
+
+/**
+ * Renders the chat history as a single markdown blob. Tool calls are
+ * collapsed to a one-line indicator since their full payloads can be very
+ * long.
+ */
+function renderChatAsMarkdown(messages: UIMessage[]): string {
+  const parts: string[] = ['## Chat history', ''];
+  for (const msg of messages) {
+    const role =
+      msg.role === 'user'
+        ? '**User**'
+        : msg.role === 'assistant'
+        ? '**Assistant**'
+        : `**${msg.role}**`;
+    const text = (msg.parts || [])
+      .map((part) => {
+        if ((part as {type?: string}).type === 'text') {
+          return (part as {text?: string}).text || '';
+        }
+        if (
+          typeof (part as {type?: string}).type === 'string' &&
+          ((part as {type: string}).type as string).startsWith('tool-')
+        ) {
+          return `_↳ ran tool ${((part as {type: string}).type as string).slice(
+            5
+          )}_`;
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+    if (text.trim()) {
+      parts.push(`${role}: ${text}`);
+      parts.push('');
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+/**
+ * Derives a short title from the first user message, truncated for
+ * readability.
+ */
+function deriveTitle(messages: UIMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user');
+  if (!firstUser) {
+    return 'Chat conversation';
+  }
+  const text = (firstUser.parts || [])
+    .map((part) =>
+      (part as {type?: string}).type === 'text'
+        ? (part as {text?: string}).text || ''
+        : ''
+    )
+    .join(' ')
+    .trim();
+  if (!text) {
+    return 'Chat conversation';
+  }
+  const firstLine = text.split('\n')[0];
+  return firstLine.length > 80 ? firstLine.slice(0, 77) + '...' : firstLine;
 }

--- a/packages/root-cms/ui/components/AgentPicker/AgentPicker.css
+++ b/packages/root-cms/ui/components/AgentPicker/AgentPicker.css
@@ -1,0 +1,53 @@
+.AgentPicker__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid #d4d4d8;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.AgentPicker__trigger:hover {
+  background: #f4f4f5;
+}
+
+.AgentPicker__triggerIcon {
+  font-size: 14px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.AgentPicker__option {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 4px 0;
+  max-width: 320px;
+}
+
+.AgentPicker__optionIcon {
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.AgentPicker__optionName {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.AgentPicker__optionDescription {
+  font-size: 12px;
+  color: #6b7280;
+  white-space: normal;
+}
+
+.AgentPicker__error {
+  color: #b91c1c;
+  font-size: 12px;
+}

--- a/packages/root-cms/ui/components/AgentPicker/AgentPicker.tsx
+++ b/packages/root-cms/ui/components/AgentPicker/AgentPicker.tsx
@@ -1,0 +1,84 @@
+import './AgentPicker.css';
+
+import {Loader, Menu} from '@mantine/core';
+import {IconRobot} from '@tabler/icons-preact';
+import {AgentSummary, useAgents} from '../../hooks/useAgents.js';
+import {joinClassNames} from '../../utils/classes.js';
+
+export interface AgentPickerProps {
+  /** Callback fired when the user picks an agent. Pass `null` to clear. */
+  onSelect: (agent: AgentSummary | null) => void;
+  /** Optional currently-selected agent name shown as the trigger label. */
+  selectedAgent?: string | null;
+  /**
+   * Optional label shown in the trigger when no agent is selected.
+   * Defaults to "Pick an agent".
+   */
+  placeholder?: string;
+  /** Optional "no assignee" item label. When omitted, the option is hidden. */
+  noAssigneeLabel?: string;
+  className?: string;
+}
+
+/**
+ * Dropdown picker listing available agents in the project. Used by the
+ * chat → task conversion flow and anywhere else the user needs to assign
+ * an agent. Reads from `/cms/api/agents.list` via `useAgents`.
+ */
+export function AgentPicker(props: AgentPickerProps) {
+  const {agents, loading, error} = useAgents();
+  const selected = props.selectedAgent
+    ? agents.find((a) => a.name === props.selectedAgent)
+    : null;
+
+  return (
+    <Menu
+      withinPortal
+      control={
+        <button
+          type="button"
+          className={joinClassNames('AgentPicker__trigger', props.className)}
+        >
+          <span className="AgentPicker__triggerIcon">
+            {selected ? selected.icon : <IconRobot size={16} />}
+          </span>
+          <span>
+            {selected ? selected.name : props.placeholder || 'Pick an agent'}
+          </span>
+        </button>
+      }
+    >
+      {loading && (
+        <Menu.Item disabled>
+          <Loader size="xs" /> Loading agents…
+        </Menu.Item>
+      )}
+      {error && (
+        <Menu.Item disabled>
+          <span className="AgentPicker__error">Error: {error}</span>
+        </Menu.Item>
+      )}
+      {!loading && !error && agents.length === 0 && (
+        <Menu.Item disabled>No agents registered</Menu.Item>
+      )}
+      {props.noAssigneeLabel && (
+        <Menu.Item onClick={() => props.onSelect(null)}>
+          {props.noAssigneeLabel}
+        </Menu.Item>
+      )}
+      {agents.map((agent) => (
+        <Menu.Item key={agent.name} onClick={() => props.onSelect(agent)}>
+          <div className="AgentPicker__option">
+            <span className="AgentPicker__optionIcon">{agent.icon}</span>
+            <div>
+              <div className="AgentPicker__optionName">{agent.name}</div>
+              <div className="AgentPicker__optionDescription">
+                {agent.description}
+              </div>
+            </div>
+          </div>
+        </Menu.Item>
+      ))}
+    </Menu>
+  );
+}

--- a/packages/root-cms/ui/components/TaskCommentInput/TaskCommentInput.tsx
+++ b/packages/root-cms/ui/components/TaskCommentInput/TaskCommentInput.tsx
@@ -340,10 +340,28 @@ export function TaskCommentInput(props: TaskCommentInputProps) {
 export function extractMentions(content: string): string[] {
   const result = new Set<string>();
   // Email-shaped token preceded by start-of-string or whitespace.
-  const re = /(^|\s)@([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/g;
+  const emailRe = /(^|\s)@([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/g;
   let match: RegExpExecArray | null;
-  while ((match = re.exec(content)) !== null) {
+  while ((match = emailRe.exec(content)) !== null) {
     result.add(match[2].toLowerCase());
+  }
+  return Array.from(result);
+}
+
+/**
+ * Extracts agent mentions from `content` of the form `@<agent-name>` where
+ * `<agent-name>` is the slug used in `defineAgent({name})`. Mentions must be
+ * preceded by a word boundary and cannot overlap with email-shaped mentions
+ * (those are picked up by `extractMentions` instead).
+ */
+export function extractAgentMentions(content: string): string[] {
+  const result = new Set<string>();
+  // Slug-shaped token preceded by start-of-string or whitespace and NOT
+  // followed by `@` (which would make it an email mention).
+  const agentRe = /(^|\s)@([a-z0-9][a-z0-9-]*)(?![A-Za-z0-9._%+-]*@)/g;
+  let match: RegExpExecArray | null;
+  while ((match = agentRe.exec(content)) !== null) {
+    result.add(match[2]);
   }
   return Array.from(result);
 }

--- a/packages/root-cms/ui/components/TaskCommentInput/extractMentions.test.ts
+++ b/packages/root-cms/ui/components/TaskCommentInput/extractMentions.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {extractMentions} from './TaskCommentInput.js';
+import {extractAgentMentions, extractMentions} from './TaskCommentInput.js';
 
 describe('extractMentions', () => {
   it('extracts a single @email mention', () => {
@@ -25,5 +25,39 @@ describe('extractMentions', () => {
   it('returns an empty array when no mentions are present', () => {
     expect(extractMentions('No mentions here')).toEqual([]);
     expect(extractMentions('')).toEqual([]);
+  });
+});
+
+describe('extractAgentMentions', () => {
+  it('extracts a slug-shaped agent mention', () => {
+    expect(extractAgentMentions('Hello @content-manager')).toEqual([
+      'content-manager',
+    ]);
+  });
+
+  it('extracts multiple mentions and dedupes them', () => {
+    expect(
+      extractAgentMentions(
+        'cc @content-manager and @translator, also again @content-manager'
+      ).sort()
+    ).toEqual(['content-manager', 'translator']);
+  });
+
+  it('does not mistake email mentions for agent mentions', () => {
+    expect(extractAgentMentions('Hello @alex@example.com')).toEqual([]);
+  });
+
+  it('ignores tokens that are not at a word boundary', () => {
+    expect(extractAgentMentions('inline-text@content-manager')).toEqual([]);
+  });
+
+  it('handles mixed agent and email mentions in the same string', () => {
+    const content = '@translator please cc @alex@example.com';
+    expect(extractAgentMentions(content)).toEqual(['translator']);
+    expect(extractMentions(content)).toEqual(['alex@example.com']);
+  });
+
+  it('returns an empty array on empty input', () => {
+    expect(extractAgentMentions('')).toEqual([]);
   });
 });

--- a/packages/root-cms/ui/hooks/useAgents.ts
+++ b/packages/root-cms/ui/hooks/useAgents.ts
@@ -1,0 +1,61 @@
+/**
+ * Hook that loads the project's registered agents from
+ * `/cms/api/agents.list`. The list is fetched once per component mount;
+ * agent definitions are configured at build time so there's no need to
+ * subscribe.
+ */
+
+import {useEffect, useState} from 'preact/hooks';
+
+export interface AgentSummary {
+  name: string;
+  icon: string;
+  description: string;
+  allowedTools: ('read' | 'propose' | 'subtask')[];
+}
+
+interface UseAgentsResult {
+  agents: AgentSummary[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useAgents(): UseAgentsResult {
+  const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    fetch('/cms/api/agents.list', {credentials: 'include'})
+      .then(async (res) => {
+        const data = (await res.json()) as {
+          success: boolean;
+          agents?: AgentSummary[];
+          error?: string;
+        };
+        if (!active) {
+          return;
+        }
+        if (!data.success) {
+          setError(data.error || 'unknown error');
+          setLoading(false);
+          return;
+        }
+        setAgents(data.agents || []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (active) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return {agents, loading, error};
+}

--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -126,7 +126,15 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   z-index: 100;
+}
+
+.AIPage__header__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .AIPage__modelPicker {

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -12,9 +12,11 @@
 import './AIPage.css';
 
 import {useChat} from '@ai-sdk/react';
-import {ActionIcon, Loader, Menu, Tooltip} from '@mantine/core';
+import {ActionIcon, Button, Loader, Menu, Tooltip} from '@mantine/core';
+import {showNotification} from '@mantine/notifications';
 import {
   IconCheck,
+  IconChecklist,
   IconChevronDown,
   IconCopy,
   IconMessageCirclePlus,
@@ -33,6 +35,7 @@ import {
 import {marked} from 'marked';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
+import {AgentPicker} from '../../components/AgentPicker/AgentPicker.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
@@ -292,6 +295,10 @@ function ChatExperience(props: {
           models={models}
           selectedModel={selectedModel}
           onSelectModel={setSelectedModelId}
+          activeChatId={activeChatId}
+          onConvertedToTask={(taskId) => {
+            route(`/cms/tasks/${taskId}`);
+          }}
         />
         <ChatPane
           key={resetKey}
@@ -370,7 +377,46 @@ function ChatHeader(props: {
   models: ModelInfo[];
   selectedModel?: ModelInfo;
   onSelectModel: (id: string) => void;
+  activeChatId: string;
+  onConvertedToTask: (taskId: string) => void;
 }) {
+  const [converting, setConverting] = useState(false);
+
+  async function convertToTask(agentName: string | null) {
+    if (!props.activeChatId) {
+      showNotification({
+        title: 'No chat to convert',
+        message: 'Send at least one message before converting.',
+        color: 'orange',
+        autoClose: 3000,
+      });
+      return;
+    }
+    setConverting(true);
+    try {
+      const res = await fetch('/cms/api/agents.chatConvertToTask', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({chatId: props.activeChatId, agentName}),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        throw new Error(data.error || 'convert failed');
+      }
+      props.onConvertedToTask(data.taskId);
+    } catch (err) {
+      showNotification({
+        title: 'Could not convert to task',
+        message: err instanceof Error ? err.message : String(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setConverting(false);
+    }
+  }
+
   return (
     <div className="AIPage__header">
       <Menu
@@ -396,15 +442,32 @@ function ChatHeader(props: {
                   {model.description}
                 </div>
               )}
-              {/* <div className="AIPage__modelPicker__option__caps">
-                {model.capabilities.tools && <span>tools</span>}
-                {model.capabilities.reasoning && <span>reasoning</span>}
-                {model.capabilities.attachments && <span>attachments</span>}
-              </div> */}
             </div>
           </Menu.Item>
         ))}
       </Menu>
+      <div className="AIPage__header__actions">
+        <AgentPicker
+          placeholder="Browse agents"
+          onSelect={(agent) => convertToTask(agent?.name || null)}
+          noAssigneeLabel="Unassigned task"
+        />
+        <Tooltip
+          label="Convert this chat into a task in the Task Manager"
+          withinPortal
+        >
+          <Button
+            size="xs"
+            variant="default"
+            loading={converting}
+            disabled={!props.activeChatId}
+            leftIcon={<IconChecklist size={14} strokeWidth="1.8" />}
+            onClick={() => convertToTask(null)}
+          >
+            Convert to task
+          </Button>
+        </Tooltip>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Final of four stacked PRs. **Stacked on top of #1113.** Closes the loop on the agent feature by adding the surfaces a user needs to actually start a run from the AI chat.

## Adds

- **`agents.chatConvertToTask`** endpoint — takes a chat id (and optional agent name), serializes the chat history as the seed comment, links back via `Task.sourceChatId`, and (when assigned to an agent) marks `agentRun.status: 'idle'` so the worker picks it up. Allocates ids transactionally to match `createTask`.
- **`useAgents` hook + `AgentPicker` component** — fetches `/cms/api/agents.list` once and renders a dropdown of icon + name + description. Reused anywhere an agent needs to be selected.
- **AIPage header** — adds a "Convert to task" button plus an inline `AgentPicker`. Picking an agent both converts and assigns; the bare button creates an unassigned task. Both navigate to `/cms/tasks/{id}` on success.
- **`extractAgentMentions`** parser — recognizes `@<agent-slug>` distinctly from `@email@host`. Both parsers can run on the same content without overlap. Tests cover the disambiguation and word-boundary cases.

## Stack — full picture

1. #1111 — Foundations (registry, schema, design doc)
2. #1112 — Runner + tools (read bundle, propose, subtask, budget)
3. #1113 — Worker + apply flow + run controls UI ← merge target of this PR
4. **This PR** — Chat → task, AgentPicker, mentions

After all four merge into `alpha`, the full end-to-end flow works:

```
1. User opens /cms/ai and chats with the assistant.
2. User clicks "Convert to task" → picks an agent (or none).
3. Server creates task with sourceChatId + seed comment + agentRun.idle.
4. Worker (running in the same Node process) snapshots the new task,
   leases it, and runs the agent loop.
5. Agent reads CMS via the read-bundle tools, posts proposals via
   proposeChange (which lands as comments on the task with diff +
   Apply/Reject buttons).
6. User reviews proposals on the task page, clicks Apply.
7. Apply runs the proposed mutating tool in the user's browser under
   their Firebase auth, finalizes the proposal status server-side,
   and the doc updates show up everywhere via the existing realtime
   listeners.
```

## Test plan

- [x] `pnpm exec vitest run` — 411 passing, 7 skipped, 1 pre-existing emulator-required suite skipped (security.test.ts)
- [x] `pnpm build:core` + `pnpm build:ui` — clean
- [x] `pnpm eslint` on all modified files — clean
- [ ] **Full E2E exercise** (the user runs this against the four-branch stack):
  - Drop an agent definition at `agents/content-manager.ts`
  - Open `/cms/ai`, chat for a turn or two
  - Click "Convert to task" with the agent selected
  - Verify the agent posts 👀, then a proposal comment with diff
  - Click Apply → confirm the doc updates and proposal flips to `applied`
  - Click Cancel run mid-flight; observe ⚠️ and `cancelled` status
  - Click Retry → confirm the run starts fresh

## Notes for review

- `chatConvertToTask` validates the agent name against the registered agents and rejects unknown ones with `UNKNOWN_AGENT`. The picker shouldn't surface unregistered agents in the first place, but the server-side check is the source of truth.
- The chat history is serialized as markdown with tool calls collapsed to one-liners (`_↳ ran tool docs_search_`). Full payloads would balloon the seed comment; the agent has access to the original chat via `Task.sourceChatId` if it ever needs them.
- `extractAgentMentions` is exported but **not yet wired into `TaskCommentInput`'s autocomplete**. The parser is the necessary piece; rendering an autocomplete dropdown over Lexical was deliberately scoped out of this PR. The parser already works for any `@<agent-name>` typed manually, and future work can layer the typeahead.

## Once the stack lands

The four PRs are designed to merge in order (1 → 2 → 3 → 4). Each merges cleanly into the next once its target lands. After PR 4 merges, the `experimental.aiAgents` flag (mentioned in the design doc) can graduate from "scaffolding" to "usable feature."

https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV

---
_Generated by [Claude Code](https://claude.ai/code/session_014vCaqqRJXAihM4CbRedCNV)_