### PR TITLE
fix: fix cmd+f searchability of collapsed array items

### DIFF
--- a/.changeset/beige-timers-walk.md
+++ b/.changeset/beige-timers-walk.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: fix cmd+f searchability of collapsed array items

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -821,17 +821,7 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
   const iconPosition = inline ? 'left' : 'right';
 
   const deeplink = useDeeplink();
-  const deeplinkOpen = deeplink.value.includes(props.deepKey);
-  const initialOpen = !collapsed || deeplinkOpen;
-  const [open, setOpen] = useState(initialOpen);
-  const [renderFields, setRenderFields] = useState(initialOpen);
-
-  useEffect(() => {
-    if (deeplinkOpen) {
-      setOpen(true);
-      setRenderFields(true);
-    }
-  }, [deeplinkOpen]);
+  const initialOpen = !collapsed || deeplink.value.includes(props.deepKey);
 
   return (
     <div
@@ -842,17 +832,7 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
     >
       <details
         className="DocEditor__ObjectFieldDrawer__drawer"
-        open={open}
-        onToggle={(e) => {
-          if (e.currentTarget !== e.target) {
-            return;
-          }
-          const isOpen = (e.target as HTMLDetailsElement).open;
-          setOpen(isOpen);
-          if (isOpen) {
-            setRenderFields(true);
-          }
-        }}
+        open={initialOpen}
       >
         <summary
           className={joinClassNames(
@@ -869,17 +849,15 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
             <IconChevronDown size={16} />
           </div>
         </summary>
-        {renderFields && (
-          <div className="DocEditor__ObjectFieldDrawer__drawer__content DocEditor__ObjectFieldDrawer__fields">
-            {field.fields.map((field) => (
-              <DocEditor.Field
-                key={field.id}
-                field={field}
-                deepKey={`${props.deepKey}.${field.id}`}
-              />
-            ))}
-          </div>
-        )}
+        <div className="DocEditor__ObjectFieldDrawer__drawer__content DocEditor__ObjectFieldDrawer__fields">
+          {field.fields.map((field) => (
+            <DocEditor.Field
+              key={field.id}
+              field={field}
+              deepKey={`${props.deepKey}.${field.id}`}
+            />
+          ))}
+        </div>
       </details>
     </div>
   );
@@ -1569,7 +1547,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
                       itemInDeeplink(key) ||
                       !!field.defaultOpen
                     }
-                    deeplinkOpen={itemInDeeplink(key)}
                     isCut={cutIndex === i}
                     aiEnabled={!!experiments.ai}
                     onFocusHeader={focusFieldHeader}
@@ -1604,7 +1581,6 @@ interface ArrayFieldItemProps {
   itemKey: string;
   index: number;
   initialOpen: boolean;
-  deeplinkOpen: boolean;
   isCut: boolean;
   aiEnabled: boolean;
   onFocusHeader: (deepKey: string, index: number) => void;
@@ -1622,18 +1598,8 @@ interface ArrayFieldItemProps {
   onRemove: (index: number) => void;
 }
 
-/** Renders one array row and lazily mounts its editor body. */
 DocEditor.ArrayFieldItem = (props: ArrayFieldItemProps) => {
   const itemDeepKey = `${props.parentDeepKey}.${props.itemKey}`;
-  const [open, setOpen] = useState(props.initialOpen);
-  const [renderBody, setRenderBody] = useState(props.initialOpen);
-
-  useEffect(() => {
-    if (props.deeplinkOpen) {
-      setOpen(true);
-      setRenderBody(true);
-    }
-  }, [props.deeplinkOpen]);
 
   return (
     <Draggable
@@ -1663,15 +1629,9 @@ DocEditor.ArrayFieldItem = (props: ArrayFieldItemProps) => {
           </div>
           <details
             className="DocEditor__ArrayField__item"
-            open={open}
+            open={props.initialOpen}
             onToggle={(e) => {
-              if (e.currentTarget !== e.target) {
-                return;
-              }
-              const isOpen = (e.target as HTMLDetailsElement).open;
-              setOpen(isOpen);
-              if (isOpen) {
-                setRenderBody(true);
+              if ((e.target as HTMLDetailsElement).open) {
                 requestHighlightNode(itemDeepKey, {scroll: true});
               } else {
                 requestHighlightNode(null);
@@ -1797,23 +1757,21 @@ DocEditor.ArrayFieldItem = (props: ArrayFieldItemProps) => {
                 </Menu>
               </div>
             </summary>
-            {renderBody && (
-              <div className="DocEditor__ArrayField__item__body">
-                <DocEditor.Field
-                  key={itemDeepKey}
-                  field={props.field.of}
-                  deepKey={itemDeepKey}
-                  hideHeader
-                  isArrayChild
-                  onFocus={() => {
-                    requestHighlightNode(itemDeepKey, {scroll: true});
-                  }}
-                  onBlur={() => {
-                    requestHighlightNode(null);
-                  }}
-                />
-              </div>
-            )}
+            <div className="DocEditor__ArrayField__item__body">
+              <DocEditor.Field
+                key={itemDeepKey}
+                field={props.field.of}
+                deepKey={itemDeepKey}
+                hideHeader
+                isArrayChild
+                onFocus={() => {
+                  requestHighlightNode(itemDeepKey, {scroll: true});
+                }}
+                onBlur={() => {
+                  requestHighlightNode(null);
+                }}
+              />
+            </div>
           </details>
         </div>
       )}


### PR DESCRIPTION
## Summary
This change removes lazy rendering of collapsed array items and object field drawers in the DocEditor. Previously, content was only rendered when expanded, which prevented browser find (cmd+f) and search panel deeplinks from reaching nested fields.

## Key Changes
- **ObjectFieldDrawer**: Removed state management (`open`, `renderFields`) and conditional rendering. Content now renders eagerly regardless of collapsed state, with the `<details>` element controlling visibility via the `open` attribute.
- **ArrayFieldItem**: Removed lazy rendering logic (`renderBody` state and `deeplinkOpen` prop). Content now always renders, allowing search functionality to access nested fields while the `<details>` element still controls visual expansion.
- Simplified toggle handlers to remove unnecessary state updates and event target checks.
- Removed the `deeplinkOpen` prop from `ArrayFieldItemProps` interface as it's no longer needed.

## Implementation Details
- The `initialOpen` state is now used directly on the `<details>` element's `open` attribute instead of managing separate state.
- Content within `<details>` elements is now always mounted in the DOM, enabling browser search and deeplink navigation to work correctly.
- Visual collapse/expand behavior is preserved through the native `<details>` element functionality.

https://claude.ai/code/session_01SQWxjoc56mJCxDqVDeDrzx