### PR TITLE
fix: serialize true for non-boolean attrs in jsx

### DIFF
--- a/.changeset/tricky-cases-add.md
+++ b/.changeset/tricky-cases-add.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: serialize true for non-boolean attrs in jsx

--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -41,6 +41,11 @@ test('renders boolean attributes', () => {
 });
 
 test('handles falsy attribute values', () => {
+  // true: boolean attrs are minimized, non-boolean attrs render as "true"
+  expect(
+    renderJsxToString(<div id={true as any} hidden data-hidden={true} />, {mode: 'minimal'})
+  ).toBe('<div id="true" hidden data-hidden="true"></div>');
+
   // false: standard/boolean removed, data-* rendered as "false"
   expect(
     renderJsxToString(<div id={false as any} hidden={false} data-hidden={false} />, {mode: 'minimal'})

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -101,6 +101,41 @@ const ALWAYS_BLOCK_ELEMENTS = new Set([
   'title',
 ]);
 
+/**
+ * HTML/SVG boolean attributes.
+ * When present with a truthy value, render as a minimized attribute.
+ */
+const BOOLEAN_ATTRS = new Set([
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'capture',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'download',
+  'draggable',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+]);
+
 /** JSX prop name -> HTML attribute name. */
 const PROP_TO_ATTR: Record<string, string> = {
   acceptCharset: 'accept-charset',
@@ -551,8 +586,9 @@ export function renderJsxToString(
 
       const attrName = PROP_TO_ATTR[key] || key;
 
-      // Boolean attributes.
-      if (value === true) {
+      // Boolean attributes are minimized when true; other attributes use
+      // explicit string serialization (e.g. id="true", data-foo="true").
+      if (value === true && BOOLEAN_ATTRS.has(attrName)) {
         result += ' ' + attrName;
         continue;
       }


### PR DESCRIPTION
### Motivation

- Ensure that only standard HTML boolean attributes are rendered in minimized form while other props with `true` are serialized as string values.
- Make attribute rendering behavior consistent for `data-*` and non-boolean attributes to avoid surprising omitted or minimized output.

### Description

- Added a `BOOLEAN_ATTRS` set listing standard HTML/SVG boolean attributes and documented their behavior. 
- Changed attribute serialization in `renderJsxToString` to minimize an attribute only when `value === true` and the attribute name is in `BOOLEAN_ATTRS`, otherwise serialize the value as a string with quotes. 
- Kept existing handling for `false`, `null`, `undefined`, empty string, and numeric values while preserving `data-*` semantics. 
- Updated `packages/root/src/jsx/jsx-render.test.tsx` expectations to reflect that non-boolean props with `true` are rendered as `"true"` while boolean attributes remain minimized.

### Testing

- Ran the package unit tests for `packages/root` (Jest) including `jsx-render.test.tsx`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fddbb06ec8323a75ff63e1c726cd2)