### PR TITLE
chore: fix loading state padding on CollectionPage

### DIFF
--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -127,6 +127,7 @@
   display: flex;
   justify-content: center;
   margin-top: 90px;
+  margin-bottom: 90px;
 }
 
 .CollectionPage__collection__docsList__doc__content__header {


### PR DESCRIPTION
## Summary
Added bottom margin spacing to the CollectionPage pagination container to improve visual balance and spacing at the bottom of the page.

## Changes
- Added `margin-bottom: 90px;` to `.CollectionPage__collection__docsList__pagination` class to match the existing top margin and provide consistent spacing

## Details
This change ensures that the pagination controls at the bottom of the collection list have adequate spacing from the bottom of the viewport or any content that follows, creating a more balanced and visually appealing layout.

https://claude.ai/code/session_01EG39Usdk3Aim13XJznptZA