### PR TITLE
fix: improve ai network payload issues via server-side calls

### DIFF
--- a/packages/root-cms/core/ai-tools.ts
+++ b/packages/root-cms/core/ai-tools.ts
@@ -1,20 +1,32 @@
 /**
  * Built-in CMS tools exposed to the chat model on the `/cms/ai` page.
  *
- * Tools are defined here as schema-only declarations (no `execute`). The
- * server passes them through to `streamText`, the model emits tool calls,
- * and the browser executes them via `onToolCall` in `useChat`. This means:
+ * Read tools (`doc_get`, `docs_list`, etc.) execute server-side via the
+ * Firebase Admin SDK when a `CmsToolContext` is passed to the factory. This
+ * keeps potentially-large doc payloads off the wire: results stay in the
+ * model's server-side context instead of round-tripping through the browser
+ * on every chat turn.
  *
- * - Reads/writes happen with the signed-in user's Firebase credentials and
- *   respect Firestore security rules.
- * - Other connected clients see writes in real time via Firestore listeners.
- * - The server stays a thin streaming proxy.
+ * Write tools (`doc_set`, `doc_create`, `doc_updateField`, `doc_duplicate`)
+ * stay schema-only here — the browser executes them via `onToolCall` so the
+ * user can approve diffs in the UI and so Firestore listeners on other tabs
+ * see the change immediately.
  *
  * Validation helpers (`validateFields`, `validateValueAtPath`) live here
- * too so the client can run the same checks the old server-side tools did.
+ * too so both browser and server can share the same checks.
+ *
+ * Browser-import safety: this module is dynamically imported by the browser
+ * bundle (cmsToolHandlers.ts) to reuse the validators, so it must not pull
+ * server-only modules into runtime imports. `RootCMSClient` and `RootConfig`
+ * are referenced as types only; the actual instance is passed in at call
+ * time via `CmsToolContext`.
  */
+import type {RootConfig} from '@blinkk/root';
 import {tool, ToolSet} from 'ai';
 import {z} from 'zod';
+import {unmarshalData} from '../shared/marshal.js';
+import {normalizeSlug} from '../shared/slug.js';
+import type {RootCMSClient} from './client.js';
 import {
   ArrayField,
   Collection,
@@ -59,12 +71,38 @@ export const READ_ONLY_CMS_TOOL_NAMES: readonly CmsToolName[] = [
 ] as const;
 
 /**
+ * Result of a server-side search invocation. Loosely-typed — the result is
+ * serialized to JSON and handed to the model, so extra fields are fine.
+ * `hits` is an array of objects each carrying at least a `docId`.
+ */
+export interface CmsSearchResult {
+  hits: Array<Record<string, unknown> | {docId: string}>;
+}
+
+/**
+ * Context passed into the tool factory to enable server-side execution of
+ * the read tools. The caller (typically `runChatStream` in `core/ai.ts`)
+ * owns the Firebase Admin client and the schema/search lookups.
+ */
+export interface CmsToolContext {
+  cmsClient: RootCMSClient;
+  user: string;
+  rootConfig: RootConfig;
+  loadCollection: (collectionId: string) => Promise<Collection | null>;
+  loadAllCollections: () => Promise<Record<string, Collection>>;
+  search: (
+    query: string,
+    options: {limit: number}
+  ) => Promise<CmsSearchResult>;
+}
+
+/**
  * Returns a `ToolSet` filtered to only the read-only CMS tools. Use this in
  * flows where the AI assists with proposing changes that the user reviews
  * and saves manually (so the model can read context but cannot mutate data).
  */
-export function createReadOnlyCmsTools(): ToolSet {
-  const all = createCmsTools();
+export function createReadOnlyCmsTools(ctx: CmsToolContext): ToolSet {
+  const all = createCmsTools(ctx);
   const out: ToolSet = {};
   for (const name of READ_ONLY_CMS_TOOL_NAMES) {
     if (all[name]) {
@@ -75,8 +113,16 @@ export function createReadOnlyCmsTools(): ToolSet {
 }
 
 /**
- * Schema-only tool definitions. The server passes these to `streamText` so
- * the model knows the contract; the browser provides the actual `execute`.
+ * Builds the full tool set advertised to the model.
+ *
+ * Read tools (`collections_list`, `docs_list`, `docs_search`, `doc_get`,
+ * `doc_getVersion`, `doc_listVersions`, `schema_get`) carry a server-side
+ * `execute` so the Vercel AI SDK runs them in-process; their results stay
+ * in the model's server-side context and never round-trip through the
+ * browser. Write tools (`doc_set`, `doc_create`, `doc_updateField`,
+ * `doc_duplicate`, `doc_translateField`) remain schema-only — the browser
+ * executes them via `onToolCall` so the user can approve diffs before
+ * persistence.
  *
  * Safety policy: this tool set is intentionally read + draft-write only.
  * The following operations are deliberately NOT exposed to the model
@@ -97,13 +143,23 @@ export function createReadOnlyCmsTools(): ToolSet {
  * If you add new write tools here, keep them limited to draft-mode edits
  * the user can easily review before publishing.
  */
-export function createCmsTools(): ToolSet {
+export function createCmsTools(ctx: CmsToolContext): ToolSet {
   return {
     collections_list: tool({
       description:
         'List all CMS collections defined in the project. Returns each ' +
         'collection id along with optional name/description metadata.',
       inputSchema: z.object({}),
+      execute: async () => {
+        const collections = await ctx.loadAllCollections();
+        return {
+          collections: Object.entries(collections).map(([id, meta]) => ({
+            id,
+            name: meta.name,
+            description: meta.description,
+          })),
+        };
+      },
     }),
 
     docs_list: tool({
@@ -121,6 +177,20 @@ export function createCmsTools(): ToolSet {
           .describe('Whether to read draft or published versions.'),
         limit: z.number().int().min(1).max(100).default(25),
       }),
+      execute: async ({collectionId, mode = 'draft', limit = 25}) => {
+        const max = clampInt(limit, 1, 100, 25);
+        const result = await ctx.cmsClient.listDocs<any>(collectionId, {
+          mode,
+          limit: max,
+        });
+        return {
+          docs: result.docs.map((d: any) => ({
+            id: d.id,
+            slug: d.slug,
+            sys: unmarshalSys(d.sys),
+          })),
+        };
+      },
     }),
 
     docs_search: tool({
@@ -131,6 +201,10 @@ export function createCmsTools(): ToolSet {
         query: z.string().min(1),
         limit: z.number().int().min(1).max(50).default(10),
       }),
+      execute: async ({query, limit = 10}) => {
+        const max = clampInt(limit, 1, 50, 10);
+        return await ctx.search(query, {limit: max});
+      },
     }),
 
     doc_get: tool({
@@ -145,6 +219,23 @@ export function createCmsTools(): ToolSet {
           ),
         mode: z.enum(['draft', 'published']).default('draft'),
       }),
+      execute: async ({docId, mode = 'draft'}) => {
+        const {collection, slug} = parseDocId(docId);
+        const raw = await ctx.cmsClient.getRawDoc(collection, slug, {mode});
+        if (!raw) {
+          return {found: false};
+        }
+        return {
+          found: true,
+          doc: {
+            id: raw.id,
+            collection: raw.collection,
+            slug: raw.slug,
+            sys: unmarshalSys(raw.sys),
+            fields: unmarshalFields(raw.fields),
+          },
+        };
+      },
     }),
 
     doc_getVersion: tool({
@@ -164,6 +255,32 @@ export function createCmsTools(): ToolSet {
             'Version identifier: "draft", "published", or a numeric timestamp.'
           ),
       }),
+      execute: async ({docId, versionId}) => {
+        const {collection, slug} = parseDocId(docId);
+        let path: string;
+        if (versionId === 'draft') {
+          path = `Projects/${ctx.cmsClient.projectId}/Collections/${collection}/Drafts/${slug}`;
+        } else if (versionId === 'published') {
+          path = `Projects/${ctx.cmsClient.projectId}/Collections/${collection}/Published/${slug}`;
+        } else {
+          path = `Projects/${ctx.cmsClient.projectId}/Collections/${collection}/Drafts/${slug}/Versions/${versionId}`;
+        }
+        const snap = await ctx.cmsClient.db.doc(path).get();
+        if (!snap.exists) {
+          return {found: false};
+        }
+        const raw = snap.data() as any;
+        return {
+          found: true,
+          doc: {
+            id: raw.id,
+            collection: raw.collection,
+            slug: raw.slug,
+            sys: unmarshalSys(raw.sys),
+            fields: unmarshalFields(raw.fields),
+          },
+        };
+      },
     }),
 
     doc_set: tool({
@@ -267,6 +384,27 @@ export function createCmsTools(): ToolSet {
           ),
         limit: z.number().int().min(1).max(50).default(10),
       }),
+      execute: async ({docId, limit = 10}) => {
+        const {collection, slug} = parseDocId(docId);
+        const max = clampInt(limit, 1, 50, 10);
+        const path = `Projects/${ctx.cmsClient.projectId}/Collections/${collection}/Drafts/${slug}/Versions`;
+        const snap = await ctx.cmsClient.db
+          .collection(path)
+          .orderBy('sys.modifiedAt', 'desc')
+          .limit(max)
+          .get();
+        return {
+          versions: snap.docs.map((d) => {
+            const data = d.data() as any;
+            return {
+              versionId: d.id,
+              sys: unmarshalSys(data.sys),
+              tags: data.tags || [],
+              publishMessage: data.publishMessage,
+            };
+          }),
+        };
+      },
     }),
 
     doc_translateField: tool({
@@ -302,8 +440,88 @@ export function createCmsTools(): ToolSet {
           .string()
           .describe('Collection id, e.g. "Pages" or "BlogPosts".'),
       }),
+      execute: async ({collectionId}) => {
+        const schema = await ctx.loadCollection(collectionId);
+        if (!schema) {
+          return {found: false, collectionId};
+        }
+        return {
+          found: true,
+          collectionId,
+          fields: simplifyFields(schema.fields || []),
+        };
+      },
     }),
   };
+}
+
+/** Parses a docId like "Pages/home" into `{collection, slug}`. */
+function parseDocId(docId: string): {collection: string; slug: string} {
+  const idx = docId.indexOf('/');
+  if (idx <= 0 || idx === docId.length - 1) {
+    throw new Error(`invalid docId: "${docId}" (expected "Collection/slug")`);
+  }
+  return {
+    collection: docId.slice(0, idx),
+    slug: normalizeSlug(docId.slice(idx + 1)),
+  };
+}
+
+/** Clamp `value` into `[min, max]`, falling back to `fallback` on NaN. */
+function clampInt(
+  value: number,
+  min: number,
+  max: number,
+  fallback: number
+): number {
+  const n = Number.isFinite(value) ? Math.trunc(value) : fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+/**
+ * Unmarshal a doc's `sys` block from Firestore Admin representation.
+ *
+ * The default duck-typing in `shared/marshal.unmarshalData` calls `toMillis()`
+ * on anything that has it, which covers both client and Admin SDK Timestamps.
+ */
+function unmarshalSys(sys: unknown): Record<string, unknown> {
+  return unmarshalData(sys ?? {}) as Record<string, unknown>;
+}
+
+/** Unmarshal a doc's `fields` block (drops `_arrayKey` arrays into arrays). */
+function unmarshalFields(fields: unknown): Record<string, unknown> {
+  return unmarshalData(fields ?? {}) as Record<string, unknown>;
+}
+
+/**
+ * Reduces a collection's field definitions down to the bits the model needs
+ * (id, type, label, options, nested shape). Drops Root-internal metadata
+ * (preview, conditional visibility, default UI widget hints, etc.) since
+ * those would bloat the model context without adding decision-useful info.
+ */
+function simplifyFields(fields: Field[]): unknown[] {
+  return fields.map((f: any) => {
+    const out: any = {id: f.id, type: f.type};
+    if (f.label) out.label = f.label;
+    if (f.description) out.description = f.description;
+    if (f.required) out.required = true;
+    if (f.translate) out.translate = true;
+    if (f.options) out.options = f.options;
+    if (f.type === 'object' && f.fields) {
+      out.fields = simplifyFields(f.fields);
+    }
+    if (f.type === 'array' && f.of) {
+      out.of = simplifyFields([f.of])[0];
+    }
+    if (f.type === 'oneof' && f.types) {
+      out.types = f.types.map((t: any) =>
+        typeof t === 'string'
+          ? t
+          : {id: t.id, fields: simplifyFields(t.fields || [])}
+      );
+    }
+    return out;
+  });
 }
 
 /**

--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -27,8 +27,14 @@ import {
   UIMessage,
 } from 'ai';
 import {Timestamp} from 'firebase-admin/firestore';
-import {createCmsTools, createReadOnlyCmsTools} from './ai-tools.js';
+import {
+  CmsToolContext,
+  createCmsTools,
+  createReadOnlyCmsTools,
+} from './ai-tools.js';
 import {RootCMSClient} from './client.js';
+import {Collection} from './schema.js';
+import {SearchIndexService} from './search-index.js';
 
 /** Filename of the project-level instructions file loaded into the AI prompt. */
 export const ROOT_MD_FILENAME = 'ROOT.md';
@@ -502,6 +508,45 @@ export interface RunChatStreamOptions {
   chatId: string;
   user: string;
   executionMode?: AiExecutionMode;
+  /**
+   * Loads a single collection's schema. The caller owns dev-vs-prod schema
+   * resolution (Vite SSR vs. prebuilt `dist/collections/*.json`).
+   */
+  loadCollection: (collectionId: string) => Promise<Collection | null>;
+  /** Loads every project collection keyed by id. */
+  loadAllCollections: () => Promise<Record<string, Collection>>;
+}
+
+/**
+ * Builds the `CmsToolContext` used by the server-side tool `execute` blocks.
+ *
+ * Search is instantiated lazily — `SearchIndexService` boots a MiniSearch
+ * index from Firestore, which is wasteful when the chat never needs it.
+ */
+function buildCmsToolContext(options: {
+  rootConfig: RootConfig;
+  cmsClient: RootCMSClient;
+  user: string;
+  loadCollection: (collectionId: string) => Promise<Collection | null>;
+  loadAllCollections: () => Promise<Record<string, Collection>>;
+}): CmsToolContext {
+  let searchService: SearchIndexService | null = null;
+  return {
+    rootConfig: options.rootConfig,
+    cmsClient: options.cmsClient,
+    user: options.user,
+    loadCollection: options.loadCollection,
+    loadAllCollections: options.loadAllCollections,
+    search: async (query, opts) => {
+      if (!searchService) {
+        searchService = new SearchIndexService(
+          options.rootConfig,
+          options.loadCollection
+        );
+      }
+      return await searchService.search(query, opts);
+    },
+  };
 }
 
 function buildExecutionModePrompt(mode: AiExecutionMode): string {
@@ -562,14 +607,23 @@ export async function runChatStream(
     user,
     chatId,
     executionMode = 'approve',
+    loadCollection,
+    loadAllCollections,
   } = options;
   const languageModel = resolveLanguageModel(model);
+  const toolContext = buildCmsToolContext({
+    rootConfig,
+    cmsClient,
+    user,
+    loadCollection,
+    loadAllCollections,
+  });
   const tools: ToolSet =
     model.capabilities?.tools === false
       ? {}
       : executionMode === 'read' || executionMode === 'suggest'
-      ? createReadOnlyCmsTools()
-      : createCmsTools();
+      ? createReadOnlyCmsTools(toolContext)
+      : createCmsTools(toolContext);
 
   const basePrompt =
     config.systemPrompt ||
@@ -622,11 +676,15 @@ export async function runChatStream(
 
 export interface RunEditObjectStreamOptions {
   rootConfig: RootConfig;
+  cmsClient: RootCMSClient;
+  user: string;
   config: AiConfig;
   model: AiModelConfig;
   messages: UIMessage[];
   /** The JSON object the user is editing. Injected as context for the model. */
   editData: unknown;
+  loadCollection: (collectionId: string) => Promise<Collection | null>;
+  loadAllCollections: () => Promise<Record<string, Collection>>;
 }
 
 /**
@@ -648,10 +706,29 @@ export interface RunEditObjectStreamOptions {
 export async function runEditObjectStream(
   options: RunEditObjectStreamOptions
 ): Promise<Response> {
-  const {rootConfig, model, config, messages, editData} = options;
+  const {
+    rootConfig,
+    cmsClient,
+    user,
+    model,
+    config,
+    messages,
+    editData,
+    loadCollection,
+    loadAllCollections,
+  } = options;
   const languageModel = resolveLanguageModel(model);
+  const toolContext = buildCmsToolContext({
+    rootConfig,
+    cmsClient,
+    user,
+    loadCollection,
+    loadAllCollections,
+  });
   const tools: ToolSet =
-    model.capabilities?.tools === false ? {} : createReadOnlyCmsTools();
+    model.capabilities?.tools === false
+      ? {}
+      : createReadOnlyCmsTools(toolContext);
 
   const editPromptText = (await import('../shared/ai/prompts/edit.txt'))
     .default;

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -763,11 +763,6 @@ export function api(server: Server, options: ApiOptions) {
     }
 
     const body = req.body || {};
-    const messages = (body.messages as UIMessage[]) || [];
-    if (!Array.isArray(messages) || messages.length === 0) {
-      res.status(400).json({success: false, error: 'MISSING_MESSAGES'});
-      return;
-    }
     const model = findModel(aiConfig, body.modelId);
     if (!model) {
       res.status(400).json({success: false, error: 'UNKNOWN_MODEL'});
@@ -780,10 +775,12 @@ export function api(server: Server, options: ApiOptions) {
     const requestedChatId =
       typeof body.chatId === 'string' ? body.chatId.trim() : '';
     let chatId = '';
+    let storedMessages: UIMessage[] = [];
     if (requestedChatId) {
       const existing = await store.getChat(requestedChatId);
       if (existing) {
         chatId = existing.id;
+        storedMessages = (existing.messages as UIMessage[]) || [];
       } else {
         // Honor the client-supplied id so a single chat session keeps the
         // same Firestore doc id even before the first response is saved.
@@ -798,6 +795,28 @@ export function api(server: Server, options: ApiOptions) {
       chatId = created.id;
     }
 
+    // Two request shapes are accepted so we can roll the client over
+    // without coordinating deploys:
+    //
+    //   - `{message: UIMessage}` (preferred): just the latest user message
+    //     or tool-result message. The server appends it to the persisted
+    //     chat history before handing off to `runChatStream`. Keeps wire
+    //     bodies small as conversations grow.
+    //   - `{messages: UIMessage[]}` (legacy): the entire local message
+    //     array. Passed through as-is, which is what the old client did.
+    //
+    // Once every reachable client has shipped the new form, the legacy
+    // branch can be deleted.
+    let messages: UIMessage[];
+    if (body.message && typeof body.message === 'object') {
+      messages = [...storedMessages, body.message as UIMessage];
+    } else if (Array.isArray(body.messages) && body.messages.length > 0) {
+      messages = body.messages as UIMessage[];
+    } else {
+      res.status(400).json({success: false, error: 'MISSING_MESSAGES'});
+      return;
+    }
+
     try {
       const streamResponse = await runChatStream({
         rootConfig: req.rootConfig!,
@@ -808,6 +827,10 @@ export function api(server: Server, options: ApiOptions) {
         chatId,
         user: req.user.email,
         executionMode,
+        loadCollection: (collectionId) =>
+          getCollectionSchema(req, collectionId),
+        loadAllCollections: async () =>
+          (await options.getRenderer(req)).getCollections(),
       });
       // Surface the chat id so clients can persist it for the next request.
       streamResponse.headers.set('x-root-cms-chat-id', chatId);
@@ -868,10 +891,16 @@ export function api(server: Server, options: ApiOptions) {
       try {
         const streamResponse = await runEditObjectStream({
           rootConfig: req.rootConfig!,
+          cmsClient: new RootCMSClient(req.rootConfig!),
+          user: req.user.email,
           config: aiConfig,
           model,
           messages,
           editData: body.editData,
+          loadCollection: (collectionId) =>
+            getCollectionSchema(req, collectionId),
+          loadAllCollections: async () =>
+            (await options.getRenderer(req)).getCollections(),
         });
         await pipeWebResponse(streamResponse, res);
       } catch (err: any) {

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -767,6 +767,15 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       server: Server,
       serverOptions: ConfigureServerOptions
     ) => {
+      // The AI chat routes echo prior tool results (e.g. full CMS docs read
+      // via `doc_get`) back to the server on every turn, so the request body
+      // can easily exceed body-parser's 100kb default. Use a larger limit for
+      // those routes only; body-parser short-circuits when `req._body` is
+      // already set, so the global parser below is a no-op for them.
+      server.use(
+        ['/cms/api/ai.chat', '/cms/api/ai.edit_object'],
+        bodyParser.json({limit: '4mb'})
+      );
       server.use(bodyParser.json());
       // Handle body-parser errors (e.g. PayloadTooLargeError) gracefully
       // instead of letting them bubble up as unhandled 500 errors.

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -688,9 +688,15 @@ function ChatPane(props: {
       new DefaultChatTransport<UIMessage>({
         api: '/cms/api/ai.chat',
         credentials: 'include',
+        // Send only the latest message (the new user turn, or a tool-result
+        // turn after an auto-resubmit). The server has the rest of the
+        // history persisted in Firestore under `chatId` and merges it in
+        // before calling `streamText`. Without this, every turn would
+        // re-POST the full conversation (including any prior tool results)
+        // and large chats would exceed body-parser's payload limit.
         prepareSendMessagesRequest: ({messages}) => ({
           body: {
-            messages,
+            message: messages.at(-1),
             chatId: effectiveChatId,
             modelId: modelRef.current,
             executionMode: executionModeRef.current,

--- a/packages/root-cms/ui/pages/AIPage/cmsToolHandlers.ts
+++ b/packages/root-cms/ui/pages/AIPage/cmsToolHandlers.ts
@@ -1,20 +1,20 @@
 /**
- * Client-side implementations of the CMS tools declared in
+ * Client-side implementations of the CMS write tools declared in
  * `core/ai-tools.ts`. Each handler runs in the browser using the signed-in
- * user's Firebase credentials.
+ * user's Firebase credentials so writes flow through Firestore listeners
+ * (other open CMS tabs see the change immediately) and trigger Firestore
+ * security rule evaluation.
  *
- * Reads/writes go directly through Firestore so other connected CMS clients
- * see updates in real time, and Firestore security rules apply naturally.
+ * Read tools (`doc_get`, `docs_list`, etc.) live server-side now — see the
+ * `execute` blocks on the read tools in `core/ai-tools.ts`. The Vercel AI
+ * SDK runs those in `streamText` directly and never invokes `onToolCall`
+ * for them, so the large doc payloads they return do not round-trip
+ * through the browser on every chat turn.
  */
 import {
-  collection as fbCollection,
   doc,
   Firestore,
   getDoc as fbGetDoc,
-  getDocs,
-  limit as fbLimit,
-  orderBy,
-  query,
   serverTimestamp,
   setDoc,
   Timestamp,
@@ -77,10 +77,6 @@ export interface CmsToolPreview {
 
 interface RootCtxLike {
   rootConfig: {projectId: string};
-  collections: Record<
-    string,
-    {name?: string; description?: string; [key: string]: any}
-  >;
   firebase: {db: Firestore; user: {email?: string | null}};
 }
 
@@ -92,7 +88,6 @@ function getCtx(): RootCtxLike {
   const w = window as any;
   return {
     rootConfig: w.__ROOT_CTX.rootConfig,
-    collections: w.__ROOT_CTX.collections || {},
     firebase: w.firebase,
   };
 }
@@ -129,38 +124,10 @@ function draftDocRef(docId: string) {
   );
 }
 
-function publishedDocRef(docId: string) {
-  const {collection, slug} = parseDocId(docId);
-  const {firebase, rootConfig} = getCtx();
-  return doc(
-    firebase.db,
-    'Projects',
-    rootConfig.projectId,
-    'Collections',
-    collection,
-    'Published',
-    slug
-  );
-}
-
-// `scheduledDocRef` was removed alongside the publish/delete handlers
-// (see safety policy in `core/ai-tools.ts`).
-
-function versionDocRef(docId: string, versionId: string) {
-  const {collection, slug} = parseDocId(docId);
-  const {firebase, rootConfig} = getCtx();
-  return doc(
-    firebase.db,
-    'Projects',
-    rootConfig.projectId,
-    'Collections',
-    collection,
-    'Drafts',
-    slug,
-    'Versions',
-    versionId
-  );
-}
+// `publishedDocRef`, `versionDocRef`, and `scheduledDocRef` were removed
+// alongside the publish/delete handlers. The remaining write handlers only
+// touch the draft path — see `draftDocRef` above and the safety policy in
+// `core/ai-tools.ts`.
 
 /** Unmarshal with Firestore Timestamp support. */
 function unmarshalData(data: any): any {
@@ -504,112 +471,11 @@ async function previewDocDuplicate(input: {
 // ---------------------------------------------------------------------------
 // Handler implementations
 // ---------------------------------------------------------------------------
-
-async function collectionsList() {
-  const {collections} = getCtx();
-  return {
-    collections: Object.entries(collections).map(([id, meta]) => ({
-      id,
-      name: meta.name,
-      description: meta.description,
-    })),
-  };
-}
-
-async function docsList(input: {
-  collectionId: string;
-  mode?: 'draft' | 'published';
-  limit?: number;
-}) {
-  const {firebase, rootConfig} = getCtx();
-  const mode = input.mode ?? 'draft';
-  const max = Math.min(Math.max(input.limit ?? 25, 1), 100);
-  const colRef = fbCollection(
-    firebase.db,
-    'Projects',
-    rootConfig.projectId,
-    'Collections',
-    input.collectionId,
-    mode === 'draft' ? 'Drafts' : 'Published'
-  );
-  const snap = await getDocs(query(colRef, fbLimit(max)));
-  return {
-    docs: snap.docs.map((d) => {
-      const data = d.data() as any;
-      return {id: data.id, slug: data.slug, sys: unmarshalData(data.sys || {})};
-    }),
-  };
-}
-
-async function docsSearch(input: {query: string; limit?: number}) {
-  const max = Math.min(Math.max(input.limit ?? 10, 1), 50);
-  const res = await fetch('/cms/api/search.query', {
-    method: 'POST',
-    credentials: 'include',
-    headers: {'content-type': 'application/json'},
-    body: JSON.stringify({q: input.query, limit: max}),
-  });
-  if (!res.ok) {
-    throw new Error(`search.query failed: ${res.status}`);
-  }
-  const data = await res.json();
-  return data;
-}
-
-async function docGet(input: {docId: string; mode?: 'draft' | 'published'}) {
-  const {firebase, rootConfig} = getCtx();
-  const {collection, slug} = parseDocId(input.docId);
-  const ref = doc(
-    firebase.db,
-    'Projects',
-    rootConfig.projectId,
-    'Collections',
-    collection,
-    input.mode === 'published' ? 'Published' : 'Drafts',
-    slug
-  );
-  const snap = await fbGetDoc(ref);
-  if (!snap.exists()) {
-    return {found: false};
-  }
-  const raw = snap.data() as any;
-  return {
-    found: true,
-    doc: {
-      id: raw.id,
-      collection: raw.collection,
-      slug: raw.slug,
-      sys: unmarshalData(raw.sys || {}),
-      fields: unmarshalData(raw.fields || {}),
-    },
-  };
-}
-
-async function docGetVersion(input: {docId: string; versionId: string}) {
-  let ref;
-  if (input.versionId === 'draft') {
-    ref = draftDocRef(input.docId);
-  } else if (input.versionId === 'published') {
-    ref = publishedDocRef(input.docId);
-  } else {
-    ref = versionDocRef(input.docId, input.versionId);
-  }
-  const snap = await fbGetDoc(ref);
-  if (!snap.exists()) {
-    return {found: false};
-  }
-  const raw = snap.data() as any;
-  return {
-    found: true,
-    doc: {
-      id: raw.id,
-      collection: raw.collection,
-      slug: raw.slug,
-      sys: unmarshalData(raw.sys || {}),
-      fields: unmarshalData(raw.fields || {}),
-    },
-  };
-}
+//
+// Only write tools live here. Read tools (`doc_get`, `docs_list`,
+// `docs_search`, `doc_getVersion`, `doc_listVersions`, `schema_get`,
+// `collections_list`) execute server-side via the `execute` blocks in
+// `core/ai-tools.ts`.
 
 async function getCachedSchema(collectionId: string): Promise<Collection> {
   return await fetchCollectionSchema(collectionId);
@@ -867,36 +733,6 @@ async function docDuplicate(input: {fromDocId: string; toDocId: string}) {
   };
 }
 
-async function docListVersions(input: {docId: string; limit?: number}) {
-  const {firebase, rootConfig} = getCtx();
-  const {collection, slug} = parseDocId(input.docId);
-  const max = Math.min(Math.max(input.limit ?? 10, 1), 50);
-  const versionsCol = fbCollection(
-    firebase.db,
-    'Projects',
-    rootConfig.projectId,
-    'Collections',
-    collection,
-    'Drafts',
-    slug,
-    'Versions'
-  );
-  const snap = await getDocs(
-    query(versionsCol, orderBy('sys.modifiedAt', 'desc'), fbLimit(max))
-  );
-  return {
-    versions: snap.docs.map((d) => {
-      const data = d.data() as any;
-      return {
-        versionId: d.id,
-        sys: unmarshalData(data.sys || {}),
-        tags: data.tags || [],
-        publishMessage: data.publishMessage,
-      };
-    }),
-  };
-}
-
 async function docTranslateField(input: {
   sourceText: string;
   targetLocales: string[];
@@ -922,58 +758,16 @@ async function docTranslateField(input: {
   return {translations: data.translations};
 }
 
-async function schemaGet(input: {collectionId: string}) {
-  const schema = await fetchCollectionSchema(input.collectionId);
-  // Return a simplified representation for the model.
-  return {
-    collectionId: input.collectionId,
-    fields: simplifyFields(schema.fields || []),
-  };
-}
-
-/** Simplifies field definitions for the model (omit internal metadata). */
-function simplifyFields(fields: any[]): any[] {
-  return fields.map((f) => {
-    const out: any = {id: f.id, type: f.type};
-    if (f.label) out.label = f.label;
-    if (f.description) out.description = f.description;
-    if (f.required) out.required = true;
-    if (f.translate) out.translate = true;
-    if (f.options) out.options = f.options;
-    if (f.type === 'object' && f.fields) {
-      out.fields = simplifyFields(f.fields);
-    }
-    if (f.type === 'array' && f.of) {
-      out.of = simplifyFields([f.of])[0];
-    }
-    if (f.type === 'oneof' && f.types) {
-      out.types = f.types.map((t: any) =>
-        typeof t === 'string'
-          ? t
-          : {id: t.id, fields: simplifyFields(t.fields || [])}
-      );
-    }
-    return out;
-  });
-}
-
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
 
 const HANDLERS: Record<string, (input: any) => Promise<unknown>> = {
-  collections_list: collectionsList,
-  docs_list: docsList,
-  docs_search: docsSearch,
-  doc_get: docGet,
-  doc_getVersion: docGetVersion,
   doc_set: docSet,
   doc_create: docCreate,
   doc_updateField: docUpdateField,
   doc_duplicate: docDuplicate,
-  doc_listVersions: docListVersions,
   doc_translateField: docTranslateField,
-  schema_get: schemaGet,
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR refactors the CMS AI tools architecture to execute read operations (`doc_get`, `docs_list`, `docs_search`, `doc_getVersion`, `doc_listVersions`, `schema_get`, `collections_list`) server-side via the Vercel AI SDK's `execute` blocks, while keeping write operations (`doc_set`, `doc_create`, `doc_updateField`, `doc_duplicate`, `doc_translateField`) as schema-only tools executed client-side.

The key benefit is that large document payloads returned by read tools now stay in the model's server-side context instead of round-tripping through the browser on every chat turn, significantly reducing request/response sizes as conversations grow.

## Key Changes

- **Introduced `CmsToolContext` interface** in `ai-tools.ts` to pass server-side dependencies (CMS client, user, schema loaders, search) to the tool factory
- **Added `execute` blocks to all read tools** in `createCmsTools()` that run server-side using Firebase Admin SDK and the CMS client
- **Moved read tool implementations from browser** (`cmsToolHandlers.ts`) to server (`ai-tools.ts`), including:
  - `collectionsList`, `docsList`, `docsSearch`, `docGet`, `docGetVersion`, `docListVersions`, `schemaGet`
  - Helper functions: `parseDocId`, `clampInt`, `unmarshalSys`, `unmarshalFields`, `simplifyFields`
- **Updated `runChatStream` and `runEditObjectStream`** to build and pass `CmsToolContext` to tool factories
- **Modified API request handling** in `api.ts` to support both legacy (`messages` array) and new (`message` single object) request shapes, allowing incremental client rollout
- **Increased body-parser limit** for AI chat routes to 4MB to accommodate larger request bodies with tool results
- **Updated client-side chat transport** to send only the latest message per turn, relying on server-persisted history in Firestore
- **Added helper functions** for unmarshaling Firestore data and simplifying field schemas for model consumption

## Implementation Details

- Read tools use lazy initialization for `SearchIndexService` to avoid unnecessary overhead when search isn't needed
- Write tools remain browser-side so users can review diffs before persistence and Firestore listeners on other tabs see changes immediately
- The `CmsToolContext` is intentionally type-only in `ai-tools.ts` to prevent server-only modules from being imported into the browser bundle
- Validation helpers (`validateFields`, `validateValueAtPath`) remain shared between browser and server

https://claude.ai/code/session_01FLSbuELSb7VFpwgMoVSHhC