### PR TITLE
chore: improve styling on ai page

### DIFF
--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -118,19 +118,24 @@
   position: relative;
 }
 
-.AIPage__header {
+.AIPage__options {
   max-width: 800px;
   margin: 10px auto 0;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   flex-wrap: wrap;
   gap: 8px;
 }
 
 .AIPage__modelPicker,
 .AIPage__modePicker {
-  font-weight: 600;
+  font-weight: 500;
+}
+
+.AIPage__modelPicker:hover,
+.AIPage__modePicker:hover {
+  background: #efefef;
 }
 
 .AIPage__modelPicker__option {
@@ -141,7 +146,7 @@
 }
 
 .AIPage__modelPicker__option__label {
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .AIPage__modelPicker__option__description {
@@ -157,7 +162,8 @@
 }
 
 .AIPage__modePicker__option__label {
-  font-weight: 600;
+  font-weight: 500;
+  margin-bottom: 4px;
 }
 
 .AIPage__modePicker__option__description {
@@ -698,6 +704,11 @@
 
 .AIPage__composer__attach {
   flex-shrink: 0;
+}
+
+.AIPage__composer__attach--disabled {
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 .AIPage__notEnabled {

--- a/packages/root-cms/ui/pages/AIPage/AIPage.css
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.css
@@ -119,50 +119,18 @@
 }
 
 .AIPage__header {
-  padding: 12px 20px;
+  max-width: 800px;
+  margin: 10px auto 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
-  gap: 12px;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 100;
+  gap: 8px;
 }
 
-.AIPage__modelPicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 14px;
-  font-weight: 600;
-  border: 1px solid var(--color-border);
-  background: var(--surface-background);
-  border-radius: 8px;
-  cursor: pointer;
-}
-
-.AIPage__modelPicker:hover {
-  background: #f1f3f5;
-}
-
+.AIPage__modelPicker,
 .AIPage__modePicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 14px;
   font-weight: 600;
-  border: 1px solid var(--color-border);
-  background: var(--surface-background);
-  border-radius: 8px;
-  cursor: pointer;
-}
-
-.AIPage__modePicker:hover {
-  background: #f1f3f5;
 }
 
 .AIPage__modelPicker__option {
@@ -730,13 +698,6 @@
 
 .AIPage__composer__attach {
   flex-shrink: 0;
-}
-
-.AIPage__composer__disclaimer {
-  margin-top: 10px;
-  text-align: center;
-  font-size: 12px;
-  color: dimgray;
 }
 
 .AIPage__notEnabled {

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -12,7 +12,6 @@
 import './AIPage.css';
 
 import {useChat} from '@ai-sdk/react';
-import type {ComponentChildren} from 'preact';
 import {ActionIcon, Badge, Button, Loader, Menu, Tooltip} from '@mantine/core';
 import {
   IconCheck,
@@ -20,6 +19,7 @@ import {
   IconCopy,
   IconMessageCirclePlus,
   IconPaperclip,
+  IconPencil,
   IconRobot,
   IconSend2,
   IconTool,
@@ -32,6 +32,7 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 import {marked} from 'marked';
+import type {ComponentChildren} from 'preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {JsDiff} from '../../components/JsDiff/JsDiff.js';
@@ -265,9 +266,8 @@ function ChatExperience(props: {
     props.config.defaultModel ||
     models[0]?.id ||
     '';
-  const [selectedModelId, setSelectedModelId] = useState<string>(
-    getPreferredModelId
-  );
+  const [selectedModelId, setSelectedModelId] =
+    useState<string>(getPreferredModelId);
   const [executionMode, setExecutionMode] = useState<ExecutionMode>(
     readStoredExecutionMode
   );
@@ -509,7 +509,38 @@ function ChatHeader(props: {
     EXECUTION_MODES.find((mode) => mode.id === props.executionMode) ||
     EXECUTION_MODES[0];
   return (
-    <div className="AIPage__header">
+    <div className="AIPage__options">
+      <Menu
+        control={
+          <Button
+            type="button"
+            className="AIPage__modePicker"
+            variant="subtle"
+            color="dark"
+            size="xs"
+            compact
+            leftIcon={<IconPencil size={16} />}
+          >
+            {selectedMode.label}
+          </Button>
+        }
+      >
+        {EXECUTION_MODES.map((mode) => (
+          <Menu.Item
+            key={mode.id}
+            onClick={() => props.onSelectExecutionMode(mode.id)}
+          >
+            <div className="AIPage__modePicker__option">
+              <div className="AIPage__modePicker__option__label">
+                {mode.label}
+              </div>
+              <div className="AIPage__modePicker__option__description">
+                {mode.description}
+              </div>
+            </div>
+          </Menu.Item>
+        ))}
+      </Menu>
       <Menu
         control={
           <Button
@@ -520,7 +551,6 @@ function ChatHeader(props: {
             size="xs"
             compact
             leftIcon={<IconRobot size={16} />}
-            rightIcon={<IconChevronDown size={14} />}
           >
             {props.selectedModel?.label || 'Select model'}
           </Button>
@@ -545,38 +575,6 @@ function ChatHeader(props: {
                 {model.capabilities.reasoning && <span>reasoning</span>}
                 {model.capabilities.attachments && <span>attachments</span>}
               </div> */}
-            </div>
-          </Menu.Item>
-        ))}
-      </Menu>
-      <Menu
-        control={
-          <Button
-            type="button"
-            className="AIPage__modePicker"
-            variant="subtle"
-            color="dark"
-            size="xs"
-            compact
-            leftIcon={<IconTool size={16} />}
-            rightIcon={<IconChevronDown size={14} />}
-          >
-            {selectedMode.label}
-          </Button>
-        }
-      >
-        {EXECUTION_MODES.map((mode) => (
-          <Menu.Item
-            key={mode.id}
-            onClick={() => props.onSelectExecutionMode(mode.id)}
-          >
-            <div className="AIPage__modePicker__option">
-              <div className="AIPage__modePicker__option__label">
-                {mode.label}
-              </div>
-              <div className="AIPage__modePicker__option__description">
-                {mode.description}
-              </div>
             </div>
           </Menu.Item>
         ))}
@@ -1495,26 +1493,32 @@ function ChatComposer(props: {
         </div>
       )}
       <div className="AIPage__composer__row">
-        {props.canAttach && (
-          <Tooltip
-            label="Attach file"
-            className="AIPage__composer__attachTooltip"
+        <Tooltip
+          label={
+            props.canAttach
+              ? 'Attach file'
+              : "Model doesn't support attachments"
+          }
+          className="AIPage__composer__attachTooltip"
+        >
+          <ActionIcon
+            component="label"
+            radius="xl"
+            className={joinClassNames(
+              'AIPage__composer__attach',
+              !props.canAttach && 'AIPage__composer__attach--disabled'
+            )}
+            disabled={!props.canAttach}
           >
-            <ActionIcon
-              component="label"
-              radius="xl"
-              className="AIPage__composer__attach"
-            >
-              {uploading ? <Loader size="xs" /> : <IconPaperclip size={18} />}
-              <input
-                ref={fileRef}
-                type="file"
-                style={{display: 'none'}}
-                onChange={onFileChange}
-              />
-            </ActionIcon>
-          </Tooltip>
-        )}
+            {uploading ? <Loader size="xs" /> : <IconPaperclip size={18} />}
+            <input
+              ref={fileRef}
+              type="file"
+              style={{display: 'none'}}
+              onChange={onFileChange}
+            />
+          </ActionIcon>
+        </Tooltip>
         <textarea
           ref={textareaRef}
           className="AIPage__composer__textarea"

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -1099,7 +1099,9 @@ function ToolPartView(props: {
         className="AIPage__tool__header"
         onClick={() => setOpen(!open)}
       >
-        <IconTool size={14} />
+        <Badge variant="filled" color="dark" size="xs">
+          {toolName}
+        </Badge>
         <span className="AIPage__tool__title">
           {prettyToolName(toolName, part.input)}
         </span>

--- a/packages/root-cms/ui/pages/AIPage/AIPage.tsx
+++ b/packages/root-cms/ui/pages/AIPage/AIPage.tsx
@@ -12,6 +12,7 @@
 import './AIPage.css';
 
 import {useChat} from '@ai-sdk/react';
+import type {ComponentChildren} from 'preact';
 import {ActionIcon, Badge, Button, Loader, Menu, Tooltip} from '@mantine/core';
 import {
   IconCheck,
@@ -115,6 +116,7 @@ const EXECUTION_MODES: ExecutionModeInfo[] = [
 ];
 
 const EXECUTION_MODE_STORAGE_KEY = 'root-cms.ai.executionMode';
+const SELECTED_MODEL_STORAGE_KEY = 'root-cms.ai.selectedModel';
 
 function isExecutionMode(value: string | null): value is ExecutionMode {
   return EXECUTION_MODES.some((mode) => mode.id === value);
@@ -133,6 +135,32 @@ function readStoredExecutionMode(): ExecutionMode {
     console.error('failed to read AI execution mode preference', err);
   }
   return 'approve';
+}
+
+function readStoredSelectedModel(models: ModelInfo[]): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const value = window.localStorage.getItem(SELECTED_MODEL_STORAGE_KEY);
+    if (value && models.some((model) => model.id === value)) {
+      return value;
+    }
+  } catch (err) {
+    console.error('failed to read AI model preference', err);
+  }
+  return null;
+}
+
+function persistSelectedModel(modelId: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, modelId);
+  } catch (err) {
+    console.error('failed to save AI model preference', err);
+  }
 }
 
 function persistExecutionMode(mode: ExecutionMode) {
@@ -232,8 +260,13 @@ function ChatExperience(props: {
 }) {
   const {route} = useLocation();
   const models = props.config.models || [];
+  const getPreferredModelId = () =>
+    readStoredSelectedModel(models) ||
+    props.config.defaultModel ||
+    models[0]?.id ||
+    '';
   const [selectedModelId, setSelectedModelId] = useState<string>(
-    props.config.defaultModel || models[0]?.id || ''
+    getPreferredModelId
   );
   const [executionMode, setExecutionMode] = useState<ExecutionMode>(
     readStoredExecutionMode
@@ -313,6 +346,7 @@ function ChatExperience(props: {
   };
 
   const startNewChat = () => {
+    setSelectedModelId(getPreferredModelId());
     setPendingChatId(NEW_CHAT_ID);
     setActiveChatId(NEW_CHAT_ID);
     setInitialMessages([]);
@@ -371,6 +405,11 @@ function ChatExperience(props: {
   const selectedModel =
     models.find((m) => m.id === selectedModelId) || models[0];
 
+  const selectModel = (id: string) => {
+    setSelectedModelId(id);
+    persistSelectedModel(id);
+  };
+
   return (
     <div className="AIPage__layout">
       <ChatHistorySidebar
@@ -381,19 +420,16 @@ function ChatExperience(props: {
         onDelete={deleteChat}
       />
       <div className="AIPage__main">
-        <ChatHeader
-          models={models}
-          selectedModel={selectedModel}
-          onSelectModel={setSelectedModelId}
-          executionMode={executionMode}
-          onSelectExecutionMode={setExecutionMode}
-        />
         <ChatPane
           key={resetKey}
           initialChatId={pendingChatId}
           model={selectedModel}
           initialMessages={initialMessages}
           executionMode={executionMode}
+          models={models}
+          selectedModel={selectedModel}
+          onSelectModel={selectModel}
+          onSelectExecutionMode={setExecutionMode}
           onChatPersisted={(id) => {
             setActiveChatId(id);
             refreshChats();
@@ -476,11 +512,18 @@ function ChatHeader(props: {
     <div className="AIPage__header">
       <Menu
         control={
-          <button type="button" className="AIPage__modelPicker">
-            <IconRobot size={16} />
-            <span>{props.selectedModel?.label || 'Select model'}</span>
-            <IconChevronDown size={14} />
-          </button>
+          <Button
+            type="button"
+            className="AIPage__modelPicker"
+            variant="subtle"
+            color="dark"
+            size="xs"
+            compact
+            leftIcon={<IconRobot size={16} />}
+            rightIcon={<IconChevronDown size={14} />}
+          >
+            {props.selectedModel?.label || 'Select model'}
+          </Button>
         }
       >
         {props.models.map((model) => (
@@ -508,11 +551,18 @@ function ChatHeader(props: {
       </Menu>
       <Menu
         control={
-          <button type="button" className="AIPage__modePicker">
-            <IconTool size={16} />
-            <span>{selectedMode.label}</span>
-            <IconChevronDown size={14} />
-          </button>
+          <Button
+            type="button"
+            className="AIPage__modePicker"
+            variant="subtle"
+            color="dark"
+            size="xs"
+            compact
+            leftIcon={<IconTool size={16} />}
+            rightIcon={<IconChevronDown size={14} />}
+          >
+            {selectedMode.label}
+          </Button>
         }
       >
         {EXECUTION_MODES.map((mode) => (
@@ -540,6 +590,10 @@ function ChatPane(props: {
   model?: ModelInfo;
   initialMessages: UIMessage[];
   executionMode: ExecutionMode;
+  models: ModelInfo[];
+  selectedModel?: ModelInfo;
+  onSelectModel: (id: string) => void;
+  onSelectExecutionMode: (mode: ExecutionMode) => void;
   onChatPersisted: (id: string) => void;
 }) {
   // Lock in the chat id for the lifetime of this mount. We generate one
@@ -758,6 +812,15 @@ function ChatPane(props: {
         canAttach={props.model?.capabilities.attachments ?? false}
         isStreaming={isStreaming}
         onStop={stop}
+        controls={
+          <ChatHeader
+            models={props.models}
+            selectedModel={props.selectedModel}
+            onSelectModel={props.onSelectModel}
+            executionMode={props.executionMode}
+            onSelectExecutionMode={props.onSelectExecutionMode}
+          />
+        }
         onSend={(text, attachments) => {
           if (!text && attachments.length === 0) {
             return;
@@ -1328,6 +1391,7 @@ function ChatComposer(props: {
   isStreaming: boolean;
   onSend: (text: string, attachments: AttachmentPreview[]) => void;
   onStop: () => void;
+  controls?: ComponentChildren;
 }) {
   const [text, setText] = useState('');
   const [attachments, setAttachments] = useState<AttachmentPreview[]>([]);
@@ -1500,9 +1564,7 @@ function ChatComposer(props: {
           </ActionIcon>
         )}
       </div>
-      <div className="AIPage__composer__disclaimer">
-        Root AI is experimental and can make mistakes. Use with caution.
-      </div>
+      {props.controls}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Move the plan mode button and model picker beneath the chat input (removing the experimental disclaimer) and make the controls visually lighter, and ensure a user-selected model is remembered across new chat sessions.

### Description

- Moved the model picker and execution-mode controls from the floating header into the composer footer by embedding `ChatHeader` as `controls` inside `ChatComposer` and removing the old disclaimer rendering.
- Replaced native control buttons with Mantine `Button` components using `variant="subtle"` and adjusted the header/footer CSS so the controls are centered under the chat bar and the old disclaimer styles were removed.
- Implemented sticky model selection using `localStorage` with `SELECTED_MODEL_STORAGE_KEY`, adding `readStoredSelectedModel` and `persistSelectedModel`, restoring the stored model on load and when starting a new chat, and persisting on selection.
- Propagated new props for model selection and execution mode through `ChatExperience` → `ChatPane` → `ChatComposer` and updated related types and state initialization to use the persisted preference.

### Testing

- `git diff --check` passed successfully.  
- Attempted `pnpm --filter @blinkk/root-cms build:ui` but it was blocked/failed due to Corepack being unable to download the configured `pnpm` version through the environment proxy.  No further automated builds/tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066fe28d9483239db6974a10c44c7d)