### PR TITLE
chore: exit beta prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@private/docs": "0.0.0",


### PR DESCRIPTION
## Summary

We're ready to move out of the `beta` prerelease, so this exits changesets prerelease mode.

- Flips `.changeset/pre.json` `mode` from `"pre"` → `"exit"` (equivalent to running `changeset pre exit`). `tag`, `initialVersions`, and the accumulated `changesets` list are left untouched.

## What happens after merge

Once this lands on `main`, the existing Release workflow (`changesets/action`) runs `pnpm run version` (`changeset version`). Because pre mode is now exited, it will:

- Consume the 18 pending changesets and bump packages to **stable** versions (no `-beta.x` suffix).
- Open the usual `ci: release` "Version Packages" PR. Merging that PR publishes the stable releases to npm.

## Test plan

- [ ] Confirm `.changeset/pre.json` shows `"mode": "exit"` and remains valid JSON (verified locally).
- [ ] After merge, verify the auto-generated `ci: release` PR proposes stable versions (e.g. `@blinkk/root` → `3.x.x`, not `3.x.x-beta.n`).

https://claude.ai/code/session_015xyXY7gc3p6JZLT2CoT8et

---
_Generated by [Claude Code](https://claude.ai/code/session_015xyXY7gc3p6JZLT2CoT8et)_