### PR TITLE
fix: move data sources filters outside the table surface

### DIFF
--- a/packages/root-cms/ui/pages/DataPage/DataPage.tsx
+++ b/packages/root-cms/ui/pages/DataPage/DataPage.tsx
@@ -98,99 +98,97 @@ DataPage.DataSourcesTable = () => {
   }, []);
 
   return (
-    <Surface className="DataPage__DataSourcesTable">
-      {loading && <Loader color="gray" size="xl" />}
-      {!loading && (
-        <>
-          {hasArchived && (
-            <div className="DataPage__DataSourcesTable__filters">
-              <Switch
-                size="sm"
-                color="dark"
-                label="Show archived"
-                checked={showArchived}
-                onChange={(e: any) =>
-                  setShowArchived(Boolean(e.currentTarget.checked))
-                }
-              />
-            </div>
-          )}
-          {filteredDataSources.length > 0 && (
-            <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
-              <thead>
-                <tr>
-                  <th>id</th>
-                  <th>description</th>
-                  <th>type</th>
-                  <th>url</th>
-                  <th>status</th>
-                  <th>last synced</th>
-                  <th>last published</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredDataSources.map((dataSource) => (
-                  <tr key={dataSource.id}>
-                    <td>
-                      <a href={`/cms/data/${dataSource.id}`}>{dataSource.id}</a>
-                    </td>
-                    <td>{dataSource.description || ''}</td>
-                    <td>{dataSource.type}</td>
-                    <td>
-                      {isGoogleSheetUrl(dataSource.url) ? (
-                        <div className="DataPage__DataSourcesTable__url">
-                          <Tooltip label="Open spreadsheet">
-                            <ActionIcon<'a'>
-                              component="a"
-                              href={dataSource.url}
-                              target="_blank"
-                              rel="noreferrer"
-                              variant="filled"
-                              color="green"
-                              size="sm"
-                              aria-label="Open spreadsheet"
-                            >
-                              <IconTable size={16} stroke="2.25" />
-                            </ActionIcon>
-                          </Tooltip>
-                          <a
-                            className="DataPage__DataSourcesTable__url__text"
+    <div className="DataPage__DataSourcesTable">
+      {!loading && hasArchived && (
+        <div className="DataPage__DataSourcesTable__filters">
+          <Switch
+            size="sm"
+            color="dark"
+            label="Show archived"
+            checked={showArchived}
+            onChange={(e: any) =>
+              setShowArchived(Boolean(e.currentTarget.checked))
+            }
+          />
+        </div>
+      )}
+      <Surface>
+        {loading && <Loader color="gray" size="xl" />}
+        {!loading && filteredDataSources.length > 0 && (
+          <Table verticalSpacing="xs" striped highlightOnHover fontSize="xs">
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>description</th>
+                <th>type</th>
+                <th>url</th>
+                <th>status</th>
+                <th>last synced</th>
+                <th>last published</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredDataSources.map((dataSource) => (
+                <tr key={dataSource.id}>
+                  <td>
+                    <a href={`/cms/data/${dataSource.id}`}>{dataSource.id}</a>
+                  </td>
+                  <td>{dataSource.description || ''}</td>
+                  <td>{dataSource.type}</td>
+                  <td>
+                    {isGoogleSheetUrl(dataSource.url) ? (
+                      <div className="DataPage__DataSourcesTable__url">
+                        <Tooltip label="Open spreadsheet">
+                          <ActionIcon<'a'>
+                            component="a"
                             href={dataSource.url}
                             target="_blank"
                             rel="noreferrer"
+                            variant="filled"
+                            color="green"
+                            size="sm"
+                            aria-label="Open spreadsheet"
                           >
-                            {dataSource.url}
-                          </a>
-                        </div>
-                      ) : (
-                        dataSource.url || ''
-                      )}
-                    </td>
-                    <td>
-                      <DataSourceStatusBadge dataSource={dataSource} />
-                    </td>
-                    <td>
-                      <DataSourceStatusButton
-                        dataSource={dataSource}
-                        action="sync"
-                      />
-                    </td>
-                    <td>
-                      <DataSourceStatusButton
-                        dataSource={dataSource}
-                        action="publish"
-                      />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          )}
-          {filteredDataSources.length === 0 && (
-            <Text as="p">No data sources found for this filter.</Text>
-          )}
-        </>
-      )}
-    </Surface>
+                            <IconTable size={16} stroke="2.25" />
+                          </ActionIcon>
+                        </Tooltip>
+                        <a
+                          className="DataPage__DataSourcesTable__url__text"
+                          href={dataSource.url}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {dataSource.url}
+                        </a>
+                      </div>
+                    ) : (
+                      dataSource.url || ''
+                    )}
+                  </td>
+                  <td>
+                    <DataSourceStatusBadge dataSource={dataSource} />
+                  </td>
+                  <td>
+                    <DataSourceStatusButton
+                      dataSource={dataSource}
+                      action="sync"
+                    />
+                  </td>
+                  <td>
+                    <DataSourceStatusButton
+                      dataSource={dataSource}
+                      action="publish"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+        {!loading && filteredDataSources.length === 0 && (
+          <Text as="p">No data sources found for this filter.</Text>
+        )}
+      </Surface>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
Restructured the DataSourcesTable component's DOM hierarchy to improve layout organization and styling flexibility.

## Key Changes
- Moved the `Surface` component to wrap only the table content, removing it from the outermost container
- Changed the root container from `<Surface>` to a `<div>` with the existing className
- Repositioned the "Show archived" filter outside the `Surface` component to sit at the top level
- Simplified conditional rendering logic by combining conditions more efficiently
- Maintained all existing functionality and visual behavior

## Implementation Details
- The filter section now renders conditionally at the root level (`!loading && hasArchived`)
- The `Surface` component now wraps only the loader and table content
- All table rendering logic and data source filtering remains unchanged
- This structure allows for better CSS styling of the filter section independently from the table surface styling

https://claude.ai/code/session_01L1zGqELJU2h9BwGZQd8Rh9