### PR TITLE
Add asset library with GCS-backed file management

### DIFF
--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -445,24 +445,27 @@ export function api(server: Server, options: ApiOptions) {
    *
    * POST /cms/api/assets.purgeDoc {"docId": "Pages/home"}
    */
-  server.use('/cms/api/assets.purgeDoc', async (req: Request, res: Response) => {
-    const cmsClient = await authorizeAssetRequest(req, res, ASSET_EDIT_ROLES);
-    if (!cmsClient) {
-      return;
+  server.use(
+    '/cms/api/assets.purgeDoc',
+    async (req: Request, res: Response) => {
+      const cmsClient = await authorizeAssetRequest(req, res, ASSET_EDIT_ROLES);
+      if (!cmsClient) {
+        return;
+      }
+      const docId = String((req.body || {}).docId || '');
+      if (!docId) {
+        res.status(400).json({success: false, error: 'MISSING_DOC_ID'});
+        return;
+      }
+      try {
+        await cmsClient.purgeDocUsages(docId);
+        res.status(200).json({success: true});
+      } catch (err: any) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
     }
-    const docId = String((req.body || {}).docId || '');
-    if (!docId) {
-      res.status(400).json({success: false, error: 'MISSING_DOC_ID'});
-      return;
-    }
-    try {
-      await cmsClient.purgeDocUsages(docId);
-      res.status(200).json({success: true});
-    } catch (err: any) {
-      console.error(err.stack || err);
-      res.status(500).json({success: false, error: 'UNKNOWN'});
-    }
-  });
+  );
 
   /**
    * Creates a library asset from an already-uploaded file.

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -32,6 +32,42 @@ function testValidCollectionId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
 }
 
+/**
+ * Validates that a request is a signed-in JSON POST from a user with one of the
+ * `allowedRoles`. On success returns an authenticated `RootCMSClient`; otherwise
+ * writes the appropriate error response and returns null.
+ */
+async function authorizeAssetRequest(
+  req: Request,
+  res: Response,
+  allowedRoles: string[]
+): Promise<RootCMSClient | null> {
+  if (
+    req.method !== 'POST' ||
+    !String(req.get('content-type')).startsWith('application/json')
+  ) {
+    res.status(400).json({success: false, error: 'BAD_REQUEST'});
+    return null;
+  }
+  if (!req.user?.email) {
+    res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+    return null;
+  }
+  const cmsClient = new RootCMSClient(req.rootConfig!);
+  try {
+    const role = await cmsClient.getUserRole(req.user.email);
+    if (!role || !allowedRoles.includes(role)) {
+      res.status(403).json({success: false, error: 'FORBIDDEN'});
+      return null;
+    }
+  } catch (err: any) {
+    console.error(err.stack || err);
+    res.status(500).json({success: false, error: 'UNKNOWN'});
+    return null;
+  }
+  return cmsClient;
+}
+
 type DocVersion = 'draft' | 'published';
 
 interface BuildDocDiffOptions {
@@ -364,6 +400,276 @@ export function api(server: Server, options: ApiOptions) {
     searchRebuildJobs.set(projectId, job);
     res.status(202).json({success: true, started: true, force});
   });
+
+  // ===========================================================================
+  // Asset library endpoints.
+  //
+  // Usage-index writes are server-authoritative because Firestore security
+  // rules only allow CONTRIBUTORs to write under `Collections/*/Drafts/**`.
+  // The bytes for create/replace are uploaded client-side (Firebase Storage SDK
+  // is client-only); these endpoints persist metadata and fan out.
+  // ===========================================================================
+  const ASSET_EDIT_ROLES = ['ADMIN', 'EDITOR', 'CONTRIBUTOR'];
+  const ASSET_MANAGE_ROLES = ['ADMIN', 'EDITOR'];
+
+  /**
+   * Reconciles the asset usage indexes for a single draft doc. Called by the
+   * editor on pick/detach and on a debounced flush.
+   *
+   * POST /cms/api/assets.syncUsages {"docId": "Pages/home"}
+   */
+  server.use(
+    '/cms/api/assets.syncUsages',
+    async (req: Request, res: Response) => {
+      const cmsClient = await authorizeAssetRequest(req, res, ASSET_EDIT_ROLES);
+      if (!cmsClient) {
+        return;
+      }
+      const docId = String((req.body || {}).docId || '');
+      if (!docId) {
+        res.status(400).json({success: false, error: 'MISSING_DOC_ID'});
+        return;
+      }
+      try {
+        await cmsClient.syncUsagesForDoc(docId);
+        res.status(200).json({success: true});
+      } catch (err: any) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
+   * Removes all usage-index entries for a doc (call on doc delete).
+   *
+   * POST /cms/api/assets.purgeDoc {"docId": "Pages/home"}
+   */
+  server.use('/cms/api/assets.purgeDoc', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_EDIT_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const docId = String((req.body || {}).docId || '');
+    if (!docId) {
+      res.status(400).json({success: false, error: 'MISSING_DOC_ID'});
+      return;
+    }
+    try {
+      await cmsClient.purgeDocUsages(docId);
+      res.status(200).json({success: true});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Creates a library asset from an already-uploaded file.
+   *
+   * POST /cms/api/assets.create {"file": {...UploadedFile}, "dir": "/logos"}
+   */
+  server.use('/cms/api/assets.create', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.file || !body.file.src) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      const asset = await cmsClient.createAsset(body.file, {
+        createdBy: req.user!.email!,
+        dir: body.dir,
+      });
+      res.status(200).json({success: true, data: asset});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Replaces an asset's file and fans the new file out to every referencing
+   * draft doc.
+   *
+   * POST /cms/api/assets.replace {"assetId": "...", "file": {...UploadedFile}}
+   */
+  server.use('/cms/api/assets.replace', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.assetId || !body.file || !body.file.src) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      const result = await cmsClient.replaceAsset(body.assetId, body.file, {
+        replacedBy: req.user!.email!,
+      });
+      res.status(200).json({success: true, data: result});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Updates an asset's (asset-authoritative) alt text and fans it out.
+   *
+   * POST /cms/api/assets.setAlt {"assetId": "...", "alt": "..."}
+   */
+  server.use('/cms/api/assets.setAlt', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.assetId) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      const result = await cmsClient.setAssetAlt(
+        body.assetId,
+        String(body.alt || ''),
+        {updatedBy: req.user!.email!}
+      );
+      res.status(200).json({success: true, data: result});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Deletes a library asset (blocked if in use unless `force`).
+   *
+   * POST /cms/api/assets.delete {"assetId": "...", "force": false}
+   */
+  server.use('/cms/api/assets.delete', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.assetId) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      await cmsClient.deleteAsset(body.assetId, {force: !!body.force});
+      res.status(200).json({success: true});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(400).json({success: false, error: err.message || 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Moves an asset into a folder. POST /cms/api/assets.move
+   * {"assetId": "...", "dir": "/logos"}
+   */
+  server.use('/cms/api/assets.move', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.assetId) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      await cmsClient.moveAsset(body.assetId, String(body.dir || '/'));
+      res.status(200).json({success: true});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Renames an asset's display filename. POST /cms/api/assets.rename
+   * {"assetId": "...", "filename": "..."}
+   */
+  server.use('/cms/api/assets.rename', async (req: Request, res: Response) => {
+    const cmsClient = await authorizeAssetRequest(req, res, ASSET_MANAGE_ROLES);
+    if (!cmsClient) {
+      return;
+    }
+    const body = req.body || {};
+    if (!body.assetId || !body.filename) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    try {
+      await cmsClient.renameAsset(body.assetId, String(body.filename));
+      res.status(200).json({success: true});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: 'UNKNOWN'});
+    }
+  });
+
+  /**
+   * Creates an asset folder. POST /cms/api/assets.createFolder
+   * {"name": "logos", "parent": "/"}
+   */
+  server.use(
+    '/cms/api/assets.createFolder',
+    async (req: Request, res: Response) => {
+      const cmsClient = await authorizeAssetRequest(
+        req,
+        res,
+        ASSET_MANAGE_ROLES
+      );
+      if (!cmsClient) {
+        return;
+      }
+      const body = req.body || {};
+      if (!body.name) {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      try {
+        const folder = await cmsClient.createAssetFolder({
+          name: String(body.name),
+          parent: body.parent,
+        });
+        res.status(200).json({success: true, data: folder});
+      } catch (err: any) {
+        console.error(err.stack || err);
+        res.status(400).json({success: false, error: err.message || 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
+   * Rebuilds the asset usage indexes from scratch (ADMIN backstop).
+   *
+   * POST /cms/api/assets.rebuildUsages {}
+   */
+  server.use(
+    '/cms/api/assets.rebuildUsages',
+    async (req: Request, res: Response) => {
+      const cmsClient = await authorizeAssetRequest(req, res, ['ADMIN']);
+      if (!cmsClient) {
+        return;
+      }
+      try {
+        const result = await cmsClient.rebuildAllUsages();
+        res.status(200).json({success: true, data: result});
+      } catch (err: any) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
 
   /**
    * Accepts a JSON object containing {headers: [...], rows: [...]} and sends

--- a/packages/root-cms/core/asset.test.ts
+++ b/packages/root-cms/core/asset.test.ts
@@ -1,0 +1,334 @@
+import {RootConfig} from '@blinkk/root';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+
+// In-memory Firestore mock. Models the subset of the firebase-admin Firestore
+// API used by the asset-library methods on RootCMSClient: doc(), collection()
+// (+ where/get/count), getAll(), batch(), and collectionGroup().
+const store = new Map<string, any>();
+
+function clone<T>(v: T): T {
+  return v === undefined ? v : JSON.parse(JSON.stringify(v));
+}
+
+function getAtDotted(obj: any, path: string): any {
+  let cur = obj;
+  for (const seg of path.split('.')) {
+    if (cur === null || typeof cur !== 'object') return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+function resolveValue(v: any): any {
+  if (v && typeof v === 'object' && v.__op === 'serverTimestamp') {
+    return 1700000000000;
+  }
+  return v;
+}
+
+function setAtDotted(obj: any, path: string, value: any) {
+  const segs = path.split('.');
+  let cur = obj;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (cur[segs[i]] === null || typeof cur[segs[i]] !== 'object') {
+      cur[segs[i]] = {};
+    }
+    cur = cur[segs[i]];
+  }
+  cur[segs[segs.length - 1]] = resolveValue(value);
+}
+
+function makeRef(path: string): any {
+  return {
+    path,
+    get id() {
+      return path.split('/').pop();
+    },
+    async get() {
+      const data = store.get(path);
+      return {exists: data !== undefined, data: () => clone(data), ref: makeRef(path)};
+    },
+    async set(data: any) {
+      store.set(path, clone(data));
+    },
+    async update(updates: Record<string, any>) {
+      const data = store.get(path) || {};
+      for (const [k, v] of Object.entries(updates)) {
+        setAtDotted(data, k, v);
+      }
+      store.set(path, data);
+    },
+    async delete() {
+      store.delete(path);
+    },
+  };
+}
+
+function makeQuery(path: string, filters: Array<{field: string; val: any}> = []): any {
+  return {
+    where(field: string, _op: string, val: any) {
+      return makeQuery(path, [...filters, {field, val}]);
+    },
+    async get() {
+      const docs: any[] = [];
+      for (const [k, data] of store) {
+        if (!k.startsWith(`${path}/`)) continue;
+        const rest = k.slice(path.length + 1);
+        if (rest.includes('/')) continue;
+        if (filters.every((f) => getAtDotted(data, f.field) === f.val)) {
+          docs.push({id: rest, ref: makeRef(k), data: () => clone(data)});
+        }
+      }
+      return {docs, empty: docs.length === 0, size: docs.length};
+    },
+    count() {
+      return {
+        get: async () => {
+          const snap = await makeQuery(path, filters).get();
+          return {data: () => ({count: snap.size})};
+        },
+      };
+    },
+  };
+}
+
+function makeBatch(): any {
+  const ops: Array<[string, string, any?]> = [];
+  return {
+    set(ref: any, data: any) {
+      ops.push(['set', ref.path, clone(data)]);
+    },
+    update(ref: any, updates: any) {
+      ops.push(['update', ref.path, updates]);
+    },
+    delete(ref: any) {
+      ops.push(['delete', ref.path]);
+    },
+    async commit() {
+      for (const [op, p, data] of ops) {
+        if (op === 'set') {
+          store.set(p, clone(data));
+        } else if (op === 'update') {
+          const cur = store.get(p) || {};
+          for (const [k, v] of Object.entries(data)) {
+            setAtDotted(cur, k, v);
+          }
+          store.set(p, cur);
+        } else if (op === 'delete') {
+          store.delete(p);
+        }
+      }
+      ops.length = 0;
+    },
+  };
+}
+
+const mockDb: any = {
+  doc: (path: string) => makeRef(path),
+  collection: (path: string) => makeQuery(path),
+  getAll: (...refs: any[]) => Promise.all(refs.map((r) => r.get())),
+  batch: () => makeBatch(),
+  collectionGroup: (name: string) => ({
+    async get() {
+      const docs: any[] = [];
+      for (const [k, data] of store) {
+        const segs = k.split('/');
+        if (segs.length >= 2 && segs[segs.length - 2] === name) {
+          docs.push({ref: makeRef(k), data: () => clone(data)});
+        }
+      }
+      return {docs};
+    },
+  }),
+};
+
+vi.mock('firebase-admin/app', () => ({
+  getApp: vi.fn(),
+  initializeApp: vi.fn(),
+  applicationDefault: vi.fn(),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: vi.fn(() => mockDb),
+  Timestamp: {now: vi.fn(() => ({toMillis: () => 1700000000000}))},
+  FieldValue: {serverTimestamp: () => ({__op: 'serverTimestamp'})},
+  DocumentReference: class {},
+  Firestore: class {},
+  Query: class {},
+  WriteBatch: class {},
+}));
+
+vi.mock('./project.js', () => ({getCollectionSchema: vi.fn()}));
+
+const PROJECT = 'test-project';
+const mockRootConfig = {
+  rootDir: '/test',
+  plugins: [
+    {
+      name: 'root-cms',
+      getConfig: () => ({id: PROJECT}),
+      getFirebaseApp: vi.fn(),
+      getFirestore: vi.fn(() => mockDb),
+    } as any,
+  ],
+} as unknown as RootConfig;
+
+function draftPath(collection: string, slug: string) {
+  return `Projects/${PROJECT}/Collections/${collection}/Drafts/${slug}`;
+}
+
+async function newClient() {
+  const {RootCMSClient} = await import('./client.js');
+  return new RootCMSClient(mockRootConfig);
+}
+
+describe('RootCMSClient asset library', () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  it('createAsset writes a v1 asset doc with a folder', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset(
+      {src: 'https://img/v1', width: 100, height: 50, filename: 'logo.png'},
+      {createdBy: 'a@b.com', dir: '/logos'}
+    );
+    expect(asset.version).toBe(1);
+    expect(asset.dir).toBe('/logos');
+    const stored = store.get(`Projects/${PROJECT}/Assets/${asset.id}`);
+    expect(stored.src).toBe('https://img/v1');
+    expect(stored.sys.createdBy).toBe('a@b.com');
+  });
+
+  it('syncUsagesForDoc records reverse + forward index entries', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    // A draft that references the asset in a nested array item.
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {
+        modules: {
+          _array: ['k1'],
+          k1: {image: {src: 'https://img/v1', assetId: asset.id, assetVersion: 1}},
+        },
+      },
+    });
+
+    await client.syncUsagesForDoc('Pages/home');
+
+    const usage = store.get(
+      `Projects/${PROJECT}/Assets/${asset.id}/Usages/Pages--home`
+    );
+    expect(usage).toMatchObject({docId: 'Pages/home', collection: 'Pages', slug: 'home'});
+    const forward = store.get(`Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`);
+    expect(forward.assetIds).toEqual([asset.id]);
+
+    // Count reflects the single usage.
+    expect(await client.getAssetUsageCount(asset.id)).toBe(1);
+  });
+
+  it('replaceAsset fans the new file out to referencing drafts (bumps version)', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset(
+      {src: 'https://img/v1', width: 100, height: 50},
+      {createdBy: 'a@b.com'}
+    );
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {
+        hero: {src: 'https://img/v1', assetId: asset.id, assetVersion: 1},
+        body: {
+          // richtext: must NOT be touched.
+          time: 1,
+          version: '2.0',
+          blocks: [{type: 'p', data: {text: 'hi'}}],
+        },
+      },
+    });
+    await client.syncUsagesForDoc('Pages/home');
+
+    const result = await client.replaceAsset(
+      asset.id,
+      {src: 'https://img/v2', width: 200, height: 80},
+      {replacedBy: 'editor@b.com'}
+    );
+
+    expect(result.docsUpdated).toBe(1);
+    expect(result.asset.version).toBe(2);
+    const draft = store.get(draftPath('Pages', 'home'));
+    expect(draft.fields.hero.src).toBe('https://img/v2');
+    expect(draft.fields.hero.width).toBe(200);
+    expect(draft.fields.hero.assetVersion).toBe(2);
+    expect(draft.fields.hero.assetId).toBe(asset.id);
+    // sys bumped by the fan-out.
+    expect(draft.sys.modifiedBy).toBe('editor@b.com');
+    // richtext untouched.
+    expect(draft.fields.body.blocks).toEqual([{type: 'p', data: {text: 'hi'}}]);
+  });
+
+  it('replaceAsset does not touch independent (non-library) uploads', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {
+        hero: {src: 'https://img/v1', assetId: asset.id},
+        other: {src: 'https://independent/x'},
+      },
+    });
+    await client.syncUsagesForDoc('Pages/home');
+    await client.replaceAsset(asset.id, {src: 'https://img/v2'}, {replacedBy: 'e@b.com'});
+
+    const draft = store.get(draftPath('Pages', 'home'));
+    expect(draft.fields.hero.src).toBe('https://img/v2');
+    expect(draft.fields.other.src).toBe('https://independent/x');
+  });
+
+  it('deleteAsset is blocked while in use, allowed with force', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {hero: {src: 'https://img/v1', assetId: asset.id}},
+    });
+    await client.syncUsagesForDoc('Pages/home');
+
+    await expect(client.deleteAsset(asset.id)).rejects.toThrow(/in use/);
+
+    await client.deleteAsset(asset.id, {force: true});
+    expect(store.get(`Projects/${PROJECT}/Assets/${asset.id}`)).toBeUndefined();
+  });
+
+  it('syncUsagesForDoc removes usages when the asset is detached', async () => {
+    const client = await newClient();
+    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {hero: {src: 'https://img/v1', assetId: asset.id}},
+    });
+    await client.syncUsagesForDoc('Pages/home');
+    expect(await client.getAssetUsageCount(asset.id)).toBe(1);
+
+    // Editor detaches: inline value no longer carries an assetId.
+    store.set(draftPath('Pages', 'home'), {
+      id: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      fields: {hero: {src: 'https://img/v1'}},
+    });
+    await client.syncUsagesForDoc('Pages/home');
+    expect(await client.getAssetUsageCount(asset.id)).toBe(0);
+    expect(store.get(`Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`)).toBeUndefined();
+  });
+});

--- a/packages/root-cms/core/asset.test.ts
+++ b/packages/root-cms/core/asset.test.ts
@@ -46,7 +46,11 @@ function makeRef(path: string): any {
     },
     async get() {
       const data = store.get(path);
-      return {exists: data !== undefined, data: () => clone(data), ref: makeRef(path)};
+      return {
+        exists: data !== undefined,
+        data: () => clone(data),
+        ref: makeRef(path),
+      };
     },
     async set(data: any) {
       store.set(path, clone(data));
@@ -64,7 +68,10 @@ function makeRef(path: string): any {
   };
 }
 
-function makeQuery(path: string, filters: Array<{field: string; val: any}> = []): any {
+function makeQuery(
+  path: string,
+  filters: Array<{field: string; val: any}> = []
+): any {
   return {
     where(field: string, _op: string, val: any) {
       return makeQuery(path, [...filters, {field, val}]);
@@ -203,7 +210,10 @@ describe('RootCMSClient asset library', () => {
 
   it('syncUsagesForDoc records reverse + forward index entries', async () => {
     const client = await newClient();
-    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    const asset = await client.createAsset(
+      {src: 'https://img/v1'},
+      {createdBy: 'a@b.com'}
+    );
     // A draft that references the asset in a nested array item.
     store.set(draftPath('Pages', 'home'), {
       id: 'Pages/home',
@@ -212,7 +222,9 @@ describe('RootCMSClient asset library', () => {
       fields: {
         modules: {
           _array: ['k1'],
-          k1: {image: {src: 'https://img/v1', assetId: asset.id, assetVersion: 1}},
+          k1: {
+            image: {src: 'https://img/v1', assetId: asset.id, assetVersion: 1},
+          },
         },
       },
     });
@@ -222,8 +234,14 @@ describe('RootCMSClient asset library', () => {
     const usage = store.get(
       `Projects/${PROJECT}/Assets/${asset.id}/Usages/Pages--home`
     );
-    expect(usage).toMatchObject({docId: 'Pages/home', collection: 'Pages', slug: 'home'});
-    const forward = store.get(`Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`);
+    expect(usage).toMatchObject({
+      docId: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+    });
+    const forward = store.get(
+      `Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`
+    );
     expect(forward.assetIds).toEqual([asset.id]);
 
     // Count reflects the single usage.
@@ -273,7 +291,10 @@ describe('RootCMSClient asset library', () => {
 
   it('replaceAsset does not touch independent (non-library) uploads', async () => {
     const client = await newClient();
-    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    const asset = await client.createAsset(
+      {src: 'https://img/v1'},
+      {createdBy: 'a@b.com'}
+    );
     store.set(draftPath('Pages', 'home'), {
       id: 'Pages/home',
       collection: 'Pages',
@@ -284,7 +305,11 @@ describe('RootCMSClient asset library', () => {
       },
     });
     await client.syncUsagesForDoc('Pages/home');
-    await client.replaceAsset(asset.id, {src: 'https://img/v2'}, {replacedBy: 'e@b.com'});
+    await client.replaceAsset(
+      asset.id,
+      {src: 'https://img/v2'},
+      {replacedBy: 'e@b.com'}
+    );
 
     const draft = store.get(draftPath('Pages', 'home'));
     expect(draft.fields.hero.src).toBe('https://img/v2');
@@ -293,7 +318,10 @@ describe('RootCMSClient asset library', () => {
 
   it('deleteAsset is blocked while in use, allowed with force', async () => {
     const client = await newClient();
-    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    const asset = await client.createAsset(
+      {src: 'https://img/v1'},
+      {createdBy: 'a@b.com'}
+    );
     store.set(draftPath('Pages', 'home'), {
       id: 'Pages/home',
       collection: 'Pages',
@@ -310,7 +338,10 @@ describe('RootCMSClient asset library', () => {
 
   it('syncUsagesForDoc removes usages when the asset is detached', async () => {
     const client = await newClient();
-    const asset = await client.createAsset({src: 'https://img/v1'}, {createdBy: 'a@b.com'});
+    const asset = await client.createAsset(
+      {src: 'https://img/v1'},
+      {createdBy: 'a@b.com'}
+    );
     store.set(draftPath('Pages', 'home'), {
       id: 'Pages/home',
       collection: 'Pages',
@@ -329,6 +360,8 @@ describe('RootCMSClient asset library', () => {
     });
     await client.syncUsagesForDoc('Pages/home');
     expect(await client.getAssetUsageCount(asset.id)).toBe(0);
-    expect(store.get(`Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`)).toBeUndefined();
+    expect(
+      store.get(`Projects/${PROJECT}/AssetUsagesByDoc/Pages--home`)
+    ).toBeUndefined();
   });
 });

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -2,12 +2,24 @@ import crypto from 'node:crypto';
 import {type Plugin, type RootConfig} from '@blinkk/root';
 import {App} from 'firebase-admin/app';
 import {
+  DocumentReference,
   FieldValue,
   Firestore,
   Query,
   Timestamp,
   WriteBatch,
 } from 'firebase-admin/firestore';
+import {
+  Asset,
+  AssetFile,
+  AssetFolder,
+  assetFieldValueIsCurrent,
+  assetToFieldValue,
+  buildUsageKey,
+  isAssetRef,
+  normalizeAssetDir,
+} from '../shared/asset.js';
+import {collectPathsByPredicate} from '../shared/marshal.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {CMSPlugin} from './plugin.js';
 import {Collection} from './schema.js';
@@ -1851,6 +1863,477 @@ export class RootCMSClient {
   createBatchRequest(options: BatchRequestOptions): BatchRequest {
     return new BatchRequest(this, options);
   }
+
+  // ===========================================================================
+  // Asset library
+  //
+  // Assets are library entries stored at `Projects/{projectId}/Assets/{assetId}`
+  // that hold canonical file metadata. When an image/file field picks an asset,
+  // the asset's data is denormalized inline onto the doc (so doc GETs stay O(1)
+  // Firestore RPCs); replacing the asset fans the new data out to every
+  // referencing DRAFT doc.
+  //
+  // Usage is tracked by two server-maintained indexes (security rules forbid
+  // client writes outside `Drafts/**`):
+  //   - reverse: `Assets/{assetId}/Usages/{docKey}` -> {docId, collection, slug}
+  //   - forward: `AssetUsagesByDoc/{docKey}`        -> {docId, assetIds: []}
+  // ===========================================================================
+
+  dbAssetsPath() {
+    return `Projects/${this.projectId}/Assets`;
+  }
+
+  dbAssetRef(assetId: string) {
+    return this.db.doc(`${this.dbAssetsPath()}/${assetId}`);
+  }
+
+  dbAssetUsagesPath(assetId: string) {
+    return `${this.dbAssetsPath()}/${assetId}/Usages`;
+  }
+
+  dbAssetUsageRef(assetId: string, docId: string) {
+    return this.db.doc(
+      `${this.dbAssetUsagesPath(assetId)}/${buildUsageKey(docId)}`
+    );
+  }
+
+  dbAssetUsagesByDocRef(docId: string) {
+    return this.db.doc(
+      `Projects/${this.projectId}/AssetUsagesByDoc/${buildUsageKey(docId)}`
+    );
+  }
+
+  dbAssetFoldersPath() {
+    return `Projects/${this.projectId}/AssetFolders`;
+  }
+
+  /** Reads a single asset. */
+  async getAsset(assetId: string): Promise<Asset | null> {
+    const snapshot = await this.dbAssetRef(assetId).get();
+    if (!snapshot.exists) {
+      return null;
+    }
+    return snapshot.data() as Asset;
+  }
+
+  /** Lists assets, optionally filtered to a single folder (`dir`). */
+  async listAssets(options?: {dir?: string}): Promise<{assets: Asset[]}> {
+    let query: Query = this.db.collection(this.dbAssetsPath());
+    if (options?.dir !== undefined) {
+      query = query.where('dir', '==', normalizeAssetDir(options.dir));
+    }
+    const snapshot = await query.get();
+    const assets = snapshot.docs.map((doc) => doc.data() as Asset);
+    return {assets};
+  }
+
+  /** Creates a new library asset from an uploaded file. */
+  async createAsset(
+    file: AssetFile,
+    options: {createdBy: string; dir?: string; assetId?: string}
+  ): Promise<Asset> {
+    const assetId = options.assetId || generateAssetId();
+    const now = Date.now();
+    const asset: Asset = {
+      ...stripUndefinedValues(file),
+      id: assetId,
+      version: 1,
+      dir: normalizeAssetDir(options.dir),
+      sys: {
+        createdAt: now,
+        createdBy: options.createdBy,
+        modifiedAt: now,
+        modifiedBy: options.createdBy,
+      },
+    };
+    await this.dbAssetRef(assetId).set(asset);
+    return asset;
+  }
+
+  /**
+   * Replaces an asset's file (bytes already uploaded to GCS by the client) and
+   * fans the new file out to every referencing draft doc.
+   */
+  async replaceAsset(
+    assetId: string,
+    newFile: AssetFile,
+    options: {replacedBy: string}
+  ): Promise<{asset: Asset; docsUpdated: number}> {
+    const existing = await this.getAsset(assetId);
+    if (!existing) {
+      throw new Error(`asset not found: ${assetId}`);
+    }
+    const now = Date.now();
+    const asset: Asset = {
+      ...existing,
+      ...stripUndefinedValues(newFile),
+      id: assetId,
+      version: (existing.version || 0) + 1,
+      // Folder placement and asset-authoritative alt are preserved across a file
+      // replacement unless the new file explicitly provides an alt.
+      dir: existing.dir,
+      alt: newFile.alt ?? existing.alt,
+      sys: {
+        ...(existing.sys || {}),
+        modifiedAt: now,
+        modifiedBy: options.replacedBy,
+        replacedAt: now,
+        replacedBy: options.replacedBy,
+      },
+    };
+    await this.dbAssetRef(assetId).set(asset);
+    const {docsUpdated} = await this.fanOutAsset(asset, options.replacedBy);
+    return {asset, docsUpdated};
+  }
+
+  /**
+   * Updates an asset's (asset-authoritative) alt text and fans it out to every
+   * referencing draft doc.
+   */
+  async setAssetAlt(
+    assetId: string,
+    alt: string,
+    options: {updatedBy: string}
+  ): Promise<{asset: Asset; docsUpdated: number}> {
+    const existing = await this.getAsset(assetId);
+    if (!existing) {
+      throw new Error(`asset not found: ${assetId}`);
+    }
+    const asset: Asset = {
+      ...existing,
+      alt,
+      version: (existing.version || 0) + 1,
+      sys: {
+        ...(existing.sys || {}),
+        modifiedAt: Date.now(),
+        modifiedBy: options.updatedBy,
+      },
+    };
+    await this.dbAssetRef(assetId).set(asset);
+    const {docsUpdated} = await this.fanOutAsset(asset, options.updatedBy);
+    return {asset, docsUpdated};
+  }
+
+  /**
+   * Rewrites the inline value(s) of every draft doc that references `asset` so
+   * they pick up the asset's current file/alt. Re-scans each doc (rather than
+   * trusting stored paths) so it is robust to array reorders, paste, and
+   * duplication. Drafts only — published copies update on next publish.
+   */
+  private async fanOutAsset(
+    asset: Asset,
+    modifiedBy: string
+  ): Promise<{docsUpdated: number}> {
+    const usagesSnapshot = await this.db
+      .collection(this.dbAssetUsagesPath(asset.id))
+      .get();
+    const usages = usagesSnapshot.docs.map(
+      (d) => d.data() as {docId: string; collection: string; slug: string}
+    );
+    if (usages.length === 0) {
+      return {docsUpdated: 0};
+    }
+
+    const newValue = assetToFieldValue(asset);
+    const predicate = (n: any) => isAssetRef(n) && n.assetId === asset.id;
+
+    let docsUpdated = 0;
+    let batch = this.db.batch();
+    let batchCount = 0;
+    const staleUsageRefs: DocumentReference[] = [];
+
+    const chunkSize = 200;
+    for (let i = 0; i < usages.length; i += chunkSize) {
+      const chunk = usages.slice(i, i + chunkSize);
+      const refs = chunk.map((u) =>
+        this.dbDocRef(u.collection, u.slug, {mode: 'draft'})
+      );
+      const snapshots = await this.db.getAll(...refs);
+      for (let j = 0; j < snapshots.length; j++) {
+        const snapshot = snapshots[j];
+        const usage = chunk[j];
+        const data = snapshot.data();
+        if (!data) {
+          staleUsageRefs.push(this.dbAssetUsageRef(asset.id, usage.docId));
+          continue;
+        }
+        const paths = collectPathsByPredicate(data.fields || {}, predicate, {
+          prefix: 'fields',
+        });
+        if (paths.length === 0) {
+          staleUsageRefs.push(this.dbAssetUsageRef(asset.id, usage.docId));
+          continue;
+        }
+        const updates: Record<string, any> = {};
+        for (const path of paths) {
+          const current = getValueAtPath(data, path);
+          if (assetFieldValueIsCurrent(current, asset)) {
+            continue;
+          }
+          updates[path] = newValue;
+        }
+        if (Object.keys(updates).length === 0) {
+          continue;
+        }
+        updates['sys.modifiedAt'] = FieldValue.serverTimestamp();
+        updates['sys.modifiedBy'] = modifiedBy;
+        batch.update(snapshot.ref, updates);
+        batchCount += 1;
+        docsUpdated += 1;
+        if (batchCount >= 400) {
+          await batch.commit();
+          batch = this.db.batch();
+          batchCount = 0;
+        }
+      }
+    }
+    if (batchCount > 0) {
+      await batch.commit();
+    }
+    if (staleUsageRefs.length > 0) {
+      await this.deleteRefs(staleUsageRefs);
+    }
+    return {docsUpdated};
+  }
+
+  /**
+   * Reconciles the usage indexes for a single draft doc. Called on pick/detach,
+   * on a debounced draft flush, and after copy/create. Server-authoritative.
+   */
+  async syncUsagesForDoc(docId: string): Promise<void> {
+    const {collection, slug} = parseDocId(docId);
+    const data = await this.getRawDoc(collection, slug, {mode: 'draft'});
+
+    const currAssetIds = new Set<string>();
+    if (data) {
+      const paths = collectPathsByPredicate(
+        data.fields || {},
+        (n) => isAssetRef(n),
+        {prefix: 'fields'}
+      );
+      for (const path of paths) {
+        const value = getValueAtPath(data, path);
+        if (value?.assetId) {
+          currAssetIds.add(value.assetId);
+        }
+      }
+    }
+
+    const forwardRef = this.dbAssetUsagesByDocRef(docId);
+    const forwardSnapshot = await forwardRef.get();
+    const prevAssetIds: string[] = forwardSnapshot.exists
+      ? forwardSnapshot.data()?.assetIds || []
+      : [];
+
+    const toAdd = [...currAssetIds].filter((id) => !prevAssetIds.includes(id));
+    const toRemove = prevAssetIds.filter((id) => !currAssetIds.has(id));
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      return;
+    }
+
+    const batch = this.db.batch();
+    for (const assetId of toAdd) {
+      batch.set(this.dbAssetUsageRef(assetId, docId), {docId, collection, slug});
+    }
+    for (const assetId of toRemove) {
+      batch.delete(this.dbAssetUsageRef(assetId, docId));
+    }
+    if (currAssetIds.size > 0) {
+      batch.set(forwardRef, {docId, assetIds: [...currAssetIds]});
+    } else {
+      batch.delete(forwardRef);
+    }
+    await batch.commit();
+  }
+
+  /** Removes all usage-index entries for a doc (call on doc delete). */
+  async purgeDocUsages(docId: string): Promise<void> {
+    const forwardRef = this.dbAssetUsagesByDocRef(docId);
+    const forwardSnapshot = await forwardRef.get();
+    if (!forwardSnapshot.exists) {
+      return;
+    }
+    const assetIds: string[] = forwardSnapshot.data()?.assetIds || [];
+    const batch = this.db.batch();
+    for (const assetId of assetIds) {
+      batch.delete(this.dbAssetUsageRef(assetId, docId));
+    }
+    batch.delete(forwardRef);
+    await batch.commit();
+  }
+
+  /** Returns the number of docs referencing an asset (reverse-index count). */
+  async getAssetUsageCount(assetId: string): Promise<number> {
+    const snapshot = await this.db
+      .collection(this.dbAssetUsagesPath(assetId))
+      .count()
+      .get();
+    return snapshot.data().count;
+  }
+
+  /**
+   * Deletes a library asset. Throws if the asset is still in use unless
+   * `force` is set. GCS bytes are intentionally NOT deleted (the same object
+   * may be referenced by independent uploads elsewhere).
+   */
+  async deleteAsset(assetId: string, options?: {force?: boolean}): Promise<void> {
+    const usageCount = await this.getAssetUsageCount(assetId);
+    if (usageCount > 0 && !options?.force) {
+      throw new Error(`asset is in use by ${usageCount} doc(s)`);
+    }
+    await this.deleteCollectionDocs(this.dbAssetUsagesPath(assetId));
+    await this.dbAssetRef(assetId).delete();
+  }
+
+  /** Lists asset folders, optionally filtered to direct children of `parent`. */
+  async listAssetFolders(parent?: string): Promise<{folders: AssetFolder[]}> {
+    let query: Query = this.db.collection(this.dbAssetFoldersPath());
+    if (parent !== undefined) {
+      query = query.where('parent', '==', normalizeAssetDir(parent));
+    }
+    const snapshot = await query.get();
+    const folders = snapshot.docs.map((d) => d.data() as AssetFolder);
+    return {folders};
+  }
+
+  /** Creates an (initially empty) asset folder. */
+  async createAssetFolder(options: {
+    name: string;
+    parent?: string;
+  }): Promise<AssetFolder> {
+    const parent = normalizeAssetDir(options.parent);
+    const name = options.name.trim();
+    if (!name || name.includes('/')) {
+      throw new Error(`invalid folder name: ${options.name}`);
+    }
+    const path = parent === '/' ? `/${name}` : `${parent}/${name}`;
+    const folderId = buildUsageKey(path.slice(1));
+    const folder: AssetFolder = {id: folderId, path, name, parent};
+    await this.db.doc(`${this.dbAssetFoldersPath()}/${folderId}`).set(folder);
+    return folder;
+  }
+
+  /** Moves an asset into a different folder (library-only; no doc fan-out). */
+  async moveAsset(assetId: string, dir: string): Promise<void> {
+    await this.dbAssetRef(assetId).update({dir: normalizeAssetDir(dir)});
+  }
+
+  /** Renames an asset's display filename (library-only; no doc fan-out). */
+  async renameAsset(assetId: string, filename: string): Promise<void> {
+    await this.dbAssetRef(assetId).update({filename});
+  }
+
+  /**
+   * Rebuilds the usage indexes from scratch by scanning all draft docs. ADMIN
+   * backstop for drift from paste/duplication/JSON edits/migration.
+   */
+  async rebuildAllUsages(): Promise<{docsScanned: number; usages: number}> {
+    const projectPrefix = `Projects/${this.projectId}/Collections/`;
+    const snapshot = await this.db.collectionGroup('Drafts').get();
+    const reverse = new Map<
+      string,
+      Map<string, {collection: string; slug: string}>
+    >();
+    const forward = new Map<string, string[]>();
+    let docsScanned = 0;
+    for (const docSnapshot of snapshot.docs) {
+      if (!docSnapshot.ref.path.startsWith(projectPrefix)) {
+        continue;
+      }
+      const data = docSnapshot.data();
+      if (!data || !data.id || !data.collection || !data.slug) {
+        continue;
+      }
+      docsScanned += 1;
+      const paths = collectPathsByPredicate(
+        data.fields || {},
+        (n) => isAssetRef(n),
+        {prefix: 'fields'}
+      );
+      const assetIds = new Set<string>();
+      for (const path of paths) {
+        const value = getValueAtPath(data, path);
+        if (value?.assetId) {
+          assetIds.add(value.assetId);
+        }
+      }
+      if (assetIds.size === 0) {
+        continue;
+      }
+      forward.set(data.id, [...assetIds]);
+      for (const assetId of assetIds) {
+        if (!reverse.has(assetId)) {
+          reverse.set(assetId, new Map());
+        }
+        reverse
+          .get(assetId)!
+          .set(data.id, {collection: data.collection, slug: data.slug});
+      }
+    }
+
+    // Wipe the existing indexes, then write the freshly computed ones.
+    await this.deleteCollectionDocs(
+      `Projects/${this.projectId}/AssetUsagesByDoc`
+    );
+    const assetsSnapshot = await this.db.collection(this.dbAssetsPath()).get();
+    for (const assetDoc of assetsSnapshot.docs) {
+      await this.deleteCollectionDocs(this.dbAssetUsagesPath(assetDoc.id));
+    }
+
+    let batch = this.db.batch();
+    let count = 0;
+    let usages = 0;
+    const maybeCommit = async (force = false) => {
+      if (count > 0 && (force || count >= 400)) {
+        await batch.commit();
+        batch = this.db.batch();
+        count = 0;
+      }
+    };
+    for (const [docId, assetIds] of forward) {
+      batch.set(this.dbAssetUsagesByDocRef(docId), {docId, assetIds});
+      count += 1;
+      await maybeCommit();
+    }
+    for (const [assetId, docs] of reverse) {
+      for (const [docId, info] of docs) {
+        batch.set(this.dbAssetUsageRef(assetId, docId), {
+          docId,
+          collection: info.collection,
+          slug: info.slug,
+        });
+        usages += 1;
+        count += 1;
+        await maybeCommit();
+      }
+    }
+    await maybeCommit(true);
+    return {docsScanned, usages};
+  }
+
+  /** Deletes every doc in a (sub)collection in chunked batches. */
+  private async deleteCollectionDocs(collectionPath: string): Promise<void> {
+    const snapshot = await this.db.collection(collectionPath).get();
+    await this.deleteRefs(snapshot.docs.map((d) => d.ref));
+  }
+
+  /** Deletes a list of doc refs in chunked batches. */
+  private async deleteRefs(refs: DocumentReference[]): Promise<void> {
+    let batch = this.db.batch();
+    let count = 0;
+    for (const ref of refs) {
+      batch.delete(ref);
+      count += 1;
+      if (count >= 400) {
+        await batch.commit();
+        batch = this.db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) {
+      await batch.commit();
+    }
+  }
 }
 
 /**
@@ -2237,6 +2720,35 @@ export function parseDocId(docId: string) {
     throw new Error(`invalid doc id: ${docId}`);
   }
   return {collection, slug};
+}
+
+/** Resolves a dotted field path against a (stored) object. */
+export function getValueAtPath(obj: any, path: string): any {
+  const segments = path.split('.');
+  let current = obj;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+/** Generates a stable, random asset id. */
+function generateAssetId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+/** Returns a shallow copy of `obj` with all `undefined` values removed. */
+function stripUndefinedValues<T extends Record<string, any>>(obj: T): T {
+  const out: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+  return out as T;
 }
 
 export interface BatchRequestOptions {

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -2133,7 +2133,11 @@ export class RootCMSClient {
 
     const batch = this.db.batch();
     for (const assetId of toAdd) {
-      batch.set(this.dbAssetUsageRef(assetId, docId), {docId, collection, slug});
+      batch.set(this.dbAssetUsageRef(assetId, docId), {
+        docId,
+        collection,
+        slug,
+      });
     }
     for (const assetId of toRemove) {
       batch.delete(this.dbAssetUsageRef(assetId, docId));
@@ -2176,7 +2180,10 @@ export class RootCMSClient {
    * `force` is set. GCS bytes are intentionally NOT deleted (the same object
    * may be referenced by independent uploads elsewhere).
    */
-  async deleteAsset(assetId: string, options?: {force?: boolean}): Promise<void> {
+  async deleteAsset(
+    assetId: string,
+    options?: {force?: boolean}
+  ): Promise<void> {
     const usageCount = await this.getAssetUsageCount(assetId);
     if (usageCount > 0 && !options?.force) {
       throw new Error(`asset is in use by ${usageCount} doc(s)`);

--- a/packages/root-cms/shared/asset.test.ts
+++ b/packages/root-cms/shared/asset.test.ts
@@ -88,9 +88,9 @@ describe('assetFieldValueIsCurrent', () => {
 
   it('returns false for a different asset or an independent upload', () => {
     expect(assetFieldValueIsCurrent({src: 'x'}, ASSET)).toBe(false);
-    expect(
-      assetFieldValueIsCurrent({src: 'x', assetId: 'other'}, ASSET)
-    ).toBe(false);
+    expect(assetFieldValueIsCurrent({src: 'x', assetId: 'other'}, ASSET)).toBe(
+      false
+    );
   });
 });
 

--- a/packages/root-cms/shared/asset.test.ts
+++ b/packages/root-cms/shared/asset.test.ts
@@ -1,0 +1,105 @@
+import {describe, it, expect} from 'vitest';
+import {
+  ASSET_ID_KEY,
+  Asset,
+  assetFieldValueIsCurrent,
+  assetToFieldValue,
+  buildUsageKey,
+  isAssetRef,
+} from './asset.js';
+
+const ASSET: Asset = {
+  id: 'asset123',
+  version: 2,
+  src: 'https://lh3.googleusercontent.com/abc',
+  filename: 'logo.png',
+  gcsPath: '/bucket/project/uploads/abc.png',
+  width: 200,
+  height: 100,
+  canvasBgColor: 'light',
+  alt: 'Company logo',
+  dir: '/logos',
+};
+
+describe('isAssetRef', () => {
+  it('returns true for values with a string assetId', () => {
+    expect(isAssetRef({src: 'x', assetId: 'asset123'})).toBe(true);
+  });
+
+  it('returns false for independent uploads (no assetId)', () => {
+    expect(isAssetRef({src: 'x', filename: 'a.png'})).toBe(false);
+  });
+
+  it('returns false for empty/non-string assetId', () => {
+    expect(isAssetRef({src: 'x', assetId: ''})).toBe(false);
+    expect(isAssetRef({src: 'x', assetId: 123})).toBe(false);
+  });
+
+  it('returns false for non-objects, null, and arrays', () => {
+    expect(isAssetRef(null)).toBe(false);
+    expect(isAssetRef('asset123')).toBe(false);
+    expect(isAssetRef([{assetId: 'asset123'}])).toBe(false);
+  });
+
+  it('uses ASSET_ID_KEY = "assetId"', () => {
+    expect(ASSET_ID_KEY).toBe('assetId');
+  });
+});
+
+describe('assetToFieldValue', () => {
+  it('denormalizes the canonical asset fields plus markers', () => {
+    const value = assetToFieldValue(ASSET);
+    expect(value).toEqual({
+      src: 'https://lh3.googleusercontent.com/abc',
+      filename: 'logo.png',
+      gcsPath: '/bucket/project/uploads/abc.png',
+      width: 200,
+      height: 100,
+      canvasBgColor: 'light',
+      alt: 'Company logo',
+      assetId: 'asset123',
+      assetVersion: 2,
+    });
+  });
+
+  it('omits undefined optional fields (Firestore rejects undefined)', () => {
+    const value = assetToFieldValue({id: 'a1', version: 1, src: 'x'});
+    expect(value).toEqual({src: 'x', assetId: 'a1', assetVersion: 1, alt: ''});
+    expect('width' in value).toBe(false);
+    expect('gcsPath' in value).toBe(false);
+  });
+
+  it('does not leak the folder dir onto the inline value', () => {
+    const value = assetToFieldValue(ASSET);
+    expect('dir' in value).toBe(false);
+  });
+});
+
+describe('assetFieldValueIsCurrent', () => {
+  it('returns true when the inline value already matches the asset', () => {
+    const value = assetToFieldValue(ASSET);
+    expect(assetFieldValueIsCurrent(value, ASSET)).toBe(true);
+  });
+
+  it('returns false when the asset has a newer src/version', () => {
+    const stale = assetToFieldValue({...ASSET, version: 1, src: 'old'});
+    expect(assetFieldValueIsCurrent(stale, ASSET)).toBe(false);
+  });
+
+  it('returns false for a different asset or an independent upload', () => {
+    expect(assetFieldValueIsCurrent({src: 'x'}, ASSET)).toBe(false);
+    expect(
+      assetFieldValueIsCurrent({src: 'x', assetId: 'other'}, ASSET)
+    ).toBe(false);
+  });
+});
+
+describe('buildUsageKey', () => {
+  it('encodes the docId slash as `--`', () => {
+    expect(buildUsageKey('Pages/home')).toBe('Pages--home');
+  });
+
+  it('encodes nested slugs', () => {
+    expect(buildUsageKey('Pages/blog--post')).toBe('Pages--blog--post');
+  });
+});

--- a/packages/root-cms/shared/asset.ts
+++ b/packages/root-cms/shared/asset.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared, Firebase-free types and helpers for the GCS-backed asset library.
+ *
+ * An "asset" is a library entry stored at `Projects/{projectId}/Assets/{assetId}`
+ * that holds the canonical file metadata. When an image/file field picks a
+ * library asset, the asset's data is denormalized inline onto the doc (so doc
+ * GETs stay O(1) Firestore RPCs) together with an `assetId` marker. Replacing an
+ * asset's file fans the new data out to every referencing draft doc.
+ *
+ * These helpers are pure (no Firebase imports) so they can run on both the
+ * client (editor UI) and the server (`core/`).
+ */
+
+/** The key used to mark an inline field value as backed by a library asset. */
+export const ASSET_ID_KEY = 'assetId';
+
+/**
+ * Canonical file metadata stored on an asset and denormalized onto referencing
+ * docs. Structurally compatible with `UploadedFile` (ui/utils/gcs.ts), but
+ * declared here so server code can use it without importing `firebase/storage`.
+ */
+export interface AssetFile {
+  src: string;
+  filename?: string;
+  gcsPath?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+  canvasBgColor?: 'light' | 'dark';
+  uploadedBy?: string;
+  uploadedAt?: string | number;
+}
+
+/** A library asset as stored at `Projects/{projectId}/Assets/{assetId}`. */
+export interface Asset extends AssetFile {
+  /** The asset id (matches the Firestore doc id). Stable across replacements. */
+  id: string;
+  /** Increments each time the asset's file or alt changes (drives fan-out). */
+  version: number;
+  /** Folder path that contains the asset in the library UI, e.g. `/logos`. */
+  dir?: string;
+  sys?: {
+    createdAt?: number;
+    createdBy?: string;
+    modifiedAt?: number;
+    modifiedBy?: string;
+    replacedAt?: number;
+    replacedBy?: string;
+  };
+}
+
+/**
+ * A folder in the asset library's filesystem-like UI. Folders are a CMS-side
+ * organizational layer (stored at `Projects/{projectId}/AssetFolders/{id}`);
+ * they are NOT GCS prefixes and never denormalize onto docs.
+ */
+export interface AssetFolder {
+  id: string;
+  /** Absolute folder path, e.g. `/logos` or `/logos/2024`. */
+  path: string;
+  /** Display name (last path segment), e.g. `2024`. */
+  name: string;
+  /** Parent folder path, e.g. `/logos` (root is `/`). */
+  parent: string;
+}
+
+/** An inline field value that is backed by a library asset. */
+export type AssetRef = AssetFile & {
+  assetId: string;
+  assetVersion?: number;
+};
+
+/**
+ * Normalizes a folder path: ensures a single leading slash, no trailing slash,
+ * and treats empty/undefined as the root `/`.
+ */
+export function normalizeAssetDir(dir?: string): string {
+  if (!dir) {
+    return '/';
+  }
+  let d = dir.trim();
+  if (!d.startsWith('/')) {
+    d = `/${d}`;
+  }
+  if (d.length > 1 && d.endsWith('/')) {
+    d = d.slice(0, -1);
+  }
+  return d || '/';
+}
+
+/** Returns true if `value` is an inline field value backed by a library asset. */
+export function isAssetRef(value: any): value is AssetRef {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof value[ASSET_ID_KEY] === 'string' &&
+    !!value[ASSET_ID_KEY]
+  );
+}
+
+/**
+ * Builds the inline field value to store on a doc when a field picks a library
+ * asset. Alt text is asset-authoritative, so the inline value is simply a
+ * denormalized snapshot of the asset's canonical fields plus the
+ * `assetId`/`assetVersion` markers. Undefined fields are omitted because
+ * Firestore rejects `undefined` values.
+ */
+export function assetToFieldValue(asset: Asset): AssetRef {
+  const value: AssetRef = {
+    src: asset.src,
+    assetId: asset.id,
+    assetVersion: asset.version,
+  };
+  if (asset.filename !== undefined) value.filename = asset.filename;
+  if (asset.gcsPath !== undefined) value.gcsPath = asset.gcsPath;
+  if (asset.width !== undefined) value.width = asset.width;
+  if (asset.height !== undefined) value.height = asset.height;
+  if (asset.canvasBgColor !== undefined) value.canvasBgColor = asset.canvasBgColor;
+  // Alt is asset-authoritative: always reflect the asset's alt (default '').
+  value.alt = asset.alt ?? '';
+  return value;
+}
+
+/**
+ * Returns true if two inline asset values are equivalent for the canonical
+ * fields owned by the asset. Used by fan-out to skip docs that are already
+ * current and avoid spurious writes / `modifiedAt` churn.
+ */
+export function assetFieldValueIsCurrent(value: any, asset: Asset): boolean {
+  if (!isAssetRef(value) || value.assetId !== asset.id) {
+    return false;
+  }
+  const next = assetToFieldValue(asset);
+  return (
+    value.src === next.src &&
+    value.gcsPath === next.gcsPath &&
+    value.width === next.width &&
+    value.height === next.height &&
+    value.canvasBgColor === next.canvasBgColor &&
+    (value.alt ?? '') === next.alt &&
+    value.assetVersion === next.assetVersion
+  );
+}
+
+/** Encodes a docId (e.g. `Pages/foo`) into a safe Firestore document key. */
+export function buildUsageKey(docId: string): string {
+  // Firestore doc ids cannot contain '/'. Encode slashes as `--`, matching the
+  // slug-encoding convention used elsewhere in the CMS. The original collection
+  // and slug are stored as fields on the usage doc, so the key only needs to be
+  // a stable, unique identifier for the docId.
+  return docId.split('/').join('--');
+}

--- a/packages/root-cms/shared/asset.ts
+++ b/packages/root-cms/shared/asset.ts
@@ -116,7 +116,8 @@ export function assetToFieldValue(asset: Asset): AssetRef {
   if (asset.gcsPath !== undefined) value.gcsPath = asset.gcsPath;
   if (asset.width !== undefined) value.width = asset.width;
   if (asset.height !== undefined) value.height = asset.height;
-  if (asset.canvasBgColor !== undefined) value.canvasBgColor = asset.canvasBgColor;
+  if (asset.canvasBgColor !== undefined)
+    value.canvasBgColor = asset.canvasBgColor;
   // Alt is asset-authoritative: always reflect the asset's alt (default '').
   value.alt = asset.alt ?? '';
   return value;

--- a/packages/root-cms/shared/marshal.test.ts
+++ b/packages/root-cms/shared/marshal.test.ts
@@ -5,6 +5,7 @@ import {
   isArrayObject,
   isRichTextData,
   resolveArrayObjectPath,
+  collectPathsByPredicate,
 } from './marshal.js';
 
 describe('marshalData', () => {
@@ -335,5 +336,101 @@ describe('isRichTextData', () => {
         },
       })
     ).toBe(false);
+  });
+});
+
+describe('collectPathsByPredicate', () => {
+  // Matches inline values backed by a library asset, like the fan-out walk does.
+  const isAsset = (n: any) => !!n && typeof n === 'object' && !!n.assetId;
+
+  it('collects a top-level matching field', () => {
+    const fields = {
+      title: 'Home',
+      hero: {src: 'a', assetId: 'logo'},
+    };
+    expect(
+      collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})
+    ).toEqual(['fields.hero']);
+  });
+
+  it('does not descend into a matched node', () => {
+    const fields = {
+      hero: {src: 'a', assetId: 'logo', nested: {assetId: 'inner'}},
+    };
+    // Only the outer match is collected; the walk stops at it.
+    expect(
+      collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})
+    ).toEqual(['fields.hero']);
+  });
+
+  it('uses stored ArrayObject keys (not numeric indices) for array items', () => {
+    const fields = {
+      modules: {
+        _array: ['k1', 'k2'],
+        k1: {image: {src: 'a', assetId: 'logo'}},
+        k2: {image: {src: 'b'}},
+      },
+    };
+    expect(
+      collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})
+    ).toEqual(['fields.modules.k1.image']);
+  });
+
+  it('reaches assets inside oneOf blocks (skips the _type marker)', () => {
+    const fields = {
+      blocks: {
+        _array: ['b1'],
+        b1: {_type: 'ImageBlock', image: {src: 'a', assetId: 'logo'}},
+      },
+    };
+    expect(
+      collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})
+    ).toEqual(['fields.blocks.b1.image']);
+  });
+
+  it('skips rich text data', () => {
+    const fields = {
+      body: {
+        time: 1,
+        version: '2.0',
+        blocks: [{type: 'image', data: {file: {assetId: 'logo'}}}],
+      },
+    };
+    expect(collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})).toEqual(
+      []
+    );
+  });
+
+  it('skips `@<field>` metadata siblings', () => {
+    const fields = {
+      image: {src: 'a', assetId: 'logo'},
+      '@image': {alt: false, assetId: 'should-be-ignored'},
+    };
+    expect(
+      collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})
+    ).toEqual(['fields.image']);
+  });
+
+  it('collects multiple matches across nested structures', () => {
+    const fields = {
+      hero: {src: 'a', assetId: 'logo'},
+      meta: {ogImage: {src: 'b', assetId: 'logo'}},
+      gallery: {
+        _array: ['g1', 'g2'],
+        g1: {photo: {src: 'c', assetId: 'logo'}},
+        g2: {photo: {src: 'd', assetId: 'other'}},
+      },
+    };
+    const onlyLogo = (n: any) => isAsset(n) && n.assetId === 'logo';
+    expect(
+      collectPathsByPredicate(fields, onlyLogo, {prefix: 'fields'}).sort()
+    ).toEqual(['fields.gallery.g1.photo', 'fields.hero', 'fields.meta.ogImage']);
+  });
+
+  it('returns no paths when nothing matches', () => {
+    const fields = {title: 'Home', hero: {src: 'a'}};
+    expect(collectPathsByPredicate(fields, isAsset, {prefix: 'fields'})).toEqual(
+      []
+    );
   });
 });

--- a/packages/root-cms/shared/marshal.ts
+++ b/packages/root-cms/shared/marshal.ts
@@ -249,3 +249,75 @@ function getType(value: any): string {
   if (typeof value === 'number' && Number.isNaN(value)) return 'nan';
   return typeof value;
 }
+
+/**
+ * Recursively walks stored (marshaled) Firestore data and returns the dotted
+ * paths of every node for which `predicate` returns true. The returned paths use
+ * stored ArrayObject keys (not numeric indices), so they can be passed directly
+ * to a Firestore `update()` call as field paths.
+ *
+ * Traversal rules:
+ * - If `predicate(node)` is true, the node's path is collected and the walk does
+ *   NOT descend into it (matched value objects have no nested matches).
+ * - Rich text data (EditorJS format) is skipped entirely.
+ * - ArrayObjects are traversed via their `_array` key order; the `_array` key
+ *   itself is not treated as a child.
+ * - For plain objects (including oneOf blocks carrying a `_type` discriminator),
+ *   keys beginning with `_` (internal markers) or `@` (field metadata siblings)
+ *   are not descended.
+ *
+ * Note: this operates on RAW stored data (ArrayObject shape), not the output of
+ * `unmarshalData` (plain arrays).
+ *
+ * @param data The stored data to walk (e.g. a doc's `fields` object).
+ * @param predicate Returns true for nodes whose path should be collected.
+ * @param options.prefix A path prefix to prepend to every collected path.
+ */
+export function collectPathsByPredicate(
+  data: any,
+  predicate: (node: any) => boolean,
+  options?: {prefix?: string}
+): string[] {
+  const results: string[] = [];
+
+  function walk(node: any, path: string) {
+    if (node === null || typeof node !== 'object') {
+      return;
+    }
+    if (predicate(node)) {
+      if (path) {
+        results.push(path);
+      }
+      return;
+    }
+    // Do not descend into rich text data (EditorJS format).
+    if (isRichTextData(node)) {
+      return;
+    }
+    if (isArrayObject(node)) {
+      for (const key of node._array) {
+        walk(node[key], path ? `${path}.${key}` : key);
+      }
+      return;
+    }
+    if (Array.isArray(node)) {
+      // Plain arrays should not appear in stored data (arrays are stored as
+      // ArrayObjects), but handle them defensively.
+      for (let i = 0; i < node.length; i++) {
+        walk(node[i], path ? `${path}.${i}` : String(i));
+      }
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      // Skip internal markers (`_array`, `_type`, `_arrayKey`, ...) and field
+      // metadata siblings (`@<fieldname>`).
+      if (key.startsWith('_') || key.startsWith('@')) {
+        continue;
+      }
+      walk(node[key], path ? `${path}.${key}` : key);
+    }
+  }
+
+  walk(data, options?.prefix || '');
+  return results;
+}

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
@@ -1,0 +1,123 @@
+.AssetBrowser {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 240px;
+}
+
+.AssetBrowser__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.AssetBrowser__breadcrumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+
+.AssetBrowser__crumb {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  color: var(--mantine-color-blue-7, #1c7ed6);
+  font: inherit;
+}
+
+.AssetBrowser__crumb:hover {
+  text-decoration: underline;
+}
+
+.AssetBrowser__crumbSep {
+  color: #999;
+  padding: 0 2px;
+}
+
+.AssetBrowser__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.AssetBrowser__loading,
+.AssetBrowser__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  color: #888;
+  grid-column: 1 / -1;
+}
+
+.AssetBrowser__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.AssetBrowser__tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  font: inherit;
+  text-align: center;
+}
+
+.AssetBrowser__tile:hover {
+  border-color: #c0c0c0;
+  background: #fafafa;
+}
+
+.AssetBrowser__tile.selected {
+  border-color: var(--mantine-color-blue-6, #228be6);
+  box-shadow: 0 0 0 1px var(--mantine-color-blue-6, #228be6);
+}
+
+.AssetBrowser__tile--folder {
+  color: var(--mantine-color-yellow-7, #f08c00);
+}
+
+.AssetBrowser__tile__thumb {
+  width: 100%;
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background:
+    repeating-conic-gradient(#f4f4f4 0% 25%, #fff 0% 50%) 50% / 16px 16px;
+  border-radius: 4px;
+}
+
+.AssetBrowser__tile__thumb img {
+  max-width: 100%;
+  max-height: 90px;
+  object-fit: contain;
+}
+
+.AssetBrowser__tile__fileExt {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #666;
+  font-weight: 600;
+}
+
+.AssetBrowser__tile__label {
+  font-size: 12px;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #333;
+}

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -1,0 +1,206 @@
+import './AssetBrowser.css';
+
+import {Button, Loader, TextInput} from '@mantine/core';
+import {IconFolder, IconFolderPlus, IconSearch} from '@tabler/icons-preact';
+import {useEffect, useMemo, useState} from 'preact/hooks';
+import {Asset, AssetFolder, normalizeAssetDir} from '../../../shared/asset.js';
+import {
+  assetsCreateFolder,
+  listAssetFolders,
+  listAssets,
+} from '../../utils/assets.js';
+import {getFileExt, testIsImageFile} from '../../utils/gcs.js';
+import {joinClassNames} from '../../utils/classes.js';
+import {notifyErrors} from '../../utils/notifications.js';
+
+export interface AssetBrowserProps {
+  /** Current folder path being viewed. */
+  currentDir: string;
+  /** Called when the user navigates into a folder (or breadcrumb). */
+  onNavigate: (dir: string) => void;
+  /** Called when an asset is clicked. */
+  onSelect: (asset: Asset) => void;
+  /** Restrict displayed assets to these file exts/mimetypes (picker mode). */
+  accept?: string[];
+  /** Currently highlighted asset id, if any. */
+  selectedAssetId?: string;
+  /** Bump to force a reload (e.g. after upload/replace). */
+  refreshKey?: number;
+  /** Whether to show the "New folder" control. */
+  allowCreateFolder?: boolean;
+}
+
+function dirSegments(dir: string): Array<{name: string; path: string}> {
+  const normalized = normalizeAssetDir(dir);
+  if (normalized === '/') {
+    return [];
+  }
+  const parts = normalized.slice(1).split('/');
+  const segments: Array<{name: string; path: string}> = [];
+  let path = '';
+  for (const part of parts) {
+    path = `${path}/${part}`;
+    segments.push({name: part, path});
+  }
+  return segments;
+}
+
+function assetMatchesAccept(asset: Asset, accept?: string[]): boolean {
+  if (!accept || accept.length === 0) {
+    return true;
+  }
+  if (accept.includes('*/*') || accept.includes('*')) {
+    return true;
+  }
+  // If the picker only wants images, filter to image assets.
+  const wantsImagesOnly = accept.every((t) => t.startsWith('image/'));
+  if (wantsImagesOnly) {
+    return testIsImageFile(asset.filename || asset.src);
+  }
+  const ext = getFileExt(asset.filename || asset.src);
+  return accept.some((t) => t.replace(/^\./, '').toLowerCase() === ext);
+}
+
+export function AssetBrowser(props: AssetBrowserProps) {
+  const {currentDir, onNavigate, onSelect} = props;
+  const [loading, setLoading] = useState(true);
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [folders, setFolders] = useState<AssetFolder[]>([]);
+  const [query, setQuery] = useState('');
+
+  async function reload() {
+    setLoading(true);
+    await notifyErrors(async () => {
+      const [assetList, folderList] = await Promise.all([
+        listAssets(currentDir),
+        listAssetFolders(currentDir),
+      ]);
+      setAssets(assetList);
+      setFolders(folderList);
+    });
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    reload();
+  }, [currentDir, props.refreshKey]);
+
+  const visibleAssets = useMemo(() => {
+    const search = query.trim().toLowerCase();
+    return assets
+      .filter((asset) => assetMatchesAccept(asset, props.accept))
+      .filter((asset) =>
+        search ? (asset.filename || '').toLowerCase().includes(search) : true
+      );
+  }, [assets, query, props.accept]);
+
+  const segments = dirSegments(currentDir);
+
+  async function handleNewFolder() {
+    const name = window.prompt('New folder name:');
+    if (!name) {
+      return;
+    }
+    await notifyErrors(async () => {
+      await assetsCreateFolder(name, currentDir);
+      await reload();
+    });
+  }
+
+  return (
+    <div className="AssetBrowser">
+      <div className="AssetBrowser__toolbar">
+        <div className="AssetBrowser__breadcrumbs">
+          <button
+            className="AssetBrowser__crumb"
+            onClick={() => onNavigate('/')}
+            type="button"
+          >
+            Assets
+          </button>
+          {segments.map((segment) => (
+            <span key={segment.path}>
+              <span className="AssetBrowser__crumbSep">/</span>
+              <button
+                className="AssetBrowser__crumb"
+                onClick={() => onNavigate(segment.path)}
+                type="button"
+              >
+                {segment.name}
+              </button>
+            </span>
+          ))}
+        </div>
+        <div className="AssetBrowser__actions">
+          <TextInput
+            size="xs"
+            placeholder="Search files"
+            icon={<IconSearch size={14} />}
+            value={query}
+            onChange={(e: any) => setQuery(e.currentTarget.value)}
+          />
+          {props.allowCreateFolder && (
+            <Button
+              size="xs"
+              variant="default"
+              leftIcon={<IconFolderPlus size={14} />}
+              onClick={handleNewFolder}
+            >
+              New folder
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="AssetBrowser__loading">
+          <Loader size="sm" />
+        </div>
+      ) : (
+        <div className="AssetBrowser__grid">
+          {folders.map((folder) => (
+            <button
+              key={folder.id}
+              type="button"
+              className="AssetBrowser__tile AssetBrowser__tile--folder"
+              onDblClick={() => onNavigate(folder.path)}
+              onClick={() => onNavigate(folder.path)}
+              title={folder.path}
+            >
+              <IconFolder size={40} />
+              <div className="AssetBrowser__tile__label">{folder.name}</div>
+            </button>
+          ))}
+          {visibleAssets.map((asset) => (
+            <button
+              key={asset.id}
+              type="button"
+              className={joinClassNames(
+                'AssetBrowser__tile AssetBrowser__tile--asset',
+                props.selectedAssetId === asset.id && 'selected'
+              )}
+              onClick={() => onSelect(asset)}
+              title={asset.filename || asset.src}
+            >
+              <div className="AssetBrowser__tile__thumb">
+                {testIsImageFile(asset.filename || asset.src) ? (
+                  <img src={asset.src} alt={asset.alt || ''} loading="lazy" />
+                ) : (
+                  <div className="AssetBrowser__tile__fileExt">
+                    {getFileExt(asset.filename || asset.src) || 'file'}
+                  </div>
+                )}
+              </div>
+              <div className="AssetBrowser__tile__label">
+                {asset.filename || asset.id}
+              </div>
+            </button>
+          ))}
+          {folders.length === 0 && visibleAssets.length === 0 && (
+            <div className="AssetBrowser__empty">This folder is empty.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -9,8 +9,8 @@ import {
   listAssetFolders,
   listAssets,
 } from '../../utils/assets.js';
-import {getFileExt, testIsImageFile} from '../../utils/gcs.js';
 import {joinClassNames} from '../../utils/classes.js';
+import {getFileExt, testIsImageFile} from '../../utils/gcs.js';
 import {notifyErrors} from '../../utils/notifications.js';
 
 export interface AssetBrowserProps {

--- a/packages/root-cms/ui/components/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/root-cms/ui/components/AssetPickerModal/AssetPickerModal.tsx
@@ -1,0 +1,56 @@
+import {ContextModalProps, useModals} from '@mantine/modals';
+import {useState} from 'preact/hooks';
+import {Asset} from '../../../shared/asset.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {AssetBrowser} from '../AssetBrowser/AssetBrowser.js';
+
+const MODAL_ID = 'AssetPickerModal';
+
+export interface AssetPickerModalProps {
+  [key: string]: unknown;
+  /** Restrict the picker to these file exts/mimetypes. */
+  accept?: string[];
+  /** Folder to open initially. */
+  initialDir?: string;
+  /** Called with the chosen asset; the modal closes afterwards. */
+  onSelect: (asset: Asset) => void;
+}
+
+export function useAssetPickerModal() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  return {
+    open: (props: AssetPickerModalProps) => {
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        title: 'Choose from asset library',
+        innerProps: props,
+        size: '760px',
+        overflow: 'inside',
+      });
+    },
+    close: () => modals.closeModal(MODAL_ID),
+  };
+}
+
+export function AssetPickerModal(
+  modalProps: ContextModalProps<AssetPickerModalProps>
+) {
+  const {innerProps} = modalProps;
+  const [currentDir, setCurrentDir] = useState(innerProps.initialDir || '/');
+  return (
+    <div className="AssetPickerModal">
+      <AssetBrowser
+        currentDir={currentDir}
+        onNavigate={setCurrentDir}
+        accept={innerProps.accept}
+        onSelect={(asset: Asset) => {
+          innerProps.onSelect(asset);
+          modalProps.context.closeModal(modalProps.id);
+        }}
+      />
+    </div>
+  );
+}
+
+AssetPickerModal.id = MODAL_ID;

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -28,6 +28,8 @@ import {
   IconExternalLink,
   IconFileUpload,
   IconInfoCircle,
+  IconLibraryPhoto,
+  IconLinkOff,
   IconPaperclip,
   IconPhotoStar,
   IconPhotoUp,
@@ -41,6 +43,8 @@ import {ChangeEvent, CSSProperties, forwardRef} from 'preact/compat';
 import {lazy, Suspense} from 'preact/compat';
 import {useContext, useMemo, useRef, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
+import {assetToFieldValue} from '../../../../shared/asset.js';
+import {useAssetPickerModal} from '../../AssetPickerModal/AssetPickerModal.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
 import {useGapiClient} from '../../../hooks/useGapiClient.js';
 import {joinClassNames} from '../../../utils/classes.js';
@@ -101,6 +105,14 @@ interface FileFieldContextValue {
   altDisabledByMetadata: boolean;
   setAltDisabledByMetadata?: (disabled: boolean) => void;
   allowEditing: boolean;
+  /** Whether to offer the "Choose from library" asset picker. */
+  enableLibraryPicker: boolean;
+  /** Whether the current value is backed by a library asset. */
+  isLibraryAsset: boolean;
+  /** Opens the asset library picker. */
+  pickFromLibrary: () => void;
+  /** Detaches the current value from its library asset (keeps the file). */
+  detachFromLibrary: () => void;
 }
 
 const FileFieldContext = createContext<FileFieldContextValue | null>(null);
@@ -136,6 +148,12 @@ export interface FileFieldInternalProps {
    * toggle to disable the alt text input on a per-instance basis.
    */
   setAltDisabledByMetadata?: (disabled: boolean) => void;
+  /**
+   * Whether to offer the "Choose from library" asset picker. Set by the
+   * doc-connected `FileField`; standalone uploaders (e.g. the asset manager)
+   * leave it off.
+   */
+  enableLibraryPicker?: boolean;
 }
 
 export function FileFieldInternal(props: FileFieldInternalProps) {
@@ -164,6 +182,28 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
   const altText = value?.alt || '';
   const altDisabledByMetadata = props.altDisabledByMetadata === true;
   const showAltText = field.alt !== false && !altDisabledByMetadata;
+
+  // Asset library integration.
+  const assetPickerModal = useAssetPickerModal();
+  const enableLibraryPicker = props.enableLibraryPicker === true;
+  const isLibraryAsset = !!value?.assetId;
+  function pickFromLibrary() {
+    assetPickerModal.open({
+      accept: acceptedFileTypes,
+      onSelect: (asset) => {
+        setValue(assetToFieldValue(asset));
+      },
+    });
+  }
+  function detachFromLibrary() {
+    if (!value) {
+      return;
+    }
+    const next = {...value};
+    delete next.assetId;
+    delete next.assetVersion;
+    setValue(next);
+  }
 
   async function uploadFile(
     file: File,
@@ -463,6 +503,10 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
         altDisabledByMetadata: altDisabledByMetadata,
         setAltDisabledByMetadata: props.setAltDisabledByMetadata,
         allowEditing: allowEditing,
+        enableLibraryPicker: enableLibraryPicker,
+        isLibraryAsset: isLibraryAsset,
+        pickFromLibrary: pickFromLibrary,
+        detachFromLibrary: detachFromLibrary,
       }}
     >
       <Modal
@@ -689,6 +733,7 @@ export function FileField(props: FileFieldProps) {
       setLoadingState={setLoadingState}
       variant={props.variant}
       allowEditing={props.allowEditing}
+      enableLibraryPicker={true}
       altDisabledByMetadata={altDisabledByMetadata}
       setAltDisabledByMetadata={
         props.variant === 'image' && field.alt !== false
@@ -808,6 +853,28 @@ FileField.Preview = () => {
                     Edit image
                   </Menu.Item>
                 )}
+              <Divider />
+            </>
+          )}
+          {ctx.enableLibraryPicker && (
+            <>
+              <Menu.Label size="sm">LIBRARY</Menu.Label>
+              <Menu.Item
+                icon={<IconLibraryPhoto size={16} />}
+                onClick={() => ctx.pickFromLibrary()}
+              >
+                {ctx.isLibraryAsset
+                  ? 'Replace from library'
+                  : 'Choose from library'}
+              </Menu.Item>
+              {ctx.isLibraryAsset && (
+                <Menu.Item
+                  icon={<IconLinkOff size={16} />}
+                  onClick={() => ctx.detachFromLibrary()}
+                >
+                  Detach from library
+                </Menu.Item>
+              )}
               <Divider />
             </>
           )}
@@ -1059,15 +1126,24 @@ FileField.Preview = () => {
               radius={0}
               className="DocEditor__ImageField__imagePreview__Image__Alt__Textarea"
               value={ctx.altText}
-              placeholder="Alt text"
+              placeholder={
+                ctx.isLibraryAsset
+                  ? 'Alt text is managed in the asset library'
+                  : 'Alt text'
+              }
               size="xs"
               autosize
+              readOnly={ctx.isLibraryAsset}
               disabled={ctx.loadingState === 'loading'}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                if (ctx.isLibraryAsset) {
+                  return;
+                }
                 ctx?.setAltText(e.currentTarget.value);
               }}
             />
             {experiments.ai &&
+              !ctx.isLibraryAsset &&
               !ctx.altText &&
               ctx.value?.src?.startsWith('http') && (
                 <Tooltip
@@ -1187,6 +1263,16 @@ FileField.Empty = () => {
     <div className="FileField__Empty">
       <div className="FileField__Empty__Label">
         <FileField.UploadButton />
+        {ctx.enableLibraryPicker && (
+          <Button
+            variant="default"
+            size="xs"
+            leftIcon={<IconLibraryPhoto size={16} />}
+            onClick={() => ctx.pickFromLibrary()}
+          >
+            Choose from library
+          </Button>
+        )}
         {testSupportsCreatePlaceholder(ctx.acceptedFileTypes) && (
           <div>
             <Tooltip label="Create placeholder image">

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -44,7 +44,6 @@ import {lazy, Suspense} from 'preact/compat';
 import {useContext, useMemo, useRef, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
 import {assetToFieldValue} from '../../../../shared/asset.js';
-import {useAssetPickerModal} from '../../AssetPickerModal/AssetPickerModal.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
 import {useGapiClient} from '../../../hooks/useGapiClient.js';
 import {joinClassNames} from '../../../utils/classes.js';
@@ -60,6 +59,7 @@ import {
   deleteFileFromGCS,
 } from '../../../utils/gcs.js';
 import {downloadFromDrive, parseGoogleDriveId} from '../../../utils/gdrive.js';
+import {useAssetPickerModal} from '../../AssetPickerModal/AssetPickerModal.js';
 import {FieldProps} from './FieldProps.js';
 import {GenerateImageForm} from './GenerateImageForm.js';
 
@@ -711,8 +711,9 @@ export function FileField(props: FileFieldProps) {
     useState<FileFieldLoadingState | null>(null);
 
   const metadataKey = getMetadataKey(props.deepKey);
-  const [metadata, setMetadata] =
-    useDraftDocValue<Record<string, any> | null>(metadataKey);
+  const [metadata, setMetadata] = useDraftDocValue<Record<string, any> | null>(
+    metadataKey
+  );
   const altDisabledByMetadata = metadata?.alt === false;
   const setAltDisabledByMetadata = (disabled: boolean) => {
     const next = {...(metadata || {})};

--- a/packages/root-cms/ui/hooks/useDraftDoc.tsx
+++ b/packages/root-cms/ui/hooks/useDraftDoc.tsx
@@ -11,6 +11,7 @@ import {
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useEffect, useMemo, useState} from 'preact/hooks';
 import {logAction} from '../utils/actions.js';
+import {assetsSyncUsages, collectAssetIds} from '../utils/assets.js';
 import {debounce} from '../utils/debounce.js';
 import {setDocToCache} from '../utils/doc-cache.js';
 import {CMSDoc} from '../utils/doc.js';
@@ -62,6 +63,11 @@ export class DraftDocController extends EventListener {
   private store: JsonTrieStore;
 
   private pendingUpdates = new Map<string, any>();
+  /**
+   * Joined, sorted set of library asset ids referenced by the draft as of the
+   * last usage reconcile. `null` until the first reconcile after load.
+   */
+  private lastAssetIdsKey: string | null = null;
   private dbUnsubscribe?: () => void;
   private saveState = SaveState.NO_CHANGES;
   private autolock = false;
@@ -368,6 +374,7 @@ export class DraftDocController extends EventListener {
         throttle: SAVE_ACTION_LOG_THROTTLE,
         throttleId: this.docId,
       });
+      this.maybeSyncAssetUsages();
     } catch (err) {
       console.error('failed to update doc:', err);
       this.setSaveState(SaveState.ERROR);
@@ -395,6 +402,35 @@ export class DraftDocController extends EventListener {
         console.log(this.pendingUpdates);
       }
     }
+  }
+
+  /**
+   * Reconciles the asset library usage index for this doc when the set of
+   * referenced library assets changes. Usage writes are server-authoritative
+   * (security rules forbid client writes to the index), so this calls the
+   * `assets.syncUsages` endpoint. Fire-and-forget; the server re-scans the
+   * draft authoritatively.
+   */
+  private maybeSyncAssetUsages() {
+    if (this.readOnly) {
+      return;
+    }
+    const data = this.getData();
+    const fields = (data && (data as any).fields) || {};
+    const key = collectAssetIds(fields).join(',');
+    if (this.lastAssetIdsKey === key) {
+      return;
+    }
+    const isFirstReconcile = this.lastAssetIdsKey === null;
+    this.lastAssetIdsKey = key;
+    // On the first reconcile after load, only sync if the doc actually
+    // references assets (avoids a no-op call for asset-free docs).
+    if (isFirstReconcile && !key) {
+      return;
+    }
+    assetsSyncUsages(this.docId).catch((err) => {
+      console.error('failed to sync asset usages:', err);
+    });
   }
 
   getLocales(): string[] {

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.css
@@ -1,10 +1,15 @@
 .AssetsPage {
   background: var(--page-background);
   padding: var(--page-padding-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .AssetsPage__header {
-  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .AssetsPage p {
@@ -12,33 +17,132 @@
   max-width: 600px;
 }
 
-.AssetsPage__content {
-  max-width: 640px;
-  width: 100%;
-  padding: 20px;
+.AssetsPage__body {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+  align-items: start;
 }
 
-.AssetsPage__urlGroup {
+@media (max-width: 900px) {
+  .AssetsPage__body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.AssetsPage__browser {
+  padding: 16px;
+}
+
+.AssetsPage__browser__toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.AssetsPage__detail {
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 12px;
+  position: sticky;
+  top: 16px;
 }
 
-.AssetsPage__urlRow__label {
-  font-size: 12px;
-  font-weight: 500;
-  color: #666;
-  margin-bottom: 4px;
-}
-
-.AssetsPage__urlRow__input {
+.AssetsPage__detail__preview {
+  width: 100%;
+  height: 180px;
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  background:
+    repeating-conic-gradient(#f4f4f4 0% 25%, #fff 0% 50%) 50% / 16px 16px;
+  border-radius: 6px;
+  overflow: hidden;
 }
 
-.AssetsPage__urlRow__input textarea {
+.AssetsPage__detail__preview img {
+  max-width: 100%;
+  max-height: 180px;
+  object-fit: contain;
+}
+
+.AssetsPage__detail__fileIcon {
   font-size: 12px;
+  color: #666;
+  padding: 8px;
+  text-align: center;
+  word-break: break-all;
+}
+
+.AssetsPage__detail__name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.AssetsPage__detail__name span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.AssetsPage__detail__meta {
+  font-size: 12px;
+  color: #666;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.AssetsPage__detail__url {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.AssetsPage__detail__url > :first-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.AssetsPage__detail__url textarea {
+  font-size: 12px;
+}
+
+.AssetsPage__detail__alt {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.AssetsPage__detail__usages {
+  font-size: 13px;
+}
+
+.AssetsPage__detail__usages__count {
+  font-weight: 600;
+}
+
+.AssetsPage__detail__usages__list {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  max-height: 140px;
+  overflow: auto;
+  font-size: 12px;
+  color: #555;
+}
+
+.AssetsPage__detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.AssetsPage__footer {
+  border-top: 1px solid #eee;
+  padding-top: 8px;
 }

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
@@ -210,7 +210,10 @@ function AssetDetail(props: AssetDetailProps) {
   }
 
   async function move() {
-    const dir = window.prompt('Move to folder (e.g. /logos):', asset.dir || '/');
+    const dir = window.prompt(
+      'Move to folder (e.g. /logos):',
+      asset.dir || '/'
+    );
     if (dir === null) {
       return;
     }

--- a/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
+++ b/packages/root-cms/ui/pages/AssetsPage/AssetsPage.tsx
@@ -1,103 +1,333 @@
-import {ActionIcon, Button, Textarea, Tooltip} from '@mantine/core';
-import {IconCopy} from '@tabler/icons-preact';
-import {useState} from 'preact/hooks';
-import {FileUploader} from '../../components/DocEditor/fields/FileUploader.js';
+import './AssetsPage.css';
+
+import {ActionIcon, Button, Loader, Textarea, Tooltip} from '@mantine/core';
+import {showNotification} from '@mantine/notifications';
+import {
+  IconCopy,
+  IconPencil,
+  IconRefresh,
+  IconTrash,
+  IconUpload,
+} from '@tabler/icons-preact';
+import {useEffect, useRef, useState} from 'preact/hooks';
+import {Asset, normalizeAssetDir} from '../../../shared/asset.js';
+import {AssetBrowser} from '../../components/AssetBrowser/AssetBrowser.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
-import './AssetsPage.css';
+import {
+  AssetUsage,
+  assetsCreate,
+  assetsDelete,
+  assetsMove,
+  assetsRebuildUsages,
+  assetsRename,
+  assetsReplace,
+  assetsSetAlt,
+  getAssetUsages,
+} from '../../utils/assets.js';
+import {testIsImageFile, uploadFileToGCS} from '../../utils/gcs.js';
+import {notifyErrors} from '../../utils/notifications.js';
 
 export function AssetsPage() {
   usePageTitle('Assets');
-  const [file, setFile] = useState<any>(null);
-  const gcsUrl = file?.gcsPath
-    ? `https://storage.googleapis.com${file.gcsPath}`
-    : '';
+  const [currentDir, setCurrentDir] = useState('/');
+  const [selected, setSelected] = useState<Asset | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const replaceInputRef = useRef<HTMLInputElement>(null);
+
+  function refresh() {
+    setRefreshKey((k) => k + 1);
+  }
+
+  async function handleUploadFiles(files: FileList | null) {
+    if (!files || files.length === 0) {
+      return;
+    }
+    setBusy(true);
+    await notifyErrors(async () => {
+      for (const file of Array.from(files)) {
+        const uploaded = await uploadFileToGCS(file);
+        await assetsCreate(uploaded, currentDir);
+      }
+      refresh();
+      showNotification({message: 'Uploaded to library', color: 'green'});
+    });
+    setBusy(false);
+  }
+
+  async function handleReplaceFile(files: FileList | null) {
+    if (!files || files.length === 0 || !selected) {
+      return;
+    }
+    setBusy(true);
+    await notifyErrors(async () => {
+      const uploaded = await uploadFileToGCS(files[0]);
+      const result = await assetsReplace(selected.id, uploaded);
+      setSelected(result.asset);
+      refresh();
+      showNotification({
+        message: `Replaced — updated ${result.docsUpdated} draft doc(s)`,
+        color: 'green',
+      });
+    });
+    setBusy(false);
+  }
 
   return (
     <Layout>
       <div className="AssetsPage" data-testid="assets-page">
         <div className="AssetsPage__header">
           <Heading size="h1">Assets</Heading>
-          <Text as="p">Upload assets to the project's GCS bucket.</Text>
+          <Text as="p">Browse and manage the project's asset library.</Text>
         </div>
-        <Surface className="AssetsPage__content">
-          <FileUploader
-            value={file}
-            onChange={setFile}
-            showNamingOptions
-            accept={['*/*']}
-            allowEditing={false}
-            className="AssetsPage__uploader"
+        <div className="AssetsPage__body">
+          <Surface className="AssetsPage__browser">
+            <div className="AssetsPage__browser__toolbar">
+              <Button
+                leftIcon={<IconUpload size={16} />}
+                loading={busy}
+                onClick={() => uploadInputRef.current?.click()}
+              >
+                Upload to this folder
+              </Button>
+              <input
+                ref={uploadInputRef}
+                type="file"
+                multiple
+                style={{display: 'none'}}
+                onChange={(e: any) => {
+                  handleUploadFiles(e.currentTarget.files);
+                  e.currentTarget.value = '';
+                }}
+              />
+            </div>
+            <AssetBrowser
+              currentDir={currentDir}
+              onNavigate={(dir) => {
+                setCurrentDir(dir);
+                setSelected(null);
+              }}
+              onSelect={(asset) => setSelected(asset)}
+              selectedAssetId={selected?.id}
+              refreshKey={refreshKey}
+              allowCreateFolder
+            />
+          </Surface>
+          {selected && (
+            <AssetDetail
+              asset={selected}
+              busy={busy}
+              onReplace={() => replaceInputRef.current?.click()}
+              onChanged={(a) => {
+                setSelected(a);
+                refresh();
+              }}
+              onDeleted={() => {
+                setSelected(null);
+                refresh();
+              }}
+            />
+          )}
+          <input
+            ref={replaceInputRef}
+            type="file"
+            style={{display: 'none'}}
+            onChange={(e: any) => {
+              handleReplaceFile(e.currentTarget.files);
+              e.currentTarget.value = '';
+            }}
           />
-          {file && gcsUrl && (
-            <div className="AssetsPage__urlGroup">
-              <UrlRow label="GCS URL" url={gcsUrl} />
-              <UrlRow label="Google Image Service URL" url={file.src} />
-            </div>
-          )}
-          {file && !gcsUrl && (
-            <div className="AssetsPage__urlGroup">
-              <UrlRow url={file.src} />
-            </div>
-          )}
-          {file && (
-            <Button
-              variant="outline"
-              fullWidth
-              onClick={() => setFile(null)}
-              mt="md"
-            >
-              Upload another file
-            </Button>
-          )}
-        </Surface>
+        </div>
+        <div className="AssetsPage__footer">
+          <Button
+            variant="subtle"
+            size="xs"
+            leftIcon={<IconRefresh size={14} />}
+            onClick={() =>
+              notifyErrors(async () => {
+                const res = await assetsRebuildUsages();
+                showNotification({
+                  message: `Rebuilt usages: scanned ${res.docsScanned} docs, ${res.usages} usages`,
+                  color: 'green',
+                });
+              })
+            }
+          >
+            Rebuild usage index (admin)
+          </Button>
+        </div>
       </div>
     </Layout>
   );
 }
 
-function UrlRow(props: {label?: string; url: string}) {
-  return (
-    <div className="AssetsPage__urlRow">
-      {props.label && (
-        <div className="AssetsPage__urlRow__label">{props.label}</div>
-      )}
-      <div className="AssetsPage__urlRow__input">
-        <Textarea
-          readOnly
-          value={props.url}
-          autosize
-          minRows={1}
-          size="xs"
-          radius="xs"
-          onClick={(e: Event) => (e.target as HTMLTextAreaElement).select()}
-          styles={{root: {flex: 1, minWidth: 0}}}
-        />
-        <CopyButton url={props.url} />
-      </div>
-    </div>
-  );
+interface AssetDetailProps {
+  asset: Asset;
+  busy: boolean;
+  onReplace: () => void;
+  onChanged: (asset: Asset) => void;
+  onDeleted: () => void;
 }
 
-function CopyButton(props: {url: string}) {
-  const [copied, setCopied] = useState(false);
+function AssetDetail(props: AssetDetailProps) {
+  const {asset} = props;
+  const [alt, setAlt] = useState(asset.alt || '');
+  const [usages, setUsages] = useState<AssetUsage[] | null>(null);
+
+  useEffect(() => {
+    setAlt(asset.alt || '');
+    setUsages(null);
+    getAssetUsages(asset.id)
+      .then(setUsages)
+      .catch(() => setUsages([]));
+  }, [asset.id, asset.version]);
+
+  async function saveAlt() {
+    await notifyErrors(async () => {
+      const result = await assetsSetAlt(asset.id, alt);
+      props.onChanged(result.asset);
+      showNotification({
+        message: `Alt updated — ${result.docsUpdated} draft doc(s)`,
+        color: 'green',
+      });
+    });
+  }
+
+  async function rename() {
+    const filename = window.prompt('Rename file:', asset.filename || '');
+    if (!filename) {
+      return;
+    }
+    await notifyErrors(async () => {
+      await assetsRename(asset.id, filename);
+      props.onChanged({...asset, filename});
+    });
+  }
+
+  async function move() {
+    const dir = window.prompt('Move to folder (e.g. /logos):', asset.dir || '/');
+    if (dir === null) {
+      return;
+    }
+    await notifyErrors(async () => {
+      await assetsMove(asset.id, dir);
+      props.onChanged({...asset, dir: normalizeAssetDir(dir)});
+    });
+  }
+
+  async function remove() {
+    const count = usages?.length ?? 0;
+    const message =
+      count > 0
+        ? `This asset is used by ${count} doc(s). Force delete anyway?`
+        : 'Delete this asset?';
+    if (!window.confirm(message)) {
+      return;
+    }
+    await notifyErrors(async () => {
+      await assetsDelete(asset.id, count > 0);
+      props.onDeleted();
+    });
+  }
+
   return (
-    <Tooltip label={copied ? 'Copied!' : 'Copy URL'} position="top" withArrow>
-      <ActionIcon
-        variant="default"
-        size="lg"
-        onClick={() => {
-          navigator.clipboard.writeText(props.url).then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-          });
-        }}
-      >
-        <IconCopy size={16} />
-      </ActionIcon>
-    </Tooltip>
+    <Surface className="AssetsPage__detail">
+      <div className="AssetsPage__detail__preview">
+        {testIsImageFile(asset.filename || asset.src) ? (
+          <img src={asset.src} alt={asset.alt || ''} />
+        ) : (
+          <div className="AssetsPage__detail__fileIcon">
+            {asset.filename || asset.id}
+          </div>
+        )}
+      </div>
+      <div className="AssetsPage__detail__name">
+        <span>{asset.filename || asset.id}</span>
+        <ActionIcon size="sm" onClick={rename} title="Rename">
+          <IconPencil size={14} />
+        </ActionIcon>
+      </div>
+      <div className="AssetsPage__detail__meta">
+        <div>Version: v{asset.version}</div>
+        <div>Folder: {asset.dir || '/'}</div>
+        {!!asset.width && !!asset.height && (
+          <div>
+            Dimensions: {asset.width}×{asset.height}
+          </div>
+        )}
+      </div>
+      <div className="AssetsPage__detail__url">
+        <Textarea value={asset.src} readOnly autosize minRows={1} size="xs" />
+        <Tooltip label="Copy URL">
+          <ActionIcon
+            onClick={() => navigator.clipboard.writeText(asset.src)}
+            title="Copy URL"
+          >
+            <IconCopy size={16} />
+          </ActionIcon>
+        </Tooltip>
+      </div>
+      <div className="AssetsPage__detail__alt">
+        <Textarea
+          label="Alt text (applies to every use)"
+          value={alt}
+          onChange={(e: any) => setAlt(e.currentTarget.value)}
+          autosize
+          minRows={2}
+          size="xs"
+        />
+        <Button
+          size="xs"
+          variant="default"
+          onClick={saveAlt}
+          disabled={alt === (asset.alt || '')}
+        >
+          Save alt text
+        </Button>
+      </div>
+      <div className="AssetsPage__detail__usages">
+        {usages === null ? (
+          <Loader size="xs" />
+        ) : (
+          <div className="AssetsPage__detail__usages__count">
+            Used in {usages.length} doc(s)
+          </div>
+        )}
+        {usages && usages.length > 0 && (
+          <ul className="AssetsPage__detail__usages__list">
+            {usages.slice(0, 20).map((u) => (
+              <li key={u.docId}>{u.docId}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="AssetsPage__detail__actions">
+        <Button
+          size="xs"
+          leftIcon={<IconUpload size={14} />}
+          loading={props.busy}
+          onClick={props.onReplace}
+        >
+          Replace file
+        </Button>
+        <Button size="xs" variant="default" onClick={move}>
+          Move
+        </Button>
+        <Button
+          size="xs"
+          color="red"
+          variant="outline"
+          leftIcon={<IconTrash size={14} />}
+          onClick={remove}
+        >
+          Delete
+        </Button>
+      </div>
+    </Surface>
   );
 }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -20,6 +20,7 @@ import type {CMSBuiltInSidebarTool} from '../core/plugin.js';
 import {Collection} from '../core/schema.js';
 import {AddToReleaseModal} from './components/AddToReleaseModal/AddToReleaseModal.js';
 import {AiEditModal} from './components/AiEditModal/AiEditModal.js';
+import {AssetPickerModal} from './components/AssetPickerModal/AssetPickerModal.js';
 import {ComponentPickerModal} from './components/ComponentPickerModal/ComponentPickerModal.js';
 import {CopyDocModal} from './components/CopyDocModal/CopyDocModal.js';
 import {DataSourceSelectModal} from './components/DataSourceSelectModal/DataSourceSelectModal.js';
@@ -246,6 +247,7 @@ function App() {
                     modals={{
                       [AddToReleaseModal.id]: AddToReleaseModal,
                       [AiEditModal.id]: AiEditModal,
+                      [AssetPickerModal.id]: AssetPickerModal,
                       [ComponentPickerModal.id]: ComponentPickerModal,
                       [CopyDocModal.id]: CopyDocModal,
                       [DocPickerModal.id]: DocPickerModal,

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -1,0 +1,211 @@
+/**
+ * Client helpers for the GCS-backed asset library.
+ *
+ * Reads (assets/folders/usages) go directly to Firestore via the web SDK
+ * (these docs are readable by VIEWER+). Mutations go through server-authoritative
+ * `/cms/api/assets.*` endpoints, because security rules forbid client writes to
+ * the usage indexes and the `Assets` collection for non-publishers.
+ */
+import {
+  collection,
+  doc,
+  getCountFromServer,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from 'firebase/firestore';
+import {
+  Asset,
+  AssetFile,
+  AssetFolder,
+  isAssetRef,
+  normalizeAssetDir,
+} from '../../shared/asset.js';
+import {collectPathsByPredicate} from '../../shared/marshal.js';
+
+export interface AssetUsage {
+  docId: string;
+  collection: string;
+  slug: string;
+}
+
+function getValueAtPath(obj: any, path: string): any {
+  let current = obj;
+  for (const segment of path.split('.')) {
+    if (current === null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+/**
+ * Returns the sorted, de-duped set of library asset ids referenced anywhere in
+ * a doc's (stored/marshaled) `fields`. Used by the draft controller to decide
+ * when to reconcile the usage index.
+ */
+export function collectAssetIds(fields: any): string[] {
+  const ids = new Set<string>();
+  const paths = collectPathsByPredicate(fields || {}, (n) => isAssetRef(n));
+  for (const path of paths) {
+    const value = getValueAtPath(fields, path);
+    if (value?.assetId) {
+      ids.add(value.assetId);
+    }
+  }
+  return [...ids].sort();
+}
+
+function projectId(): string {
+  return window.__ROOT_CTX.rootConfig.projectId;
+}
+
+async function postJson<T = any>(endpoint: string, body: any): Promise<T> {
+  const res = await window.fetch(endpoint, {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify(body || {}),
+  });
+  const text = await res.text();
+  let data: any = null;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    // Fall back to the raw response text for the error message below.
+  }
+  if (!res.ok || data?.success === false) {
+    const message = (data && (data.error || data.message)) || text;
+    throw new Error(message || `request failed: ${endpoint}`);
+  }
+  return data?.data as T;
+}
+
+// ---------------------------------------------------------------------------
+// Firestore reads.
+// ---------------------------------------------------------------------------
+
+function assetsCollection() {
+  return collection(window.firebase.db, 'Projects', projectId(), 'Assets');
+}
+
+function assetFoldersCollection() {
+  return collection(window.firebase.db, 'Projects', projectId(), 'AssetFolders');
+}
+
+/** Lists assets, optionally filtered to a single folder (`dir`). */
+export async function listAssets(dir?: string): Promise<Asset[]> {
+  const coll = assetsCollection();
+  const q =
+    dir !== undefined
+      ? query(coll, where('dir', '==', normalizeAssetDir(dir)))
+      : coll;
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => d.data() as Asset);
+}
+
+/** Reads a single asset. */
+export async function getAsset(assetId: string): Promise<Asset | null> {
+  const ref = doc(
+    window.firebase.db,
+    'Projects',
+    projectId(),
+    'Assets',
+    assetId
+  );
+  const snapshot = await getDoc(ref);
+  return snapshot.exists() ? (snapshot.data() as Asset) : null;
+}
+
+/** Lists asset folders, optionally filtered to direct children of `parent`. */
+export async function listAssetFolders(
+  parent?: string
+): Promise<AssetFolder[]> {
+  const coll = assetFoldersCollection();
+  const q =
+    parent !== undefined
+      ? query(coll, where('parent', '==', normalizeAssetDir(parent)))
+      : coll;
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => d.data() as AssetFolder);
+}
+
+function assetUsagesCollection(assetId: string) {
+  return collection(
+    window.firebase.db,
+    'Projects',
+    projectId(),
+    'Assets',
+    assetId,
+    'Usages'
+  );
+}
+
+/** Counts how many docs reference an asset (reverse-index count). */
+export async function getAssetUsageCount(assetId: string): Promise<number> {
+  const snapshot = await getCountFromServer(assetUsagesCollection(assetId));
+  return snapshot.data().count;
+}
+
+/** Lists the docs that reference an asset. */
+export async function getAssetUsages(assetId: string): Promise<AssetUsage[]> {
+  const snapshot = await getDocs(assetUsagesCollection(assetId));
+  return snapshot.docs.map((d) => d.data() as AssetUsage);
+}
+
+// ---------------------------------------------------------------------------
+// API mutations (server-authoritative).
+// ---------------------------------------------------------------------------
+
+export function assetsCreate(file: AssetFile, dir?: string): Promise<Asset> {
+  return postJson('/cms/api/assets.create', {file, dir});
+}
+
+export function assetsReplace(
+  assetId: string,
+  file: AssetFile
+): Promise<{asset: Asset; docsUpdated: number}> {
+  return postJson('/cms/api/assets.replace', {assetId, file});
+}
+
+export function assetsSetAlt(
+  assetId: string,
+  alt: string
+): Promise<{asset: Asset; docsUpdated: number}> {
+  return postJson('/cms/api/assets.setAlt', {assetId, alt});
+}
+
+export function assetsDelete(assetId: string, force?: boolean): Promise<void> {
+  return postJson('/cms/api/assets.delete', {assetId, force});
+}
+
+export function assetsMove(assetId: string, dir: string): Promise<void> {
+  return postJson('/cms/api/assets.move', {assetId, dir});
+}
+
+export function assetsRename(assetId: string, filename: string): Promise<void> {
+  return postJson('/cms/api/assets.rename', {assetId, filename});
+}
+
+export function assetsCreateFolder(
+  name: string,
+  parent?: string
+): Promise<AssetFolder> {
+  return postJson('/cms/api/assets.createFolder', {name, parent});
+}
+
+export function assetsSyncUsages(docId: string): Promise<void> {
+  return postJson('/cms/api/assets.syncUsages', {docId});
+}
+
+export function assetsPurgeDoc(docId: string): Promise<void> {
+  return postJson('/cms/api/assets.purgeDoc', {docId});
+}
+
+export function assetsRebuildUsages(): Promise<{
+  docsScanned: number;
+  usages: number;
+}> {
+  return postJson('/cms/api/assets.rebuildUsages', {});
+}

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -91,7 +91,12 @@ function assetsCollection() {
 }
 
 function assetFoldersCollection() {
-  return collection(window.firebase.db, 'Projects', projectId(), 'AssetFolders');
+  return collection(
+    window.firebase.db,
+    'Projects',
+    projectId(),
+    'AssetFolders'
+  );
 }
 
 /** Lists assets, optionally filtered to a single folder (`dir`). */

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -24,11 +24,7 @@ import {
 } from 'firebase/firestore';
 import {testValidRichTextData} from '../../shared/richtext.js';
 import {logAction} from './actions.js';
-import {
-  assetsPurgeDoc,
-  assetsSyncUsages,
-  collectAssetIds,
-} from './assets.js';
+import {assetsPurgeDoc, assetsSyncUsages, collectAssetIds} from './assets.js';
 import {removeDocFromCache, removeDocsFromCache} from './doc-cache.js';
 import {GoogleSheetId} from './gsheets.js';
 import {

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -24,6 +24,11 @@ import {
 } from 'firebase/firestore';
 import {testValidRichTextData} from '../../shared/richtext.js';
 import {logAction} from './actions.js';
+import {
+  assetsPurgeDoc,
+  assetsSyncUsages,
+  collectAssetIds,
+} from './assets.js';
 import {removeDocFromCache, removeDocsFromCache} from './doc-cache.js';
 import {GoogleSheetId} from './gsheets.js';
 import {
@@ -115,6 +120,8 @@ export async function cmsDeleteDoc(docId: string) {
   await batch.commit();
   console.log(`deleted doc: ${docId}`);
   logAction('doc.delete', {metadata: {docId}});
+  // Drop any asset-library usage-index entries for the deleted doc.
+  assetsPurgeDoc(docId).catch((err) => console.error(err));
 }
 
 export async function cmsPublishDoc(
@@ -615,6 +622,10 @@ export async function cmsCreateDoc(
 
   await setDoc(docRef, data);
   logAction('doc.create', {metadata: {docId}});
+  // Register asset-library usages for any assets carried in via copy/duplicate.
+  if (collectAssetIds(data.fields).length > 0) {
+    assetsSyncUsages(docId).catch((err) => console.error(err));
+  }
 }
 
 export interface CsvTranslation {

--- a/packages/root-cms/ui/utils/gcs.ts
+++ b/packages/root-cms/ui/utils/gcs.ts
@@ -55,6 +55,15 @@ export interface UploadedFile {
   canvasBgColor?: 'light' | 'dark';
   /** The original source URL if the image has been edited. */
   originalSrc?: string;
+  /**
+   * Set when this value is backed by a library asset. The asset's data is
+   * denormalized inline (so doc GETs stay O(1)); `assetId` links the value back
+   * to the library so a replace can fan the new file out. Not part of the
+   * public `RootCMSImage` type — renderers ignore it.
+   */
+  assetId?: string;
+  /** The asset `version` denormalized at pick/replace time (advisory). */
+  assetVersion?: number;
 }
 
 /** Uploads a File object to GCS. */


### PR DESCRIPTION
## Summary
Implements a complete asset library system for managing reusable files and images in the CMS. Assets are stored in Firestore with canonical metadata and denormalized onto referencing documents for O(1) read performance. File replacements automatically fan out to all draft documents that reference the asset.

## Key Changes

### Core Asset Library (`core/client.ts`, `core/api.ts`)
- Added asset CRUD operations: `createAsset()`, `replaceAsset()`, `setAssetAlt()`, `getAsset()`, `listAssets()`
- Implemented usage index tracking with reverse (`Assets/{id}/Usages`) and forward (`AssetUsagesByDoc`) indexes
- Added `fanOutAsset()` to propagate file/alt changes to all referencing draft documents
- Added `syncUsagesForDoc()` to reconcile usage indexes when assets are picked/detached
- Added server-authoritative API endpoints (`/cms/api/assets.*`) for mutations with role-based access control

### Shared Types (`shared/asset.ts`)
- Defined `Asset`, `AssetFile`, `AssetRef`, and `AssetFolder` types
- Added helpers: `isAssetRef()`, `assetToFieldValue()`, `assetFieldValueIsCurrent()`, `buildUsageKey()`, `normalizeAssetDir()`
- Asset references are marked with `assetId` and `assetVersion` for tracking

### UI Components
- **AssetsPage**: Complete redesign with browser/detail panel layout, upload controls, and asset management
- **AssetBrowser**: New component for browsing assets and folders with search, breadcrumbs, and folder navigation
- **AssetPickerModal**: Modal for selecting assets from the library in file fields
- **FileField**: Integrated asset library picker alongside existing upload/Drive options

### Client Utilities (`ui/utils/assets.ts`)
- Firestore read helpers: `listAssets()`, `getAsset()`, `listAssetFolders()`, `getAssetUsages()`
- Server mutation helpers: `assetsCreate()`, `assetsReplace()`, `assetsSetAlt()`, `assetsDelete()`, `assetsSyncUsages()`
- `collectAssetIds()` to extract referenced asset IDs from document fields

### Draft Document Integration (`ui/hooks/useDraftDoc.tsx`)
- Added debounced `syncUsagesForDoc()` call on draft flush to keep usage indexes current
- Added `purgeDocUsages()` call on document deletion to clean up stale usage entries

### Testing
- Added comprehensive test suite for asset library operations (`core/asset.test.ts`)
- Added unit tests for shared asset helpers (`shared/asset.test.ts`)
- Added tests for `collectPathsByPredicate()` utility used in fan-out walks

## Notable Implementation Details

- **Denormalization strategy**: Asset metadata is copied inline onto referencing documents (with `assetId` marker) so document reads remain O(1) Firestore RPCs, while replacements fan out asynchronously
- **Usage tracking**: Dual-index approach enables efficient reverse lookups (which docs use an asset) and forward lookups (which assets a doc uses)
- **Fan-out robustness**: Re-scans each document during fan-out rather than trusting stored paths, making it resilient to array reorders, paste, and duplication
- **Batch efficiency**: Fan-out uses 200-doc chunks and 400-operation batches to stay within Firestore limits
- **Security**: Usage index writes are server-authoritative; Firestore rules prevent client writes outside draft documents

https://claude.ai/code/session_013RULzfguifiVURuuYnXEbG