### PR TITLE
feat: add mock OpenAI-compatible LLM server for local UI testing

### DIFF
--- a/.changeset/few-dryers-design.md
+++ b/.changeset/few-dryers-design.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add mock OpenAI-compatible LLM server for local UI testing

--- a/apps/mock-localllm/mock.config.js
+++ b/apps/mock-localllm/mock.config.js
@@ -102,8 +102,21 @@ export default {
       // with a longer array + delay, this is handy for exercising streaming UI.
       prompt: /\b(stream|loading|long)\b/i,
       response: [
-        'Streaming ', 'this ', 'response ', 'one ', 'word ', 'at ', 'a ',
-        'time ', 'so ', 'you ', 'can ', 'watch ', 'the ', 'UI ', 'update ',
+        'Streaming ',
+        'this ',
+        'response ',
+        'one ',
+        'word ',
+        'at ',
+        'a ',
+        'time ',
+        'so ',
+        'you ',
+        'can ',
+        'watch ',
+        'the ',
+        'UI ',
+        'update ',
         'incrementally.',
       ],
       delay: {min: 120, max: 400},
@@ -151,6 +164,28 @@ export default {
           ],
         },
         'Those are the top results from the CMS search above.',
+      ],
+    },
+    {
+      // A tool-call loop that exercises a real Root CMS write tool. The CMS
+      // previews write tools in the browser so users can approve and save the
+      // draft change manually.
+      prompt: 'update sandbox title',
+      responses: [
+        {
+          text: 'I can update the Sandbox test title.\n\n',
+          toolCalls: [
+            {
+              name: 'doc_updateField',
+              arguments: {
+                docId: 'Sandbox/test',
+                path: 'meta.title',
+                value: 'Updated sandbox title',
+              },
+            },
+          ],
+        },
+        'I prepared the draft title update for Sandbox/test.',
       ],
     },
   ],

--- a/apps/mock-localllm/mock.config.js
+++ b/apps/mock-localllm/mock.config.js
@@ -5,10 +5,18 @@
  * request is matched against `rules` from top to bottom (first match wins); if
  * nothing matches, `fallback` is used.
  *
- * A `response` may be either:
- *   - a string         — delivered as a single chunk, or
- *   - an array of strings — streamed back one element at a time, with a random
- *     delay between chunks (see `delay`) to imitate real token streaming.
+ * A rule replies with an assistant "turn", which may contain text, tool calls,
+ * or both:
+ *   - a string         — text, delivered as a single chunk;
+ *   - an array of strings — text, streamed chunk-by-chunk with a random delay
+ *     between chunks (see `delay`) to imitate real token streaming;
+ *   - an object `{text, toolCalls}` — text and/or mocked tool calls.
+ *
+ * To mock a tool-call loop, use `responses` (plural): an array of turns indexed
+ * by how many assistant turns have happened since the user's message. Turn 0
+ * can request a tool call; once the client runs the tool and sends the result
+ * back, the server advances to turn 1, and so on. The final turn should be
+ * text so the loop terminates.
  *
  * Restart the server after editing to pick up changes. You can also point the
  * server at a different file with `--config <path>` or the `MOCK_CONFIG` env
@@ -18,10 +26,26 @@
 /** @typedef {{min: number, max: number} | number} Delay */
 
 /**
+ * @typedef {object} MockToolCall
+ * @property {string} name Function name the model "calls".
+ * @property {object | string} [arguments] Call arguments — an object (JSON-encoded for you) or a pre-encoded JSON string.
+ * @property {string} [id] Tool-call id. Auto-generated when omitted.
+ */
+
+/**
+ * A single assistant turn. One of:
+ *  - a string — text delivered as one chunk;
+ *  - an array of strings — text streamed chunk-by-chunk;
+ *  - an object with `text` (string or string array) and/or `toolCalls`.
+ * @typedef {string | string[] | {text?: string | string[], toolCalls?: MockToolCall[]}} MockTurn
+ */
+
+/**
  * @typedef {object} MockRule
  * @property {string | RegExp} prompt Text or pattern matched against the latest user message.
  * @property {'includes' | 'exact' | 'startsWith' | 'regex'} [match] How a string `prompt` is compared (default `'includes'`, case-insensitive). Ignored for RegExp prompts.
- * @property {string | string[]} response The mock reply. An array is streamed chunk-by-chunk.
+ * @property {MockTurn} [response] Single-turn reply. Use this OR `responses`.
+ * @property {MockTurn[]} [responses] Multi-turn replies for tool-call loops, indexed by the assistant-turn count since the user's message. The final turn should be text.
  * @property {Delay} [delay] Optional per-rule override of the inter-chunk streaming delay.
  */
 
@@ -30,7 +54,7 @@
  * @property {number} [port] Default listen port. Overridden by `--port` or the `PORT` env var.
  * @property {string[]} [models] Model ids advertised by `GET /v1/models`.
  * @property {Delay} [delay] Delay between streamed chunks, in milliseconds.
- * @property {string | string[]} fallback Response used when no rule matches.
+ * @property {MockTurn} fallback Reply used when no rule matches.
  * @property {MockRule[]} rules Ordered match rules; the first match wins.
  */
 
@@ -94,6 +118,39 @@ export default {
         '- two\n',
         '- three\n\n',
         '```js\nconsole.log("hello from the mock LLM");\n```\n',
+      ],
+    },
+    {
+      // A mocked tool-call loop. Turn 0 emits a tool call; the client runs the
+      // tool and sends the result back, then the server advances to turn 1.
+      // `getWeather` is a generic example — swap in whatever tool name your UI
+      // registers.
+      prompt: 'weather',
+      responses: [
+        {
+          text: 'Let me check the weather for you.\n\n',
+          toolCalls: [
+            {name: 'getWeather', arguments: {location: 'San Francisco, CA'}},
+          ],
+        },
+        ['It is currently ', '68°F and sunny ', 'in San Francisco.'],
+      ],
+    },
+    {
+      // A tool-call loop that exercises a real Root CMS tool. When the "Local
+      // LLM" model is configured with `capabilities.tools: true`, the CMS sends
+      // its own tool definitions, so a mocked tool call must use one of those
+      // tool names (e.g. `docs_search`, `collections_list`, `doc_get`). The CMS
+      // runs `docs_search` server-side and sends the result back for turn 1.
+      prompt: 'search the cms',
+      responses: [
+        {
+          text: 'Searching the CMS for matching docs.\n\n',
+          toolCalls: [
+            {name: 'docs_search', arguments: {query: 'home', limit: 5}},
+          ],
+        },
+        'Those are the top results from the CMS search above.',
       ],
     },
   ],

--- a/apps/mock-localllm/mock.config.js
+++ b/apps/mock-localllm/mock.config.js
@@ -1,0 +1,100 @@
+/**
+ * Mock LLM configuration.
+ *
+ * Edit this file to control how the mock server responds. Each incoming chat
+ * request is matched against `rules` from top to bottom (first match wins); if
+ * nothing matches, `fallback` is used.
+ *
+ * A `response` may be either:
+ *   - a string         — delivered as a single chunk, or
+ *   - an array of strings — streamed back one element at a time, with a random
+ *     delay between chunks (see `delay`) to imitate real token streaming.
+ *
+ * Restart the server after editing to pick up changes. You can also point the
+ * server at a different file with `--config <path>` or the `MOCK_CONFIG` env
+ * var.
+ */
+
+/** @typedef {{min: number, max: number} | number} Delay */
+
+/**
+ * @typedef {object} MockRule
+ * @property {string | RegExp} prompt Text or pattern matched against the latest user message.
+ * @property {'includes' | 'exact' | 'startsWith' | 'regex'} [match] How a string `prompt` is compared (default `'includes'`, case-insensitive). Ignored for RegExp prompts.
+ * @property {string | string[]} response The mock reply. An array is streamed chunk-by-chunk.
+ * @property {Delay} [delay] Optional per-rule override of the inter-chunk streaming delay.
+ */
+
+/**
+ * @typedef {object} MockConfig
+ * @property {number} [port] Default listen port. Overridden by `--port` or the `PORT` env var.
+ * @property {string[]} [models] Model ids advertised by `GET /v1/models`.
+ * @property {Delay} [delay] Delay between streamed chunks, in milliseconds.
+ * @property {string | string[]} fallback Response used when no rule matches.
+ * @property {MockRule[]} rules Ordered match rules; the first match wins.
+ */
+
+/** @type {MockConfig} */
+export default {
+  port: 8765,
+
+  models: ['mock-llm'],
+
+  // A random delay in this range (ms) is applied between streamed chunks.
+  delay: {min: 40, max: 280},
+
+  // Returned when no rule below matches the user's prompt.
+  fallback: [
+    'This is the mock LLM. ',
+    'No rule matched your prompt — ',
+    'edit `apps/mock-localllm/mock.config.js` to add one.',
+  ],
+
+  rules: [
+    {
+      // Case-insensitive substring match is the default strategy.
+      prompt: 'hello',
+      response: [
+        'Hello there! ',
+        'I am a mock LLM. ',
+        'How can I help you today?',
+      ],
+    },
+    {
+      prompt: 'tell me a joke',
+      response: [
+        'Why do programmers prefer dark mode?\n\n',
+        'Because light attracts bugs.',
+      ],
+    },
+    {
+      // Exact match against the whole (trimmed) user message.
+      prompt: 'ping',
+      match: 'exact',
+      response: 'pong',
+    },
+    {
+      // RegExp prompts are tested directly against the message text. Combined
+      // with a longer array + delay, this is handy for exercising streaming UI.
+      prompt: /\b(stream|loading|long)\b/i,
+      response: [
+        'Streaming ', 'this ', 'response ', 'one ', 'word ', 'at ', 'a ',
+        'time ', 'so ', 'you ', 'can ', 'watch ', 'the ', 'UI ', 'update ',
+        'incrementally.',
+      ],
+      delay: {min: 120, max: 400},
+    },
+    {
+      // A response with markdown, for testing rich rendering.
+      prompt: 'markdown',
+      response: [
+        '# Mock heading\n\n',
+        'Some **bold** text and a list:\n\n',
+        '- one\n',
+        '- two\n',
+        '- three\n\n',
+        '```js\nconsole.log("hello from the mock LLM");\n```\n',
+      ],
+    },
+  ],
+};

--- a/apps/mock-localllm/package.json
+++ b/apps/mock-localllm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@private/mock-localllm",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Mock OpenAI-compatible LLM server for local UI testing.",
+  "type": "module",
+  "main": "src/index.js",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "dev": "node src/index.js",
+    "start": "node src/index.js"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/apps/mock-localllm/src/index.js
+++ b/apps/mock-localllm/src/index.js
@@ -1,0 +1,109 @@
+/**
+ * Entry point for the mock LLM server.
+ *
+ * Resolves configuration (CLI flags > environment variables > the values in
+ * `mock.config.js`), starts the OpenAI-compatible HTTP server, and prints the
+ * `baseURL` to wire into an `openai-compatible` model config.
+ *
+ * Usage:
+ *   node src/index.js [--port <port>] [--config <path>]
+ *
+ * Environment variables:
+ *   PORT          Overrides the listen port.
+ *   MOCK_CONFIG   Path to the mock config module (defaults to ../mock.config.js).
+ */
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {createServer} from './server.js';
+
+/** Fallback port, used when none is set via flag, env var, or config. */
+const DEFAULT_PORT = 8765;
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Parses `--key value` and `--key=value` style flags from an argv slice. */
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const eq = arg.indexOf('=');
+    if (eq !== -1) {
+      args[arg.slice(2, eq)] = arg.slice(eq + 1);
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[arg.slice(2)] = next;
+      i++;
+    } else {
+      args[arg.slice(2)] = true;
+    }
+  }
+  return args;
+}
+
+/** Dynamically imports the mock config module at `configPath`. */
+async function loadConfig(configPath) {
+  const mod = await import(pathToFileURL(configPath).href);
+  const config = mod.default || mod;
+  if (!config || typeof config !== 'object') {
+    throw new Error(`mock config at ${configPath} must export a config object`);
+  }
+  return config;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const configPath = path.resolve(
+    args.config ||
+      process.env.MOCK_CONFIG ||
+      path.join(dirname, '..', 'mock.config.js')
+  );
+
+  let config;
+  try {
+    config = await loadConfig(configPath);
+  } catch (err) {
+    console.error(`[mock-localllm] failed to load config from ${configPath}`);
+    console.error(err);
+    process.exit(1);
+    return;
+  }
+
+  const port = Number(
+    args.port || process.env.PORT || config.port || DEFAULT_PORT
+  );
+  const server = createServer(config);
+
+  server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`[mock-localllm] port ${port} is already in use.`);
+    } else {
+      console.error('[mock-localllm] server error:', err);
+    }
+    process.exit(1);
+  });
+
+  server.listen(port, () => {
+    const ruleCount = Array.isArray(config.rules) ? config.rules.length : 0;
+    console.log('[mock-localllm] mock OpenAI-compatible LLM server running');
+    console.log(`[mock-localllm]   url:     http://localhost:${port}`);
+    console.log(`[mock-localllm]   baseURL: http://localhost:${port}/v1`);
+    console.log(`[mock-localllm]   config:  ${configPath}`);
+    console.log(`[mock-localllm]   rules:   ${ruleCount}`);
+  });
+
+  const shutdown = () => {
+    console.log('\n[mock-localllm] shutting down');
+    server.close(() => process.exit(0));
+    // Force-exit if connections linger (e.g. an open SSE stream).
+    setTimeout(() => process.exit(0), 1000).unref();
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main();

--- a/apps/mock-localllm/src/matcher.js
+++ b/apps/mock-localllm/src/matcher.js
@@ -2,9 +2,16 @@
  * Prompt extraction and rule matching for the mock LLM server.
  *
  * The server pulls the latest user message out of an OpenAI-style request and
- * runs it past the user-defined `rules` in `mock.config.js`, returning the
- * configured response (or the fallback) for the server to deliver.
+ * runs it past the user-defined `rules` in `mock.config.js`. A matched rule
+ * resolves to a single assistant "turn" — text, tool calls, or both — which
+ * the server then delivers in buffered or streamed form.
+ *
+ * Tool-call loops are supported via a rule's `responses` array: the server
+ * picks the entry matching how many assistant turns have happened since the
+ * last user message, so turn 0 can request a tool call and turn 1 can answer
+ * once the client sends the tool result back.
  */
+import {createToolCallId} from './openai.js';
 
 /**
  * Extracts the text of the most recent `user` message from an OpenAI-style
@@ -45,36 +52,96 @@ function contentToText(content) {
 }
 
 /**
- * @typedef {object} MatchResult
- * @property {string | string[]} response The matched rule's response (or the fallback).
- * @property {{min: number, max: number} | number | undefined} delay Effective inter-chunk delay.
- * @property {number} ruleIndex Index of the matched rule, or `-1` for the fallback.
+ * Counts the assistant messages that appear after the last `user` message.
+ * This is the current tool-call loop depth: it is 0 for a fresh user prompt
+ * and increments by one each time the model replies and the client sends tool
+ * results back. It is used to index into a rule's `responses` array.
+ */
+export function resolveTurnIndex(messages) {
+  if (!Array.isArray(messages)) {
+    return 0;
+  }
+  let lastUser = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i] && messages[i].role === 'user') {
+      lastUser = i;
+      break;
+    }
+  }
+  let count = 0;
+  for (let i = lastUser + 1; i < messages.length; i++) {
+    if (messages[i] && messages[i].role === 'assistant') {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * @typedef {object} NormalizedToolCall
+ * @property {string} id Tool-call id (generated when the config omits one).
+ * @property {string} name Function name to call.
+ * @property {string} arguments JSON-encoded argument string.
  */
 
 /**
- * Finds the first rule whose `prompt` matches `promptText` and returns its
- * response plus the effective delay config. Falls back to `config.fallback`
- * when no rule matches.
+ * @typedef {object} MatchResult
+ * @property {string} promptText The latest user prompt text.
+ * @property {string[]} text Assistant message text, as ordered stream chunks.
+ * @property {NormalizedToolCall[]} toolCalls Tool calls to emit this turn.
+ * @property {{min: number, max: number} | number | undefined} delay Effective inter-chunk delay.
+ * @property {number} ruleIndex Index of the matched rule, or `-1` for the fallback.
+ * @property {number} turnIndex Tool-call loop depth used to pick the turn.
+ */
+
+/**
+ * Matches an incoming request against the configured rules and resolves the
+ * assistant turn to deliver. Falls back to `config.fallback` when no rule
+ * matches.
  *
  * @returns {MatchResult}
  */
-export function matchRule(config, promptText) {
+export function matchRule(config, messages) {
+  const promptText = extractPrompt(messages);
+  const turnIndex = resolveTurnIndex(messages);
   const rules = Array.isArray(config.rules) ? config.rules : [];
   for (let i = 0; i < rules.length; i++) {
     const rule = rules[i];
     if (ruleMatches(rule, promptText)) {
+      const normalized = normalizeTurn(selectTurn(rule, turnIndex));
       return {
-        response: rule.response,
+        promptText,
+        text: normalized.text,
+        toolCalls: normalized.toolCalls,
         delay: rule.delay ?? config.delay,
         ruleIndex: i,
+        turnIndex,
       };
     }
   }
+  const normalized = normalizeTurn(config.fallback);
   return {
-    response: config.fallback,
+    promptText,
+    text: normalized.text,
+    toolCalls: normalized.toolCalls,
     delay: config.delay,
     ruleIndex: -1,
+    turnIndex,
   };
+}
+
+/**
+ * Picks the turn a rule should reply with. A rule using `responses` (a
+ * multi-turn array, for tool-call loops) is indexed by `turnIndex`, clamped to
+ * the last entry. A rule using the single `response` field always replies with
+ * that value.
+ */
+function selectTurn(rule, turnIndex) {
+  if (Array.isArray(rule.responses) && rule.responses.length > 0) {
+    const index = Math.min(turnIndex, rule.responses.length - 1);
+    return rule.responses[index];
+  }
+  return rule.response;
 }
 
 /**
@@ -103,4 +170,63 @@ function ruleMatches(rule, promptText) {
     default:
       return haystack.includes(needle);
   }
+}
+
+/**
+ * Normalizes a turn value into `{text, toolCalls}`. A turn may be a string, an
+ * array of strings, or an object with `text` and/or `toolCalls`.
+ *
+ * @returns {{text: string[], toolCalls: NormalizedToolCall[]}}
+ */
+export function normalizeTurn(turn) {
+  if (turn === undefined || turn === null) {
+    return {text: [], toolCalls: []};
+  }
+  if (typeof turn === 'string' || Array.isArray(turn)) {
+    return {text: normalizeText(turn), toolCalls: []};
+  }
+  if (typeof turn === 'object') {
+    return {
+      text: normalizeText(turn.text),
+      toolCalls: normalizeToolCalls(turn.toolCalls),
+    };
+  }
+  return {text: [String(turn)], toolCalls: []};
+}
+
+/** Normalizes turn text (a string, string array, or undefined) into stream chunks. */
+function normalizeText(text) {
+  if (Array.isArray(text)) {
+    return text.map((part) => String(part));
+  }
+  if (typeof text === 'string') {
+    return [text];
+  }
+  return [];
+}
+
+/**
+ * Normalizes a config tool-call list into wire-ready tool calls: each gets a
+ * generated id when one is not supplied, and object arguments are JSON-encoded
+ * (string arguments pass through as-is). Entries without a `name` are dropped.
+ */
+function normalizeToolCalls(toolCalls) {
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  const out = [];
+  for (const toolCall of toolCalls) {
+    if (!toolCall || !toolCall.name) {
+      continue;
+    }
+    out.push({
+      id: toolCall.id || createToolCallId(),
+      name: String(toolCall.name),
+      arguments:
+        typeof toolCall.arguments === 'string'
+          ? toolCall.arguments
+          : JSON.stringify(toolCall.arguments ?? {}),
+    });
+  }
+  return out;
 }

--- a/apps/mock-localllm/src/matcher.js
+++ b/apps/mock-localllm/src/matcher.js
@@ -1,0 +1,106 @@
+/**
+ * Prompt extraction and rule matching for the mock LLM server.
+ *
+ * The server pulls the latest user message out of an OpenAI-style request and
+ * runs it past the user-defined `rules` in `mock.config.js`, returning the
+ * configured response (or the fallback) for the server to deliver.
+ */
+
+/**
+ * Extracts the text of the most recent `user` message from an OpenAI-style
+ * `messages` array. Handles both the plain-string `content` form and the
+ * multimodal content-parts array form, ignoring non-text parts (e.g. images).
+ *
+ * Returns an empty string when there is no user message.
+ */
+export function extractPrompt(messages) {
+  if (!Array.isArray(messages)) {
+    return '';
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message && message.role === 'user') {
+      return contentToText(message.content);
+    }
+  }
+  return '';
+}
+
+/** Flattens OpenAI message `content` (a string or content-parts array) to plain text. */
+function contentToText(content) {
+  if (typeof content === 'string') {
+    return content.trim();
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (part) =>
+          part && part.type === 'text' && typeof part.text === 'string'
+      )
+      .map((part) => part.text)
+      .join(' ')
+      .trim();
+  }
+  return '';
+}
+
+/**
+ * @typedef {object} MatchResult
+ * @property {string | string[]} response The matched rule's response (or the fallback).
+ * @property {{min: number, max: number} | number | undefined} delay Effective inter-chunk delay.
+ * @property {number} ruleIndex Index of the matched rule, or `-1` for the fallback.
+ */
+
+/**
+ * Finds the first rule whose `prompt` matches `promptText` and returns its
+ * response plus the effective delay config. Falls back to `config.fallback`
+ * when no rule matches.
+ *
+ * @returns {MatchResult}
+ */
+export function matchRule(config, promptText) {
+  const rules = Array.isArray(config.rules) ? config.rules : [];
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    if (ruleMatches(rule, promptText)) {
+      return {
+        response: rule.response,
+        delay: rule.delay ?? config.delay,
+        ruleIndex: i,
+      };
+    }
+  }
+  return {
+    response: config.fallback,
+    delay: config.delay,
+    ruleIndex: -1,
+  };
+}
+
+/**
+ * Tests a single rule against the prompt text. A RegExp `prompt` is tested
+ * directly; a string `prompt` is compared per the rule's `match` strategy
+ * (`'includes'` by default), case-insensitively.
+ */
+function ruleMatches(rule, promptText) {
+  if (!rule || rule.prompt === undefined || rule.prompt === null) {
+    return false;
+  }
+  const {prompt} = rule;
+  if (prompt instanceof RegExp) {
+    return prompt.test(promptText);
+  }
+  const haystack = promptText.toLowerCase();
+  const needle = String(prompt).toLowerCase().trim();
+  switch (rule.match || 'includes') {
+    case 'exact':
+      return haystack.trim() === needle;
+    case 'startsWith':
+      return haystack.trimStart().startsWith(needle);
+    case 'regex':
+      return new RegExp(String(prompt), 'i').test(promptText);
+    case 'includes':
+    default:
+      return haystack.includes(needle);
+  }
+}

--- a/apps/mock-localllm/src/openai.js
+++ b/apps/mock-localllm/src/openai.js
@@ -3,14 +3,20 @@
  *
  * The mock server only speaks the slice of the OpenAI API that the Vercel AI
  * SDK's `openai-compatible` provider relies on: the `POST /v1/chat/completions`
- * endpoint, in both buffered (JSON) and streamed (SSE) forms. These helpers are
- * pure — they build plain objects and leave all I/O to the server.
+ * endpoint, in both buffered (JSON) and streamed (SSE) forms, including
+ * assistant tool calls. These helpers are pure — they build plain objects and
+ * leave all I/O to the server.
  */
 import crypto from 'node:crypto';
 
 /** Generates a unique completion id, matching OpenAI's `chatcmpl-` prefix. */
 export function createCompletionId() {
   return `chatcmpl-${crypto.randomBytes(12).toString('hex')}`;
+}
+
+/** Generates a unique tool-call id, matching OpenAI's `call_` prefix. */
+export function createToolCallId() {
+  return `call_${crypto.randomBytes(12).toString('hex')}`;
 }
 
 /**
@@ -26,18 +32,47 @@ export function estimateTokens(text) {
 }
 
 /**
- * Builds a buffered (non-streaming) `chat.completion` response object.
+ * Estimates the completion tokens for an assistant turn, accounting for both
+ * the message text and any tool-call names and arguments.
+ */
+function estimateCompletionTokens(content, toolCalls) {
+  let text = content || '';
+  for (const toolCall of toolCalls || []) {
+    text += toolCall.name + toolCall.arguments;
+  }
+  return estimateTokens(text);
+}
+
+/** Maps normalized tool calls to the OpenAI `message.tool_calls` array shape. */
+function toToolCallsField(toolCalls) {
+  return toolCalls.map((toolCall) => ({
+    id: toolCall.id,
+    type: 'function',
+    function: {name: toolCall.name, arguments: toolCall.arguments},
+  }));
+}
+
+/**
+ * Builds a buffered (non-streaming) `chat.completion` response object. When
+ * `toolCalls` is non-empty the assistant message carries a `tool_calls` array
+ * and the choice's `finish_reason` becomes `'tool_calls'`.
  *
  * @param {object} options
  * @param {string} options.id Completion id from `createCompletionId()`.
  * @param {string} options.model Model id echoed back to the client.
- * @param {string} options.content Full assistant message text.
+ * @param {string} options.content Assistant message text (may be empty).
  * @param {string} options.promptText User prompt text, used for token counts.
+ * @param {Array<{id: string, name: string, arguments: string}>} [options.toolCalls] Tool calls to emit.
  */
 export function buildCompletion(options) {
-  const {id, model, content, promptText} = options;
+  const {id, model, content, promptText, toolCalls = []} = options;
+  const hasToolCalls = toolCalls.length > 0;
+  const message = {role: 'assistant', content: content || null};
+  if (hasToolCalls) {
+    message.tool_calls = toToolCallsField(toolCalls);
+  }
   const promptTokens = estimateTokens(promptText);
-  const completionTokens = estimateTokens(content);
+  const completionTokens = estimateCompletionTokens(content, toolCalls);
   return {
     id,
     object: 'chat.completion',
@@ -46,8 +81,8 @@ export function buildCompletion(options) {
     choices: [
       {
         index: 0,
-        message: {role: 'assistant', content},
-        finish_reason: 'stop',
+        message,
+        finish_reason: hasToolCalls ? 'tool_calls' : 'stop',
       },
     ],
     usage: {
@@ -65,7 +100,7 @@ export function buildCompletion(options) {
  * @param {string} options.id Completion id, shared across every chunk.
  * @param {string} options.model Model id echoed back to the client.
  * @param {object} options.delta Partial message delta (e.g. `{content: 'hi'}`).
- * @param {string | null} [options.finishReason] Set to `'stop'` on the final chunk.
+ * @param {string | null} [options.finishReason] Set on the final chunk (`'stop'` or `'tool_calls'`).
  */
 export function buildChunk(options) {
   const {id, model, delta, finishReason = null} = options;
@@ -85,6 +120,40 @@ export function buildChunk(options) {
 }
 
 /**
+ * Builds the streaming delta that opens a tool call, carrying its id and
+ * function name with an empty argument string (the arguments follow in a
+ * later delta, mirroring how the real API streams them).
+ *
+ * @param {number} index Position of the tool call within the turn.
+ * @param {{id: string, name: string}} toolCall Normalized tool call.
+ */
+export function toolCallOpenDelta(index, toolCall) {
+  return {
+    tool_calls: [
+      {
+        index,
+        id: toolCall.id,
+        type: 'function',
+        function: {name: toolCall.name, arguments: ''},
+      },
+    ],
+  };
+}
+
+/**
+ * Builds the streaming delta that carries a slice of a tool call's JSON
+ * argument string. The mock sends the arguments in a single slice per call.
+ *
+ * @param {number} index Position of the tool call within the turn.
+ * @param {string} argsSlice Portion of the JSON-encoded arguments.
+ */
+export function toolCallArgsDelta(index, argsSlice) {
+  return {
+    tool_calls: [{index, function: {arguments: argsSlice}}],
+  };
+}
+
+/**
  * Builds the trailing usage-only chunk. OpenAI emits this (with an empty
  * `choices` array) just before `[DONE]` when the request sets
  * `stream_options.include_usage`.
@@ -93,12 +162,13 @@ export function buildChunk(options) {
  * @param {string} options.id Completion id, shared across every chunk.
  * @param {string} options.model Model id echoed back to the client.
  * @param {string} options.promptText User prompt text, used for token counts.
- * @param {string} options.content Full assistant message text.
+ * @param {string} options.content Assistant message text (may be empty).
+ * @param {Array<{name: string, arguments: string}>} [options.toolCalls] Tool calls emitted this turn.
  */
 export function buildUsageChunk(options) {
-  const {id, model, promptText, content} = options;
+  const {id, model, promptText, content, toolCalls = []} = options;
   const promptTokens = estimateTokens(promptText);
-  const completionTokens = estimateTokens(content);
+  const completionTokens = estimateCompletionTokens(content, toolCalls);
   return {
     id,
     object: 'chat.completion.chunk',

--- a/apps/mock-localllm/src/openai.js
+++ b/apps/mock-localllm/src/openai.js
@@ -1,0 +1,114 @@
+/**
+ * Builders for OpenAI-compatible Chat Completions payloads.
+ *
+ * The mock server only speaks the slice of the OpenAI API that the Vercel AI
+ * SDK's `openai-compatible` provider relies on: the `POST /v1/chat/completions`
+ * endpoint, in both buffered (JSON) and streamed (SSE) forms. These helpers are
+ * pure — they build plain objects and leave all I/O to the server.
+ */
+import crypto from 'node:crypto';
+
+/** Generates a unique completion id, matching OpenAI's `chatcmpl-` prefix. */
+export function createCompletionId() {
+  return `chatcmpl-${crypto.randomBytes(12).toString('hex')}`;
+}
+
+/**
+ * Produces a rough token estimate used to populate the `usage` field. This is
+ * deliberately approximate (~4 characters per token); it only needs to be
+ * plausible enough for UI that displays token counts.
+ */
+export function estimateTokens(text) {
+  if (!text) {
+    return 0;
+  }
+  return Math.max(1, Math.ceil(String(text).length / 4));
+}
+
+/**
+ * Builds a buffered (non-streaming) `chat.completion` response object.
+ *
+ * @param {object} options
+ * @param {string} options.id Completion id from `createCompletionId()`.
+ * @param {string} options.model Model id echoed back to the client.
+ * @param {string} options.content Full assistant message text.
+ * @param {string} options.promptText User prompt text, used for token counts.
+ */
+export function buildCompletion(options) {
+  const {id, model, content, promptText} = options;
+  const promptTokens = estimateTokens(promptText);
+  const completionTokens = estimateTokens(content);
+  return {
+    id,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {role: 'assistant', content},
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  };
+}
+
+/**
+ * Builds a single `chat.completion.chunk` object for a streamed response.
+ *
+ * @param {object} options
+ * @param {string} options.id Completion id, shared across every chunk.
+ * @param {string} options.model Model id echoed back to the client.
+ * @param {object} options.delta Partial message delta (e.g. `{content: 'hi'}`).
+ * @param {string | null} [options.finishReason] Set to `'stop'` on the final chunk.
+ */
+export function buildChunk(options) {
+  const {id, model, delta, finishReason = null} = options;
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: delta || {},
+        finish_reason: finishReason,
+      },
+    ],
+  };
+}
+
+/**
+ * Builds the trailing usage-only chunk. OpenAI emits this (with an empty
+ * `choices` array) just before `[DONE]` when the request sets
+ * `stream_options.include_usage`.
+ *
+ * @param {object} options
+ * @param {string} options.id Completion id, shared across every chunk.
+ * @param {string} options.model Model id echoed back to the client.
+ * @param {string} options.promptText User prompt text, used for token counts.
+ * @param {string} options.content Full assistant message text.
+ */
+export function buildUsageChunk(options) {
+  const {id, model, promptText, content} = options;
+  const promptTokens = estimateTokens(promptText);
+  const completionTokens = estimateTokens(content);
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  };
+}

--- a/apps/mock-localllm/src/server.js
+++ b/apps/mock-localllm/src/server.js
@@ -1,0 +1,306 @@
+/**
+ * OpenAI-compatible HTTP server for the mock LLM.
+ *
+ * Implements just enough of the OpenAI API for the Vercel AI SDK's
+ * `openai-compatible` provider and other OpenAI-style clients:
+ *  - `POST /v1/chat/completions` — buffered and streamed chat completions.
+ *  - `GET  /v1/models` — lists the mock model ids.
+ *  - `GET  /` — a small health/info payload for manual checks.
+ *
+ * Responses are driven entirely by the user-supplied `mock.config.js`: a
+ * matched rule's `response` may be a single string (delivered as one chunk) or
+ * an array of strings (streamed chunk-by-chunk with a randomized inter-chunk
+ * delay, so streaming UI can be exercised without a real model).
+ *
+ * The endpoints are also accepted without the `/v1` prefix so the server works
+ * regardless of whether the configured `baseURL` includes it.
+ */
+import http from 'node:http';
+import {extractPrompt, matchRule} from './matcher.js';
+import {
+  buildChunk,
+  buildCompletion,
+  buildUsageChunk,
+  createCompletionId,
+} from './openai.js';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+/** Maximum accepted request body size, as a guard against a runaway client. */
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+/** Pauses for `ms` milliseconds. */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolves a delay config to a concrete millisecond value. The config may be a
+ * fixed number, a `{min, max}` range (re-rolled on every call so streamed
+ * chunks arrive at varying intervals), or undefined (no delay).
+ */
+function resolveDelayMs(delay) {
+  if (typeof delay === 'number' && delay >= 0) {
+    return delay;
+  }
+  if (delay && typeof delay === 'object') {
+    const min = Number(delay.min) || 0;
+    const max = Number(delay.max) || min;
+    if (max <= min) {
+      return min;
+    }
+    return Math.floor(min + Math.random() * (max - min));
+  }
+  return 0;
+}
+
+/**
+ * Normalizes a rule `response` into an array of chunk strings. A plain string
+ * becomes a single-element array; an array is returned with its items coerced
+ * to strings. Anything else yields a single empty chunk.
+ */
+function toChunks(response) {
+  if (Array.isArray(response)) {
+    return response.map((part) => String(part));
+  }
+  if (typeof response === 'string') {
+    return [response];
+  }
+  if (response === undefined || response === null) {
+    return [''];
+  }
+  return [String(response)];
+}
+
+/** Sends a JSON response with CORS headers. */
+function sendJson(res, status, body) {
+  res.writeHead(status, {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json',
+  });
+  res.end(JSON.stringify(body, null, 2));
+}
+
+/** Sends an OpenAI-shaped error response. */
+function sendError(res, status, message, type = 'invalid_request_error') {
+  sendJson(res, status, {error: {message, type}});
+}
+
+/** Reads and JSON-parses the full request body, rejecting on invalid input. */
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8').trim();
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new Error('invalid JSON request body'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+/** Truncates a prompt for single-line logging. */
+function previewText(text) {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > 60 ? `${collapsed.slice(0, 57)}...` : collapsed;
+}
+
+/** Handles `POST /v1/chat/completions`, in both buffered and streamed modes. */
+async function handleChatCompletions(req, res, config) {
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (err) {
+    sendError(res, 400, err.message);
+    return;
+  }
+
+  const modelId =
+    body.model || (config.models && config.models[0]) || 'mock-llm';
+  const promptText = extractPrompt(body.messages);
+  const {response, delay, ruleIndex} = matchRule(config, promptText);
+  const chunks = toChunks(response);
+  const fullText = chunks.join('');
+  const stream = body.stream === true;
+  const includeUsage = Boolean(
+    body.stream_options && body.stream_options.include_usage
+  );
+  const id = createCompletionId();
+
+  const ruleLabel = ruleIndex >= 0 ? `rule #${ruleIndex}` : 'fallback';
+  console.log(
+    `[mock-localllm] chat.completions ${stream ? 'stream' : 'buffered'} ` +
+      `model=${modelId} match=${ruleLabel} ` +
+      `prompt=${JSON.stringify(previewText(promptText))}`
+  );
+
+  if (!stream) {
+    sendJson(
+      res,
+      200,
+      buildCompletion({id, model: modelId, content: fullText, promptText})
+    );
+    return;
+  }
+
+  // Streamed Server-Sent Events response.
+  res.writeHead(200, {
+    ...CORS_HEADERS,
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+  });
+
+  // The client may hang up mid-stream (e.g. the user stops a generation); stop
+  // emitting chunks and clear any pending delay timer when that happens.
+  let aborted = false;
+  const onClose = () => {
+    aborted = true;
+  };
+  res.on('close', onClose);
+
+  const writeChunk = (chunk) => {
+    if (aborted || res.writableEnded) {
+      return;
+    }
+    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  };
+
+  try {
+    // The opening chunk announces the assistant role, like the real API.
+    writeChunk(
+      buildChunk({id, model: modelId, delta: {role: 'assistant', content: ''}})
+    );
+    for (const part of chunks) {
+      if (aborted) {
+        break;
+      }
+      const ms = resolveDelayMs(delay);
+      if (ms > 0) {
+        await sleep(ms);
+      }
+      writeChunk(buildChunk({id, model: modelId, delta: {content: part}}));
+    }
+    if (!aborted) {
+      writeChunk(
+        buildChunk({id, model: modelId, delta: {}, finishReason: 'stop'})
+      );
+      if (includeUsage) {
+        writeChunk(
+          buildUsageChunk({id, model: modelId, promptText, content: fullText})
+        );
+      }
+      if (!res.writableEnded) {
+        res.write('data: [DONE]\n\n');
+      }
+    }
+  } finally {
+    res.off('close', onClose);
+    if (!res.writableEnded) {
+      res.end();
+    }
+  }
+}
+
+/** Handles `GET /v1/models`, listing the configured mock model ids. */
+function handleModels(res, config) {
+  const ids =
+    Array.isArray(config.models) && config.models.length > 0
+      ? config.models
+      : ['mock-llm'];
+  const created = Math.floor(Date.now() / 1000);
+  sendJson(res, 200, {
+    object: 'list',
+    data: ids.map((id) => ({
+      id,
+      object: 'model',
+      created,
+      owned_by: 'mock-localllm',
+    })),
+  });
+}
+
+/** Handles `GET /` — a small status payload useful for manual checks. */
+function handleHealth(res, config) {
+  sendJson(res, 200, {
+    name: 'mock-localllm',
+    status: 'ok',
+    models: config.models || ['mock-llm'],
+    rules: Array.isArray(config.rules) ? config.rules.length : 0,
+    endpoints: ['POST /v1/chat/completions', 'GET /v1/models'],
+  });
+}
+
+/**
+ * Creates (but does not start) the mock LLM HTTP server for the given config.
+ * Call `.listen(port)` on the returned server to start it.
+ */
+export function createServer(config) {
+  return http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    const pathname = url.pathname.replace(/\/+$/, '') || '/';
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, CORS_HEADERS);
+      res.end();
+      return;
+    }
+
+    if (
+      req.method === 'POST' &&
+      (pathname === '/v1/chat/completions' || pathname === '/chat/completions')
+    ) {
+      handleChatCompletions(req, res, config).catch((err) => {
+        console.error('[mock-localllm] request failed:', err);
+        if (!res.headersSent) {
+          sendError(res, 500, 'internal mock server error', 'server_error');
+        } else if (!res.writableEnded) {
+          res.end();
+        }
+      });
+      return;
+    }
+
+    if (
+      req.method === 'GET' &&
+      (pathname === '/v1/models' || pathname === '/models')
+    ) {
+      handleModels(res, config);
+      return;
+    }
+
+    if (req.method === 'GET' && (pathname === '/' || pathname === '/health')) {
+      handleHealth(res, config);
+      return;
+    }
+
+    console.warn(`[mock-localllm] 404 ${req.method} ${pathname}`);
+    sendError(
+      res,
+      404,
+      `no mock route for ${req.method} ${pathname}`,
+      'not_found'
+    );
+  });
+}

--- a/apps/mock-localllm/src/server.js
+++ b/apps/mock-localllm/src/server.js
@@ -3,25 +3,29 @@
  *
  * Implements just enough of the OpenAI API for the Vercel AI SDK's
  * `openai-compatible` provider and other OpenAI-style clients:
- *  - `POST /v1/chat/completions` — buffered and streamed chat completions.
+ *  - `POST /v1/chat/completions` — buffered and streamed chat completions,
+ *    including assistant tool calls.
  *  - `GET  /v1/models` — lists the mock model ids.
  *  - `GET  /` — a small health/info payload for manual checks.
  *
  * Responses are driven entirely by the user-supplied `mock.config.js`: a
- * matched rule's `response` may be a single string (delivered as one chunk) or
- * an array of strings (streamed chunk-by-chunk with a randomized inter-chunk
- * delay, so streaming UI can be exercised without a real model).
+ * matched rule resolves to an assistant turn that may contain text and/or tool
+ * calls. Text given as an array of strings is streamed chunk-by-chunk with a
+ * randomized inter-chunk delay, so streaming UI can be exercised without a
+ * real model.
  *
  * The endpoints are also accepted without the `/v1` prefix so the server works
  * regardless of whether the configured `baseURL` includes it.
  */
 import http from 'node:http';
-import {extractPrompt, matchRule} from './matcher.js';
+import {matchRule} from './matcher.js';
 import {
   buildChunk,
   buildCompletion,
   buildUsageChunk,
   createCompletionId,
+  toolCallArgsDelta,
+  toolCallOpenDelta,
 } from './openai.js';
 
 const CORS_HEADERS = {
@@ -56,24 +60,6 @@ function resolveDelayMs(delay) {
     return Math.floor(min + Math.random() * (max - min));
   }
   return 0;
-}
-
-/**
- * Normalizes a rule `response` into an array of chunk strings. A plain string
- * becomes a single-element array; an array is returned with its items coerced
- * to strings. Anything else yields a single empty chunk.
- */
-function toChunks(response) {
-  if (Array.isArray(response)) {
-    return response.map((part) => String(part));
-  }
-  if (typeof response === 'string') {
-    return [response];
-  }
-  if (response === undefined || response === null) {
-    return [''];
-  }
-  return [String(response)];
 }
 
 /** Sends a JSON response with CORS headers. */
@@ -138,10 +124,11 @@ async function handleChatCompletions(req, res, config) {
 
   const modelId =
     body.model || (config.models && config.models[0]) || 'mock-llm';
-  const promptText = extractPrompt(body.messages);
-  const {response, delay, ruleIndex} = matchRule(config, promptText);
-  const chunks = toChunks(response);
-  const fullText = chunks.join('');
+  const {promptText, text, toolCalls, delay, ruleIndex, turnIndex} = matchRule(
+    config,
+    body.messages
+  );
+  const fullText = text.join('');
   const stream = body.stream === true;
   const includeUsage = Boolean(
     body.stream_options && body.stream_options.include_usage
@@ -149,9 +136,13 @@ async function handleChatCompletions(req, res, config) {
   const id = createCompletionId();
 
   const ruleLabel = ruleIndex >= 0 ? `rule #${ruleIndex}` : 'fallback';
+  const toolLabel =
+    toolCalls.length > 0
+      ? ` tools=${toolCalls.map((toolCall) => toolCall.name).join(',')}`
+      : '';
   console.log(
     `[mock-localllm] chat.completions ${stream ? 'stream' : 'buffered'} ` +
-      `model=${modelId} match=${ruleLabel} ` +
+      `model=${modelId} match=${ruleLabel} turn=${turnIndex}${toolLabel} ` +
       `prompt=${JSON.stringify(previewText(promptText))}`
   );
 
@@ -159,7 +150,13 @@ async function handleChatCompletions(req, res, config) {
     sendJson(
       res,
       200,
-      buildCompletion({id, model: modelId, content: fullText, promptText})
+      buildCompletion({
+        id,
+        model: modelId,
+        content: fullText,
+        promptText,
+        toolCalls,
+      })
     );
     return;
   }
@@ -187,28 +184,61 @@ async function handleChatCompletions(req, res, config) {
     res.write(`data: ${JSON.stringify(chunk)}\n\n`);
   };
 
+  // Pauses for the configured inter-chunk delay, if any.
+  const pause = async () => {
+    const ms = resolveDelayMs(delay);
+    if (ms > 0) {
+      await sleep(ms);
+    }
+  };
+
   try {
     // The opening chunk announces the assistant role, like the real API.
     writeChunk(
       buildChunk({id, model: modelId, delta: {role: 'assistant', content: ''}})
     );
-    for (const part of chunks) {
+    // Stream the message text, one configured chunk at a time.
+    for (const part of text) {
       if (aborted) {
         break;
       }
-      const ms = resolveDelayMs(delay);
-      if (ms > 0) {
-        await sleep(ms);
-      }
+      await pause();
       writeChunk(buildChunk({id, model: modelId, delta: {content: part}}));
     }
-    if (!aborted) {
+    // Stream any tool calls: an opening delta (id + name) then the arguments.
+    for (let i = 0; i < toolCalls.length; i++) {
+      if (aborted) {
+        break;
+      }
+      const toolCall = toolCalls[i];
+      await pause();
       writeChunk(
-        buildChunk({id, model: modelId, delta: {}, finishReason: 'stop'})
+        buildChunk({id, model: modelId, delta: toolCallOpenDelta(i, toolCall)})
       );
+      if (aborted) {
+        break;
+      }
+      await pause();
+      writeChunk(
+        buildChunk({
+          id,
+          model: modelId,
+          delta: toolCallArgsDelta(i, toolCall.arguments),
+        })
+      );
+    }
+    if (!aborted) {
+      const finishReason = toolCalls.length > 0 ? 'tool_calls' : 'stop';
+      writeChunk(buildChunk({id, model: modelId, delta: {}, finishReason}));
       if (includeUsage) {
         writeChunk(
-          buildUsageChunk({id, model: modelId, promptText, content: fullText})
+          buildUsageChunk({
+            id,
+            model: modelId,
+            promptText,
+            content: fullText,
+            toolCalls,
+          })
         );
       }
       if (!res.writableEnded) {

--- a/docs/root.config.ts
+++ b/docs/root.config.ts
@@ -66,6 +66,20 @@ export default defineConfig({
             apiKey: process.env.ANTHROPIC_API_KEY,
             capabilities: {tools: true, reasoning: true, attachments: true},
           },
+          {
+            // Mock LLM served by the `apps/mock-localllm` package. Run
+            // `pnpm --filter @private/mock-localllm dev` to start it, then
+            // pick "Local LLM" in the model picker to test the AI UI without
+            // calling a real provider. Responses are defined in
+            // `apps/mock-localllm/mock.config.js`.
+            id: 'local-llm',
+            label: 'Local LLM',
+            provider: 'openai-compatible',
+            modelId: 'mock-llm',
+            baseURL: 'http://localhost:8765/v1',
+            apiKey: 'mock',
+            capabilities: {tools: false, reasoning: false, attachments: false},
+          },
         ],
       },
       translations: [

--- a/docs/root.config.ts
+++ b/docs/root.config.ts
@@ -69,16 +69,16 @@ export default defineConfig({
           {
             // Mock LLM served by the `apps/mock-localllm` package. Run
             // `pnpm --filter @private/mock-localllm dev` to start it, then
-            // pick "Local LLM" in the model picker to test the AI UI without
-            // calling a real provider. Responses are defined in
-            // `apps/mock-localllm/mock.config.js`.
+            // pick "Local LLM" in the model picker to test the AI UI (chat,
+            // streaming, and tool calls) without calling a real provider.
+            // Responses are defined in `apps/mock-localllm/mock.config.js`.
             id: 'local-llm',
             label: 'Local LLM',
             provider: 'openai-compatible',
             modelId: 'mock-llm',
             baseURL: 'http://localhost:8765/v1',
             apiKey: 'mock',
-            capabilities: {tools: false, reasoning: false, attachments: false},
+            capabilities: {tools: true, reasoning: false, attachments: false},
           },
         ],
       },

--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -513,13 +513,6 @@
 
 .AIPage__approval__status {
   align-self: flex-start;
-  color: #1864ab;
-  background: #e7f5ff;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 12px;
-  font-weight: 700;
-  white-space: nowrap;
 }
 
 .AIPage__approval__details,
@@ -566,36 +559,6 @@
   padding: 10px 12px;
 }
 
-.AIPage__approval__button {
-  border: 1px solid var(--color-border);
-  background: #fff;
-  color: #212529;
-  border-radius: 6px;
-  padding: 7px 10px;
-  font: inherit;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.AIPage__approval__button:hover:not(:disabled) {
-  background: #f1f3f5;
-}
-
-.AIPage__approval__button--primary {
-  border-color: #1864ab;
-  background: #1864ab;
-  color: #fff;
-}
-
-.AIPage__approval__button--primary:hover:not(:disabled) {
-  background: #0b5ca8;
-}
-
-.AIPage__approval__button:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
 .AIPage__receipt {
   background: #fff;
   border: 1px solid #b2dfb2;
@@ -618,15 +581,7 @@
 }
 
 .AIPage__receipt__link {
-  display: inline-flex;
   margin: 10px 12px;
-  font-weight: 700;
-  color: #1864ab;
-  text-decoration: none;
-}
-
-.AIPage__receipt__link:hover {
-  text-decoration: underline;
 }
 
 .AIPage__tool__body {

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -12,7 +12,7 @@
 import './AIPage.css';
 
 import {useChat} from '@ai-sdk/react';
-import {ActionIcon, Loader, Menu, Tooltip} from '@mantine/core';
+import {ActionIcon, Badge, Button, Loader, Menu, Tooltip} from '@mantine/core';
 import {
   IconCheck,
   IconChevronDown,
@@ -235,8 +235,9 @@ function ChatExperience(props: {
   const [selectedModelId, setSelectedModelId] = useState<string>(
     props.config.defaultModel || models[0]?.id || ''
   );
-  const [executionMode, setExecutionMode] =
-    useState<ExecutionMode>(readStoredExecutionMode);
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>(
+    readStoredExecutionMode
+  );
   // The chat id used for the next mount of `ChatPane`. Empty for "new chat".
   const [pendingChatId, setPendingChatId] = useState<string>(
     props.initialChatId || NEW_CHAT_ID
@@ -570,7 +571,12 @@ function ChatPane(props: {
   }, []);
 
   const waitForApproval = useCallback(
-    (toolCallId: string, toolName: string, input: any, preview: CmsToolPreview) =>
+    (
+      toolCallId: string,
+      toolName: string,
+      input: any,
+      preview: CmsToolPreview
+    ) =>
       new Promise<'approve' | 'reject'>((resolve) => {
         approvalResolvers.current[toolCallId] = resolve;
         setPendingApprovals((prev) => ({
@@ -882,11 +888,7 @@ function MessageView(props: {
         <div className="AIPage__message__username">{username}</div>
         <div className="AIPage__message__parts">
           {(message.parts || []).map((part, i) => (
-            <PartView
-              key={i}
-              part={part}
-              toolApprovals={props.toolApprovals}
-            />
+            <PartView key={i} part={part} toolApprovals={props.toolApprovals} />
           ))}
         </div>
         <button
@@ -1213,9 +1215,13 @@ function ToolApprovalCard(props: {
           <div className="AIPage__approval__title">{preview.title}</div>
           <div className="AIPage__approval__summary">{preview.summary}</div>
         </div>
-        <div className="AIPage__approval__status">
+        <Badge
+          className="AIPage__approval__status"
+          variant="light"
+          color="gray"
+        >
           {props.approval.status === 'executing' ? 'Applying' : 'Review'}
-        </div>
+        </Badge>
       </div>
       {preview.details.length > 0 && (
         <div className="AIPage__approval__details">
@@ -1235,22 +1241,28 @@ function ToolApprovalCard(props: {
         />
       )}
       <div className="AIPage__approval__actions">
-        <button
+        <Button
+          variant="default"
+          color="dark"
+          size="xs"
           type="button"
           className="AIPage__approval__button"
           disabled={props.approval.status === 'executing'}
           onClick={props.onReject}
         >
           Reject
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="filled"
+          color="green"
+          size="xs"
           type="button"
           className="AIPage__approval__button AIPage__approval__button--primary"
           disabled={props.approval.status === 'executing'}
           onClick={props.onApprove}
         >
           Approve draft edit
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -1276,9 +1288,16 @@ function ToolReceipt(props: {output: any}) {
         </div>
       )}
       {receipt.adminUrl && (
-        <a className="AIPage__receipt__link" href={receipt.adminUrl}>
+        <Button
+          component="a"
+          className="AIPage__receipt__link"
+          variant="default"
+          size="xs"
+          compact
+          href={receipt.adminUrl}
+        >
           Open document
-        </a>
+        </Button>
       )}
     </div>
   );
@@ -1500,7 +1519,9 @@ function prepareAttachmentsForSend(attachments: AttachmentPreview[]): {
     .map(formatAttachmentForPrompt);
   return {
     files,
-    text: textBlocks.length ? `Attached files:\n\n${textBlocks.join('\n\n')}` : '',
+    text: textBlocks.length
+      ? `Attached files:\n\n${textBlocks.join('\n\n')}`
+      : '',
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
+  apps/mock-localllm: {}
+
   docs:
     dependencies:
       '@blinkk/root':


### PR DESCRIPTION
This PR introduces a new `mock-localllm` package that provides a mock OpenAI-compatible HTTP server for local UI testing without calling real LLM providers.

## Summary
The mock server implements a minimal subset of the OpenAI Chat Completions API, allowing developers to test AI features (chat, streaming, tool calls) locally with configurable responses defined in `mock.config.js`.

## Key Changes

- **New `apps/mock-localllm` package** with a complete mock LLM server:
  - `src/index.js` — Entry point that loads config, starts the server, and handles CLI flags/env vars
  - `src/server.js` — HTTP server implementing OpenAI-compatible endpoints:
    - `POST /v1/chat/completions` — Buffered and streamed chat completions with tool call support
    - `GET /v1/models` — Lists configured mock model IDs
    - `GET /` — Health/info endpoint
  - `src/matcher.js` — Prompt extraction and rule matching logic for selecting responses
  - `src/openai.js` — Builders for OpenAI-compatible response payloads
  - `mock.config.js` — Configuration file with example rules and tool-call loops

- **Features**:
  - Rule-based response matching (substring, exact, startsWith, regex)
  - Streamed responses with configurable inter-chunk delays to simulate real token streaming
  - Tool-call loop support via multi-turn `responses` arrays
  - CORS headers for cross-origin requests
  - Graceful handling of client disconnections during streaming
  - Token usage estimation for realistic response metadata

- **Integration with Root CMS**:
  - Updated `docs/root.config.ts` to register the mock LLM as a model option ("Local LLM")
  - Includes example tool-call configuration for CMS-specific tools (`docs_search`, etc.)

## Implementation Details

- The server uses Node.js built-in `http` module (no external dependencies)
- Supports both `/v1/` and non-prefixed endpoint paths for flexibility
- Streaming responses use Server-Sent Events (SSE) format matching OpenAI's API
- Tool calls are normalized with auto-generated IDs when not provided
- Configuration is dynamically loaded via ES modules, allowing hot-reload by restarting the server

https://claude.ai/code/session_019MJ1K7hrajmgAHU7mW9m4n