### PR TITLE
fix: fix device resolution label visibility in preview pane

### DIFF
--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -832,9 +832,12 @@ DocumentPage.Preview = (props: PreviewProps) => {
 
     const normalizedScale = Number(scale.toFixed(4)) || 1;
 
-    // When expanding vertically, adjust iframe height to fill available space.
+    // When expanding vertically, adjust iframe height to fill the available
+    // space, reserving a little room at the bottom so the device resolution
+    // label remains visible below the iframe.
+    const labelReserve = 28;
     const iframeHeight = expandVertically
-      ? `${availableHeight / normalizedScale}px`
+      ? `${Math.max(availableHeight - labelReserve, 0) / normalizedScale}px`
       : `${height}px`;
 
     const nextStyle = {


### PR DESCRIPTION
## Summary
Fixed the preview iframe height calculation to reserve space for the device resolution label that appears below the iframe when expanding vertically.

## Key Changes
- Added a `labelReserve` constant (28px) to account for the space needed by the device resolution label
- Updated the iframe height calculation to subtract the reserved space from available height when expanding vertically
- Added safeguard using `Math.max()` to ensure height never goes negative

## Implementation Details
When the preview expands vertically, the iframe height is now calculated as `(availableHeight - labelReserve) / normalizedScale` instead of just `availableHeight / normalizedScale`. This ensures the device resolution label remains visible below the iframe rather than being cut off or overlapped.

https://claude.ai/code/session_019g1hqmrdta8Eiu4tUr3oK8