### PR TITLE
fix: resolve pod assets in asset map

### DIFF
--- a/.changeset/pod-route-asset-alias.md
+++ b/.changeset/pod-route-asset-alias.md
@@ -2,4 +2,4 @@
 '@blinkk/root': patch
 ---
 
-Fix pod route asset resolution so SSR no longer logs "could not find build asset" for pod-contributed HTML routes, and the route's CSS deps are collected correctly.
+fix: resolve pod assets in asset map

--- a/.changeset/pod-route-asset-alias.md
+++ b/.changeset/pod-route-asset-alias.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+Fix pods: resolve pod route assets at render time so SSR no longer logs "could not find build asset: pod/<name>/..." for pod route HTML pages. The build now aliases each pod route's virtual `pod/<name>/...` src to the asset built from the route's real file path, so the route's CSS deps are collected correctly.

--- a/.changeset/pod-route-asset-alias.md
+++ b/.changeset/pod-route-asset-alias.md
@@ -2,4 +2,4 @@
 '@blinkk/root': patch
 ---
 
-Fix pods: resolve pod route assets at render time so SSR no longer logs "could not find build asset: pod/<name>/..." for pod route HTML pages. The build now aliases each pod route's virtual `pod/<name>/...` src to the asset built from the route's real file path, so the route's CSS deps are collected correctly.
+Fix pod route asset resolution so SSR no longer logs "could not find build asset" for pod-contributed HTML routes, and the route's CSS deps are collected correctly.

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -295,10 +295,17 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
 
   // Use the output of the client build to generate an asset map, which is used
   // by the renderer for automatically injecting dependencies for a page.
+  const podRoutes = pods.flatMap((pod) =>
+    pod.routeFiles.map((route) => ({
+      src: `pod/${pod.name}/${route.relPath}`,
+      filePath: route.filePath,
+    }))
+  );
   const assetMap = BuildAssetMap.fromViteManifest(
     rootConfig,
     clientManifest,
-    elementGraph
+    elementGraph,
+    podRoutes
   );
 
   // Save the root's asset map to `dist/.root/manifest.json` for use by the prod

--- a/packages/root/src/render/asset-map/build-asset-map.ts
+++ b/packages/root/src/render/asset-map/build-asset-map.ts
@@ -121,10 +121,14 @@ export class BuildAssetMap implements AssetMap {
       const relPath = path
         .relative(rootConfig.rootDir, podRoute.filePath)
         .replace(/\\/g, '/');
-      const candidateKeys = [
-        relPath,
-        realPathRelativeTo(rootConfig.rootDir, relPath),
-      ];
+      // `realPathRelativeTo()` returns a `path.relative()` result with
+      // OS-specific separators; normalize to forward slashes to match the
+      // manifest keys (and `relPath` above) on Windows/symlinked setups.
+      const realPath = realPathRelativeTo(rootConfig.rootDir, relPath).replace(
+        /\\/g,
+        '/'
+      );
+      const candidateKeys = [relPath, realPath];
       for (const key of candidateKeys) {
         const asset = assetMap.srcToAsset.get(key);
         if (asset) {

--- a/packages/root/src/render/asset-map/build-asset-map.ts
+++ b/packages/root/src/render/asset-map/build-asset-map.ts
@@ -17,6 +17,17 @@ export type BuildAssetManifest = Record<
   }
 >;
 
+/**
+ * A pod route, used to alias the route's virtual `pod/<name>/...` src to the
+ * real asset built from the route's file. See `fromViteManifest()`.
+ */
+export interface PodRouteAsset {
+  /** Virtual src, e.g. `pod/<name>/<relPath>`. */
+  src: string;
+  /** Absolute path to the pod route file. */
+  filePath: string;
+}
+
 export class BuildAssetMap implements AssetMap {
   private rootConfig: RootConfig;
   private srcToAsset: Map<string, BuildAsset>;
@@ -58,7 +69,8 @@ export class BuildAssetMap implements AssetMap {
   static fromViteManifest(
     rootConfig: RootConfig,
     clientManifest: Manifest,
-    elementsGraph: ElementGraph
+    elementsGraph: ElementGraph,
+    podRoutes: PodRouteAsset[] = []
   ) {
     const assetMap = new BuildAssetMap(rootConfig);
 
@@ -94,6 +106,38 @@ export class BuildAssetMap implements AssetMap {
         isElement: isElement,
       };
       assetMap.add(new BuildAsset(assetMap, assetData));
+    });
+
+    // Pod routes are looked up by their virtual `pod/<name>/...` src at render
+    // time, but the manifest keys them by their real file path. Register an
+    // alias for each pod route so `get(route.src)` resolves to the built asset
+    // (and the route's CSS deps are collected) instead of logging
+    // "could not find build asset". Like user `routes/`, the alias has no asset
+    // URL of its own (the route's client JS is injected via elements/bundles).
+    podRoutes.forEach((podRoute) => {
+      if (assetMap.srcToAsset.has(podRoute.src)) {
+        return;
+      }
+      const relPath = path
+        .relative(rootConfig.rootDir, podRoute.filePath)
+        .replace(/\\/g, '/');
+      const candidateKeys = [
+        relPath,
+        realPathRelativeTo(rootConfig.rootDir, relPath),
+      ];
+      for (const key of candidateKeys) {
+        const asset = assetMap.srcToAsset.get(key);
+        if (asset) {
+          assetMap.add(
+            new BuildAsset(assetMap, {
+              ...asset.toJson(),
+              src: podRoute.src,
+              assetUrl: '',
+            })
+          );
+          break;
+        }
+      }
     });
 
     return assetMap;

--- a/packages/root/test/build-asset-map.test.ts
+++ b/packages/root/test/build-asset-map.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type {Manifest} from 'vite';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {RootConfig} from '../src/core/config.js';
+import {ElementGraph} from '../src/node/element-graph.js';
+import {BuildAssetMap} from '../src/render/asset-map/build-asset-map.js';
+
+let rootDir: string;
+
+beforeEach(() => {
+  rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-asset-map-'));
+});
+
+afterEach(() => {
+  if (rootDir) {
+    fs.rmSync(rootDir, {recursive: true, force: true});
+  }
+});
+
+const emptyElementGraph = new ElementGraph({});
+
+test('aliases pod route srcs to their built asset', async () => {
+  // A pod route file built into the manifest under its real (relative) path.
+  const routeRelPath = 'pods/blog/routes/index.tsx';
+  const routeFilePath = path.join(rootDir, routeRelPath);
+  fs.mkdirSync(path.dirname(routeFilePath), {recursive: true});
+  fs.writeFileSync(routeFilePath, 'export default () => null;\n');
+
+  const clientManifest = {
+    [routeRelPath]: {
+      file: 'assets/index.abcd1234.js',
+      src: routeRelPath,
+      isEntry: true,
+      css: ['assets/index.abcd1234.css'],
+    },
+  } as unknown as Manifest;
+
+  const assetMap = BuildAssetMap.fromViteManifest(
+    {rootDir} as RootConfig,
+    clientManifest,
+    emptyElementGraph,
+    [{src: 'pod/blog/index.tsx', filePath: routeFilePath}]
+  );
+
+  // The virtual src resolves (no "could not find build asset") and inherits the
+  // route's CSS deps, with no asset URL of its own.
+  const asset = await assetMap.get('pod/blog/index.tsx');
+  expect(asset).not.toBeNull();
+  expect(asset!.assetUrl).toBe('');
+  expect(await asset!.getCssDeps()).toEqual(['/assets/index.abcd1234.css']);
+});
+
+test('does not alias when the pod route has no built asset', async () => {
+  const routeFilePath = path.join(rootDir, 'pods/blog/routes/api.ts');
+  fs.mkdirSync(path.dirname(routeFilePath), {recursive: true});
+  fs.writeFileSync(routeFilePath, 'export const handle = () => {};\n');
+
+  const assetMap = BuildAssetMap.fromViteManifest(
+    {rootDir} as RootConfig,
+    {} as Manifest,
+    emptyElementGraph,
+    [{src: 'pod/blog/api.ts', filePath: routeFilePath}]
+  );
+
+  const asset = await assetMap.get('pod/blog/api.ts');
+  expect(asset).toBeNull();
+});

--- a/packages/root/test/build-asset-map.test.ts
+++ b/packages/root/test/build-asset-map.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type {Manifest} from 'vite';
-import {afterEach, beforeEach, expect, test} from 'vitest';
+import {afterEach, beforeEach, expect, test, vi} from 'vitest';
 import {RootConfig} from '../src/core/config.js';
 import {ElementGraph} from '../src/node/element-graph.js';
 import {BuildAssetMap} from '../src/render/asset-map/build-asset-map.js';
@@ -64,6 +64,16 @@ test('does not alias when the pod route has no built asset', async () => {
     [{src: 'pod/blog/api.ts', filePath: routeFilePath}]
   );
 
-  const asset = await assetMap.get('pod/blog/api.ts');
-  expect(asset).toBeNull();
+  // The missing-asset lookup logs via console.log; stub it so the test output
+  // stays clean, and assert it fired.
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    const asset = await assetMap.get('pod/blog/api.ts');
+    expect(asset).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      'could not find build asset: pod/blog/api.ts'
+    );
+  } finally {
+    logSpy.mockRestore();
+  }
 });


### PR DESCRIPTION
Fixes #1201.

## Problem

When a pod contributes an HTML-rendering route (via `routesDir`), every SSR
render of that route logs:

```
could not find build asset: pod/<pod-name>/<relPath>
```

The page still renders, but the route's CSS deps aren't collected and the log
line appears on every request.

## Cause

Pod routes are registered in the router with a **virtual** src,
`pod/${pod.name}/${route.relPath}` (`pods-vite-plugin.ts`). At render time the
renderer calls `assetMap.get(route.src)` with that virtual src
(`render/render.tsx`). But `BuildAssetMap` is keyed from the Vite client
manifest, which keys the route by its **real** file path — so the lookup misses
and falls through to `console.log("could not find build asset: ...")`. The
existing `realPathRelativeTo` fallback can't help because `pod/<name>/...` is a
synthetic prefix, not a real path.

## Fix

`BuildAssetMap.fromViteManifest()` now accepts the list of pod routes and, after
populating the map from the manifest, registers an **alias** for each pod route:
the virtual `pod/<name>/...` src points at the asset built from the route's real
file path. This mirrors how the same function already double-registers element
source files under both their `relPath` and resolved real path.

Like user `routes/` entries, the alias has no asset URL of its own (a pod
route's client JS is injected via elements/bundles, not the route chunk), so its
`assetUrl` is set to `''`. The alias is written into `dist/.root/manifest.json`,
so it also applies to the prod SSR server (which rebuilds the map via
`fromRootManifest`).

Pod routes that ship no client asset (e.g. pure JSON API routes) are simply not
aliased; those never reach this lookup since they don't render HTML.

## Testing

- Added `test/build-asset-map.test.ts` covering both the alias-hit case (CSS
  deps resolved, no asset URL) and the no-asset case.
- `pnpm test` (162 passing), `tsc --noEmit`, eslint, and prettier all pass.
