### PR TITLE
fix: write .root gitignore entry at git repo root

### DIFF
--- a/.changeset/cold-sites-double.md
+++ b/.changeset/cold-sites-double.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: write .root gitignore entry at git repo root

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out/
 *.code-workspace
 .vitest-attachments/
 .claude/
+.root/

--- a/packages/root/src/cli/secrets.ts
+++ b/packages/root/src/cli/secrets.ts
@@ -424,9 +424,16 @@ function printPushResult(
   console.log();
 }
 
-/** Ensures `.root/` is git-ignored; returns true if it added the entry. */
+/**
+ * Ensures `.root/` is git-ignored; returns true if it added the entry. In a
+ * monorepo the project may live in a subdirectory, so the entry is written to
+ * the `.gitignore` at the enclosing git repository root (falling back to
+ * `rootDir` when not inside a git repo). The `.root/` pattern matches the
+ * directory at any depth, so it still ignores the project's `.root/` folder.
+ */
 async function ensureRootGitignored(rootDir: string): Promise<boolean> {
-  const gitignore = path.join(rootDir, '.gitignore');
+  const gitRoot = (await gitToplevel(rootDir)) ?? rootDir;
+  const gitignore = path.join(gitRoot, '.gitignore');
   let content = '';
   try {
     content = await fs.promises.readFile(gitignore, 'utf8');
@@ -450,6 +457,33 @@ async function warnIfEnvNotIgnored(rootDir: string): Promise<void> {
       `${BAR}   ${yellow('warning:')} ${dim('.env is not git-ignored — add it to .gitignore')}`
     );
   }
+}
+
+/**
+ * Returns the absolute path of the enclosing git repository's top-level
+ * directory, or undefined if `rootDir` is not inside a git repo (or git is
+ * unavailable).
+ */
+function gitToplevel(rootDir: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn('git', ['rev-parse', '--show-toplevel'], {
+        cwd: rootDir,
+      });
+      let stdout = '';
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.on('error', () => resolve(undefined));
+      child.on('close', (code) => {
+        const toplevel = stdout.trim();
+        resolve(code === 0 && toplevel ? toplevel : undefined);
+      });
+    } catch {
+      resolve(undefined);
+    }
+  });
 }
 
 /** Returns true/false if known, or undefined if git can't answer. */


### PR DESCRIPTION
## Summary
Updated the `.gitignore` management logic to write the `.root/` entry to the git repository root instead of the project root. This ensures proper git-ignoring of the `.root/` directory in monorepo setups where the project lives in a subdirectory.

## Key Changes
- Modified `ensureRootGitignored()` to detect the git repository root using a new `gitToplevel()` helper function and write `.gitignore` there instead of the project root
- Added `gitToplevel()` function that spawns `git rev-parse --show-toplevel` to find the enclosing git repository's top-level directory, with graceful fallback to `rootDir` when not in a git repo
- Enhanced JSDoc documentation to explain the monorepo behavior and clarify that the `.root/` pattern matches the directory at any depth

## Implementation Details
- The `gitToplevel()` function safely handles cases where git is unavailable or the directory is not in a git repository by returning `undefined`
- The `.gitignore` entry is now written to the correct location for monorepo projects while maintaining backward compatibility for single-project repositories
- Error handling includes both spawn errors and non-zero exit codes from the git command

https://claude.ai/code/session_01Cg7fcbf7ufoZEGr3B6ASHX