### PR TITLE
docs: add v3 migration guide to guides sidebar

### DIFF
--- a/docs/routes/guide/[[...guide]].tsx
+++ b/docs/routes/guide/[[...guide]].tsx
@@ -68,6 +68,13 @@ const GUIDE_LINKS = [
       return ctx.currentPath === '/guide/migration/v2/';
     },
   },
+  {
+    label: 'v3 Migration Guide',
+    href: '/guide/migration/v3',
+    isActive: (ctx: RequestContext) => {
+      return ctx.currentPath === '/guide/migration/v3/';
+    },
+  },
 ];
 
 const CMS_LINKS = [


### PR DESCRIPTION
## Summary
Added a new navigation link for the v3 migration guide to the guide routes configuration.

## Key Changes
- Added a new guide link entry for the v3 migration guide with:
  - Label: "v3 Migration Guide"
  - Route: `/guide/migration/v3`
  - Active state detection matching the v3 migration guide path

## Implementation Details
The new link follows the same pattern as the existing v2 migration guide entry, including proper route matching logic in the `isActive` function to highlight the navigation item when users are viewing the v3 migration guide.

https://claude.ai/code/session_018Yy7iNT2SY6EHy8G4tghU7