### PR TITLE
chore: optimize JSX rendering

### DIFF
--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -162,6 +162,11 @@ const LT = '&lt;';
 const GT = '&gt;';
 const QUOT = '&quot;';
 
+// Shared empty object reused as the per-component context map when no contexts
+// have ever been pushed. Components only ever read from this map, so sharing is
+// safe and avoids a per-render allocation in the common case.
+const EMPTY_GLOBAL_CTX: Record<string, any> = {};
+
 /** Returns `true` when `value` is neither `null` nor `undefined`. */
 function isDef<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
@@ -204,14 +209,24 @@ function escapeAttr(str: string): string {
   return result + str.slice(last);
 }
 
+const STYLE_KEY_CACHE = new Map<string, string>();
+const UPPERCASE_RE = /[A-Z]/g;
+
+function toKebabCase(key: string): string {
+  let cached = STYLE_KEY_CACHE.get(key);
+  if (cached === undefined) {
+    cached = key.replace(UPPERCASE_RE, (m) => '-' + m.toLowerCase());
+    STYLE_KEY_CACHE.set(key, cached);
+  }
+  return cached;
+}
+
 function styleToString(style: Record<string, any>): string {
   const parts: string[] = [];
   for (const key in style) {
     const value = style[key];
     if (!isDef(value) || value === '') continue;
-    // Convert camelCase to kebab-case.
-    const cssKey = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-    parts.push(`${cssKey}:${value}`);
+    parts.push(`${toKebabCase(key)}:${value}`);
   }
   return parts.join(';');
 }
@@ -232,15 +247,27 @@ export function renderJsxToString(
 ): string {
   const mode = options?.mode ?? 'pretty';
   const isPretty = mode === 'pretty';
-  const blockSet = new Set(DEFAULT_BLOCK_ELEMENTS);
-  if (options?.blockElements) {
+  // In minimal mode `blockSet` is unused (the `isPretty` guard short-circuits
+  // any `.has()` call). In pretty mode without custom block elements, reuse the
+  // module-level Set instead of allocating a copy.
+  let blockSet: ReadonlySet<string> = DEFAULT_BLOCK_ELEMENTS;
+  if (isPretty && options?.blockElements && options.blockElements.length > 0) {
+    const merged = new Set(DEFAULT_BLOCK_ELEMENTS);
     for (const el of options.blockElements) {
-      blockSet.add(el);
+      merged.add(el);
     }
+    blockSet = merged;
   }
 
   // Context stacks: context.__c (id) -> value[]
   const contextStacks = new Map<string, any[]>();
+
+  // Version counter that bumps whenever a context value is pushed or popped.
+  // `buildGlobalContext` uses it to skip rebuilding when nothing changed
+  // between sibling component renders (the common case).
+  let ctxVersion = 0;
+  let cachedGlobalCtx: Record<string, any> = EMPTY_GLOBAL_CTX;
+  let cachedGlobalCtxVersion = 0;
 
   function pushCtx(contextId: string, value: any) {
     let stack = contextStacks.get(contextId);
@@ -249,14 +276,22 @@ export function renderJsxToString(
       contextStacks.set(contextId, stack);
     }
     stack.push(value);
+    ctxVersion++;
   }
 
   function popCtx(contextId: string) {
     contextStacks.get(contextId)?.pop();
+    ctxVersion++;
   }
 
   /** Builds the __n (global context) map for hooks. */
   function buildGlobalContext(): Record<string, any> {
+    if (ctxVersion === cachedGlobalCtxVersion) return cachedGlobalCtx;
+    if (contextStacks.size === 0) {
+      cachedGlobalCtx = EMPTY_GLOBAL_CTX;
+      cachedGlobalCtxVersion = ctxVersion;
+      return cachedGlobalCtx;
+    }
     const globalCtx: Record<string, any> = {};
     for (const [contextId, stack] of contextStacks) {
       if (stack.length > 0) {
@@ -267,6 +302,8 @@ export function renderJsxToString(
         };
       }
     }
+    cachedGlobalCtx = globalCtx;
+    cachedGlobalCtxVersion = ctxVersion;
     return globalCtx;
   }
 
@@ -275,7 +312,13 @@ export function renderJsxToString(
     if (typeof node === 'string') return escapeHtml(node);
     if (typeof node === 'number' || typeof node === 'bigint')
       return String(node);
-    if (Array.isArray(node)) return node.map((n) => render(n, inline)).join('');
+    if (Array.isArray(node)) {
+      let out = '';
+      for (let i = 0; i < node.length; i++) {
+        out += render(node[i], inline);
+      }
+      return out;
+    }
 
     // Must be a VNode-like object.
     if (typeof node !== 'object' || !('type' in node)) return '';
@@ -511,7 +554,11 @@ export function renderJsxToString(
     if (!isDef(children)) return '';
     if (Array.isArray(children)) {
       const inline = isPretty && hasMixedContent(children);
-      return children.map((child) => render(child, inline)).join('');
+      let out = '';
+      for (let i = 0; i < children.length; i++) {
+        out += render(children[i], inline);
+      }
+      return out;
     }
     return render(children);
   }

--- a/packages/root/src/jsx/jsx-runtime.ts
+++ b/packages/root/src/jsx/jsx-runtime.ts
@@ -99,18 +99,20 @@ export function jsx(
   props: Record<string, any>,
   key?: Key
 ): VNode {
-  const resolvedKey = key !== undefined ? key : props.key ?? null;
+  const propsKey = props.key;
+  // `key` is stored on the VNode directly; strip it from props when present so
+  // it doesn't leak into rendered attributes.
+  let finalProps = props;
+  if (propsKey !== undefined) {
+    const {key: _, ...rest} = props;
+    finalProps = rest;
+  }
+
   const vnode: VNode = {
     type,
-    props,
-    key: resolvedKey,
+    props: finalProps,
+    key: key !== undefined ? key : propsKey ?? null,
   };
-
-  // Strip `key` from props (it's stored on the VNode directly).
-  if (props.key !== undefined) {
-    const {key: _, ...rest} = props;
-    vnode.props = rest;
-  }
 
   if (options.vnode) {
     options.vnode(vnode);


### PR DESCRIPTION
## Summary
This PR improves the performance of JSX rendering by introducing caching mechanisms and reducing unnecessary allocations in hot paths.

## Key Changes

- **Context caching**: Added version-based caching for the global context map (`buildGlobalContext`). The context is now only rebuilt when context values actually change, and reuses a shared empty object in the common case of no contexts.

- **Style key caching**: Introduced a `Map`-based cache for camelCase-to-kebab-case conversions in `toKebabCase`, avoiding repeated regex operations on the same style property names.

- **Block elements optimization**: Changed `blockSet` to reuse the module-level `DEFAULT_BLOCK_ELEMENTS` Set in pretty mode when no custom block elements are provided, eliminating unnecessary Set allocations.

- **Array rendering optimization**: Replaced `.map().join()` patterns with explicit loops when rendering arrays, reducing intermediate array allocations.

- **Props handling refactor**: Optimized the `jsx` function to avoid creating a new props object when `key` is not present in props, and to determine the final props before creating the VNode.

## Implementation Details

- The context caching uses a `ctxVersion` counter that increments on every `pushCtx`/`popCtx` call, allowing `buildGlobalContext` to quickly determine if a rebuild is needed.
- The `EMPTY_GLOBAL_CTX` shared object is safe to reuse since components only read from the context map.
- Style key caching uses a module-level `Map` that persists across renders, providing benefits for repeated style applications.
- The array rendering changes trade slightly more verbose code for better memory efficiency in the common case.

https://claude.ai/code/session_01XA3suqzHD9c6szRhZXgYQv