### PR TITLE
fix: fix array field rendering in rich text component modal

### DIFF
--- a/.changeset/all-nails-kiss.md
+++ b/.changeset/all-nails-kiss.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: fix array field rendering in rich text component modal

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -352,6 +352,7 @@
 
 .DocEditor__ArrayField__item__header__preview__title {
   font-family: var(--font-family-mono);
+  font-size: 12px;
   font-weight: 500;
   flex: 1;
   padding-right: 8px;

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/BlockComponentModal.visual.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/BlockComponentModal.visual.test.tsx
@@ -1,0 +1,115 @@
+import '../LexicalEditor.css';
+import '../../../../styles/global.css';
+import '../../../../styles/theme.css';
+
+import {MantineProvider} from '@mantine/core';
+import {ModalsProvider} from '@mantine/modals';
+import {cleanup, render} from '@testing-library/preact';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import * as schema from '../../../../../core/schema.js';
+import {DeeplinkProvider} from '../../../../hooks/useDeeplink.js';
+import {BlockComponentModal} from './BlockComponentModal.js';
+
+// Mock the context.
+window.__ROOT_CTX = {
+  experiments: {},
+  rootConfig: {projectId: 'test-project'},
+  collections: {},
+} as any;
+
+vi.mock('../../../EditTranslationsModal/EditTranslationsModal.js', () => ({
+  useEditTranslationsModal: () => ({open: vi.fn()}),
+}));
+
+const carouselSchema = schema.define({
+  name: 'MediaCarousel',
+  label: 'Media Carousel',
+  fields: [
+    schema.array({
+      id: 'slides',
+      label: 'Slides',
+      of: schema.object({
+        fields: [schema.string({id: 'title', label: 'Title'})],
+      }),
+    }),
+  ],
+}) as unknown as schema.Schema;
+
+function renderModal(initialValue: Record<string, any>) {
+  return render(
+    <MantineProvider>
+      <ModalsProvider>
+        <DeeplinkProvider>
+          <BlockComponentModal
+            schema={carouselSchema}
+            opened={true}
+            initialValue={initialValue}
+            mode="edit"
+            onClose={() => {}}
+            onSubmit={() => {}}
+          />
+        </DeeplinkProvider>
+      </ModalsProvider>
+    </MantineProvider>
+  );
+}
+
+describe('BlockComponentModal', () => {
+  afterEach(() => cleanup());
+
+  it('renders array items on first open (array-map form)', async () => {
+    const initialValue = {
+      slides: {
+        _array: ['k1', 'k2'],
+        k1: {title: 'Slide 1'},
+        k2: {title: 'Slide 2'},
+      },
+    };
+    renderModal(initialValue);
+    // Wait for items to render. Items are rendered as ArrayField list entries.
+    await vi.waitFor(
+      () => {
+        const items = document.body.querySelectorAll(
+          '.DocEditor__ArrayField__item'
+        );
+        expect(items.length).toBe(2);
+      },
+      {timeout: 2000}
+    );
+  });
+
+  it('renders items after close+reopen (array-map preserved)', async () => {
+    const initialValue = {
+      slides: {
+        _array: ['k1', 'k2'],
+        k1: {title: 'Slide 1'},
+        k2: {title: 'Slide 2'},
+      },
+    };
+    // First open.
+    const first = renderModal(initialValue);
+    await vi.waitFor(
+      () => {
+        const items = document.body.querySelectorAll(
+          '.DocEditor__ArrayField__item'
+        );
+        expect(items.length).toBe(2);
+      },
+      {timeout: 2000}
+    );
+    // Close (unmount).
+    first.unmount();
+    cleanup();
+    // Reopen with the same data (simulates close+reopen without editing).
+    renderModal(initialValue);
+    await vi.waitFor(
+      () => {
+        const items = document.body.querySelectorAll(
+          '.DocEditor__ArrayField__item'
+        );
+        expect(items.length).toBe(2);
+      },
+      {timeout: 2000}
+    );
+  });
+});

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/InMemoryDraftDocController.test.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/InMemoryDraftDocController.test.ts
@@ -26,4 +26,19 @@ describe('InMemoryDraftDocController', () => {
 
       controller.updateKey('block.foo', 'baz');
     }));
+
+  it('should expose a subscribeSubtree method', () => {
+    // `DocEditor.ArrayFieldPreview` calls `draft.subscribeSubtree(...)`, so the
+    // in-memory controller must expose this API for block edit modals to work.
+    const controller = new InMemoryDraftDocController({foo: 'bar'});
+    expect(typeof controller.subscribeSubtree).toBe('function');
+    const seen: any[] = [];
+    const unsubscribe = controller.subscribeSubtree('block.foo', (value) => {
+      seen.push(value);
+    });
+    expect(seen).toEqual(['bar']);
+    controller.updateKey('block.foo', 'baz');
+    expect(seen).toEqual(['bar', 'baz']);
+    unsubscribe();
+  });
 });

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/InMemoryDraftDocController.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/InMemoryDraftDocController.ts
@@ -50,6 +50,20 @@ export class InMemoryDraftDocController extends EventListener {
     };
   }
 
+  /**
+   * Subscribes to changes anywhere within a given key's subtree. Mirrors the
+   * `DraftDocController.subscribeSubtree` API so that components like
+   * `DocEditor.ArrayFieldPreview` (which expect this method) work when
+   * rendered inside a `DocEditor` driven by this in-memory controller.
+   *
+   * Since `notify()` already walks the key hierarchy and fires every ancestor
+   * listener whenever any descendant changes, plain `subscribe` provides the
+   * same subtree-change semantics here.
+   */
+  subscribeSubtree(key: string, cb: Listener) {
+    return this.subscribe(key, cb);
+  }
+
   getDataSnapshot() {
     return cloneData(this.data);
   }
@@ -115,3 +129,4 @@ export function getKeyHierarchy(key: string) {
   }
   return keys;
 }
+


### PR DESCRIPTION
## Summary

Fixes a bug where opening a lexical block-edit modal (`BlockComponentModal` / `InlineComponentModal`) for a block whose schema contains an `ArrayField` (e.g. a media carousel block's `slides`) would render "No items" — the items failed to appear in the modal.

## Root cause

`DocEditor.ArrayFieldPreview` (the collapsed preview shown for each array item) registers a listener via `draft.subscribeSubtree(...)` inside a `useEffect`. The `InMemoryDraftDocController` that backs the in-memory draft for block edit modals only implemented `subscribe` — not `subscribeSubtree` — so the effect threw `TypeError: draft.subscribeSubtree is not a function` and the array items failed to render.

## Fix

Add `subscribeSubtree(key, cb)` to `InMemoryDraftDocController`. It aliases `subscribe`, since the controller's `notify()` already walks the key hierarchy via `getKeyHierarchy` and fires every ancestor listener on any descendant change — providing the samAdd `subscribeSubtree(key, cb)` to `InMemorraftDocConAddller` doeAdd `subscribeSubtree(key, cb)` to `InMemoryDraftDocController`. It aliases `subscribe`, since the controller's `notify()` already walks the key hierarchy via `getKeyHierarchy` and fires every ancestor listener on any descendant change — providing the samAddrst-open and reopen.

## Changeset

`.changeset/all-nails-kiss.md` — `@blinkk/root-cms: patch`.
