### PR TITLE
feat: add profile images to user list

### DIFF
--- a/packages/root-cms/ui/components/EmailAvatar/EmailAvatar.css
+++ b/packages/root-cms/ui/components/EmailAvatar/EmailAvatar.css
@@ -1,0 +1,6 @@
+.EmailAvatar {
+  border-radius: 50%;
+  display: block;
+  object-fit: cover;
+  flex-shrink: 0;
+}

--- a/packages/root-cms/ui/components/EmailAvatar/EmailAvatar.tsx
+++ b/packages/root-cms/ui/components/EmailAvatar/EmailAvatar.tsx
@@ -1,0 +1,60 @@
+import {useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
+import {
+  UserProfile,
+  getAvatarColor,
+  getEmailAvatarInitial,
+} from '../../utils/user-profile.js';
+import './EmailAvatar.css';
+
+export interface EmailAvatarProps {
+  email: string;
+  profile?: UserProfile | null;
+  size?: number;
+  className?: string;
+}
+
+/** Renders a profile photo or one-letter SVG fallback for an email entry. */
+export function EmailAvatar(props: EmailAvatarProps) {
+  const size = props.size || 28;
+  const [imgError, setImgError] = useState(false);
+  const photoURL = props.profile?.photoURL || '';
+  const displayName = props.profile?.displayName || props.email;
+  const className = joinClassNames('EmailAvatar', props.className);
+  const style = {width: size, height: size};
+
+  if (photoURL && !imgError) {
+    return (
+      <img
+        className={className}
+        style={style}
+        src={photoURL}
+        alt={displayName}
+        onError={() => setImgError(true)}
+      />
+    );
+  }
+
+  return (
+    <svg
+      className={className}
+      style={style}
+      viewBox="0 0 28 28"
+      role="img"
+      aria-label={displayName}
+    >
+      <circle cx="14" cy="14" r="14" fill={getAvatarColor(props.email)} />
+      <text
+        x="14"
+        y="14"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fff"
+        fontSize="13"
+        fontWeight="600"
+      >
+        {getEmailAvatarInitial(props.email)}
+      </text>
+    </svg>
+  );
+}

--- a/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.css
+++ b/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.css
@@ -21,7 +21,7 @@
   transform: rotate(-90deg);
 }
 
-.PermissionGroupsBox__accordion [aria-expanded="true"] .mantine-Accordion-icon {
+.PermissionGroupsBox__accordion [aria-expanded='true'] .mantine-Accordion-icon {
   transform: rotate(0deg) !important;
 }
 
@@ -102,14 +102,15 @@
 
 .PermissionGroupsBox__editor__userItem {
   display: grid;
-  grid-template-columns: 28px minmax(0, 1fr) auto;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
   font-size: 13px;
 }
 
-.PermissionGroupsBox__editor__userItem + .PermissionGroupsBox__editor__userItem {
+.PermissionGroupsBox__editor__userItem
+  + .PermissionGroupsBox__editor__userItem {
   border-top: 1px solid var(--color-border);
 }
 
@@ -125,8 +126,8 @@
 }
 
 .PermissionGroupsBox__editor__userItem__avatar {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
 }
 
 .PermissionGroupsBox__editor__footer {

--- a/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.css
+++ b/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.css
@@ -30,6 +30,10 @@
   padding-bottom: 12px;
 }
 
+.PermissionGroupsBox__accordion .mantine-Accordion-item:last-child {
+  border-bottom: none;
+}
+
 .PermissionGroupsBox__trigger {
   display: flex;
   align-items: center;
@@ -97,9 +101,9 @@
 }
 
 .PermissionGroupsBox__editor__userItem {
-  display: flex;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   padding: 6px 12px;
   font-size: 13px;
@@ -118,6 +122,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+
+.PermissionGroupsBox__editor__userItem__avatar {
+  width: 28px;
+  height: 28px;
 }
 
 .PermissionGroupsBox__editor__footer {

--- a/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx
+++ b/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx
@@ -267,6 +267,7 @@ function PermissionGroupEditor(props: PermissionGroupEditorProps) {
                     className="PermissionGroupsBox__editor__userItem__avatar"
                     email={email}
                     profile={profile}
+                    size={24}
                   />
                   <span className="PermissionGroupsBox__editor__userItem__email">
                     {email}

--- a/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx
+++ b/packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx
@@ -10,11 +10,14 @@ import {
 import {IconTrash, IconX} from '@tabler/icons-preact';
 import {useMemo, useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
+import {useUserProfiles} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {
   PermissionGroup,
   newPermissionGroup,
 } from '../../utils/permissionGroups.js';
+import {UserProfile, isOrgEmail} from '../../utils/user-profile.js';
+import {EmailAvatar} from '../EmailAvatar/EmailAvatar.js';
 import {Text} from '../Text/Text.js';
 import './PermissionGroupsBox.css';
 
@@ -139,6 +142,8 @@ interface PermissionGroupEditorProps {
 function PermissionGroupEditor(props: PermissionGroupEditorProps) {
   const {group, collectionOptions, disabled} = props;
   const [emailInput, setEmailInput] = useState('');
+  const profileEmails = group.users.filter((email) => !isOrgEmail(email));
+  const {profiles} = useUserProfiles(profileEmails);
 
   function setName(name: string) {
     props.onChange({...group, name});
@@ -250,22 +255,34 @@ function PermissionGroupEditor(props: PermissionGroupEditorProps) {
         </form>
         {group.users.length > 0 && (
           <ul className="PermissionGroupsBox__editor__userList">
-            {group.users.map((email) => (
-              <li key={email} className="PermissionGroupsBox__editor__userItem">
-                <span className="PermissionGroupsBox__editor__userItem__email">
-                  {email}
-                </span>
-                <ActionIcon
-                  size="sm"
-                  variant="transparent"
-                  disabled={disabled}
-                  onClick={() => removeUser(email)}
-                  title={`Remove ${email}`}
+            {group.users.map((email) => {
+              const profile: UserProfile | null =
+                profiles.get(email.toLowerCase()) || null;
+              return (
+                <li
+                  key={email}
+                  className="PermissionGroupsBox__editor__userItem"
                 >
-                  <IconX size={14} />
-                </ActionIcon>
-              </li>
-            ))}
+                  <EmailAvatar
+                    className="PermissionGroupsBox__editor__userItem__avatar"
+                    email={email}
+                    profile={profile}
+                  />
+                  <span className="PermissionGroupsBox__editor__userItem__email">
+                    {email}
+                  </span>
+                  <ActionIcon
+                    size="sm"
+                    variant="transparent"
+                    disabled={disabled}
+                    onClick={() => removeUser(email)}
+                    title={`Remove ${email}`}
+                  >
+                    <IconX size={14} />
+                  </ActionIcon>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -16,7 +16,7 @@
 }
 
 .ShareBox__user {
-  grid-template-columns: 28px minmax(0, 1fr) 120px;
+  grid-template-columns: 24px minmax(0, 1fr) 120px;
   padding: 6px 16px;
 }
 
@@ -44,8 +44,8 @@
 }
 
 .ShareBox__user__avatar {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   display: block;
   object-fit: cover;

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -7,12 +7,16 @@
 .ShareBox__user {
   width: 100%;
   display: grid;
-  grid-template-columns: 1fr 120px;
   align-items: center;
   gap: 8px;
 }
 
+.ShareBox__addUser {
+  grid-template-columns: 1fr 120px;
+}
+
 .ShareBox__user {
+  grid-template-columns: 28px minmax(0, 1fr) 120px;
   padding: 6px 16px;
 }
 
@@ -37,4 +41,13 @@
 .ShareBox__user__email {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.ShareBox__user__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: block;
+  object-fit: cover;
+  flex-shrink: 0;
 }

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -4,11 +4,8 @@ import {UserRole} from '../../../core/client.js';
 import {useUserProfiles} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {sortByKey} from '../../utils/objects.js';
-import {
-  UserProfile,
-  getAvatarColor,
-  getEmailAvatarInitial,
-} from '../../utils/user-profile.js';
+import {UserProfile, isOrgEmail} from '../../utils/user-profile.js';
+import {EmailAvatar} from '../EmailAvatar/EmailAvatar.js';
 import {Text} from '../Text/Text.js';
 import './ShareBox.css';
 
@@ -111,53 +108,15 @@ export interface ShareBoxUserProps {
   onRemove: (email: string) => void;
 }
 
-function isOrgEmail(email: string): boolean {
-  return email.trim().startsWith('*@');
-}
-
-function ShareBoxAvatar(props: {email: string; profile?: UserProfile | null}) {
-  const [imgError, setImgError] = useState(false);
-  const photoURL = props.profile?.photoURL || '';
-  const displayName = props.profile?.displayName || props.email;
-  if (photoURL && !imgError) {
-    return (
-      <img
-        className="ShareBox__user__avatar"
-        src={photoURL}
-        alt={displayName}
-        onError={() => setImgError(true)}
-      />
-    );
-  }
-  const initial = getEmailAvatarInitial(props.email);
-  return (
-    <svg
-      className="ShareBox__user__avatar"
-      viewBox="0 0 28 28"
-      role="img"
-      aria-label={displayName}
-    >
-      <circle cx="14" cy="14" r="14" fill={getAvatarColor(props.email)} />
-      <text
-        x="14"
-        y="14"
-        textAnchor="middle"
-        dominantBaseline="central"
-        fill="#fff"
-        fontSize="13"
-        fontWeight="600"
-      >
-        {initial}
-      </text>
-    </svg>
-  );
-}
-
 ShareBox.User = (props: ShareBoxUserProps) => {
   const isCurrentUser = props.email === window.firebase.user.email;
   return (
     <div className="ShareBox__user">
-      <ShareBoxAvatar email={props.email} profile={props.profile} />
+      <EmailAvatar
+        className="ShareBox__user__avatar"
+        email={props.email}
+        profile={props.profile}
+      />
       <Text
         className="ShareBox__user__email"
         size="body-sm"

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -116,6 +116,7 @@ ShareBox.User = (props: ShareBoxUserProps) => {
         className="ShareBox__user__avatar"
         email={props.email}
         profile={props.profile}
+        size={24}
       />
       <Text
         className="ShareBox__user__email"

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -1,8 +1,14 @@
 import {Button, Select, TextInput} from '@mantine/core';
 import {useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
+import {useUserProfiles} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {sortByKey} from '../../utils/objects.js';
+import {
+  UserProfile,
+  getAvatarColor,
+  getEmailAvatarInitial,
+} from '../../utils/user-profile.js';
 import {Text} from '../Text/Text.js';
 import './ShareBox.css';
 
@@ -16,6 +22,10 @@ export interface ShareBoxProps {
 export function ShareBox(props: ShareBoxProps) {
   const {roles, onChange, currentUserIsAdmin} = props;
   const [emailInput, setEmailInput] = useState('');
+  const profileEmails = Object.keys(roles).filter(
+    (email) => !isOrgEmail(email)
+  );
+  const {profiles} = useUserProfiles(profileEmails);
 
   function setRole(email: string, role: UserRole) {
     onChange({...roles, [email]: role});
@@ -38,7 +48,11 @@ export function ShareBox(props: ShareBoxProps) {
 
   const users: ShareBoxUserProps[] = sortByKey(
     Object.keys(roles).map((email) => {
-      return {email, role: roles[email]};
+      return {
+        email,
+        role: roles[email],
+        profile: profiles.get(email.toLowerCase()) || null,
+      };
     }),
     'email'
   );
@@ -91,15 +105,59 @@ export function ShareBox(props: ShareBoxProps) {
 export interface ShareBoxUserProps {
   email: string;
   role: UserRole;
+  profile?: UserProfile | null;
   currentUserIsAdmin: boolean;
   onRoleChange: (email: string, newRole: UserRole) => void;
   onRemove: (email: string) => void;
+}
+
+function isOrgEmail(email: string): boolean {
+  return email.trim().startsWith('*@');
+}
+
+function ShareBoxAvatar(props: {email: string; profile?: UserProfile | null}) {
+  const [imgError, setImgError] = useState(false);
+  const photoURL = props.profile?.photoURL || '';
+  const displayName = props.profile?.displayName || props.email;
+  if (photoURL && !imgError) {
+    return (
+      <img
+        className="ShareBox__user__avatar"
+        src={photoURL}
+        alt={displayName}
+        onError={() => setImgError(true)}
+      />
+    );
+  }
+  const initial = getEmailAvatarInitial(props.email);
+  return (
+    <svg
+      className="ShareBox__user__avatar"
+      viewBox="0 0 28 28"
+      role="img"
+      aria-label={displayName}
+    >
+      <circle cx="14" cy="14" r="14" fill={getAvatarColor(props.email)} />
+      <text
+        x="14"
+        y="14"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fff"
+        fontSize="13"
+        fontWeight="600"
+      >
+        {initial}
+      </text>
+    </svg>
+  );
 }
 
 ShareBox.User = (props: ShareBoxUserProps) => {
   const isCurrentUser = props.email === window.firebase.user.email;
   return (
     <div className="ShareBox__user">
+      <ShareBoxAvatar email={props.email} profile={props.profile} />
       <Text
         className="ShareBox__user__email"
         size="body-sm"

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
@@ -6,8 +6,15 @@
 .SettingsPage__section {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  align-items: start;
   gap: var(--page-padding-lg);
   max-width: 1280px;
+}
+
+.SettingsPage__section__left {
+  position: sticky;
+  top: var(--page-padding-lg);
+  align-self: start;
 }
 
 .SettingsPage__section__left__title {
@@ -78,6 +85,10 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.SettingsPage__share__subsection .SettingsPage__section__right__title {
+  margin-bottom: 0;
 }
 
 .SettingsPage__share__saveBar {

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
@@ -13,7 +13,7 @@
 
 .SettingsPage__section__left {
   position: sticky;
-  top: var(--page-padding-lg);
+  top: 0;
   align-self: start;
 }
 

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -401,7 +401,6 @@ function ShareSection() {
             <Heading className="SettingsPage__section__right__title" size="h3">
               Groups
             </Heading>
-            <Text></Text>
             <PermissionGroupsBox
               groups={draft.permissionGroups}
               onChange={setGroups}

--- a/packages/root-cms/ui/utils/user-profile.test.ts
+++ b/packages/root-cms/ui/utils/user-profile.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it} from 'vitest';
-import {getAvatarColor, getUserInitials} from './user-profile.js';
+import {
+  getAvatarColor,
+  getEmailAvatarInitial,
+  getUserInitials,
+} from './user-profile.js';
 
 describe('getUserInitials', () => {
   it('uses the first letters of two display name words', () => {
@@ -35,5 +39,24 @@ describe('getAvatarColor', () => {
 
   it('returns a hex color from the predefined palette', () => {
     expect(getAvatarColor('zoe@example.com')).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe('getEmailAvatarInitial', () => {
+  it('uses the first letter of a user email local part', () => {
+    expect(getEmailAvatarInitial('alex@example.com')).toBe('A');
+  });
+
+  it('uses the first letter of the domain for org wildcards', () => {
+    expect(getEmailAvatarInitial('*@blinkk.com')).toBe('B');
+  });
+
+  it('strips non-alphanumeric characters', () => {
+    expect(getEmailAvatarInitial('.zoe@example.com')).toBe('Z');
+  });
+
+  it('returns a placeholder when no usable characters exist', () => {
+    expect(getEmailAvatarInitial('')).toBe('?');
+    expect(getEmailAvatarInitial('*@...')).toBe('?');
   });
 });

--- a/packages/root-cms/ui/utils/user-profile.test.ts
+++ b/packages/root-cms/ui/utils/user-profile.test.ts
@@ -3,6 +3,7 @@ import {
   getAvatarColor,
   getEmailAvatarInitial,
   getUserInitials,
+  isOrgEmail,
 } from './user-profile.js';
 
 describe('getUserInitials', () => {
@@ -58,5 +59,15 @@ describe('getEmailAvatarInitial', () => {
   it('returns a placeholder when no usable characters exist', () => {
     expect(getEmailAvatarInitial('')).toBe('?');
     expect(getEmailAvatarInitial('*@...')).toBe('?');
+  });
+});
+
+describe('isOrgEmail', () => {
+  it('returns true for domain wildcard role entries', () => {
+    expect(isOrgEmail('*@blinkk.com')).toBe(true);
+  });
+
+  it('returns false for concrete user emails', () => {
+    expect(isOrgEmail('test@blinkk.com')).toBe(false);
   });
 });

--- a/packages/root-cms/ui/utils/user-profile.ts
+++ b/packages/root-cms/ui/utils/user-profile.ts
@@ -200,12 +200,17 @@ export function getEmailAvatarInitial(email: string): string {
     return '?';
   }
   const [localPart, domain = ''] = trimmed.split('@');
-  const source = localPart === '*' ? domain : localPart || trimmed;
+  const source = isOrgEmail(trimmed) ? domain : localPart || trimmed;
   const alphanum = source.replace(/[^a-zA-Z0-9]/g, '');
   if (alphanum.length === 0) {
     return '?';
   }
   return alphanum[0].toUpperCase();
+}
+
+/** Returns true when an email role entry represents a domain wildcard. */
+export function isOrgEmail(email: string): boolean {
+  return email.trim().startsWith('*@');
 }
 
 /**

--- a/packages/root-cms/ui/utils/user-profile.ts
+++ b/packages/root-cms/ui/utils/user-profile.ts
@@ -193,6 +193,21 @@ export function getUserInitials(email: string, displayName?: string): string {
   return alphanum.slice(0, 2).toUpperCase();
 }
 
+/** Returns the one-letter fallback for settings user-list avatars. */
+export function getEmailAvatarInitial(email: string): string {
+  const trimmed = email.trim();
+  if (!trimmed) {
+    return '?';
+  }
+  const [localPart, domain = ''] = trimmed.split('@');
+  const source = localPart === '*' ? domain : localPart || trimmed;
+  const alphanum = source.replace(/[^a-zA-Z0-9]/g, '');
+  if (alphanum.length === 0) {
+    return '?';
+  }
+  return alphanum[0].toUpperCase();
+}
+
 /**
  * Returns a deterministic background color for an email so missing-photo
  * avatars are visually distinct but stable across renders.


### PR DESCRIPTION
## Summary
- Add a shared email avatar renderer for Settings share users and permission group users.
- Use stored profile photos when available, with SVG one-letter fallbacks for user emails and domain wildcard entries.
- Set Settings share and group avatars to 24px.
- Make the Settings left-column descriptions sticky without adding extra resting top offset.
- Tighten group list spacing/borders.

## Tests
- git diff --check
- pnpm exec eslint packages/root-cms/ui/components/ShareBox/ShareBox.tsx packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx
- pnpm exec prettier --check packages/root-cms/ui/components/ShareBox/ShareBox.tsx packages/root-cms/ui/components/ShareBox/ShareBox.css packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.tsx packages/root-cms/ui/components/PermissionGroupsBox/PermissionGroupsBox.css
- pnpm --filter="@blinkk/root-cms" build

## Screenshot
<img width="634" height="454" alt="image" src="https://github.com/user-attachments/assets/8cdfb81f-92ee-48ee-938c-e73de8611a39" />