### PR TITLE
feat: add json utilities for normalizing line endings

### DIFF
--- a/packages/root/esbuild.config.json
+++ b/packages/root/esbuild.config.json
@@ -8,7 +8,8 @@
     "jsx/jsx-dev-runtime": "src/jsx/jsx-dev-runtime.ts",
     "middleware": "src/middleware/middleware.ts",
     "node": "src/node/node.ts",
-    "render": "src/render/render.tsx"
+    "render": "src/render/render.tsx",
+    "utils": "src/utils/utils.ts"
   },
   "dtsProject": "tsconfig.build.json",
   "external": ["virtual:*"],

--- a/packages/root/package.json
+++ b/packages/root/package.json
@@ -63,6 +63,10 @@
     "./render": {
       "types": "./dist/render/render.d.ts",
       "import": "./dist/render.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/utils.d.ts",
+      "import": "./dist/utils.js"
     }
   },
   "scripts": {

--- a/packages/root/src/utils/jsonutils.test.ts
+++ b/packages/root/src/utils/jsonutils.test.ts
@@ -1,6 +1,6 @@
 import {assert, test} from 'vitest';
 
-import {normalizeLineEndings, stringifyJson} from './jsonutils.js';
+import {jsonStringify, normalizeLineEndings} from './jsonutils.js';
 
 test('normalizeLineEndings converts CRLF to LF', () => {
   assert.equal(normalizeLineEndings('a\r\nb'), 'a\nb');
@@ -14,19 +14,19 @@ test('normalizeLineEndings leaves LF alone', () => {
   assert.equal(normalizeLineEndings('a\nb'), 'a\nb');
 });
 
-test('stringifyJson normalizes CRLF in string values', () => {
-  const out = stringifyJson({msg: 'hello\r\nworld'});
+test('jsonStringify normalizes CRLF in string values', () => {
+  const out = jsonStringify({msg: 'hello\r\nworld'});
   assert.equal(out, '{"msg":"hello\\nworld"}');
   assert.deepEqual(JSON.parse(out), {msg: 'hello\nworld'});
 });
 
-test('stringifyJson normalizes lone CR in string values', () => {
-  const out = stringifyJson({msg: 'hello\rworld'});
+test('jsonStringify normalizes lone CR in string values', () => {
+  const out = jsonStringify({msg: 'hello\rworld'});
   assert.deepEqual(JSON.parse(out), {msg: 'hello\nworld'});
 });
 
-test('stringifyJson normalizes nested values', () => {
-  const out = stringifyJson({
+test('jsonStringify normalizes nested values', () => {
+  const out = jsonStringify({
     list: ['a\r\nb', {nested: 'c\rd'}],
   });
   assert.deepEqual(JSON.parse(out), {
@@ -34,14 +34,23 @@ test('stringifyJson normalizes nested values', () => {
   });
 });
 
-test('stringifyJson supports indentation', () => {
-  const out = stringifyJson({a: 1, b: 2}, 2);
+test('jsonStringify supports indent option', () => {
+  const out = jsonStringify({a: 1, b: 2}, {indent: 2});
   assert.equal(out, '{\n  "a": 1,\n  "b": 2\n}');
   assert.notInclude(out, '\r');
 });
 
-test('stringifyJson handles primitive values', () => {
-  assert.equal(stringifyJson('a\r\nb'), '"a\\nb"');
-  assert.equal(stringifyJson(42), '42');
-  assert.equal(stringifyJson(null), 'null');
+test('jsonStringify supports string indent', () => {
+  const out = jsonStringify({a: 1}, {indent: '\t'});
+  assert.equal(out, '{\n\t"a": 1\n}');
+});
+
+test('jsonStringify handles primitive values', () => {
+  assert.equal(jsonStringify('a\r\nb'), '"a\\nb"');
+  assert.equal(jsonStringify(42), '42');
+  assert.equal(jsonStringify(null), 'null');
+});
+
+test('jsonStringify works without options', () => {
+  assert.equal(jsonStringify({a: 1}), '{"a":1}');
 });

--- a/packages/root/src/utils/jsonutils.test.ts
+++ b/packages/root/src/utils/jsonutils.test.ts
@@ -1,0 +1,47 @@
+import {assert, test} from 'vitest';
+
+import {normalizeLineEndings, stringifyJson} from './jsonutils.js';
+
+test('normalizeLineEndings converts CRLF to LF', () => {
+  assert.equal(normalizeLineEndings('a\r\nb'), 'a\nb');
+});
+
+test('normalizeLineEndings converts lone CR to LF', () => {
+  assert.equal(normalizeLineEndings('a\rb'), 'a\nb');
+});
+
+test('normalizeLineEndings leaves LF alone', () => {
+  assert.equal(normalizeLineEndings('a\nb'), 'a\nb');
+});
+
+test('stringifyJson normalizes CRLF in string values', () => {
+  const out = stringifyJson({msg: 'hello\r\nworld'});
+  assert.equal(out, '{"msg":"hello\\nworld"}');
+  assert.deepEqual(JSON.parse(out), {msg: 'hello\nworld'});
+});
+
+test('stringifyJson normalizes lone CR in string values', () => {
+  const out = stringifyJson({msg: 'hello\rworld'});
+  assert.deepEqual(JSON.parse(out), {msg: 'hello\nworld'});
+});
+
+test('stringifyJson normalizes nested values', () => {
+  const out = stringifyJson({
+    list: ['a\r\nb', {nested: 'c\rd'}],
+  });
+  assert.deepEqual(JSON.parse(out), {
+    list: ['a\nb', {nested: 'c\nd'}],
+  });
+});
+
+test('stringifyJson supports indentation', () => {
+  const out = stringifyJson({a: 1, b: 2}, 2);
+  assert.equal(out, '{\n  "a": 1,\n  "b": 2\n}');
+  assert.notInclude(out, '\r');
+});
+
+test('stringifyJson handles primitive values', () => {
+  assert.equal(stringifyJson('a\r\nb'), '"a\\nb"');
+  assert.equal(stringifyJson(42), '42');
+  assert.equal(stringifyJson(null), 'null');
+});

--- a/packages/root/src/utils/jsonutils.ts
+++ b/packages/root/src/utils/jsonutils.ts
@@ -24,19 +24,27 @@ function normalizeData(value: unknown): unknown {
   return value;
 }
 
+export interface JsonStringifyOptions {
+  /**
+   * Indentation passed through to `JSON.stringify`. Accepts a number of
+   * spaces or an indent string.
+   */
+  indent?: number | string;
+}
+
 /**
  * Serializes data to a JSON string with Unix (LF) line endings.
  *
  * Unlike `JSON.stringify()`, this:
  * - Recursively normalizes `\r\n` and `\r` to `\n` in string values, so
- *   round-tripping through JSON.parse won't yield CRLF line endings.
+ *   round-tripping through `JSON.parse` won't yield CRLF line endings.
  * - Normalizes line endings in the resulting JSON string itself.
- *
- * The signature mirrors `JSON.stringify`'s common form (value + optional
- * indent).
  */
-export function stringifyJson(value: unknown, indent?: number | string): string {
+export function jsonStringify(
+  value: unknown,
+  options?: JsonStringifyOptions
+): string {
   const normalized = normalizeData(value);
-  const serialized = JSON.stringify(normalized, null, indent);
+  const serialized = JSON.stringify(normalized, null, options?.indent);
   return normalizeLineEndings(serialized);
 }

--- a/packages/root/src/utils/jsonutils.ts
+++ b/packages/root/src/utils/jsonutils.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalizes line endings in a string to LF (`\n`).
+ *
+ * Converts CRLF (`\r\n`) and lone CR (`\r`) to LF.
+ */
+export function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function normalizeData(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return normalizeLineEndings(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeData);
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      result[key] = normalizeData((value as Record<string, unknown>)[key]);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Serializes data to a JSON string with Unix (LF) line endings.
+ *
+ * Unlike `JSON.stringify()`, this:
+ * - Recursively normalizes `\r\n` and `\r` to `\n` in string values, so
+ *   round-tripping through JSON.parse won't yield CRLF line endings.
+ * - Normalizes line endings in the resulting JSON string itself.
+ *
+ * The signature mirrors `JSON.stringify`'s common form (value + optional
+ * indent).
+ */
+export function stringifyJson(value: unknown, indent?: number | string): string {
+  const normalized = normalizeData(value);
+  const serialized = JSON.stringify(normalized, null, indent);
+  return normalizeLineEndings(serialized);
+}

--- a/packages/root/src/utils/utils.ts
+++ b/packages/root/src/utils/utils.ts
@@ -1,0 +1,1 @@
+export * from './jsonutils.js';


### PR DESCRIPTION
## Summary
Add utility functions for handling line ending normalization in JSON serialization. This ensures consistent Unix (LF) line endings across different platforms and prevents CRLF/CR characters from being preserved when round-tripping through JSON.

## Changes
- **`normalizeLineEndings()`**: Converts CRLF (`\r\n`) and lone CR (`\r`) to LF (`\n`) in strings
- **`stringifyJson()`**: Serializes data to JSON while recursively normalizing line endings in all string values and the resulting JSON output itself
  - Mirrors `JSON.stringify()` signature with optional indentation support
  - Handles nested objects, arrays, and primitive values
  - Ensures consistent line endings in both the data and the JSON string itself

## Implementation Details
- Line ending normalization is applied recursively to all string values in the data structure before serialization
- The resulting JSON string is also normalized to remove any CRLF characters
- Comprehensive test coverage validates behavior with CRLF, CR, nested structures, indentation, and primitive values

https://claude.ai/code/session_01H5nPS4SUjgxRDdimMCdBMS