### PR TITLE
fix: normalize line endings in html output files

### DIFF
--- a/.changeset/twenty-comics-guess.md
+++ b/.changeset/twenty-comics-guess.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: normalize line endings in html output files

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -457,7 +457,7 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
             const outFilePath = urlPath.slice(1);
             const outPath = path.join(buildDir, outFilePath);
             await makeDir(path.dirname(outPath));
-            await writeFile(outPath, body);
+            await writeFile(outPath, normalizeLineEndings(body));
             printFileOutput(fileSize(outPath), 'dist/html/', outFilePath);
             return;
           }
@@ -506,7 +506,7 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
           } else if (rootConfig.minifyHtml) {
             html = await htmlMinify(html, rootConfig.minifyHtmlOptions);
           }
-          await writeFile(outPath, html);
+          await writeFile(outPath, normalizeLineEndings(html));
 
           printFileOutput(fileSize(outPath), 'dist/html/', outFilePath);
         } catch (e) {
@@ -642,4 +642,8 @@ function formatParams(params: Record<string, string>) {
       return `  ${key}: ${value}`;
     })
     .join('\n');
+}
+
+function normalizeLineEndings(str: string): string {
+  return str.replace(/\r\n?/g, '\n');
 }


### PR DESCRIPTION
## Summary
This change ensures consistent line endings (LF) in generated HTML output files by normalizing all line endings to Unix-style (`\n`) before writing to disk.

## Key Changes
- Added `normalizeLineEndings()` utility function that converts all line ending variants (`\r\n` and `\r`) to Unix-style line endings (`\n`)
- Applied line ending normalization to HTML output in two locations:
  - Static HTML file generation (line 460)
  - Dynamic HTML file generation after minification (line 509)

## Implementation Details
The `normalizeLineEndings()` function uses a regex pattern (`/\r\n?/g`) to match both Windows (`\r\n`) and old Mac (`\r`) line endings and replaces them with Unix-style (`\n`) line endings. This ensures consistent output regardless of the platform or source of the HTML content.

https://claude.ai/code/session_01JohdCfzDpQWv4pZswG4brt