### PR TITLE
fix: add default markdown styles for Root AI chat messages

### DIFF
--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -400,6 +400,41 @@
   margin-top: 1em;
 }
 
+.RootAIChat__textPart :is(h1, h2, h3, h4, h5, h6) {
+  margin: 1em 0 0.5em;
+  line-height: 1.3;
+}
+
+.RootAIChat__textPart :is(h1, h2) {
+  font-size: 1.2em;
+}
+
+.RootAIChat__textPart :is(h3, h4, h5, h6) {
+  font-size: 1.05em;
+}
+
+.RootAIChat__textPart :is(ul, ol) {
+  margin: 0.75em 0;
+  padding-left: 1.5em;
+}
+
+.RootAIChat__textPart li + li {
+  margin-top: 0.25em;
+}
+
+.RootAIChat__textPart blockquote {
+  margin: 1em 0;
+  padding: 0.5em 0 0.5em 1em;
+  border-left: 3px solid #DADCE0;
+  color: #5f6368;
+}
+
+.RootAIChat__textPart a {
+  color: #0b57d0;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
 .RootAIChat__textPart pre {
   background: #f8f9fa;
   border: 1px solid #DADCE0;
@@ -414,6 +449,13 @@
 .RootAIChat__textPart code {
   font-family: var(--font-family-mono);
   font-size: 0.9em;
+}
+
+.RootAIChat__textPart :not(pre) > code {
+  background: #f1f3f4;
+  border: 1px solid #DADCE0;
+  border-radius: 4px;
+  padding: 0.1em 0.3em;
 }
 
 .RootAIChat__reasoning {


### PR DESCRIPTION
### Motivation
- Improve the default presentation of markdown rendered inside the Root AI chat so headings, lists, blockquotes, links, and inline code read well out of the box.
- Provide consistent spacing and typographic defaults for AI-generated markdown content to match other CMS UI elements.

### Description
- Added baseline typography and spacing rules under `.RootAIChat__textPart` in `packages/root-cms/ui/components/RootAIChat/RootAIChat.css` to style `h1..h6`, lists (`ul`, `ol`), and `li` spacing.
- Added a blockquote style with left border and muted color, and a link style that uses the CMS link color and underline.
- Preserved existing fenced code block (`pre`) styling and added an inline code rule `:not(pre) > code` for subtle background, border, and padding.

### Testing
- No automated tests were run for this change (per request to avoid writing or running tests unless explicitly prompted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7d8a89bc8323bd0c445883f2e58d)