### PR TITLE
chore: fix flaky unit test

### DIFF
--- a/packages/root-cms/cli/import.test.ts
+++ b/packages/root-cms/cli/import.test.ts
@@ -5,7 +5,16 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 
 // Mock dependencies.
 vi.mock('node:fs');
-vi.mock('node:readline');
+// Mock readline so promptYesNo() always resolves to "yes". This must be a
+// single top-level mock: declaring multiple vi.mock('node:readline', ...) calls
+// (e.g. inside individual tests) races with this one after Vitest hoists them,
+// which made these tests flaky on CI.
+vi.mock('node:readline', () => ({
+  createInterface: () => ({
+    question: (_q: string, cb: (a: string) => void) => cb('yes'),
+    close: vi.fn(),
+  }),
+}));
 vi.mock('cli-progress');
 vi.mock('@blinkk/root/node', () => ({
   loadRootConfig: vi.fn().mockResolvedValue({}),
@@ -76,14 +85,6 @@ describe('Import CLI', () => {
         return '{}';
       });
 
-      // Mock prompt to say yes.
-      vi.mock('node:readline', () => ({
-        createInterface: () => ({
-          question: (_q: string, cb: (a: string) => void) => cb('yes'),
-          close: vi.fn(),
-        }),
-      }));
-
       const mockDocRef = {
         set: vi.fn().mockResolvedValue(undefined),
       };
@@ -128,14 +129,6 @@ describe('Import CLI', () => {
         })
       );
 
-      // Mock prompt.
-      vi.mock('node:readline', () => ({
-        createInterface: () => ({
-          question: (_q: string, cb: (a: string) => void) => cb('yes'),
-          close: vi.fn(),
-        }),
-      }));
-
       const mockDocRef = {
         set: vi.fn().mockResolvedValue(undefined),
       };
@@ -174,14 +167,6 @@ describe('Import CLI', () => {
           ref: {_referencePath: 'Projects/other'},
         })
       );
-
-      // Mock prompt.
-      vi.mock('node:readline', () => ({
-        createInterface: () => ({
-          question: (_q: string, cb: (a: string) => void) => cb('yes'),
-          close: vi.fn(),
-        }),
-      }));
 
       const mockDocRef = {
         set: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
Refactored the test file to fix flaky test behavior caused by multiple `vi.mock()` calls for the same module being hoisted at different times by Vitest.

## Key Changes
- Moved the `node:readline` mock from individual test cases to a single top-level mock declaration at the module level
- Consolidated three duplicate mock implementations into one, eliminating code duplication
- Added explanatory comment documenting why the mock must be at the top level to avoid race conditions with Vitest's hoisting behavior

## Implementation Details
The issue occurred because Vitest hoists all `vi.mock()` calls to the top of the module during compilation. When multiple `vi.mock('node:readline', ...)` calls existed in different test cases, they would race with each other, causing non-deterministic behavior and test flakiness on CI.

By consolidating to a single top-level mock that always resolves `promptYesNo()` to "yes", the mock behavior is now consistent and deterministic across all tests.

https://claude.ai/code/session_01PqpgWH1stSm5G2xuAiqRKV