### PR TITLE
chore: switch prerelease tag from alpha to beta

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "alpha",
+  "tag": "beta",
   "initialVersions": {
     "@private/docs": "0.0.0",
     "@examples/basepath": "0.0.0",


### PR DESCRIPTION
## Summary
Updates the pre-release configuration to use the "beta" tag instead of "alpha" for pre-release versions.

## Changes
- Changed the `tag` value in `.changeset/pre.json` from "alpha" to "beta"

## Details
This change updates the pre-release versioning scheme, indicating a transition from alpha to beta pre-release status. This will affect how pre-release versions are tagged and identified in the release process.

https://claude.ai/code/session_01Gbbbm34RdQZxgB8LXNWyNX