### PR TITLE
feat: switch field metadata to `{translate: false}` and add `{alt: false}` toggle

### DIFF
--- a/packages/root-cms/core/checks-translations.ts
+++ b/packages/root-cms/core/checks-translations.ts
@@ -35,7 +35,7 @@ function extractTranslatableStrings(
 
       const metadataKey = `@${field.id}`;
       const metadata = fieldData[metadataKey];
-      if (metadata?.translate === false) {
+      if (metadata?.translate === false || metadata?.disableTranslations) {
         continue;
       }
 

--- a/packages/root-cms/core/checks-translations.ts
+++ b/packages/root-cms/core/checks-translations.ts
@@ -33,18 +33,21 @@ function extractTranslatableStrings(
         continue;
       }
 
-      // Check for "do not translate" metadata.
       const metadataKey = `@${field.id}`;
       const metadata = fieldData[metadataKey];
-      if (metadata?.disableTranslations) {
+      if (metadata?.translate === false) {
         continue;
       }
 
-      walkField(field, value);
+      walkField(field, value, metadata);
     }
   }
 
-  function walkField(field: schema.Field, value: any) {
+  function walkField(
+    field: schema.Field,
+    value: any,
+    metadata?: Record<string, any>
+  ) {
     if (!value) {
       return;
     }
@@ -66,7 +69,8 @@ function extractTranslatableStrings(
       if (
         (field as schema.ImageField).translate &&
         value.alt &&
-        (field as schema.ImageField).alt !== false
+        (field as schema.ImageField).alt !== false &&
+        metadata?.alt !== false
       ) {
         addString(value.alt);
       }

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -702,7 +702,6 @@ DocEditor.FieldHeaderTranslationsActionIconInner = (
     [field, types, value]
   );
 
-  // Check for disableTranslations metadata.
   const [doNotTranslate, setDoNotTranslate] = useState(false);
 
   useEffect(() => {
@@ -713,7 +712,7 @@ DocEditor.FieldHeaderTranslationsActionIconInner = (
     const unsubscribe = draft.controller.subscribe(
       metadataKey,
       (metadata: any) => {
-        setDoNotTranslate(metadata?.disableTranslations || false);
+        setDoNotTranslate(metadata?.translate === false);
       }
     );
     return unsubscribe;

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -98,6 +98,8 @@ interface FileFieldContextValue {
   showAltText: boolean;
   altText: string;
   setAltText: (altText: string) => void;
+  altDisabledByMetadata: boolean;
+  setAltDisabledByMetadata?: (disabled: boolean) => void;
   allowEditing: boolean;
 }
 
@@ -127,6 +129,13 @@ export interface FileFieldInternalProps {
   showNamingOptions?: boolean;
   accept?: string[];
   allowEditing?: boolean;
+  /** Whether the alt text field is disabled via per-field metadata. */
+  altDisabledByMetadata?: boolean;
+  /**
+   * Setter for the per-field `alt` metadata. When provided, the menu shows a
+   * toggle to disable the alt text input on a per-instance basis.
+   */
+  setAltDisabledByMetadata?: (disabled: boolean) => void;
 }
 
 export function FileFieldInternal(props: FileFieldInternalProps) {
@@ -153,7 +162,8 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
     (props.variant === 'image' ? IMAGE_MIMETYPES : []);
 
   const altText = value?.alt || '';
-  const showAltText = field.alt !== false;
+  const altDisabledByMetadata = props.altDisabledByMetadata === true;
+  const showAltText = field.alt !== false && !altDisabledByMetadata;
 
   async function uploadFile(
     file: File,
@@ -450,6 +460,8 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
         showAltText: showAltText,
         altText: altText,
         setAltText: setAltText,
+        altDisabledByMetadata: altDisabledByMetadata,
+        setAltDisabledByMetadata: props.setAltDisabledByMetadata,
         allowEditing: allowEditing,
       }}
     >
@@ -654,6 +666,20 @@ export function FileField(props: FileFieldProps) {
   const [loadingState, setLoadingState] =
     useState<FileFieldLoadingState | null>(null);
 
+  const metadataKey = getMetadataKey(props.deepKey);
+  const [metadata, setMetadata] =
+    useDraftDocValue<Record<string, any> | null>(metadataKey);
+  const altDisabledByMetadata = metadata?.alt === false;
+  const setAltDisabledByMetadata = (disabled: boolean) => {
+    const next = {...(metadata || {})};
+    if (disabled) {
+      next.alt = false;
+    } else {
+      delete next.alt;
+    }
+    setMetadata(Object.keys(next).length === 0 ? null : next);
+  };
+
   return (
     <FileFieldInternal
       field={field}
@@ -663,6 +689,12 @@ export function FileField(props: FileFieldProps) {
       setLoadingState={setLoadingState}
       variant={props.variant}
       allowEditing={props.allowEditing}
+      altDisabledByMetadata={altDisabledByMetadata}
+      setAltDisabledByMetadata={
+        props.variant === 'image' && field.alt !== false
+          ? setAltDisabledByMetadata
+          : undefined
+      }
     />
   );
 }
@@ -832,6 +864,23 @@ FileField.Preview = () => {
                 Use dark canvas
               </Menu.Item>
             )}
+          {ctx.allowEditing && ctx.setAltDisabledByMetadata && (
+            <Menu.Item
+              icon={
+                ctx.altDisabledByMetadata ? (
+                  <IconSquareCheckFilled size={16} />
+                ) : (
+                  <IconSquareCheck size={16} style={{opacity: 0.25}} />
+                )
+              }
+              closeOnItemClick={false}
+              onClick={() => {
+                ctx.setAltDisabledByMetadata?.(!ctx.altDisabledByMetadata);
+              }}
+            >
+              Disable alt text
+            </Menu.Item>
+          )}
           <Divider />
           <Menu.Item
             color="red"
@@ -1307,6 +1356,12 @@ function canvasPreviewInlineStyles(uploadedFile: UploadedFile) {
     inlineStyles['--canvas-bg-color'] = '#000';
   }
   return inlineStyles;
+}
+
+function getMetadataKey(key: string) {
+  const parts = key.split('.');
+  const last = parts.pop();
+  return [...parts, `@${last}`].join('.');
 }
 
 /** Returns whether a string is an SVG. */

--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.test.tsx
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.test.tsx
@@ -84,7 +84,7 @@ describe('EditTranslationsModal', () => {
 
   it('should load translation metadata from draft controller', async () => {
     mockDraft.controller.getValue.mockReturnValue({
-      disableTranslations: true,
+      translate: false,
       description: 'Keep it simple',
     });
 
@@ -119,7 +119,7 @@ describe('EditTranslationsModal', () => {
 
   it('should hide translation table when "Do not translate" is checked', async () => {
     mockDraft.controller.getValue.mockReturnValue({
-      disableTranslations: true,
+      translate: false,
     });
 
     render(<EditTranslationsModal {...defaultProps} />);
@@ -154,7 +154,7 @@ describe('EditTranslationsModal', () => {
       expect(mockDraft.controller.updateKey).toHaveBeenCalledWith(
         'fields.@title',
         expect.objectContaining({
-          disableTranslations: true,
+          translate: false,
           description: 'Important context',
         })
       );
@@ -162,7 +162,7 @@ describe('EditTranslationsModal', () => {
     });
   });
 
-  it('should not import translations when disableTranslations is true', async () => {
+  it('should not import translations when translate is false', async () => {
     mockDraft.controller.getValue.mockReturnValue({});
 
     render(<EditTranslationsModal {...defaultProps} />);

--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
@@ -93,7 +93,7 @@ export function EditTranslationsModal(
     if (props.field?.deepKey && draft?.controller) {
       const metadataKey = getMetadataKey(props.field.deepKey);
       const metadata = draft.controller.getValue(metadataKey) || {};
-      setDoNotTranslate(metadata.disableTranslations || false);
+      setDoNotTranslate(metadata.translate === false);
       setDescription(metadata.description || '');
     }
   }, [props.field?.deepKey, draft?.controller]);
@@ -128,9 +128,9 @@ export function EditTranslationsModal(
         const metadata = draft.controller.getValue(metadataKey) || {};
         // Only store non-default values to avoid superfluous data.
         if (doNotTranslate) {
-          metadata.disableTranslations = true;
+          metadata.translate = false;
         } else {
-          delete metadata.disableTranslations;
+          delete metadata.translate;
         }
         if (description) {
           metadata.description = description;

--- a/packages/root-cms/ui/utils/extract.test.ts
+++ b/packages/root-cms/ui/utils/extract.test.ts
@@ -23,7 +23,7 @@ describe('extract', () => {
       expect(strings.has('hello-world')).toBe(false);
     });
 
-    it('should skip fields marked with disableTranslations', () => {
+    it('should skip fields marked with translate: false', () => {
       const fields: schema.Field[] = [
         {type: 'string', id: 'title', translate: true},
         {type: 'string', id: 'description', translate: true},
@@ -32,7 +32,7 @@ describe('extract', () => {
         title: 'Hello World',
         description: 'This is a description',
         '@description': {
-          disableTranslations: true,
+          translate: false,
         },
       };
       const strings = new Set<string>();
@@ -43,7 +43,7 @@ describe('extract', () => {
       expect(strings.has('This is a description')).toBe(false);
     });
 
-    it('should extract fields without disableTranslations metadata', () => {
+    it('should extract fields when translate metadata is not false', () => {
       const fields: schema.Field[] = [
         {type: 'string', id: 'title', translate: true},
         {type: 'string', id: 'description', translate: true},
@@ -52,7 +52,7 @@ describe('extract', () => {
         title: 'Hello World',
         description: 'This is a description',
         '@description': {
-          disableTranslations: false,
+          description: 'translator note',
         },
       };
       const strings = new Set<string>();
@@ -89,14 +89,14 @@ describe('extract', () => {
       });
     });
 
-    it('should skip fields marked with disableTranslations', () => {
+    it('should skip fields marked with translate: false', () => {
       const fields: schema.Field[] = [
         {type: 'string', id: 'title', translate: true},
       ];
       const data = {
         title: 'Hello World',
         '@title': {
-          disableTranslations: true,
+          translate: false,
           description: 'Some description',
         },
       };
@@ -142,6 +142,21 @@ describe('extract', () => {
       extractField(strings, field, value);
 
       expect(strings.has('Hero image')).toBe(true);
+    });
+
+    it('should skip image alt text when metadata alt is false', () => {
+      const fields: schema.Field[] = [
+        {type: 'image', id: 'hero', translate: true},
+      ];
+      const data = {
+        hero: {src: 'image.jpg', alt: 'Hero image'},
+        '@hero': {alt: false},
+      };
+      const strings = new Set<string>();
+
+      extractFields(strings, fields, data);
+
+      expect(strings.has('Hero image')).toBe(false);
     });
 
     it('should extract multiselect values when translate is true', () => {

--- a/packages/root-cms/ui/utils/extract.test.ts
+++ b/packages/root-cms/ui/utils/extract.test.ts
@@ -43,6 +43,26 @@ describe('extract', () => {
       expect(strings.has('This is a description')).toBe(false);
     });
 
+    it('should skip fields marked with legacy disableTranslations', () => {
+      const fields: schema.Field[] = [
+        {type: 'string', id: 'title', translate: true},
+        {type: 'string', id: 'description', translate: true},
+      ];
+      const data = {
+        title: 'Hello World',
+        description: 'This is a description',
+        '@description': {
+          disableTranslations: true,
+        },
+      };
+      const strings = new Set<string>();
+
+      extractFields(strings, fields, data);
+
+      expect(strings.has('Hello World')).toBe(true);
+      expect(strings.has('This is a description')).toBe(false);
+    });
+
     it('should extract fields when translate metadata is not false', () => {
       const fields: schema.Field[] = [
         {type: 'string', id: 'title', translate: true},

--- a/packages/root-cms/ui/utils/extract.ts
+++ b/packages/root-cms/ui/utils/extract.ts
@@ -71,7 +71,7 @@ export function extractFields(
 
     const metadataKey = `@${field.id}`;
     const metadata = data[metadataKey];
-    if (metadata?.translate === false) {
+    if (metadata?.translate === false || metadata?.disableTranslations) {
       return;
     }
 
@@ -93,7 +93,7 @@ export function extractFieldsWithMetadata(
 
     const metadataKey = `@${field.id}`;
     const metadata = data[metadataKey];
-    if (metadata?.translate === false) {
+    if (metadata?.translate === false || metadata?.disableTranslations) {
       return;
     }
 

--- a/packages/root-cms/ui/utils/extract.ts
+++ b/packages/root-cms/ui/utils/extract.ts
@@ -69,14 +69,13 @@ export function extractFields(
     }
     const fieldValue = data[field.id];
 
-    // Check if field has "do not translate" metadata
     const metadataKey = `@${field.id}`;
     const metadata = data[metadataKey];
-    if (metadata?.disableTranslations) {
-      return; // Skip this field
+    if (metadata?.translate === false) {
+      return;
     }
 
-    extractField(strings, field, fieldValue, types);
+    extractField(strings, field, fieldValue, types, metadata);
   });
 }
 
@@ -92,11 +91,10 @@ export function extractFieldsWithMetadata(
     }
     const fieldValue = data[field.id];
 
-    // Check if field has "do not translate" metadata
     const metadataKey = `@${field.id}`;
     const metadata = data[metadataKey];
-    if (metadata?.disableTranslations) {
-      return; // Skip this field
+    if (metadata?.translate === false) {
+      return;
     }
 
     const description = metadata?.description;
@@ -105,7 +103,8 @@ export function extractFieldsWithMetadata(
       field,
       fieldValue,
       types,
-      description
+      description,
+      metadata
     );
   });
 }
@@ -114,7 +113,8 @@ export function extractField(
   strings: Set<string>,
   field: schema.Field,
   fieldValue: any,
-  types: Record<string, schema.Schema> = {}
+  types: Record<string, schema.Schema> = {},
+  metadata?: Record<string, any>
 ) {
   if (!fieldValue) {
     return;
@@ -143,7 +143,8 @@ export function extractField(
       field.translate &&
       fieldValue &&
       fieldValue.alt &&
-      field.alt !== false
+      field.alt !== false &&
+      metadata?.alt !== false
     ) {
       addString(fieldValue.alt);
     }
@@ -182,7 +183,8 @@ export function extractFieldWithMetadata(
   field: schema.Field,
   fieldValue: any,
   types: Record<string, schema.Schema> = {},
-  description?: string
+  description?: string,
+  metadata?: Record<string, any>
 ) {
   if (!fieldValue) {
     return;
@@ -225,7 +227,8 @@ export function extractFieldWithMetadata(
       field.translate &&
       fieldValue &&
       fieldValue.alt &&
-      field.alt !== false
+      field.alt !== false &&
+      metadata?.alt !== false
     ) {
       addStringWithMeta(fieldValue.alt);
     }


### PR DESCRIPTION
## Summary
This PR introduces a metadata-driven approach for controlling alt text and translation settings on a per-field basis. It replaces the `disableTranslations` metadata key with a more semantic `translate: false` convention and adds support for disabling alt text on individual image fields through metadata.

## Key Changes

- **Alt text metadata control**: Added `altDisabledByMetadata` and `setAltDisabledByMetadata` to `FileFieldContextValue` and `FileFieldInternalProps`, allowing users to disable alt text input on a per-instance basis via a menu toggle
- **Metadata key generation**: Introduced `getMetadataKey()` utility function that converts field keys (e.g., `fields.hero`) to metadata keys (e.g., `fields.@hero`)
- **Translation metadata standardization**: Replaced `disableTranslations` with `translate: false` across all translation-related code for consistency and clarity
- **Extract utilities enhancement**: Updated `extractField()` and `extractFieldWithMetadata()` to accept and respect metadata, specifically checking `metadata?.alt !== false` before extracting image alt text
- **Translation checks**: Updated `checks-translations.ts` to use the new `translate: false` metadata convention
- **UI updates**: Added a "Disable alt text" menu item in the FileField preview that appears when editing is allowed and the setter is provided

## Implementation Details

- The metadata system uses a naming convention where field metadata is stored with an `@` prefix (e.g., `@fieldName`)
- Alt text can be disabled per-field by setting `metadata.alt = false`, which prevents both the UI input and translation extraction
- The translation disable/enable logic now uses `metadata.translate === false` instead of `metadata.disableTranslations`
- Metadata is only persisted when it contains non-default values to avoid unnecessary data storage
- The alt text disable toggle is only shown for image fields when the field schema allows alt text (`field.alt !== false`)

https://claude.ai/code/session_01Fa7Z7JbaB3U7ouQKduN3nt