### PR TITLE
fix: preserve string-valued event handler attrs in jsx render

### DIFF
--- a/.changeset/silly-mangos-juggle.md
+++ b/.changeset/silly-mangos-juggle.md
@@ -2,4 +2,4 @@
 '@blinkk/root': patch
 ---
 
-fix: preserve string-valued event handler attrs (e.g. `<select onChange="...">`) when rendering jsx to html
+fix: preserve string-valued event handler attrs in jsx render

--- a/.changeset/silly-mangos-juggle.md
+++ b/.changeset/silly-mangos-juggle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: preserve string-valued event handler attrs (e.g. `<select onChange="...">`) when rendering jsx to html

--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -196,7 +196,7 @@ test('renders numbers and ignores booleans/null', () => {
   expect(output).toBe('<div>42text</div>');
 });
 
-test('skips event handlers', () => {
+test('skips function event handlers', () => {
   const vnode = (
     <button onClick={() => {}} onMouseOver={() => {}}>
       click
@@ -204,6 +204,36 @@ test('skips event handlers', () => {
   );
   const output = renderJsxToString(vnode, {mode: 'minimal'});
   expect(output).toBe('<button>click</button>');
+});
+
+test('preserves string event handlers', () => {
+  const vnode = (
+    <select onChange={'this.form.submit()'}>
+      <option value="a">a</option>
+    </select>
+  );
+  const output = renderJsxToString(vnode, {mode: 'minimal'});
+  expect(output).toBe(
+    '<select onChange="this.form.submit()"><option value="a">a</option></select>'
+  );
+});
+
+test('preserves and escapes string event handlers, skips function ones', () => {
+  const vnode = (
+    <button onClick={'doStuff("a" & "b")'} onMouseOver={() => {}}>
+      click
+    </button>
+  );
+  const output = renderJsxToString(vnode, {mode: 'minimal'});
+  expect(output).toBe(
+    '<button onClick="doStuff(&quot;a&quot; &amp; &quot;b&quot;)">click</button>'
+  );
+});
+
+test('skips function-valued non-event props', () => {
+  const vnode = <div title={(() => 'x') as any} />;
+  const output = renderJsxToString(vnode, {mode: 'minimal'});
+  expect(output).toBe('<div></div>');
 });
 
 // --- Pretty mode tests ---

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -529,11 +529,14 @@ export function renderJsxToString(
       if (tag === 'textarea' && (key === 'value' || key === 'defaultValue')) {
         continue;
       }
-      // Skip event handlers.
-      if (key.length > 2 && key[0] === 'o' && key[1] === 'n') continue;
 
       let value = props[key];
       if (!isDef(value)) continue;
+      // Skip function-valued props such as event handlers (e.g. onClick={fn}):
+      // client-side handler functions can't be serialized to HTML. String
+      // values like <select onChange="..."> are inline HTML event attributes,
+      // so they are preserved and rendered as-is.
+      if (typeof value === 'function') continue;
       // For standard and boolean attributes, `false` removes the attribute.
       // For data-* attributes, `false` is rendered as the string "false".
       if (value === false && !key.startsWith('data-')) continue;

--- a/packages/root/src/jsx/types.ts
+++ b/packages/root/src/jsx/types.ts
@@ -78,8 +78,10 @@ export interface DOMAttributes {
   onError?: EventHandler;
 }
 
+// Event handler props accept a function (client-side handler, stripped during
+// SSR) or a string (an inline HTML event attribute, preserved in the output).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type EventHandler = (...args: any[]) => void;
+type EventHandler = string | ((...args: any[]) => void);
 
 export interface AriaAttributes {
   role?: string;


### PR DESCRIPTION
## Summary
Updated JSX to HTML string rendering to preserve string-valued event handler attributes (e.g., `<select onChange="...">`) while continuing to skip function-valued event handlers that cannot be serialized.

## Key Changes
- **jsx-render.ts**: Changed event handler filtering logic from checking attribute name pattern (`on*`) to checking value type. Now only skips function-valued props, allowing string-valued event attributes to be rendered and properly HTML-escaped.
- **types.ts**: Updated `EventHandler` type definition to accept both `string` and function types, reflecting that event handlers can be either inline HTML event attributes or client-side handler functions.
- **jsx-render.test.tsx**: 
  - Renamed existing test from "skips event handlers" to "skips function event handlers" for clarity
  - Added test for preserving string event handlers
  - Added test for preserving and escaping string event handlers while skipping function ones
  - Added test for skipping function-valued non-event props

## Implementation Details
The key insight is distinguishing between two types of event handler values:
- **Function values** (e.g., `onClick={() => {}}`) - client-side handlers that cannot be serialized to HTML, so they are skipped during SSR
- **String values** (e.g., `onChange="this.form.submit()"`) - inline HTML event attributes that are valid HTML and should be preserved and properly escaped in the output

This allows developers to use inline event handlers in server-rendered HTML while maintaining the existing behavior of stripping client-side handler functions.

https://claude.ai/code/session_01RJ3wrwnPTEKvumdoXDWwL8