### PR TITLE
fix: hide archived data sources from release selection modal

### DIFF
--- a/.changeset/quiet-trains-march.md
+++ b/.changeset/quiet-trains-march.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: hide archived data sources from release selection modal

--- a/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.tsx
+++ b/packages/root-cms/ui/components/DataSourceSelectModal/DataSourceSelectModal.tsx
@@ -42,7 +42,7 @@ export function DataSourceSelectModal(
   useEffect(() => {
     async function init() {
       const res = await listDataSources();
-      setDataSources(res);
+      setDataSources(res.filter((ds) => !ds.archivedAt));
       setLoading(false);
     }
     init();


### PR DESCRIPTION
## Summary
This change filters out archived data sources from the release selection modal to prevent users from selecting inactive data sources.

## Key Changes
- Modified `DataSourceSelectModal.tsx` to filter the data sources list and exclude any sources with an `archivedAt` timestamp
- The filter is applied when data sources are fetched and stored in state

## Implementation Details
The fix is minimal and non-breaking: when `listDataSources()` returns the list of available data sources, we now filter the results to only include sources where `archivedAt` is not set (i.e., `!ds.archivedAt`). This ensures that archived data sources are hidden from the UI without affecting the underlying data or API.

https://claude.ai/code/session_01MjjL3RVTraJc5xFagkeg4k