### PR TITLE
chore: format select/option elements as block-level

### DIFF
--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -375,6 +375,53 @@ test('pretty mode: custom block elements', () => {
 `);
 });
 
+test('pretty mode: select renders each option on its own line', () => {
+  const vnode = (
+    <select name="color">
+      <option value="r">Red</option>
+      <option value="g">Green</option>
+    </select>
+  );
+  const output = renderJsxToString(vnode, {mode: 'pretty'});
+  expect(output).toBe(`<select name="color">
+<option value="r">Red</option>
+<option value="g">Green</option>
+</select>
+`);
+});
+
+test('pretty mode: select with optgroups breaks onto their own lines', () => {
+  const vnode = (
+    <select name="food">
+      <optgroup label="Fruit">
+        <option value="a">Apple</option>
+        <option value="b">Banana</option>
+      </optgroup>
+    </select>
+  );
+  const output = renderJsxToString(vnode, {mode: 'pretty'});
+  expect(output).toBe(`<select name="food">
+<optgroup label="Fruit">
+<option value="a">Apple</option>
+<option value="b">Banana</option>
+</optgroup>
+</select>
+`);
+});
+
+test('minimal mode: select options stay compact', () => {
+  const vnode = (
+    <select name="color">
+      <option value="r">Red</option>
+      <option value="g">Green</option>
+    </select>
+  );
+  const output = renderJsxToString(vnode, {mode: 'minimal'});
+  expect(output).toBe(
+    '<select name="color"><option value="r">Red</option><option value="g">Green</option></select>'
+  );
+});
+
 test('minimal mode: no extra whitespace', () => {
   const vnode = (
     <html>

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -22,7 +22,11 @@ const VOID_ELEMENTS = new Set([
 /** Tags whose text content may contain literal newlines that should not be treated as block-child indicators. */
 const RAW_CONTENT_ELEMENTS = new Set(['pre', 'textarea', 'script', 'style']);
 
-/** Standard HTML block-level elements. */
+/**
+ * Standard HTML block-level elements. Also includes the `<select>` content
+ * model (`select`/`optgroup`/`option`) so that each `<option>` renders on its
+ * own line in pretty mode, even though those tags aren't block-level per CSS.
+ */
 const DEFAULT_BLOCK_ELEMENTS = new Set([
   'address',
   'article',
@@ -59,11 +63,14 @@ const DEFAULT_BLOCK_ELEMENTS = new Set([
   'nav',
   'noscript',
   'ol',
+  'optgroup',
+  'option',
   'p',
   'pre',
   'script',
   'search',
   'section',
+  'select',
   'style',
   'summary',
   'table',


### PR DESCRIPTION
## Summary
Updated the JSX renderer to treat `<select>`, `<optgroup>`, and `<option>` elements as block-level elements in pretty mode, ensuring each option renders on its own line for improved readability.

## Changes
- Added `select`, `optgroup`, and `option` to the `DEFAULT_BLOCK_ELEMENTS` set in `jsx-render.ts`
- Updated the documentation comment for `DEFAULT_BLOCK_ELEMENTS` to clarify that it includes the `<select>` content model elements, which are treated as block-level for formatting purposes even though they aren't block-level in CSS
- Added three new test cases in `jsx-render.test.tsx`:
  - Pretty mode: `<select>` with `<option>` elements renders each option on its own line
  - Pretty mode: `<select>` with `<optgroup>` renders optgroups and options on separate lines
  - Minimal mode: `<select>` options remain compact without extra whitespace

## Implementation Details
The change leverages the existing block-element formatting logic to provide consistent, readable output for select form elements in pretty mode, while maintaining compact output in minimal mode.

https://claude.ai/code/session_018trqLPbYktAttgcgrBNxNX