### PR TITLE
fix: update the reload url used by the iframe preview

### DIFF
--- a/.changeset/great-animals-film.md
+++ b/.changeset/great-animals-film.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: update the reload url used by the iframe preview

--- a/.changeset/great-animals-film.md
+++ b/.changeset/great-animals-film.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-feat: update the reload url used by the iframe preview
+fix: update the reload url used by the iframe preview

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -729,17 +729,12 @@ DocumentPage.Preview = (props: PreviewProps) => {
         !iframeWindow.location.href.startsWith('about:blank')
       ) {
         const currentUrl = iframeWindow.location;
-        // Strip `preview=true` from the displayed URL so the URL bar mirrors
-        // the public/prod URL. This avoids editors accidentally copying a
-        // preview-only URL into places like social media.
-        const displaySearchParams = new URLSearchParams(currentUrl.search);
-        displaySearchParams.delete('preview');
-        const displaySearch = displaySearchParams.toString();
-        setIframeUrl(
-          `${domain}${currentUrl.pathname}${
-            displaySearch ? `?${displaySearch}` : ''
-          }${currentUrl.hash}`
-        );
+        // Strip query params and hash from the displayed URL so the URL bar
+        // mirrors the public/prod URL. This avoids editors accidentally
+        // copying preview-only params (e.g. `preview=true`, debug flags) or
+        // internal hash state into places like social media. The "open in
+        // new tab" button still uses the full preview URL.
+        setIframeUrl(`${domain}${currentUrl.pathname}`);
       }
     }
     iframe.addEventListener('load', onIframeLoad);

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -65,23 +65,39 @@ function getPreviewUrl(
 }
 
 /**
- * Reuses the child frame's current URL so query params added by the preview can
- * survive content-triggered reloads, while still forcing preview mode on.
+ * Builds the URL to use when reloading the preview iframe.
+ *
+ * Preserves query params and hash that the child frame may have added (e.g.
+ * preview/debug flags toggled inside the previewed page) so they survive
+ * content-triggered reloads, while still forcing `preview=true` on.
+ *
+ * Only reuses the child URL when its pathname matches the expected preview
+ * path -- if the user has navigated the iframe to an unrelated page, we
+ * deliberately reset back to the canonical preview URL rather than reloading
+ * whatever site happens to be loaded.
  */
 function getReloadUrl(iframe: HTMLIFrameElement, fallbackUrl: string) {
+  const reloadUrl = new URL(fallbackUrl, window.location.origin);
   try {
-    const currentUrl = iframe.contentWindow?.location.href;
-    if (currentUrl && !currentUrl.startsWith('about:blank')) {
-      const reloadUrl = new URL(currentUrl);
-      reloadUrl.searchParams.set('preview', 'true');
-      return reloadUrl.toString();
+    const currentHref = iframe.contentWindow?.location.href;
+    if (currentHref && !currentHref.startsWith('about:blank')) {
+      const currentUrl = new URL(currentHref);
+      if (
+        currentUrl.origin === reloadUrl.origin &&
+        currentUrl.pathname === reloadUrl.pathname
+      ) {
+        // Carry over any params/hash the child added on top of the canonical
+        // preview URL.
+        currentUrl.searchParams.forEach((value, key) => {
+          reloadUrl.searchParams.set(key, value);
+        });
+        reloadUrl.hash = currentUrl.hash;
+      }
     }
   } catch {
-    // Fall back to the canonical preview url if the iframe location is not
-    // readable.
+    // Cross-origin or otherwise unreadable iframe location -- fall back to the
+    // canonical preview URL.
   }
-
-  const reloadUrl = new URL(fallbackUrl, window.location.origin);
   reloadUrl.searchParams.set('preview', 'true');
   return reloadUrl.toString();
 }

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -64,6 +64,28 @@ function getPreviewUrl(
   return `${basePreviewPath}?${query}`;
 }
 
+/**
+ * Reuses the child frame's current URL so query params added by the preview can
+ * survive content-triggered reloads, while still forcing preview mode on.
+ */
+function getReloadUrl(iframe: HTMLIFrameElement, fallbackUrl: string) {
+  try {
+    const currentUrl = iframe.contentWindow?.location.href;
+    if (currentUrl && !currentUrl.startsWith('about:blank')) {
+      const reloadUrl = new URL(currentUrl);
+      reloadUrl.searchParams.set('preview', 'true');
+      return reloadUrl.toString();
+    }
+  } catch {
+    // Fall back to the canonical preview url if the iframe location is not
+    // readable.
+  }
+
+  const reloadUrl = new URL(fallbackUrl, window.location.origin);
+  reloadUrl.searchParams.set('preview', 'true');
+  return reloadUrl.toString();
+}
+
 export function DocumentPage(props: DocumentPageProps) {
   const collectionId = props.collection;
   const slug = props.slug;
@@ -659,10 +681,11 @@ DocumentPage.Preview = (props: PreviewProps) => {
       return;
     }
     const iframe = iframeRef.current!;
+    const nextUrl = getReloadUrl(iframe, localizedPreviewUrl);
     iframe.src = 'about:blank';
     window.requestAnimationFrame(() => {
-      if (iframe.src !== localizedPreviewUrl) {
-        iframe.src = localizedPreviewUrl;
+      if (iframe.src !== nextUrl) {
+        iframe.src = nextUrl;
       } else {
         iframe.contentWindow!.location.reload();
       }
@@ -684,8 +707,10 @@ DocumentPage.Preview = (props: PreviewProps) => {
         basePreviewPath === servingPath &&
         !iframeWindow.location.href.startsWith('about:blank')
       ) {
-        const currentPath = iframeWindow.location.pathname;
-        setIframeUrl(`${domain}${currentPath}`);
+        const currentUrl = iframeWindow.location;
+        setIframeUrl(
+          `${domain}${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`
+        );
       }
     }
     iframe.addEventListener('load', onIframeLoad);

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -677,6 +677,11 @@ DocumentPage.Preview = (props: PreviewProps) => {
   const locales = draft.controller!.getLocales() || [];
 
   const localizedPreviewUrl = getPreviewUrl(collectionId, slug, selectedLocale);
+  // Keep the latest preview URL in a ref so long-lived callbacks (e.g. the
+  // onFlush handler registered once on mount) always reload to the current
+  // locale's URL instead of the locale active at mount time.
+  const localizedPreviewUrlRef = useRef(localizedPreviewUrl);
+  localizedPreviewUrlRef.current = localizedPreviewUrl;
 
   const localeOptions = useMemo(
     () => [
@@ -697,7 +702,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
       return;
     }
     const iframe = iframeRef.current!;
-    const nextUrl = getReloadUrl(iframe, localizedPreviewUrl);
+    const nextUrl = getReloadUrl(iframe, localizedPreviewUrlRef.current);
     iframe.src = 'about:blank';
     window.requestAnimationFrame(() => {
       if (iframe.src !== nextUrl) {
@@ -724,8 +729,16 @@ DocumentPage.Preview = (props: PreviewProps) => {
         !iframeWindow.location.href.startsWith('about:blank')
       ) {
         const currentUrl = iframeWindow.location;
+        // Strip `preview=true` from the displayed URL so the URL bar mirrors
+        // the public/prod URL. This avoids editors accidentally copying a
+        // preview-only URL into places like social media.
+        const displaySearchParams = new URLSearchParams(currentUrl.search);
+        displaySearchParams.delete('preview');
+        const displaySearch = displaySearchParams.toString();
         setIframeUrl(
-          `${domain}${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`
+          `${domain}${currentUrl.pathname}${
+            displaySearch ? `?${displaySearch}` : ''
+          }${currentUrl.hash}`
         );
       }
     }


### PR DESCRIPTION
This PR slightly tweaks the URLs used when the iframe preview refreshes after content changes.

- Previously, it would use the original URL. This would replace any client-side URL changes made by the child page (e.g. if the user uses a feature flag picker to change the flags on a page, the flags in the URL parameters would be wiped out on save.)
- Now, it reuses the iframe's existing URL (and for good measure, just forces `preview=true`).