### PR TITLE
chore: root ai style tweaks

### DIFF
--- a/.changeset/breezy-guests-speak.md
+++ b/.changeset/breezy-guests-speak.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+chore: root ai style tweaks

--- a/packages/root-cms/ui/components/BouncingLoader/BouncingLoader.css
+++ b/packages/root-cms/ui/components/BouncingLoader/BouncingLoader.css
@@ -1,0 +1,56 @@
+.BouncingLoader {
+  --_g: no-repeat radial-gradient(farthest-side, #000 94%, #0000);
+  background:
+    var(--_g) 50% 0,
+    var(--_g) 100% 0;
+  background-size: calc(var(--dot-size) * 0.86) calc(var(--dot-size) * 0.86);
+  position: relative;
+  animation: BouncingLoader--shift 1.5s linear infinite;
+}
+
+.BouncingLoader::before {
+  content: '';
+  position: absolute;
+  height: calc(var(--dot-size) * 0.86);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #000;
+  left: 0;
+  top: 0;
+  animation:
+    BouncingLoader--slide 1.5s linear infinite,
+    BouncingLoader--bounce 0.5s cubic-bezier(0, 200, 0.8, 200) infinite;
+}
+
+@keyframes BouncingLoader--shift {
+  0%, 31% {
+    background-position: 50% 0, 100% 0;
+  }
+  33% {
+    background-position: 50% 100%, 100% 0;
+  }
+  43%, 64% {
+    background-position: 50% 0, 100% 0;
+  }
+  66% {
+    background-position: 50% 0, 100% 100%;
+  }
+  79% {
+    background-position: 50% 0, 100% 0;
+  }
+  100% {
+    transform: translateX(calc(-100% / 3));
+  }
+}
+
+@keyframes BouncingLoader--slide {
+  100% {
+    left: calc(100% + 7px);
+  }
+}
+
+@keyframes BouncingLoader--bounce {
+  100% {
+    top: -0.1px;
+  }
+}

--- a/packages/root-cms/ui/components/BouncingLoader/BouncingLoader.tsx
+++ b/packages/root-cms/ui/components/BouncingLoader/BouncingLoader.tsx
@@ -1,0 +1,23 @@
+import './BouncingLoader.css';
+
+interface BouncingLoaderProps {
+  size?: number;
+}
+
+export function BouncingLoader(props: BouncingLoaderProps) {
+  const {size = 14} = props;
+  const width = size * 3.57;
+  const height = size * 2;
+  return (
+    <div
+      className="BouncingLoader"
+      style={
+        {
+          '--dot-size': `${size}px`,
+          width: `${width}px`,
+          height: `${height}px`,
+        } as React.CSSProperties
+      }
+    />
+  );
+}

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -374,7 +374,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1.6;
 }
 
@@ -451,6 +451,29 @@
   border: 1px solid #DADCE0;
   border-radius: 4px;
   padding: 0.1em 0.3em;
+}
+
+.RootAIChat__textPart table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+  font-size: 0.9em;
+}
+
+.RootAIChat__textPart th,
+.RootAIChat__textPart td {
+  border: 1px solid #DADCE0;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.RootAIChat__textPart th {
+  background: #f1f3f4;
+  font-weight: 600;
+}
+
+.RootAIChat__textPart tr:nth-child(even) {
+  background: #f8f9fa;
 }
 
 .RootAIChat__reasoning {

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -283,11 +283,6 @@
 }
 
 .RootAIChat__streamingIndicator {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  font-size: 14px;
-  color: dimgray;
   padding-left: 44px;
 }
 

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -86,7 +86,7 @@
 }
 
 .RootAIChat__sidebar__item--active {
-  background: #e7f5ff;
+  background: #f5f5f5;
 }
 
 .RootAIChat__sidebar__item__title {
@@ -535,14 +535,8 @@
   font-size: 12px;
 }
 
-.RootAIChat__toolSummary {
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 8px 10px;
-}
-
 .RootAIChat__toolSummary__label {
+  display: none;
   font-size: 12px;
   font-weight: 700;
   color: #495057;

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -39,12 +39,12 @@ import {marked} from 'marked';
 import type {ComponentChildren} from 'preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
-import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
-import {JsDiff} from '../JsDiff/JsDiff.js';
-import {Markdown} from '../Markdown/Markdown.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {stableJsonStringify} from '../../utils/objects.js';
+import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
+import {JsDiff} from '../JsDiff/JsDiff.js';
+import {Markdown} from '../Markdown/Markdown.js';
 import type {CmsToolPreview} from './cmsToolHandlers.js';
 import {
   executeCmsTool,
@@ -243,10 +243,7 @@ export function RootAIChat(props: RootAIChatProps) {
 
   return (
     <div
-      className={joinClassNames(
-        'RootAIChat',
-        `RootAIChat--${props.variant}`
-      )}
+      className={joinClassNames('RootAIChat', `RootAIChat--${props.variant}`)}
     >
       {!config && !configError ? (
         <div className="RootAIChat__loading">
@@ -256,7 +253,9 @@ export function RootAIChat(props: RootAIChatProps) {
         <ChatExperience
           variant={props.variant}
           config={config!}
-          initialChatId={props.variant === 'panel' ? undefined : props.initialChatId}
+          initialChatId={
+            props.variant === 'panel' ? undefined : props.initialChatId
+          }
           docContext={props.docContext}
           onClose={props.onClose}
         />

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -971,7 +971,7 @@ function ChatTranscript(props: {
         ))}
         {props.isStreaming && (
           <div className="RootAIChat__streamingIndicator">
-            <BouncingLoader size={8} />
+            <BouncingLoader size={6} />
           </div>
         )}
       </div>

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -39,6 +39,7 @@ import {marked} from 'marked';
 import type {ComponentChildren} from 'preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
+import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
 import {JsDiff} from '../JsDiff/JsDiff.js';
 import {Markdown} from '../Markdown/Markdown.js';
 import {joinClassNames} from '../../utils/classes.js';
@@ -971,8 +972,7 @@ function ChatTranscript(props: {
         ))}
         {props.isStreaming && (
           <div className="RootAIChat__streamingIndicator">
-            <Loader size="xs" color="gray" />
-            <span>Thinking…</span>
+            <BouncingLoader size={8} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Replace the Mantine `<Loader>` spinner + "Thinking…" text in the Root AI chat streaming indicator with a new `BouncingLoader` component
- The new component renders a three-dot bouncing animation that feels more natural as a "thinking" indicator
- `BouncingLoader` accepts an optional `size` prop (default 14px) to scale the animation proportionally

## Changes

- **New:** `BouncingLoader` component (`BouncingLoader.tsx` + `BouncingLoader.css`) with BEM-style CSS naming conventions matching the rest of root-cms
- **Updated:** `RootAIChat.tsx` — swapped `<Loader size="xs" color="gray" />` + `<span>Thinking…</span>` for `<BouncingLoader size={8} />`
- **Updated:** `RootAIChat.css` — simplified `.RootAIChat__streamingIndicator` styles (removed flex/gap/font properties no longer needed)

## Test plan

- [ ] Open the Root AI chat and send a message
- [ ] Verify the bouncing dots animation appears while the AI is streaming
- [ ] Verify the animation disappears once the response completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)