### PR TITLE
docs: add AI guidance on when and how to use changesets

### DIFF
--- a/.agent/rules/documentation.md
+++ b/.agent/rules/documentation.md
@@ -62,6 +62,9 @@ When working on this project, please adhere to the following guidelines:
 ### Version Control & Contributions
 
 - **Changesets**: If your changes require a release (version bump), you must create a changeset. Run `pnpm changeset` and follow the prompts.
+  - **When to create one**: Only create a changeset when the feature or bug fix is big/important enough to be worth mentioning in the changelog. Never create changesets for small bug fixes or style changes.
+  - **Message format**: The changeset message should be a single line, similar to the first line of the git commit message.
+  - Use conventional commit style messages (e.g. `feat:`, `fix:`, `chore:`). Do NOT prefix the package name in the message (bad: `feat(root-cms): lorem ipsum`, good: `feat: lorem ipsum`).
 - **Commit Messages**: Follow the conventional commit format (e.g., `feat: add new feature`, `fix: resolve issue`).
   - Use `feat` for new features, `fix` for bug fixes, `ci` for github actions workflows, `chore` for general cleanups / style tweaks / etc. Avoid other prefixes.
   - Avoid adding the package name in the commit message (bad: `feat(root-cms): lorem ipsum`, good: `feat: lorem ipsum`).


### PR DESCRIPTION
## What changed

Expanded the **Changesets** guidance in `.agent/rules/documentation.md` to tell AI agents when and how to create changesets:

- **When to create one**: Only when the feature or bug fix is big/important enough to warrant a changelog entry. Never for small bug fixes or style changes.
- **Message format**: A single line, similar to the first line of the git commit message.
- **Conventional commit style**: e.g. `feat:`, `fix:`, `chore:`, with no package-name prefix (e.g. `feat:` not `feat(root-cms):`).

## Why

Agents were creating changesets too liberally and with inconsistent message formatting. This codifies the project's expectations so generated changesets match the changelog conventions.