### PR TITLE
feat: add npm version check as a startup task

### DIFF
--- a/.changeset/all-eyes-exist.md
+++ b/.changeset/all-eyes-exist.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add npm version check as a startup task

--- a/packages/root/src/cli/cli.ts
+++ b/packages/root/src/cli/cli.ts
@@ -77,7 +77,10 @@ class CliRunner {
         '--host <host>',
         'network address the server should listen on, e.g. 127.0.0.1'
       )
-      .action(dev);
+      .action((rootProjectDir, options) => {
+        options.version = this.version;
+        dev(rootProjectDir, options);
+      });
     program
       .command('gae-deploy <appdir>')
       .description(

--- a/packages/root/src/cli/dev.ts
+++ b/packages/root/src/cli/dev.ts
@@ -28,6 +28,7 @@ import {DevServerAssetMap} from '../render/asset-map/dev-asset-map.js';
 import {dirExists, isDirectory, isJsFile} from '../utils/fsutils.js';
 import {findOpenPort} from '../utils/ports.js';
 import {getSessionCookieSecret} from '../utils/rand.js';
+import {runStartupTasks} from './startup/startup-tasks.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -38,6 +39,7 @@ const DEV_SERVER_404_LOG_IGNORE_PATHS = new Set([
 
 export interface DevOptions {
   host?: string;
+  version?: string;
 }
 
 export async function dev(rootProjectDir?: string, options?: DevOptions) {
@@ -46,6 +48,10 @@ export async function dev(rootProjectDir?: string, options?: DevOptions) {
   const defaultPort = parseInt(process.env.PORT || '4007');
   const host = options?.host || 'localhost';
   const port = await findOpenPort(defaultPort, defaultPort + 10);
+
+  // Run startup tasks (e.g. the npm version check) without blocking server
+  // startup. Failures are handled internally and never interrupt `root dev`.
+  void runStartupTasks({rootDir, version: options?.version});
 
   let currentServer: http.Server | null = null;
   let currentViteServer: ViteDevServer | null = null;

--- a/packages/root/src/cli/startup/check-version.test.ts
+++ b/packages/root/src/cli/startup/check-version.test.ts
@@ -1,0 +1,18 @@
+import {assert, test} from 'vitest';
+
+import {isNewerVersion} from './check-version.js';
+
+test('isNewerVersion compares semantic versions', () => {
+  assert.isTrue(isNewerVersion('3.0.2', '3.0.3'));
+  assert.isTrue(isNewerVersion('3.0.2', '3.1.0'));
+  assert.isTrue(isNewerVersion('3.0.2', '4.0.0'));
+  assert.isFalse(isNewerVersion('3.0.2', '3.0.2'));
+  assert.isFalse(isNewerVersion('3.0.2', '3.0.1'));
+  assert.isFalse(isNewerVersion('3.1.0', '3.0.9'));
+  assert.isFalse(isNewerVersion('4.0.0', '3.9.9'));
+});
+
+test('isNewerVersion ignores pre-release identifiers', () => {
+  assert.isFalse(isNewerVersion('3.0.2', '3.0.2-rc.1'));
+  assert.isTrue(isNewerVersion('3.0.2-rc.1', '3.1.0'));
+});

--- a/packages/root/src/cli/startup/check-version.test.ts
+++ b/packages/root/src/cli/startup/check-version.test.ts
@@ -1,6 +1,6 @@
 import {assert, test} from 'vitest';
 
-import {isNewerVersion} from './check-version.js';
+import {isNewerVersion, isPrerelease} from './check-version.js';
 
 test('isNewerVersion compares semantic versions', () => {
   assert.isTrue(isNewerVersion('3.0.2', '3.0.3'));
@@ -15,4 +15,13 @@ test('isNewerVersion compares semantic versions', () => {
 test('isNewerVersion ignores pre-release identifiers', () => {
   assert.isFalse(isNewerVersion('3.0.2', '3.0.2-rc.1'));
   assert.isTrue(isNewerVersion('3.0.2-rc.1', '3.1.0'));
+});
+
+test('isPrerelease detects alpha/beta/rc builds', () => {
+  assert.isTrue(isPrerelease('3.1.0-alpha'));
+  assert.isTrue(isPrerelease('3.1.0-alpha.1'));
+  assert.isTrue(isPrerelease('3.1.0-beta.2'));
+  assert.isTrue(isPrerelease('3.1.0-rc.1'));
+  assert.isFalse(isPrerelease('3.1.0'));
+  assert.isFalse(isPrerelease('3.1.0-canary.1'));
 });

--- a/packages/root/src/cli/startup/check-version.ts
+++ b/packages/root/src/cli/startup/check-version.ts
@@ -14,19 +14,40 @@ const REGISTRY_TIMEOUT_MS = 3000;
 export const checkVersionTask: StartupTask = {
   name: 'check-version',
   throttle: ONE_DAY_MS,
+  // Skip the check when disabled via env var, when the version is unknown, or
+  // for pre-release (alpha/beta/rc) builds that are intentionally ahead of the
+  // latest stable release.
+  enabled(ctx) {
+    return (
+      !isVersionCheckDisabled() && !!ctx.version && !isPrerelease(ctx.version)
+    );
+  },
   async run(ctx) {
     const current = ctx.version;
-    // Skip the check for pre-release builds: users on alpha/beta/rc versions
-    // are intentionally ahead of the latest stable release.
-    if (!current || isPrerelease(current)) {
-      return;
-    }
     const latest = await fetchLatestVersion();
-    if (latest && isNewerVersion(current, latest)) {
+    if (current && latest && isNewerVersion(current, latest)) {
       printUpdateNotice(current, latest);
     }
   },
 };
+
+/**
+ * Whether the version check has been disabled via environment variable. Honors
+ * the `@blinkk/root`-specific `ROOT_DISABLE_VERSION_CHECK` as well as the de
+ * facto `NO_UPDATE_NOTIFIER` convention. Either can be set in the shell or in a
+ * project's `.env` file, which the CLI loads on startup.
+ */
+function isVersionCheckDisabled(): boolean {
+  return (
+    isEnvEnabled('ROOT_DISABLE_VERSION_CHECK') ||
+    isEnvEnabled('NO_UPDATE_NOTIFIER')
+  );
+}
+
+function isEnvEnabled(name: string): boolean {
+  const value = (process.env[name] || '').trim().toLowerCase();
+  return value !== '' && value !== '0' && value !== 'false';
+}
 
 async function fetchLatestVersion(): Promise<string | null> {
   const controller = new AbortController();

--- a/packages/root/src/cli/startup/check-version.ts
+++ b/packages/root/src/cli/startup/check-version.ts
@@ -16,7 +16,9 @@ export const checkVersionTask: StartupTask = {
   throttle: ONE_DAY_MS,
   async run(ctx) {
     const current = ctx.version;
-    if (!current) {
+    // Skip the check for pre-release builds: users on alpha/beta/rc versions
+    // are intentionally ahead of the latest stable release.
+    if (!current || isPrerelease(current)) {
       return;
     }
     const latest = await fetchLatestVersion();
@@ -61,6 +63,14 @@ export function isNewerVersion(current: string, latest: string): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Returns true if `version` is an alpha, beta, or rc pre-release build, e.g.
+ * `3.1.0-rc.1`.
+ */
+export function isPrerelease(version: string): boolean {
+  return /-(alpha|beta|rc)\b/i.test(version);
 }
 
 function parseVersion(version: string): [number, number, number] {

--- a/packages/root/src/cli/startup/check-version.ts
+++ b/packages/root/src/cli/startup/check-version.ts
@@ -1,0 +1,85 @@
+import {cyan, dim, green, yellow} from 'kleur/colors';
+
+import type {StartupTask} from './startup-tasks.js';
+
+const PACKAGE_NAME = '@blinkk/root';
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const REGISTRY_TIMEOUT_MS = 3000;
+
+/**
+ * Startup task that checks whether a newer version of `@blinkk/root` has been
+ * published to npm and, if so, prints an update notice. Throttled to run at
+ * most once per day.
+ */
+export const checkVersionTask: StartupTask = {
+  name: 'check-version',
+  throttle: ONE_DAY_MS,
+  async run(ctx) {
+    const current = ctx.version;
+    if (!current) {
+      return;
+    }
+    const latest = await fetchLatestVersion();
+    if (latest && isNewerVersion(current, latest)) {
+      printUpdateNotice(current, latest);
+    }
+  },
+};
+
+async function fetchLatestVersion(): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
+  try {
+    const url = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+    const res = await fetch(url, {signal: controller.signal});
+    if (!res.ok) {
+      return null;
+    }
+    const data = (await res.json()) as {version?: string};
+    return data.version || null;
+  } catch {
+    // Network error, timeout, or invalid response; skip the check.
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Returns true if `latest` is a higher semantic version than `current`.
+ * Pre-release identifiers are ignored.
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const a = parseVersion(latest);
+  const b = parseVersion(current);
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) {
+      return true;
+    }
+    if (a[i] < b[i]) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const main = version.split('-')[0];
+  const parts = main.split('.');
+  const toInt = (value: string | undefined) => {
+    const num = parseInt(value || '0', 10);
+    return isNaN(num) ? 0 : num;
+  };
+  return [toInt(parts[0]), toInt(parts[1]), toInt(parts[2])];
+}
+
+function printUpdateNotice(current: string, latest: string) {
+  const bar = dim('┃');
+  const cmd = cyan(`npm i ${PACKAGE_NAME}@latest`);
+  console.log();
+  console.log(
+    `${bar} ${yellow('Update available:')} ${dim(current)} → ${green(latest)}`
+  );
+  console.log(`${bar} Run ${cmd} to update.`);
+  console.log();
+}

--- a/packages/root/src/cli/startup/check-version.ts
+++ b/packages/root/src/cli/startup/check-version.ts
@@ -1,4 +1,4 @@
-import {cyan, dim, green, yellow} from 'kleur/colors';
+import {dim, green, yellow} from 'kleur/colors';
 
 import type {StartupTask} from './startup-tasks.js';
 
@@ -106,11 +106,8 @@ function parseVersion(version: string): [number, number, number] {
 
 function printUpdateNotice(current: string, latest: string) {
   const bar = dim('┃');
-  const cmd = cyan(`npm i ${PACKAGE_NAME}@latest`);
+  const label = yellow(`Update available for ${PACKAGE_NAME}:`);
   console.log();
-  console.log(
-    `${bar} ${yellow('Update available:')} ${dim(current)} → ${green(latest)}`
-  );
-  console.log(`${bar} Run ${cmd} to update.`);
+  console.log(`${bar} ${label} ${dim(current)} → ${green(latest)}`);
   console.log();
 }

--- a/packages/root/src/cli/startup/startup-tasks.test.ts
+++ b/packages/root/src/cli/startup/startup-tasks.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 function loggedUpdateNotice(log: ReturnType<typeof vi.spyOn>): boolean {
@@ -57,6 +58,20 @@ test('no notice when already on the latest version', async () => {
 
   await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
   assert.equal(fetchMock.mock.calls.length, 1);
+  assert.isFalse(loggedUpdateNotice(log));
+});
+
+test('version check can be disabled via env var', async () => {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({version: '99.0.0'}),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubEnv('ROOT_DISABLE_VERSION_CHECK', '1');
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  assert.equal(fetchMock.mock.calls.length, 0);
   assert.isFalse(loggedUpdateNotice(log));
 });
 

--- a/packages/root/src/cli/startup/startup-tasks.test.ts
+++ b/packages/root/src/cli/startup/startup-tasks.test.ts
@@ -1,0 +1,74 @@
+import {afterEach, assert, beforeEach, test, vi} from 'vitest';
+
+// In-memory replacement for the on-disk state file.
+const {store} = vi.hoisted(() => ({store: new Map<string, string>()}));
+
+vi.mock('../../utils/fsutils.js', () => ({
+  fileExists: async (filepath: string) => store.has(filepath),
+  loadJson: async (filepath: string) => JSON.parse(store.get(filepath) || '{}'),
+  writeJson: async (filepath: string, data: unknown) => {
+    store.set(filepath, JSON.stringify(data));
+  },
+}));
+
+import {runStartupTasks} from './startup-tasks.js';
+
+beforeEach(() => {
+  store.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function loggedUpdateNotice(log: ReturnType<typeof vi.spyOn>): boolean {
+  return log.mock.calls.some((args) =>
+    String(args[0]).includes('Update available')
+  );
+}
+
+test('version check notifies once, then throttles for a day', async () => {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({version: '99.0.0'}),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  assert.equal(fetchMock.mock.calls.length, 1);
+  assert.isTrue(loggedUpdateNotice(log));
+
+  // A second run within the throttle window skips the task entirely (no fetch).
+  log.mockClear();
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  assert.equal(fetchMock.mock.calls.length, 1);
+  assert.isFalse(loggedUpdateNotice(log));
+});
+
+test('no notice when already on the latest version', async () => {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({version: '1.0.0'}),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  assert.equal(fetchMock.mock.calls.length, 1);
+  assert.isFalse(loggedUpdateNotice(log));
+});
+
+test('a failing task never throws and is still throttled', async () => {
+  const fetchMock = vi.fn(async () => {
+    throw new Error('network down');
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  // The attempt is recorded even on failure, so the next run is throttled.
+  await runStartupTasks({rootDir: '/tmp/project', version: '1.0.0'});
+  assert.equal(fetchMock.mock.calls.length, 1);
+});

--- a/packages/root/src/cli/startup/startup-tasks.test.ts
+++ b/packages/root/src/cli/startup/startup-tasks.test.ts
@@ -60,6 +60,19 @@ test('no notice when already on the latest version', async () => {
   assert.isFalse(loggedUpdateNotice(log));
 });
 
+test('pre-release builds skip the version check (no network call)', async () => {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({version: '99.0.0'}),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await runStartupTasks({rootDir: '/tmp/project', version: '3.1.0-rc.1'});
+  assert.equal(fetchMock.mock.calls.length, 0);
+  assert.isFalse(loggedUpdateNotice(log));
+});
+
 test('a failing task never throws and is still throttled', async () => {
   const fetchMock = vi.fn(async () => {
     throw new Error('network down');

--- a/packages/root/src/cli/startup/startup-tasks.ts
+++ b/packages/root/src/cli/startup/startup-tasks.ts
@@ -1,0 +1,110 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import {fileExists, loadJson, writeJson} from '../../utils/fsutils.js';
+import {checkVersionTask} from './check-version.js';
+
+export interface StartupTaskContext {
+  /** Absolute path to the root project directory. */
+  rootDir: string;
+  /** Currently installed version of the `@blinkk/root` package. */
+  version?: string;
+}
+
+export interface StartupTask {
+  /**
+   * Unique id for the task. Used as the persistence key for the last run time,
+   * so it must remain stable across releases.
+   */
+  name: string;
+  /**
+   * Minimum time (in milliseconds) that must elapse between runs. When set, the
+   * task is skipped if it last ran more recently than this interval. Omit to
+   * run on every startup.
+   */
+  throttle?: number;
+  /**
+   * Task logic. Thrown errors are swallowed by the runner so that a failing
+   * startup task never prevents `root` commands from starting.
+   */
+  run: (ctx: StartupTaskContext) => Promise<void>;
+}
+
+/**
+ * Registered startup tasks. Add new startup tasks to this list.
+ */
+const STARTUP_TASKS: StartupTask[] = [checkVersionTask];
+
+const STATE_FILE = path.join(os.homedir(), '.root', 'startup-tasks.json');
+
+interface StartupTasksState {
+  /** Map of task name to last run time (ms since epoch). */
+  lastRun: Record<string, number>;
+}
+
+/**
+ * Runs all registered startup tasks, honoring each task's throttle interval.
+ *
+ * Tasks are best-effort: failures are swallowed and never block startup. The
+ * last run time of each task is persisted to the user's home directory so that
+ * throttled tasks (e.g. the version check) run at most once per interval across
+ * separate `root` invocations.
+ */
+export async function runStartupTasks(ctx: StartupTaskContext): Promise<void> {
+  try {
+    const state = await readState();
+    const now = Date.now();
+    const dueTasks = STARTUP_TASKS.filter((task) =>
+      isDue(task, state.lastRun[task.name], now)
+    );
+    if (dueTasks.length === 0) {
+      return;
+    }
+    await Promise.all(
+      dueTasks.map(async (task) => {
+        try {
+          await task.run(ctx);
+        } catch {
+          // Startup tasks are best-effort; ignore failures.
+        }
+        // Record the attempt regardless of outcome so a failing task (e.g. no
+        // network) doesn't retry on every startup.
+        state.lastRun[task.name] = Date.now();
+      })
+    );
+    await writeState(state);
+  } catch {
+    // Never let startup tasks interfere with the command.
+  }
+}
+
+function isDue(
+  task: StartupTask,
+  lastRun: number | undefined,
+  now: number
+): boolean {
+  if (!task.throttle || !lastRun) {
+    return true;
+  }
+  return now - lastRun >= task.throttle;
+}
+
+async function readState(): Promise<StartupTasksState> {
+  if (await fileExists(STATE_FILE)) {
+    try {
+      const state = await loadJson<Partial<StartupTasksState>>(STATE_FILE);
+      return {lastRun: state.lastRun || {}};
+    } catch {
+      // Corrupt or unreadable state file; start fresh.
+    }
+  }
+  return {lastRun: {}};
+}
+
+async function writeState(state: StartupTasksState): Promise<void> {
+  try {
+    await writeJson(STATE_FILE, state);
+  } catch {
+    // Ignore write failures (e.g. read-only home directory).
+  }
+}

--- a/packages/root/src/cli/startup/startup-tasks.ts
+++ b/packages/root/src/cli/startup/startup-tasks.ts
@@ -24,6 +24,12 @@ export interface StartupTask {
    */
   throttle?: number;
   /**
+   * Optional predicate evaluated before the throttle check. When it returns
+   * false the task is skipped entirely (and its throttle is left untouched).
+   * Useful for opt-out flags, e.g. an env var that disables the task.
+   */
+  enabled?: (ctx: StartupTaskContext) => boolean;
+  /**
    * Task logic. Thrown errors are swallowed by the runner so that a failing
    * startup task never prevents `root` commands from starting.
    */
@@ -54,8 +60,9 @@ export async function runStartupTasks(ctx: StartupTaskContext): Promise<void> {
   try {
     const state = await readState();
     const now = Date.now();
-    const dueTasks = STARTUP_TASKS.filter((task) =>
-      isDue(task, state.lastRun[task.name], now)
+    const dueTasks = STARTUP_TASKS.filter(
+      (task) =>
+        isEnabled(task, ctx) && isDue(task, state.lastRun[task.name], now)
     );
     if (dueTasks.length === 0) {
       return;
@@ -76,6 +83,10 @@ export async function runStartupTasks(ctx: StartupTaskContext): Promise<void> {
   } catch {
     // Never let startup tasks interfere with the command.
   }
+}
+
+function isEnabled(task: StartupTask, ctx: StartupTaskContext): boolean {
+  return !task.enabled || task.enabled(ctx);
 }
 
 function isDue(


### PR DESCRIPTION
## Summary
Introduces a startup tasks framework that runs best-effort background tasks when the CLI starts, with built-in throttling support. Implements the first startup task: an npm version checker that notifies users when a newer version of `@blinkk/root` is available.

## Key Changes
- **New startup tasks framework** (`startup-tasks.ts`):
  - Generic task runner that executes registered tasks on CLI startup
  - Persists task execution state to `~/.root/startup-tasks.json` to track last run times
  - Supports per-task throttle intervals to limit execution frequency
  - Failures are swallowed and never block CLI startup

- **Version check task** (`check-version.ts`):
  - Fetches the latest published version from npm registry
  - Compares semantic versions and displays an update notice if a newer version is available
  - Throttled to run at most once per day
  - Includes 3-second timeout for registry requests to prevent hanging
  - Ignores pre-release identifiers when comparing versions

- **Integration with CLI**:
  - Passes package version from `CliRunner` to the `dev` command via options
  - Runs startup tasks asynchronously without blocking server startup in `dev.ts`

- **Comprehensive test coverage**:
  - Unit tests for version comparison logic
  - Integration tests for task throttling and state persistence
  - Tests for error handling and best-effort execution

## Implementation Details
- State file uses in-memory mocking in tests via `vi.mock()` for filesystem operations
- Task execution is parallelized with `Promise.all()` but state updates are sequential
- Version parsing handles malformed version strings gracefully by defaulting to 0
- Console output uses colored formatting (via `kleur`) for better visibility of update notices

https://claude.ai/code/session_01Y8g6G3uGT4KeabbbQJZvYn