### PR TITLE
chore: consolidate imports from @blinkk/root package

### DIFF
--- a/docs/components/Block/Block.tsx
+++ b/docs/components/Block/Block.tsx
@@ -1,7 +1,6 @@
 import path from 'node:path';
-import {ComponentChildren} from '@blinkk/root/jsx/jsx-runtime';
+import {ComponentChildren, FunctionalComponent} from '@blinkk/root/jsx';
 import {RichTextContext} from '@blinkk/root-cms/richtext';
-import {FunctionalComponent} from 'preact';
 import {buildModuleInfo, ModuleInfoContext} from '@/hooks/useModuleInfo.js';
 import {RootNode} from '../RootNode/RootNode.js';
 


### PR DESCRIPTION
This PR consolidates and reorganizes imports in the Block component to use a single source for related types from the @blinkk/root package.

**Key changes:**
- Moved `FunctionalComponent` import from `preact` to `@blinkk/root/jsx` to align with the project's JSX runtime
- Consolidated `ComponentChildren` and `FunctionalComponent` imports into a single import statement from `@blinkk/root/jsx`
- Removed the separate import from `preact` package

**Benefits:**
- Reduces dependency on external packages by using the project's own JSX abstractions
- Simplifies the import structure with fewer import statements
- Ensures consistent use of the @blinkk/root package's type definitions across the codebase

https://claude.ai/code/session_01FgHvyDQet9zWw2FHy88nMj