### PR TITLE
chore: add xmlns attribute to SVGAttributes type definition

### DIFF
--- a/packages/root/src/jsx/types.ts
+++ b/packages/root/src/jsx/types.ts
@@ -411,6 +411,7 @@ export interface SVGAttributes<T = SVGElement> extends HTMLAttributes<T> {
   xlinkShow?: string;
   xlinkTitle?: string;
   xlinkType?: string;
+  xmlns?: string;
   xmlBase?: string;
   xmlLang?: string;
   xmlSpace?: string;


### PR DESCRIPTION
## Summary
Added the `xmlns` attribute to the `SVGAttributes` interface to properly support the XML namespace declaration on SVG elements.

## Changes
- Added `xmlns?: string;` property to the `SVGAttributes<T>` interface in `packages/root/src/jsx/types.ts`
- The attribute is positioned alphabetically among other XML-related attributes (between `xlinkType` and `xmlBase`)

## Details
The `xmlns` attribute is a standard SVG attribute used to declare the XML namespace for SVG elements. This addition ensures that TypeScript users can properly type SVG elements with namespace declarations without encountering type errors.

https://claude.ai/code/session_01HQsM3E4Zoq4U3Fjv9JJ2R5