### PR TITLE
feat: add `excludeLocalesFromTranslations` config to exclude locales from translation import/export

### DIFF
--- a/.changeset/strong-locales-hide.md
+++ b/.changeset/strong-locales-hide.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-feat: add `csv.excludeLocales` config to exclude locales from CSV import/export
+feat: add `excludeLocalesFromTranslations` config to exclude locales from translation import/export

--- a/.changeset/strong-locales-hide.md
+++ b/.changeset/strong-locales-hide.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add `csv.excludeLocales` config to exclude locales from CSV import/export

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -146,9 +146,8 @@ export async function renderApp(
       hasExport: isFunction(t.onExport),
     })),
     defaultOneOfVariant: cmsConfig.defaultOneOfVariant || 'dropdown',
-    csv: {
-      excludeLocales: cmsConfig.csv?.excludeLocales || [],
-    },
+    excludeLocalesFromTranslations:
+      cmsConfig.excludeLocalesFromTranslations || [],
   };
   const projectName = cmsConfig.name || cmsConfig.id || '';
   const title = getCmsTitle(projectName, cmsConfig.minimalBranding);

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -146,6 +146,9 @@ export async function renderApp(
       hasExport: isFunction(t.onExport),
     })),
     defaultOneOfVariant: cmsConfig.defaultOneOfVariant || 'dropdown',
+    csv: {
+      excludeLocales: cmsConfig.csv?.excludeLocales || [],
+    },
   };
   const projectName = cmsConfig.name || cmsConfig.id || '';
   const title = getCmsTitle(projectName, cmsConfig.minimalBranding);

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -473,6 +473,30 @@ export type CMSPluginOptions = {
    * override this by setting their own `variant`. Defaults to `'dropdown'`.
    */
   defaultOneOfVariant?: 'dropdown' | 'picker';
+
+  /**
+   * Configuration for the CSV import/export feature in the Localization modal.
+   */
+  csv?: {
+    /**
+     * Locales to exclude from CSV import and export. Each entry is matched
+     * against the locale id and supports wildcards, where `*` matches any
+     * number of characters and `?` matches a single character. Matching is
+     * case-insensitive. Excluded locales are omitted from the exported CSV and
+     * ignored when importing.
+     *
+     * Example:
+     * ```ts
+     * cmsPlugin({
+     *   csv: {
+     *     // Exclude pseudo-locales like `ALL_es`, `ALL_fr`, etc.
+     *     excludeLocales: ['ALL_*'],
+     *   },
+     * });
+     * ```
+     */
+    excludeLocales?: string[];
+  };
 };
 
 export type CMSPlugin = Plugin & {

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -475,28 +475,22 @@ export type CMSPluginOptions = {
   defaultOneOfVariant?: 'dropdown' | 'picker';
 
   /**
-   * Configuration for the CSV import/export feature in the Localization modal.
+   * Locales to exclude from translation import and export (CSV, Google Sheets,
+   * and any registered translation services). Each entry is matched against
+   * the locale id and supports wildcards, where `*` matches any number of
+   * characters and `?` matches a single character. Matching is
+   * case-insensitive. Excluded locales are omitted from exports and ignored
+   * when importing.
+   *
+   * Example:
+   * ```ts
+   * cmsPlugin({
+   *   // Exclude pseudo-locales like `ALL_es`, `ALL_fr`, etc.
+   *   excludeLocalesFromTranslations: ['ALL_*'],
+   * });
+   * ```
    */
-  csv?: {
-    /**
-     * Locales to exclude from CSV import and export. Each entry is matched
-     * against the locale id and supports wildcards, where `*` matches any
-     * number of characters and `?` matches a single character. Matching is
-     * case-insensitive. Excluded locales are omitted from the exported CSV and
-     * ignored when importing.
-     *
-     * Example:
-     * ```ts
-     * cmsPlugin({
-     *   csv: {
-     *     // Exclude pseudo-locales like `ALL_es`, `ALL_fr`, etc.
-     *     excludeLocales: ['ALL_*'],
-     *   },
-     * });
-     * ```
-     */
-    excludeLocales?: string[];
-  };
+  excludeLocalesFromTranslations?: string[];
 };
 
 export type CMSPlugin = Plugin & {

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -61,6 +61,7 @@ import {
 import {
   batchSaveTranslations,
   batchUpdateTags,
+  isCsvLocaleExcluded,
   sourceHash,
 } from '../../utils/l10n.js';
 import {TranslationsMap, loadTranslations} from '../../utils/l10n.js';
@@ -649,7 +650,9 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   }
 
   function formatCsvData() {
-    const nonEnLocales = locales.filter((l) => l !== 'en');
+    const nonEnLocales = locales.filter(
+      (l) => l !== 'en' && !isCsvLocaleExcluded(l)
+    );
     const headers = ['source', 'en', ...nonEnLocales];
     const rows: Array<Record<string, string>> = [];
     sourceStrings.forEach((source) => {
@@ -702,9 +705,21 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
             throw new Error(`RPCError: ${errorText}`);
           }
           const resData = (await res.json()).data;
+          // Drop columns for any excluded locales so they aren't imported.
+          const filteredData = (resData as Array<Record<string, string>>).map(
+            (row) => {
+              const filtered: Record<string, string> = {};
+              Object.entries(row).forEach(([column, value]) => {
+                if (column === 'source' || !isCsvLocaleExcluded(column)) {
+                  filtered[column] = value;
+                }
+              });
+              return filtered;
+            }
+          );
           const importedTranslations = await cmsDocImportTranslations(
             props.docId,
-            resData
+            filteredData
           );
           setTranslationsMap((currentTranslations) => {
             return mergeTranslations(currentTranslations, importedTranslations);

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -61,7 +61,7 @@ import {
 import {
   batchSaveTranslations,
   batchUpdateTags,
-  isCsvLocaleExcluded,
+  isLocaleExcludedFromTranslations,
   sourceHash,
 } from '../../utils/l10n.js';
 import {TranslationsMap, loadTranslations} from '../../utils/l10n.js';
@@ -651,7 +651,7 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
 
   function formatCsvData() {
     const nonEnLocales = locales.filter(
-      (l) => l !== 'en' && !isCsvLocaleExcluded(l)
+      (l) => l !== 'en' && !isLocaleExcludedFromTranslations(l)
     );
     const headers = ['source', 'en', ...nonEnLocales];
     const rows: Array<Record<string, string>> = [];
@@ -705,21 +705,9 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
             throw new Error(`RPCError: ${errorText}`);
           }
           const resData = (await res.json()).data;
-          // Drop columns for any excluded locales so they aren't imported.
-          const filteredData = (resData as Array<Record<string, string>>).map(
-            (row) => {
-              const filtered: Record<string, string> = {};
-              Object.entries(row).forEach(([column, value]) => {
-                if (column === 'source' || !isCsvLocaleExcluded(column)) {
-                  filtered[column] = value;
-                }
-              });
-              return filtered;
-            }
-          );
           const importedTranslations = await cmsDocImportTranslations(
             props.docId,
-            filteredData
+            resData
           );
           setTranslationsMap((currentTranslations) => {
             return mergeTranslations(currentTranslations, importedTranslations);

--- a/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.tsx
+++ b/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.tsx
@@ -36,7 +36,11 @@ import {
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import {useArrayParam, useStringParam} from '../../hooks/useQueryParam.js';
 import {joinClassNames} from '../../utils/classes.js';
-import {batchUpdateTags, loadTranslations} from '../../utils/l10n.js';
+import {
+  batchUpdateTags,
+  isLocaleExcludedFromTranslations,
+  loadTranslations,
+} from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
@@ -57,7 +61,11 @@ export function TranslationsTable() {
   const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
   const allLocales = [
     'en',
-    ...locales.filter((l: string) => l !== 'en').sort(),
+    ...locales
+      .filter(
+        (l: string) => l !== 'en' && !isLocaleExcludedFromTranslations(l)
+      )
+      .sort(),
   ];
 
   // URL State.

--- a/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
+++ b/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
@@ -32,6 +32,7 @@ import {GoogleSheetId, getSpreadsheetUrl} from '../../utils/gsheets.js';
 import {
   Translation,
   TranslationsMap,
+  isLocaleExcludedFromTranslations,
   loadTranslations,
 } from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
@@ -58,7 +59,9 @@ export function DocTranslationsPage(props: DocTranslationsPageProps) {
   const pruneModal = usePruneTranslationsModal();
 
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const defaultLocales = i18nConfig.locales || [];
+  const defaultLocales = (i18nConfig.locales || []).filter(
+    (l) => !isLocaleExcludedFromTranslations(l)
+  );
   const [i18nLocales, setI18nLocales] = useArrayParam('locale', defaultLocales);
 
   async function init() {
@@ -283,7 +286,9 @@ interface DocTranslationsPageTableProps {
 
 DocTranslationsPage.Table = (props: DocTranslationsPageTableProps) => {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const allLocales = i18nConfig.locales || [];
+  const allLocales = (i18nConfig.locales || []).filter(
+    (l) => !isLocaleExcludedFromTranslations(l)
+  );
   const sourceToTranslationsMap = useMemo(() => {
     const results: {[source: string]: Record<string, string>} = {};
     Object.values(props.translationsMap).forEach(

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -223,6 +223,14 @@ declare global {
       }>;
       /** Default UI variant for `oneOf` fields. */
       defaultOneOfVariant?: 'dropdown' | 'picker';
+      /** Configuration for the CSV import/export feature. */
+      csv?: {
+        /**
+         * Locales to exclude from CSV import/export. Patterns support
+         * wildcards, e.g. `ALL_*`.
+         */
+        excludeLocales?: string[];
+      };
     };
     firebase: FirebaseContextObject;
   }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -223,14 +223,11 @@ declare global {
       }>;
       /** Default UI variant for `oneOf` fields. */
       defaultOneOfVariant?: 'dropdown' | 'picker';
-      /** Configuration for the CSV import/export feature. */
-      csv?: {
-        /**
-         * Locales to exclude from CSV import/export. Patterns support
-         * wildcards, e.g. `ALL_*`.
-         */
-        excludeLocales?: string[];
-      };
+      /**
+       * Locales to exclude from translation import/export. Patterns support
+       * wildcards, e.g. `ALL_*`.
+       */
+      excludeLocalesFromTranslations?: string[];
     };
     firebase: FirebaseContextObject;
   }

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -28,6 +28,7 @@ import {removeDocFromCache, removeDocsFromCache} from './doc-cache.js';
 import {GoogleSheetId} from './gsheets.js';
 import {
   getTranslationsCollection,
+  isLocaleExcludedFromTranslations,
   normalizeString,
   sourceHash,
 } from './l10n.js';
@@ -659,7 +660,8 @@ export async function cmsDocImportTranslations(
         return;
       }
       const locale = normalizeLocale(column);
-      if (locale) {
+      // Skip locales excluded from translation import/export (e.g. `ALL_*`).
+      if (locale && !isLocaleExcludedFromTranslations(locale)) {
         translation[locale] = normalizeString(str || '');
       }
     });

--- a/packages/root-cms/ui/utils/l10n.test.ts
+++ b/packages/root-cms/ui/utils/l10n.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {batchUpdateTags, isCsvLocaleExcluded} from './l10n.js';
+import {batchUpdateTags, isLocaleExcludedFromTranslations} from './l10n.js';
 
 // Mock values used in the function.
 const mockProjectId = 'test-project-id';
@@ -39,7 +39,7 @@ vi.mock('firebase/firestore', () => ({
   where: vi.fn(),
 }));
 
-describe('isCsvLocaleExcluded', () => {
+describe('isLocaleExcludedFromTranslations', () => {
   const originalCtx = window.__ROOT_CTX;
 
   afterEach(() => {
@@ -49,55 +49,55 @@ describe('isCsvLocaleExcluded', () => {
   function setExcludeLocales(patterns?: string[]) {
     window.__ROOT_CTX = {
       ...originalCtx,
-      csv: patterns ? {excludeLocales: patterns} : undefined,
+      excludeLocalesFromTranslations: patterns,
     } as any;
   }
 
   it('returns false when no patterns are configured', () => {
     setExcludeLocales();
-    expect(isCsvLocaleExcluded('en')).toBe(false);
-    expect(isCsvLocaleExcluded('ALL_es')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('en')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('ALL_es')).toBe(false);
   });
 
   it('matches `*` wildcard patterns', () => {
     setExcludeLocales(['ALL_*']);
-    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
-    expect(isCsvLocaleExcluded('ALL_fr')).toBe(true);
-    expect(isCsvLocaleExcluded('ALL_')).toBe(true);
-    expect(isCsvLocaleExcluded('es')).toBe(false);
-    expect(isCsvLocaleExcluded('es_ALL')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('ALL_es')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('ALL_fr')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('ALL_')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('es')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('es_ALL')).toBe(false);
   });
 
   it('matches `?` single-character wildcard patterns', () => {
     setExcludeLocales(['e?']);
-    expect(isCsvLocaleExcluded('en')).toBe(true);
-    expect(isCsvLocaleExcluded('es')).toBe(true);
-    expect(isCsvLocaleExcluded('e')).toBe(false);
-    expect(isCsvLocaleExcluded('eng')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('en')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('es')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('e')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('eng')).toBe(false);
   });
 
   it('matches case-insensitively', () => {
     setExcludeLocales(['all_*']);
-    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('ALL_es')).toBe(true);
   });
 
   it('supports exact (non-wildcard) patterns', () => {
     setExcludeLocales(['de']);
-    expect(isCsvLocaleExcluded('de')).toBe(true);
-    expect(isCsvLocaleExcluded('de_DE')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('de')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('de_DE')).toBe(false);
   });
 
   it('matches if any of multiple patterns match', () => {
     setExcludeLocales(['ALL_*', 'xx']);
-    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
-    expect(isCsvLocaleExcluded('xx')).toBe(true);
-    expect(isCsvLocaleExcluded('en')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('ALL_es')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('xx')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('en')).toBe(false);
   });
 
   it('treats regex special chars in patterns literally', () => {
     setExcludeLocales(['en.US']);
-    expect(isCsvLocaleExcluded('en.US')).toBe(true);
-    expect(isCsvLocaleExcluded('enXUS')).toBe(false);
+    expect(isLocaleExcludedFromTranslations('en.US')).toBe(true);
+    expect(isLocaleExcludedFromTranslations('enXUS')).toBe(false);
   });
 });
 

--- a/packages/root-cms/ui/utils/l10n.test.ts
+++ b/packages/root-cms/ui/utils/l10n.test.ts
@@ -1,5 +1,5 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {batchUpdateTags} from './l10n.js';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {batchUpdateTags, isCsvLocaleExcluded} from './l10n.js';
 
 // Mock values used in the function.
 const mockProjectId = 'test-project-id';
@@ -38,6 +38,68 @@ vi.mock('firebase/firestore', () => ({
   updateDoc: vi.fn(),
   where: vi.fn(),
 }));
+
+describe('isCsvLocaleExcluded', () => {
+  const originalCtx = window.__ROOT_CTX;
+
+  afterEach(() => {
+    window.__ROOT_CTX = originalCtx;
+  });
+
+  function setExcludeLocales(patterns?: string[]) {
+    window.__ROOT_CTX = {
+      ...originalCtx,
+      csv: patterns ? {excludeLocales: patterns} : undefined,
+    } as any;
+  }
+
+  it('returns false when no patterns are configured', () => {
+    setExcludeLocales();
+    expect(isCsvLocaleExcluded('en')).toBe(false);
+    expect(isCsvLocaleExcluded('ALL_es')).toBe(false);
+  });
+
+  it('matches `*` wildcard patterns', () => {
+    setExcludeLocales(['ALL_*']);
+    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
+    expect(isCsvLocaleExcluded('ALL_fr')).toBe(true);
+    expect(isCsvLocaleExcluded('ALL_')).toBe(true);
+    expect(isCsvLocaleExcluded('es')).toBe(false);
+    expect(isCsvLocaleExcluded('es_ALL')).toBe(false);
+  });
+
+  it('matches `?` single-character wildcard patterns', () => {
+    setExcludeLocales(['e?']);
+    expect(isCsvLocaleExcluded('en')).toBe(true);
+    expect(isCsvLocaleExcluded('es')).toBe(true);
+    expect(isCsvLocaleExcluded('e')).toBe(false);
+    expect(isCsvLocaleExcluded('eng')).toBe(false);
+  });
+
+  it('matches case-insensitively', () => {
+    setExcludeLocales(['all_*']);
+    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
+  });
+
+  it('supports exact (non-wildcard) patterns', () => {
+    setExcludeLocales(['de']);
+    expect(isCsvLocaleExcluded('de')).toBe(true);
+    expect(isCsvLocaleExcluded('de_DE')).toBe(false);
+  });
+
+  it('matches if any of multiple patterns match', () => {
+    setExcludeLocales(['ALL_*', 'xx']);
+    expect(isCsvLocaleExcluded('ALL_es')).toBe(true);
+    expect(isCsvLocaleExcluded('xx')).toBe(true);
+    expect(isCsvLocaleExcluded('en')).toBe(false);
+  });
+
+  it('treats regex special chars in patterns literally', () => {
+    setExcludeLocales(['en.US']);
+    expect(isCsvLocaleExcluded('en.US')).toBe(true);
+    expect(isCsvLocaleExcluded('enXUS')).toBe(false);
+  });
+});
 
 describe('batchUpdateTags', () => {
   beforeEach(() => {

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -189,12 +189,14 @@ function wildcardToRegExp(pattern: string): RegExp {
 }
 
 /**
- * Returns true if a locale should be excluded from CSV import/export, based on
- * the `csv.excludeLocales` patterns configured in the CMS plugin. Patterns
- * support wildcards, e.g. `ALL_*`.
+ * Returns true if a locale should be excluded from translation import/export
+ * (CSV, Google Sheets, translation services), based on the
+ * `excludeLocalesFromTranslations` patterns configured in the CMS plugin.
+ * Patterns support wildcards, e.g. `ALL_*`.
  */
-export function isCsvLocaleExcluded(locale: string): boolean {
-  const patterns = window.__ROOT_CTX.csv?.excludeLocales || [];
+export function isLocaleExcludedFromTranslations(locale: string): boolean {
+  const patterns =
+    window.__ROOT_CTX.excludeLocalesFromTranslations || [];
   return patterns.some((pattern) => wildcardToRegExp(pattern).test(locale));
 }
 

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -175,17 +175,30 @@ function removeTrailingWhitespace(str: string) {
 }
 
 /**
+ * Cache of compiled wildcard patterns. Imports can call
+ * `isLocaleExcludedFromTranslations()` many times per row/column, so we avoid
+ * recompiling the same pattern on every call.
+ */
+const wildcardRegExpCache = new Map<string, RegExp>();
+
+/**
  * Converts a wildcard pattern (e.g. `ALL_*`) to a case-insensitive RegExp.
  * Supports `*` (matches any number of characters) and `?` (matches a single
- * character).
+ * character). Compiled regexes are memoized per pattern.
  */
 function wildcardToRegExp(pattern: string): RegExp {
+  const cached = wildcardRegExpCache.get(pattern);
+  if (cached) {
+    return cached;
+  }
   const regexStr = pattern
     // Escape regex special chars except `*` and `?`.
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*/g, '.*')
     .replace(/\?/g, '.');
-  return new RegExp(`^${regexStr}$`, 'i');
+  const regExp = new RegExp(`^${regexStr}$`, 'i');
+  wildcardRegExpCache.set(pattern, regExp);
+  return regExp;
 }
 
 /**

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -174,6 +174,30 @@ function removeTrailingWhitespace(str: string) {
     .replace(/&nbsp;$/, '');
 }
 
+/**
+ * Converts a wildcard pattern (e.g. `ALL_*`) to a case-insensitive RegExp.
+ * Supports `*` (matches any number of characters) and `?` (matches a single
+ * character).
+ */
+function wildcardToRegExp(pattern: string): RegExp {
+  const regexStr = pattern
+    // Escape regex special chars except `*` and `?`.
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${regexStr}$`, 'i');
+}
+
+/**
+ * Returns true if a locale should be excluded from CSV import/export, based on
+ * the `csv.excludeLocales` patterns configured in the CMS plugin. Patterns
+ * support wildcards, e.g. `ALL_*`.
+ */
+export function isCsvLocaleExcluded(locale: string): boolean {
+  const patterns = window.__ROOT_CTX.csv?.excludeLocales || [];
+  return patterns.some((pattern) => wildcardToRegExp(pattern).test(locale));
+}
+
 export function normalizeLocale(locale: string) {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
   const i18nLocales = i18nConfig.locales || ['en'];


### PR DESCRIPTION
## Summary
This PR adds a new `excludeLocalesFromTranslations` configuration option to the CMS plugin that allows excluding specific locales from CSV import and export operations in the Localization modal. This is useful for excluding pseudo-locales or test locales (e.g., `ALL_es`, `ALL_fr`) from CSV workflows.

## Key Changes
- **New configuration option**: Added `excludeLocalesFromTranslations` to `CMSPluginOptions` in `plugin.ts` with support for wildcard patterns (`*` for any characters, `?` for single character)
- **Utility function**: Implemented `isCsvLocaleExcluded()` in `l10n.ts` that checks if a locale matches any exclude patterns with case-insensitive matching
- **Helper function**: Added `wildcardToRegExp()` to convert wildcard patterns to RegExp, properly escaping regex special characters while supporting `*` and `?` wildcards
- **CSV export filtering**: Modified `formatCsvData()` to exclude matching locales from the exported CSV headers and data
- **CSV import filtering**: Added logic to filter out excluded locale columns during CSV import so they aren't processed
- **Type definitions**: Updated `window.__ROOT_CTX` type in `ui.tsx` to include the new `csv` configuration
- **App initialization**: Updated `renderApp()` in `app.tsx` to pass the `csv.excludeLocales` config to the UI context
- **Comprehensive tests**: Added full test suite for `isCsvLocaleExcluded()` covering wildcard patterns, case-insensitivity, exact matches, multiple patterns, and literal regex character handling

## Implementation Details
- Patterns are matched case-insensitively against locale IDs
- Regex special characters in patterns are treated literally (e.g., `en.US` matches exactly, not as a regex)
- Both export and import operations respect the exclude list to maintain consistency
- The feature is backward compatible—if no patterns are configured, all locales are included

https://claude.ai/code/session_01MVfE3rU7rirVnLpiRehC8Z