### PR TITLE
chore: update ui styles for ai tool calls

### DIFF
--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -525,15 +525,7 @@
 }
 
 .RootAIChat__tool {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background: #f8f9fa;
   font-size: 13px;
-}
-
-.RootAIChat__tool--approval {
-  border-color: #99c2ff;
-  background: #f5f9ff;
 }
 
 .RootAIChat__tool__header {
@@ -541,7 +533,7 @@
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 8px 12px;
+  padding: 4px 0;
   background: transparent;
   border: none;
   font: inherit;
@@ -556,18 +548,6 @@
 .RootAIChat__tool__state {
   color: dimgray;
   font-size: 12px;
-}
-
-.RootAIChat__toolSummary__label {
-  display: none;
-  font-size: 12px;
-  font-weight: 700;
-  color: #495057;
-}
-
-.RootAIChat__toolSummary__text {
-  margin-top: 2px;
-  color: #343a40;
 }
 
 .RootAIChat__approval {
@@ -669,7 +649,7 @@
 }
 
 .RootAIChat__tool__body {
-  padding: 0 12px 12px;
+  padding: 4px 0 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -683,9 +663,26 @@
 }
 
 .RootAIChat__tool__body summary {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   font-weight: 600;
   cursor: pointer;
   font-size: 12px;
+  list-style: none;
+}
+
+.RootAIChat__tool__body summary::-webkit-details-marker {
+  display: none;
+}
+
+.RootAIChat__tool__json__icon {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.RootAIChat__tool__body details[open] > summary .RootAIChat__tool__json__icon {
+  transform: rotate(90deg);
 }
 
 .RootAIChat__tool__body pre {

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -540,6 +540,15 @@
   cursor: pointer;
 }
 
+.RootAIChat__tool__header__icon {
+  transform: rotate(-90deg);
+  transition: transform 0.15s ease;
+}
+
+.RootAIChat__tool__header__icon--open {
+  transform: rotate(0deg);
+}
+
 .RootAIChat__tool__title {
   font-weight: 600;
   color: #212529;
@@ -649,7 +658,7 @@
 }
 
 .RootAIChat__tool__body {
-  padding: 4px 0 8px;
+  padding: 4px 0 8px 18px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -21,6 +21,7 @@ import {ActionIcon, Badge, Button, Loader, Menu, Tooltip} from '@mantine/core';
 import {
   IconCheck,
   IconChevronDown,
+  IconChevronRight,
   IconCopy,
   IconMessageCirclePlus,
   IconPaperclip,
@@ -1166,19 +1167,15 @@ function ToolPartView(props: {
     : undefined;
   const [open, setOpen] = useState(!!approval);
 
+  // Auto-open only for pending approvals, which need a user decision.
   useEffect(() => {
-    if (approval || part.output || part.errorText) {
+    if (approval) {
       setOpen(true);
     }
-  }, [approval, part.output, part.errorText]);
+  }, [approval]);
 
   return (
-    <div
-      className={joinClassNames(
-        'RootAIChat__tool',
-        approval && 'RootAIChat__tool--approval'
-      )}
-    >
+    <div className="RootAIChat__tool">
       <button
         type="button"
         className="RootAIChat__tool__header"
@@ -1205,12 +1202,6 @@ function ToolPartView(props: {
       </button>
       {open && (
         <div className="RootAIChat__tool__body">
-          <ToolTimelineSummary
-            toolName={toolName}
-            input={part.input}
-            output={part.output}
-            approval={approval}
-          />
           {approval && approvalControls && (
             <ToolApprovalCard
               approval={approval}
@@ -1221,13 +1212,25 @@ function ToolPartView(props: {
           {part.output?.receipt && <ToolReceipt output={part.output} />}
           {part.input && (
             <details>
-              <summary>Input</summary>
+              <summary>
+                <IconChevronRight
+                  size={14}
+                  className="RootAIChat__tool__json__icon"
+                />
+                <span>Input</span>
+              </summary>
               <pre>{JSON.stringify(part.input, null, 2)}</pre>
             </details>
           )}
           {part.output && (
             <details>
-              <summary>Output</summary>
+              <summary>
+                <IconChevronRight
+                  size={14}
+                  className="RootAIChat__tool__json__icon"
+                />
+                <span>Output</span>
+              </summary>
               <pre>{JSON.stringify(part.output, null, 2)}</pre>
             </details>
           )}
@@ -1274,80 +1277,6 @@ function prettyToolName(toolName: string, input: any): string {
       return `Read ${input?.collectionId || 'collection'} schema`;
     default:
       return toolName;
-  }
-}
-
-function ToolTimelineSummary(props: {
-  toolName: string;
-  input: any;
-  output: any;
-  approval?: PendingToolApproval;
-}) {
-  const summary = getToolSummary(props.toolName, props.input, props.output);
-  if (!summary && !props.approval) {
-    return null;
-  }
-  return (
-    <div className="RootAIChat__toolSummary">
-      <div className="RootAIChat__toolSummary__label">
-        {props.approval ? 'Waiting for approval' : summary?.label}
-      </div>
-      <div className="RootAIChat__toolSummary__text">
-        {props.approval ? props.approval.preview.summary : summary?.text}
-      </div>
-    </div>
-  );
-}
-
-function getToolSummary(toolName: string, input: any, output: any) {
-  if (output?.receipt) {
-    return {label: 'Applied draft change', text: output.receipt.summary};
-  }
-  if (output?.error) {
-    return {
-      label: 'Needs attention',
-      text: output.message || output.hint || String(output.error),
-    };
-  }
-  switch (toolName) {
-    case 'collections_list':
-      return {label: 'Read context', text: 'Loaded available CMS collections.'};
-    case 'docs_list':
-      return {
-        label: 'Read context',
-        text: `Loaded documents from ${input?.collectionId || 'a collection'}.`,
-      };
-    case 'docs_search':
-      return {
-        label: 'Read context',
-        text: `Searched indexed docs for "${input?.query || ''}".`,
-      };
-    case 'doc_get':
-      return {
-        label: 'Read context',
-        text: `Loaded ${input?.docId || 'a document'}.`,
-      };
-    case 'doc_getVersion':
-      return {
-        label: 'Read context',
-        text: `Loaded ${input?.docId || 'a document'} at ${
-          input?.versionId || 'a version'
-        }.`,
-      };
-    case 'doc_listVersions':
-      return {
-        label: 'Read context',
-        text: `Loaded version history for ${input?.docId || 'a document'}.`,
-      };
-    case 'schema_get':
-      return {
-        label: 'Read context',
-        text: `Loaded the ${input?.collectionId || 'collection'} schema.`,
-      };
-    case 'doc_translateField':
-      return {label: 'Generated translation', text: 'Translated field text.'};
-    default:
-      return null;
   }
 }
 

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -1181,7 +1181,14 @@ function ToolPartView(props: {
         className="RootAIChat__tool__header"
         onClick={() => setOpen(!open)}
       >
-        <Badge variant="filled" color="dark" size="xs">
+        <IconChevronDown
+          className={joinClassNames(
+            'RootAIChat__tool__header__icon',
+            open && 'RootAIChat__tool__header__icon--open'
+          )}
+          size={14}
+        />
+        <Badge color="dark" variant="filled" size="xs">
           {toolName}
         </Badge>
         <span className="RootAIChat__tool__title">
@@ -1192,13 +1199,6 @@ function ToolPartView(props: {
             ? prettyApprovalState(approval.status)
             : prettyToolState(state)}
         </span>
-        <IconChevronDown
-          size={14}
-          style={{
-            marginLeft: 'auto',
-            transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
-          }}
-        />
       </button>
       {open && (
         <div className="RootAIChat__tool__body">


### PR DESCRIPTION
## Summary
This PR refactors the tool display UI in RootAIChat by removing the timeline summary component and simplifying the tool container styling. The changes focus on streamlining the approval workflow and improving the details/summary UI for input/output inspection.

## Key Changes
- **Removed `ToolTimelineSummary` component** and `getToolSummary` function that displayed contextual information about tool execution
- **Simplified auto-open logic** to only expand tool details when there's a pending approval that requires user decision, rather than auto-opening for any output or error
- **Removed approval-specific styling** (`.RootAIChat__tool--approval` class) and simplified the base tool container styling
- **Enhanced details/summary UI** with custom chevron icons that rotate when expanded, replacing the default browser disclosure triangle
- **Reduced padding and spacing** on tool headers and bodies for a more compact layout
- **Added custom styling** for the details/summary elements including:
  - Flexbox layout for summary with icon and text alignment
  - Hidden default disclosure marker
  - Smooth rotation animation for the chevron icon on expand/collapse

## Implementation Details
- The `IconChevronRight` icon is imported and used in both Input and Output summary elements
- The chevron rotation is handled via CSS transform on the `.RootAIChat__tool__json__icon` class when the parent `details` element has the `[open]` attribute
- Tool container now has minimal styling, relying on the approval card for visual distinction when needed
- The dependency on `part.output` and `part.errorText` for auto-opening has been removed, focusing the expand behavior on user-actionable approvals

https://claude.ai/code/session_01Wid71MqgRgs4J4ot4fUB1X