### PR TITLE
feat: add context menu to drawers/objects

### DIFF
--- a/.changeset/funky-kings-cheer.md
+++ b/.changeset/funky-kings-cheer.md
@@ -3,7 +3,3 @@
 ---
 
 feat: add context menu to drawers
-
-- previously, it was impossible to clear/copy/paste/edit drawers
-- we need a way to fully clear out all the fields inside a drawer
-- this adds it

--- a/.changeset/funky-kings-cheer.md
+++ b/.changeset/funky-kings-cheer.md
@@ -1,0 +1,9 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add context menu to drawers
+
+- previously, it was impossible to clear/copy/paste/edit drawers
+- we need a way to fully clear out all the fields inside a drawer
+- this adds it

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -199,16 +199,42 @@
   transition: transform 0.3s ease;
 }
 
+.DocEditor__ObjectFieldDrawer__drawer__toggle__controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .DocEditor__ObjectFieldDrawer__drawer[open] > summary > .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
   transform: rotate(-180deg);
 }
 
+.DocEditor__ObjectFieldDrawer__drawer[open] > summary .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
+  transform: rotate(-180deg);
+}
+
 .DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle {
-  flex-direction: row-reverse;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 16px;
   border-top: none;
   border-bottom: none;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__controls {
+  display: contents;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
+  order: 1;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__header {
+  order: 2;
+}
+
+.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__menu {
+  order: 3;
+  margin-left: auto;
 }
 
 .DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__content {
@@ -398,24 +424,29 @@
   font-family: var(--font-family-mono);
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"] {
+.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"],
+.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"] {
   padding: 8px 12px;
   font-size: 14px;
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:hover {
+.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:hover,
+.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"]:hover {
   background-color: var(--button-background-hover);
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:active {
+.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:active,
+.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"]:active {
   background-color: var(--button-background-active);
 }
 
-.DocEditor__ArrayField__menu__item {
+.DocEditor__ArrayField__menu__item,
+.DocEditor__ObjectFieldDrawer__drawer__menu__item {
   padding: 6px 10px;
 }
 
-.DocEditor__ArrayField__menu__item .mantine-Menu-itemLabel {
+.DocEditor__ArrayField__menu__item .mantine-Menu-itemLabel,
+.DocEditor__ObjectFieldDrawer__drawer__menu__item .mantine-Menu-itemLabel {
   font-size: 12px;
 }
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -177,7 +177,7 @@
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   cursor: pointer;
   transition: all 0.3s ease;
   user-select: none;
@@ -188,7 +188,9 @@
 }
 
 .DocEditor__ObjectFieldDrawer__drawer__toggle__header {
+  flex: 1;
   margin-bottom: 0;
+  min-width: 0;
 }
 
 .DocEditor__ObjectFieldDrawer__drawer__content {
@@ -199,42 +201,32 @@
   transition: transform 0.3s ease;
 }
 
-.DocEditor__ObjectFieldDrawer__drawer__toggle__controls {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 .DocEditor__ObjectFieldDrawer__drawer[open] > summary > .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
-  transform: rotate(-180deg);
+  transform: rotate(90deg);
 }
 
-.DocEditor__ObjectFieldDrawer__drawer[open] > summary .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
-  transform: rotate(-180deg);
+.DocEditor__ObjectFieldDrawer__drawer__menu {
+  margin-left: auto;
+  padding-right: 4px;
+}
+
+.DocEditor__ObjectFieldDrawer__drawer__menu__dots {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  min-height: 20px;
+  padding: 0;
+  line-height: 1;
+}
+
+.DocEditor__ObjectFieldDrawer__confirmText {
+  text-wrap: pretty;
 }
 
 .DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle {
   justify-content: flex-start;
-  gap: 16px;
   border-top: none;
   border-bottom: none;
-}
-
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__controls {
-  display: contents;
-}
-
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
-  order: 1;
-}
-
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle__header {
-  order: 2;
-}
-
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__menu {
-  order: 3;
-  margin-left: auto;
 }
 
 .DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__content {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -22,6 +22,7 @@ import {
   IconCircleArrowDown,
   IconCircleArrowUp,
   IconCirclePlus,
+  IconClipboard,
   IconClipboardCopy,
   IconGripVertical,
   IconCopy,
@@ -819,9 +820,59 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
   const collapsed = field.drawerOptions?.collapsed || false;
   const inline = field.drawerOptions?.inline || false;
   const iconPosition = inline ? 'left' : 'right';
+  const draft = useDraftDoc().controller;
+  const virtualClipboard = useVirtualClipboard();
+  const editJsonModal = useEditJsonModal();
 
   const deeplink = useDeeplink();
   const initialOpen = !collapsed || deeplink.value.includes(props.deepKey);
+
+  const copyToClipboard = () => {
+    const data = draft.getValue(props.deepKey) || {};
+    virtualClipboard.set(data);
+    showNotification({
+      message: 'Copied to clipboard',
+      autoClose: 2000,
+    });
+  };
+
+  const pasteFromClipboard = async () => {
+    const data = await virtualClipboard.get();
+    if (!data || typeof data !== 'object') {
+      showNotification({
+        message: 'Clipboard empty (nothing to paste)',
+        color: 'red',
+        autoClose: 2000,
+      });
+      return;
+    }
+    draft.updateKey(props.deepKey, data);
+    showNotification({
+      message: 'Pasted from clipboard',
+      autoClose: 2000,
+    });
+  };
+
+  const clearValue = async () => {
+    await draft.removeKey(props.deepKey);
+    showNotification({
+      message: 'Cleared',
+      autoClose: 2000,
+    });
+    // Clear is destructive, so persist immediately instead of waiting for autosave.
+    await draft.flush();
+  };
+
+  const editJson = () => {
+    const data = draft.getValue(props.deepKey) || {};
+    editJsonModal.open({
+      data: data,
+      onSave: (newValue) => {
+        draft.updateKey(props.deepKey, newValue);
+        editJsonModal.close();
+      },
+    });
+  };
 
   return (
     <div
@@ -845,8 +896,58 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
             field={field}
             deepKey={props.deepKey}
           />
-          <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__icon">
-            <IconChevronDown size={16} />
+          <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__controls">
+            <Menu
+              className="DocEditor__ObjectFieldDrawer__drawer__menu"
+              position="bottom"
+              transitionDuration={0}
+              control={
+                <ActionIcon
+                  className="DocEditor__ObjectFieldDrawer__drawer__menu__dots"
+                  onClick={(e: MouseEvent) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
+                >
+                  <IconDotsVertical size={16} />
+                </ActionIcon>
+              }
+            >
+              <Menu.Label>CLIPBOARD</Menu.Label>
+              <Menu.Item
+                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+                icon={<IconClipboardCopy size={18} />}
+                onClick={copyToClipboard}
+              >
+                Copy
+              </Menu.Item>
+              <Menu.Item
+                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+                icon={<IconClipboard size={18} />}
+                onClick={pasteFromClipboard}
+              >
+                Paste
+              </Menu.Item>
+              <Menu.Label>CODE</Menu.Label>
+              <Menu.Item
+                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+                icon={<IconBraces size={18} />}
+                onClick={editJson}
+              >
+                Edit JSON
+              </Menu.Item>
+              <Menu.Label>ACTIONS</Menu.Label>
+              <Menu.Item
+                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+                icon={<IconTrash size={18} />}
+                onClick={clearValue}
+              >
+                Clear
+              </Menu.Item>
+            </Menu>
+            <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__icon">
+              <IconChevronDown size={16} />
+            </div>
           </div>
         </summary>
         <div className="DocEditor__ObjectFieldDrawer__drawer__content DocEditor__ObjectFieldDrawer__fields">
@@ -1908,8 +2009,9 @@ DocEditor.OneOfField = (props: FieldProps) => {
   }
 
   useDraftDocField(props.deepKey, (newValue: any) => {
+    // Keep local selection state in sync when the value is cleared externally.
+    setType(newValue?._type || '');
     if (newValue?._type) {
-      setType(newValue._type || '');
       cachedValues[newValue._type] = newValue;
     }
   });

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -15,10 +15,12 @@ import {
   Select,
   Tooltip,
 } from '@mantine/core';
+import {useModals} from '@mantine/modals';
 import {showNotification} from '@mantine/notifications';
 import {
   IconBraces,
   IconChevronDown,
+  IconChevronRight,
   IconCircleArrowDown,
   IconCircleArrowUp,
   IconCirclePlus,
@@ -67,6 +69,7 @@ import {
   useDraftDocField,
   useDraftDocSaveState,
 } from '../../hooks/useDraftDoc.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {
   ClipboardData,
@@ -108,6 +111,7 @@ import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
 import {useLockPublishingModal} from '../LockPublishingModal/LockPublishingModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
+import {Text} from '../Text/Text.js';
 import {Viewers} from '../Viewers/Viewers.js';
 import {BooleanField} from './fields/BooleanField.js';
 import {DateField} from './fields/DateField.js';
@@ -819,10 +823,11 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
   const field = props.field as schema.ObjectField;
   const collapsed = field.drawerOptions?.collapsed || false;
   const inline = field.drawerOptions?.inline || false;
-  const iconPosition = inline ? 'left' : 'right';
   const draft = useDraftDoc().controller;
   const virtualClipboard = useVirtualClipboard();
   const editJsonModal = useEditJsonModal();
+  const modals = useModals();
+  const modalTheme = useModalTheme();
 
   const deeplink = useDeeplink();
   const initialOpen = !collapsed || deeplink.value.includes(props.deepKey);
@@ -853,14 +858,40 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
     });
   };
 
-  const clearValue = async () => {
+  const clearValue = async (modalId?: string) => {
     await draft.removeKey(props.deepKey);
     showNotification({
       message: 'Cleared',
       autoClose: 2000,
     });
-    // Clear is destructive, so persist immediately instead of waiting for autosave.
+    // Clear is destructive, so persist immediately instead of waiting for
+    // autosave.
     await draft.flush();
+    if (modalId) {
+      modals.closeModal(modalId);
+    }
+  };
+
+  const confirmClear = () => {
+    const label = field.label || field.id || 'drawer';
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: `Clear ${label}?`,
+      children: (
+        <Text
+          size="body-sm"
+          weight="semi-bold"
+          className="DocEditor__ObjectFieldDrawer__confirmText"
+        >
+          This will clear all values in this section. There is no undo.
+        </Text>
+      ),
+      labels: {confirm: 'Clear', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      closeOnConfirm: false,
+      onConfirm: () => clearValue(modalId),
+    });
   };
 
   const editJson = () => {
@@ -885,70 +916,63 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
         className="DocEditor__ObjectFieldDrawer__drawer"
         open={initialOpen}
       >
-        <summary
-          className={joinClassNames(
-            'DocEditor__ObjectFieldDrawer__drawer__toggle',
-            `DocEditor__ObjectFieldDrawer__drawer__toggle--icon-${iconPosition}`
-          )}
-        >
+        <summary className="DocEditor__ObjectFieldDrawer__drawer__toggle">
+          <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__icon">
+            <IconChevronRight size={16} />
+          </div>
           <DocEditor.FieldHeader
             className="DocEditor__ObjectFieldDrawer__drawer__toggle__header"
             field={field}
             deepKey={props.deepKey}
           />
-          <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__controls">
-            <Menu
-              className="DocEditor__ObjectFieldDrawer__drawer__menu"
-              position="bottom"
-              transitionDuration={0}
-              control={
-                <ActionIcon
-                  className="DocEditor__ObjectFieldDrawer__drawer__menu__dots"
-                  onClick={(e: MouseEvent) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                  }}
-                >
-                  <IconDotsVertical size={16} />
-                </ActionIcon>
-              }
+          <Menu
+            className="DocEditor__ObjectFieldDrawer__drawer__menu"
+            position="bottom"
+            transitionDuration={0}
+            control={
+              <ActionIcon
+                className="DocEditor__ObjectFieldDrawer__drawer__menu__dots"
+                onClick={(e: MouseEvent) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+              >
+                <IconDotsVertical size={16} />
+              </ActionIcon>
+            }
+          >
+            <Menu.Label>CLIPBOARD</Menu.Label>
+            <Menu.Item
+              className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+              icon={<IconClipboardCopy size={18} />}
+              onClick={copyToClipboard}
             >
-              <Menu.Label>CLIPBOARD</Menu.Label>
-              <Menu.Item
-                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
-                icon={<IconClipboardCopy size={18} />}
-                onClick={copyToClipboard}
-              >
-                Copy
-              </Menu.Item>
-              <Menu.Item
-                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
-                icon={<IconClipboard size={18} />}
-                onClick={pasteFromClipboard}
-              >
-                Paste
-              </Menu.Item>
-              <Menu.Label>CODE</Menu.Label>
-              <Menu.Item
-                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
-                icon={<IconBraces size={18} />}
-                onClick={editJson}
-              >
-                Edit JSON
-              </Menu.Item>
-              <Menu.Label>ACTIONS</Menu.Label>
-              <Menu.Item
-                className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
-                icon={<IconTrash size={18} />}
-                onClick={clearValue}
-              >
-                Clear
-              </Menu.Item>
-            </Menu>
-            <div className="DocEditor__ObjectFieldDrawer__drawer__toggle__icon">
-              <IconChevronDown size={16} />
-            </div>
-          </div>
+              Copy
+            </Menu.Item>
+            <Menu.Item
+              className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+              icon={<IconClipboard size={18} />}
+              onClick={pasteFromClipboard}
+            >
+              Paste
+            </Menu.Item>
+            <Menu.Label>CODE</Menu.Label>
+            <Menu.Item
+              className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+              icon={<IconBraces size={18} />}
+              onClick={editJson}
+            >
+              Edit JSON
+            </Menu.Item>
+            <Menu.Label>ACTIONS</Menu.Label>
+            <Menu.Item
+              className="DocEditor__ObjectFieldDrawer__drawer__menu__item"
+              icon={<IconTrash size={18} />}
+              onClick={confirmClear}
+            >
+              Clear
+            </Menu.Item>
+          </Menu>
         </summary>
         <div className="DocEditor__ObjectFieldDrawer__drawer__content DocEditor__ObjectFieldDrawer__fields">
           {field.fields.map((field) => (

--- a/packages/root-cms/ui/hooks/useDraftDoc.test.ts
+++ b/packages/root-cms/ui/hooks/useDraftDoc.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {removeOverlappingChildUpdates} from './useDraftDoc.js';
+
+describe('removeOverlappingChildUpdates', () => {
+  it('keeps parent updates and removes overlapping descendant updates', () => {
+    expect(
+      removeOverlappingChildUpdates({
+        'fields.meta.title': 'Stale title',
+        'fields.meta': undefined,
+        'fields.meta.image.src': 'Stale image',
+        'fields.other.title': 'Other title',
+      })
+    ).toEqual({
+      'fields.meta': undefined,
+      'fields.other.title': 'Other title',
+    });
+  });
+});

--- a/packages/root-cms/ui/hooks/useDraftDoc.tsx
+++ b/packages/root-cms/ui/hooks/useDraftDoc.tsx
@@ -212,9 +212,9 @@ export class DraftDocController extends EventListener {
     }
     if (value === undefined) {
       // Firestore doesn't support `undefined`, so use deleteField() instead.
-      this.pendingUpdates.set(key, deleteField());
+      this.setPendingUpdate(key, deleteField());
     } else {
-      this.pendingUpdates.set(key, value);
+      this.setPendingUpdate(key, value);
     }
     this.store.set(key, value);
     this.setSaveState(SaveState.UPDATES_PENDING);
@@ -236,9 +236,9 @@ export class DraftDocController extends EventListener {
         // Firestore doesn't support `undefined`, so use deleteField() instead.
         // NOTE(stevenle): this doesn't currently handle nested `undefined`
         // values.
-        this.pendingUpdates.set(key, deleteField());
+        this.setPendingUpdate(key, deleteField());
       } else {
-        this.pendingUpdates.set(key, val);
+        this.setPendingUpdate(key, val);
       }
     }
     this.store.update(updates);
@@ -255,12 +255,34 @@ export class DraftDocController extends EventListener {
     if (this.readOnly) {
       return;
     }
-    this.pendingUpdates.set(key, deleteField());
+    this.setPendingUpdate(key, deleteField());
     this.store.set(key, undefined);
     this.setSaveState(SaveState.UPDATES_PENDING);
     if (this.autoSave) {
       this.queueChanges();
     }
+  }
+
+  /**
+   * Adds a pending Firestore update for a key while removing queued descendant
+   * updates that would conflict with it in a single updateDoc() payload.
+   */
+  private setPendingUpdate(key: string, value: any) {
+    // Firestore updateDoc() rejects ancestor/descendant paths in one payload.
+    // If a parent object is replaced or deleted, that parent update wins.
+    for (const pendingKey of this.pendingUpdates.keys()) {
+      if (isDescendantKey(pendingKey, key)) {
+        this.pendingUpdates.delete(pendingKey);
+      }
+    }
+    this.pendingUpdates.set(key, value);
+  }
+
+  /** Returns pending updates normalized for Firestore updateDoc(). */
+  private getPendingUpdates() {
+    return removeOverlappingChildUpdates(
+      Object.fromEntries(this.pendingUpdates)
+    );
   }
 
   /**
@@ -310,7 +332,7 @@ export class DraftDocController extends EventListener {
       return;
     }
 
-    const updates = Object.fromEntries(this.pendingUpdates);
+    const updates = this.getPendingUpdates();
     updates['sys.modifiedAt'] = serverTimestamp();
     updates['sys.modifiedBy'] = window.firebase.user.email;
 
@@ -418,6 +440,36 @@ function splitKey(key: string) {
   const head = key.substring(0, index);
   const tail = key.substring(index + 1);
   return [head, tail] as const;
+}
+
+/**
+ * Returns a copy of the update payload with child paths removed whenever their
+ * parent path is also present.
+ */
+export function removeOverlappingChildUpdates(updates: Record<string, any>) {
+  const result = {...updates};
+  for (const key in result) {
+    if (hasAncestorKey(key, result)) {
+      delete result[key];
+    }
+  }
+  return result;
+}
+
+/** Returns true when any ancestor of a dot-notation key exists in values. */
+function hasAncestorKey(key: string, values: Record<string, any>) {
+  const segments = key.split('.');
+  for (let i = 1; i < segments.length; i++) {
+    if (segments.slice(0, i).join('.') in values) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Returns true when key is nested below parentKey. */
+function isDescendantKey(key: string, parentKey: string) {
+  return key.startsWith(`${parentKey}.`);
 }
 
 export interface DraftDocProviderProps {

--- a/packages/root-cms/ui/utils/json-trie-store.test.ts
+++ b/packages/root-cms/ui/utils/json-trie-store.test.ts
@@ -82,4 +82,54 @@ describe('JsonTrieStore', () => {
     expect(abcSubtree).toHaveBeenCalledOnce();
     expect(abcSubtree).toHaveBeenCalledWith({title: 'New'});
   });
+
+  it('notifies descendant subscribers when clearing a parent object', async () => {
+    const store = new JsonTrieStore({
+      fields: {
+        meta: {
+          title: 'Old title',
+          nested: {body: 'Old body'},
+        },
+      },
+    });
+    const titleExact = vi.fn();
+    const bodyExact = vi.fn();
+
+    store.subscribe('fields.meta.title', titleExact);
+    store.subscribe('fields.meta.nested.body', bodyExact);
+    await waitForInitialSubscriptionCallbacks();
+    titleExact.mockClear();
+    bodyExact.mockClear();
+
+    store.update({'fields.meta': undefined});
+
+    expect(titleExact).toHaveBeenCalledOnce();
+    expect(titleExact).toHaveBeenCalledWith(undefined);
+    expect(bodyExact).toHaveBeenCalledOnce();
+    expect(bodyExact).toHaveBeenCalledWith(undefined);
+  });
+
+  it('notifies descendant subscribers when replacing an empty parent with an object', async () => {
+    const store = new JsonTrieStore({
+      fields: {},
+    });
+    const titleExact = vi.fn();
+    const bodyExact = vi.fn();
+
+    store.subscribe('fields.meta.title', titleExact);
+    store.subscribe('fields.meta.nested.body', bodyExact);
+    await waitForInitialSubscriptionCallbacks();
+
+    store.update({
+      'fields.meta': {
+        title: 'New title',
+        nested: {body: 'New body'},
+      },
+    });
+
+    expect(titleExact).toHaveBeenCalledOnce();
+    expect(titleExact).toHaveBeenCalledWith('New title');
+    expect(bodyExact).toHaveBeenCalledOnce();
+    expect(bodyExact).toHaveBeenCalledWith('New body');
+  });
 });

--- a/packages/root-cms/ui/utils/json-trie-store.ts
+++ b/packages/root-cms/ui/utils/json-trie-store.ts
@@ -71,21 +71,21 @@ export class JsonTrieStore extends EventListener {
 
     const addPathToNotify = (path: string, oldValue: any, newValue: any) => {
       pathsToNotify.set(path, newValue);
-      // Add child paths.
-      if (isObject(oldValue) && isObject(newValue)) {
-        Object.entries(newValue).forEach(([key, childValue]) => {
-          const childOldValue = oldValue[key];
-          if (!deepEqual(childOldValue, childValue)) {
-            addPathToNotify(`${path}.${key}`, childOldValue, childValue);
-          }
-        });
-        // Notify any deleted keys.
-        Object.keys(oldValue).forEach((key) => {
-          if (!(key in newValue)) {
-            addPathToNotify(`${path}.${key}`, oldValue[key], undefined);
-          }
-        });
+      if (!isObject(oldValue) && !isObject(newValue)) {
+        return;
       }
+
+      // Parent object replacement/deletion must wake descendant subscribers.
+      const oldKeys = isObject(oldValue) ? Object.keys(oldValue) : [];
+      const newKeys = isObject(newValue) ? Object.keys(newValue) : [];
+      const childKeys = new Set([...oldKeys, ...newKeys]);
+      childKeys.forEach((key) => {
+        const childOldValue = isObject(oldValue) ? oldValue[key] : undefined;
+        const childNewValue = isObject(newValue) ? newValue[key] : undefined;
+        if (!deepEqual(childOldValue, childNewValue)) {
+          addPathToNotify(`${path}.${key}`, childOldValue, childNewValue);
+        }
+      });
     };
 
     // Apply all mutations to the data object in-place.


### PR DESCRIPTION
This PR adds a context menu to the drawers, allowing users to edit/copy/paste/clear them. Previously, there was no way using the UI to entirely clear a nested object within a drawer (and you had to use "Edit JSON" at the parent level to do it!)

Feedback welcome on the placement of the menu 
<img width="701" height="539" alt="image" src="https://github.com/user-attachments/assets/9c561a8a-98fa-4bed-9822-326ea6caf04e" />
