### PR TITLE
fix: consolidate html transform logic

### DIFF
--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -16,8 +16,7 @@ import {rootPodsVitePlugin} from '../node/pods-vite-plugin.js';
 import {pruneEmptyChunksPlugin} from '../node/vite-plugin-prune-empty-chunks.js';
 import {preactToRootJsxPlugin} from '../node/vite-plugin-root-jsx-virtual.js';
 import {BuildAssetMap} from '../render/asset-map/build-asset-map.js';
-import {htmlMinify} from '../render/html-minify.js';
-import {htmlPretty} from '../render/html-pretty.js';
+import {transformHtml} from '../render/html-transform.js';
 import {batchAsyncCalls} from '../utils/batch.js';
 import {
   copyGlob,
@@ -499,13 +498,7 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
           }
 
           // Render html and save the file to dist/html.
-          // TODO(stevenle): consolidate post-build html transformation logic.
-          let html = data.html || '';
-          if (rootConfig.prettyHtml) {
-            html = await htmlPretty(html, rootConfig.prettyHtmlOptions);
-          } else if (rootConfig.minifyHtml) {
-            html = await htmlMinify(html, rootConfig.minifyHtmlOptions);
-          }
+          const html = await transformHtml(data.html || '', rootConfig);
           await writeFile(outPath, normalizeLineEndings(html));
 
           printFileOutput(fileSize(outPath), 'dist/html/', outFilePath);

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -98,8 +98,11 @@ export interface RootUserConfig {
   jsxRenderer?: JsxRenderOptions;
 
   /**
-   * Whether to automatically minify HTML output. This is enabled by default,
-   * in order to disable, pass `minifyHtml: false` to root.config.ts.
+   * Whether to minify HTML output via html-minifier-terser. Disabled by
+   * default; pass `minifyHtml: true` to opt in.
+   *
+   * Ignored when the built-in JSX renderer (`jsxRenderer`) is enabled, since
+   * that renderer controls its own output formatting via its `mode` option.
    */
   minifyHtml?: boolean;
 
@@ -109,7 +112,12 @@ export interface RootUserConfig {
   minifyHtmlOptions?: HtmlMinifyOptions;
 
   /**
-   * Whether to pretty print HTML output.
+   * Whether to pretty print HTML output via js-beautify. Disabled by default;
+   * pass `prettyHtml: true` to opt in. When both `prettyHtml` and `minifyHtml`
+   * are set, `prettyHtml` takes precedence.
+   *
+   * Ignored when the built-in JSX renderer (`jsxRenderer`) is enabled, since
+   * that renderer controls its own output formatting via its `mode` option.
    */
   prettyHtml?: boolean;
 

--- a/packages/root/src/render/html-transform.test.ts
+++ b/packages/root/src/render/html-transform.test.ts
@@ -1,0 +1,56 @@
+import {expect, test} from 'vitest';
+import {RootConfig} from '../core/config.js';
+import {transformHtml} from './html-transform.js';
+
+const HTML = '<!doctype html>\n<div>lorem ipsum <my-element>bar</my-element></div>\n';
+
+function config(overrides: Partial<RootConfig>): RootConfig {
+  return overrides as RootConfig;
+}
+
+test('no formatting by default (opt-in)', async () => {
+  const output = await transformHtml(HTML, config({}));
+  expect(output).toBe(HTML);
+});
+
+test('minifyHtml: true opts in to minification', async () => {
+  const output = await transformHtml(HTML, config({minifyHtml: true}));
+  expect(output).toBe(
+    '<!doctype html>\n<div>lorem ipsum<my-element>bar</my-element></div>\n'
+  );
+});
+
+test('prettyHtml: true opts in to pretty printing', async () => {
+  const output = await transformHtml(HTML, config({prettyHtml: true}));
+  expect(output).toContain('<my-element>bar</my-element>');
+  // js-beautify reformats but preserves content.
+  expect(output).toContain('lorem ipsum');
+});
+
+test('prettyHtml takes precedence over minifyHtml', async () => {
+  const output = await transformHtml(
+    HTML,
+    config({prettyHtml: true, minifyHtml: true})
+  );
+  // If minify had run, the space before <my-element> would be collapsed.
+  expect(output).not.toContain('lorem ipsum<my-element>');
+  expect(output).toContain('lorem ipsum <my-element>');
+});
+
+test('jsxRenderer mode ignores minifyHtml', async () => {
+  const output = await transformHtml(
+    HTML,
+    config({jsxRenderer: {mode: 'pretty'}, minifyHtml: true})
+  );
+  // The built-in JSX renderer controls its own formatting, so minifyHtml is
+  // ignored and the html is returned untouched (whitespace preserved).
+  expect(output).toBe(HTML);
+});
+
+test('jsxRenderer mode ignores prettyHtml', async () => {
+  const output = await transformHtml(
+    HTML,
+    config({jsxRenderer: {mode: 'minimal'}, prettyHtml: true})
+  );
+  expect(output).toBe(HTML);
+});

--- a/packages/root/src/render/html-transform.ts
+++ b/packages/root/src/render/html-transform.ts
@@ -1,0 +1,32 @@
+import {RootConfig} from '../core/config.js';
+import {htmlMinify} from './html-minify.js';
+import {htmlPretty} from './html-pretty.js';
+
+/**
+ * Applies optional HTML post-processing (pretty-printing or minification) to
+ * rendered HTML, based on the project's `root.config.ts`. Shared by both the SSR
+ * render path and the SSG build so the two stay in sync.
+ *
+ * Behavior:
+ * - When the built-in Root.js JSX renderer is enabled (`jsxRenderer.mode`), the
+ *   renderer already controls output formatting, so `prettyHtml` and
+ *   `minifyHtml` are ignored entirely and the html is returned unchanged.
+ * - Otherwise (i.e. `preact-render-to-string`), formatting is strictly opt-in:
+ *   `prettyHtml: true` pretty-prints via js-beautify, and `minifyHtml: true`
+ *   minifies via html-minifier-terser. Neither runs by default.
+ */
+export async function transformHtml(
+  html: string,
+  rootConfig: RootConfig
+): Promise<string> {
+  if (rootConfig.jsxRenderer?.mode) {
+    return html;
+  }
+  if (rootConfig.prettyHtml) {
+    return htmlPretty(html, rootConfig.prettyHtmlOptions);
+  }
+  if (rootConfig.minifyHtml) {
+    return htmlMinify(html, rootConfig.minifyHtmlOptions);
+  }
+  return html;
+}

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -34,8 +34,7 @@ import {parseTagNames} from '../utils/elements.js';
 import {toHrefLang} from '../utils/i18n.js';
 import {replaceParams} from '../utils/url-path-params.js';
 import {AssetMap} from './asset-map/asset-map.js';
-import {htmlMinify} from './html-minify.js';
-import {htmlPretty} from './html-pretty.js';
+import {transformHtml} from './html-transform.js';
 import {getFallbackLocales} from './i18n-fallbacks.js';
 import {normalizeUrlPath, Router} from './router.js';
 
@@ -405,13 +404,7 @@ export class Renderer {
         nonce,
       });
 
-      // TODO(stevenle): consolidate post-build html transformation logic.
-      let html = output.html;
-      if (this.rootConfig.prettyHtml) {
-        html = await htmlPretty(html, this.rootConfig.prettyHtmlOptions);
-      } else if (this.rootConfig.minifyHtml !== false) {
-        html = await htmlMinify(html, this.rootConfig.minifyHtmlOptions);
-      }
+      let html = await transformHtml(output.html, this.rootConfig);
       if (req.viteServer) {
         html = await req.viteServer.transformIndexHtml(currentPath, html);
         if (nonce) {


### PR DESCRIPTION
## What changed

Consolidated the HTML post-processing logic shared by the SSR render path ([`render.tsx`](packages/root/src/render/render.tsx)) and the SSG build path ([`build.ts`](packages/root/src/cli/build.ts)) into a single helper, [`transformHtml()`](packages/root/src/render/html-transform.ts), and changed the formatting defaults.

New behavior in `transformHtml(html, rootConfig)`:

1. **When the built-in JSX renderer is enabled** (`jsxRenderer.mode` set) → `minifyHtml` and `prettyHtml` are **ignored entirely**. The renderer already controls output formatting via its `mode` option.
2. **Otherwise** (preact-render-to-string) → formatting is **strictly opt-in**: `prettyHtml: true` pretty-prints via js-beautify, `minifyHtml: true` minifies via html-minifier-terser. Neither runs by default. `prettyHtml` takes precedence when both are set.

Also:
- Removed the two duplicated post-processing blocks and the long-standing `TODO(stevenle): consolidate post-build html transformation logic` comments.
- Updated the `minifyHtml` / `prettyHtml` doc comments in [`config.ts`](packages/root/src/core/config.ts) to reflect the opt-in behavior and the `jsxRenderer` interaction.

## Why

The two paths were inconsistent: SSR minified **by default** (`minifyHtml !== false`) while SSG only minified on **opt-in** (`minifyHtml` truthy). The default-on minify in SSR collapsed significant whitespace around custom elements — e.g. `lorem ipsum <my-element>bar</my-element>` rendered as `lorem ipsum<my-element>bar</my-element>` (`html-minifier-terser`'s `collapseWhitespace` treats unknown/custom elements as block-level and strips adjacent whitespace).

When the native Root.js JSX renderer is in use it manages its own formatting, so the old minify/pretty options should not apply at all. For projects still on preact-render-to-string, formatting is now opt-in rather than silently on.

## Behavior change for reviewers

⚠️ **The SSR dev/preview path no longer minifies HTML by default.** Projects relying on the implicit default must now set `minifyHtml: true` explicitly. Projects using `jsxRenderer` are unaffected by `minifyHtml`/`prettyHtml` either way.

## Tests

- New unit tests in [`html-transform.test.ts`](packages/root/src/render/html-transform.test.ts) (6 cases): no formatting by default, `minifyHtml`/`prettyHtml` opt-in, precedence, and `jsxRenderer` mode ignoring both.
- Full package suite passes: **160/160** across 29 files (all SSR/SSG fixture builds included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)