### PR TITLE
fix: exit with error code when secrets sync encounters gcloud failures

### DIFF
--- a/packages/root/src/cli/secrets.test.ts
+++ b/packages/root/src/cli/secrets.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {Command} from 'commander';
+import {afterEach, assert, beforeEach, test, vi} from 'vitest';
+
+// In-memory stand-in for Google Cloud Secret Manager, with a toggle to simulate
+// a failing `gcloud` invocation (auth/permission/CLI-missing, etc.).
+const {gsmStore, gcloud} = vi.hoisted(() => ({
+  gsmStore: new Map<string, Record<string, string>>(),
+  gcloud: {fail: false},
+}));
+
+vi.mock('../secrets/gcloud.js', () => ({
+  accessSecretJson: async (gsmKey: string) => {
+    if (gcloud.fail) {
+      throw new Error(
+        'Not authenticated with Google Cloud. Run `gcloud auth login`.'
+      );
+    }
+    return {...(gsmStore.get(gsmKey) || {})};
+  },
+  writeSecretJson: async (
+    gsmKey: string,
+    _project: string,
+    data: Record<string, string>
+  ) => {
+    gsmStore.set(gsmKey, {...data});
+  },
+}));
+
+import {manifestPath} from '../secrets/manifest.js';
+import {registerSecretsCommands} from './secrets.js';
+
+let rootDir: string;
+let cwd: string;
+let exitCode: typeof process.exitCode;
+let logs: string[];
+
+beforeEach(() => {
+  rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-secrets-cli-'));
+  fs.writeFileSync(
+    manifestPath(rootDir),
+    JSON.stringify({
+      version: 1,
+      gcpProjectId: 'proj',
+      gsmKey: 'site-a',
+      secrets: {API_KEY: {updatedAt: 't1'}},
+    })
+  );
+  cwd = process.cwd();
+  process.chdir(rootDir);
+  exitCode = process.exitCode;
+  process.exitCode = 0;
+  gsmStore.clear();
+  gcloud.fail = false;
+  logs = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.join(' '));
+  });
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  process.exitCode = exitCode;
+  fs.rmSync(rootDir, {recursive: true, force: true});
+  delete process.env.API_KEY;
+  vi.restoreAllMocks();
+});
+
+/** Runs `root secrets <args...>` against a fresh commander program. */
+async function runSecrets(...args: string[]) {
+  const program = new Command('root').exitOverride();
+  registerSecretsCommands(program);
+  await program.parseAsync(['node', 'root', 'secrets', ...args]);
+}
+
+function envExists(): boolean {
+  return fs.existsSync(path.join(rootDir, '.env'));
+}
+
+test('sync exits non-zero and does not report "up to date" when gcloud fails', async () => {
+  gcloud.fail = true;
+
+  await runSecrets('sync');
+
+  const output = logs.join('\n');
+  assert.equal(process.exitCode, 1, 'a failed gcloud fetch must fail the CLI');
+  assert.notInclude(output, 'up to date');
+  assert.include(output, 'Not authenticated');
+  assert.isFalse(envExists(), 'nothing should be written on failure');
+});
+
+test('pull also fails the CLI when gcloud fails', async () => {
+  gcloud.fail = true;
+
+  await runSecrets('pull');
+
+  assert.equal(process.exitCode, 1);
+  assert.notInclude(logs.join('\n'), 'up to date');
+});
+
+test('a successful sync writes .env, reports the update, and exits clean', async () => {
+  gsmStore.set('site-a', {API_KEY: 'v1'});
+
+  await runSecrets('sync');
+
+  const output = logs.join('\n');
+  assert.equal(process.exitCode, 0);
+  assert.include(output, 'updated');
+  assert.notInclude(output, 'error');
+  assert.isTrue(envExists());
+});

--- a/packages/root/src/cli/secrets.ts
+++ b/packages/root/src/cli/secrets.ts
@@ -244,12 +244,23 @@ async function secretsSync() {
   const rootDir = process.cwd();
   const result = await syncSecrets({rootDir, apply: true});
   printSyncSummary(result);
+  // syncSecrets never throws for gcloud/network failures (it records them so
+  // they retry), so the CLI must translate them into a non-zero exit itself.
+  failOnSyncErrors(result);
 }
 
 async function secretsPull() {
   const rootDir = process.cwd();
   const result = await syncSecrets({rootDir, apply: true, force: true});
   printSyncSummary(result, {pull: true});
+  failOnSyncErrors(result);
+}
+
+/** Marks the process as failed when a sync hit any gcloud fetch errors. */
+function failOnSyncErrors(result: SyncResult) {
+  if (result.errors.length > 0) {
+    process.exitCode = 1;
+  }
 }
 
 async function secretsStatus() {
@@ -345,6 +356,11 @@ function printSyncSummary(
   }
   if (result.conflicts.length) {
     parts.push(yellow(`${result.conflicts.length} conflict`));
+  }
+  // Surface failures in the headline so a sync that fetched nothing can never
+  // masquerade as "up to date".
+  if (result.errors.length) {
+    parts.push(red(`${result.errors.length} error`));
   }
 
   console.log();


### PR DESCRIPTION
## Summary
This PR ensures that the `secrets sync` and `secrets pull` CLI commands exit with a non-zero exit code when they encounter gcloud authentication or network failures, rather than silently succeeding.

## Key Changes
- Added `failOnSyncErrors()` function that sets `process.exitCode = 1` when sync results contain errors
- Called `failOnSyncErrors()` in both `secretsSync()` and `secretsPull()` commands to propagate gcloud failures as CLI failures
- Updated `printSyncSummary()` to include error count in the output headline, preventing failed syncs from being reported as "up to date"
- Added comprehensive test suite (`secrets.test.ts`) covering:
  - Sync/pull failure scenarios when gcloud is unavailable
  - Successful sync scenarios with proper exit codes and output
  - Verification that `.env` files are not written on failure

## Implementation Details
- The underlying `syncSecrets()` function doesn't throw on gcloud failures; instead it records them in the result object for retry logic
- The CLI layer now translates these recorded errors into appropriate exit codes
- Error reporting is surfaced in the sync summary output to ensure visibility of failures

https://claude.ai/code/session_01PpSdT8obGYC1c7bKSKoGkT