### PR TITLE
fix: prevent gzip buffering of AI chat streaming responses

### DIFF
--- a/.changeset/ai-streaming-no-transform.md
+++ b/.changeset/ai-streaming-no-transform.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: prevent gzip buffering of AI chat streaming responses

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -96,9 +96,37 @@ function isDocVersion(value: unknown): value is DocVersion {
 }
 
 /**
+ * Returns the given `Cache-Control` value with the `no-transform` directive
+ * added (defaulting to `no-cache` when none is set). `no-transform` instructs
+ * the Express `compression` middleware and any intermediary proxy to leave the
+ * body untouched — i.e. not gzip it. This is required for SSE/streaming
+ * responses: gzip buffers a window of output before flushing, so without it the
+ * stream is delivered to the client all at once instead of incrementally.
+ */
+function withNoTransform(cacheControl: string | null): string {
+  const value = cacheControl?.trim() || 'no-cache';
+  if (/(?:^|,)\s*no-transform\s*(?:,|$)/i.test(value)) {
+    return value;
+  }
+  return `${value}, no-transform`;
+}
+
+/**
  * Pipes a Web `Response` (e.g. from `streamText().toUIMessageStreamResponse()`)
- * to an Express `Response`. Headers are copied verbatim and the body is
- * streamed without buffering.
+ * to an Express `Response`, streaming the body through without buffering.
+ *
+ * Two upstream layers will otherwise hold the SSE chunks back:
+ * - The global `compression()` middleware (added in `root start`) treats
+ *   `text/event-stream` as compressible and keeps chunks in a gzip window, so
+ *   nothing reaches the client until the response ends. Adding `no-transform`
+ *   to `Cache-Control` makes `compression` skip the response, and signals any
+ *   intermediary proxy not to gzip it either.
+ * - Reverse proxies (nginx and friends) buffer unless sent
+ *   `X-Accel-Buffering: no`.
+ *
+ * Note: App Engine *Standard* additionally buffers every response into a single
+ * reply at its frontend and does not stream incrementally, regardless of these
+ * headers. Deploy on Cloud Run or App Engine Flexible for real-time streaming.
  */
 async function pipeWebResponse(
   webResponse: globalThis.Response,
@@ -108,7 +136,13 @@ async function pipeWebResponse(
   webResponse.headers.forEach((value, key) => {
     res.setHeader(key, value);
   });
-  // Disable buffering for streaming responses.
+  // Keep the stream unbuffered: `no-transform` disables gzip (in the
+  // `compression` middleware and proxies), and `X-Accel-Buffering` covers
+  // nginx-style reverse proxies.
+  res.setHeader(
+    'Cache-Control',
+    withNoTransform(webResponse.headers.get('cache-control'))
+  );
   res.setHeader('X-Accel-Buffering', 'no');
   if (!webResponse.body) {
     res.end();


### PR DESCRIPTION
## Summary
This change fixes streaming responses (like AI chat) being buffered instead of delivered incrementally to clients. The issue occurs because the Express `compression` middleware and reverse proxies buffer gzipped content before sending it.

## Key Changes
- Added `withNoTransform()` helper function that ensures the `no-transform` directive is present in the `Cache-Control` header (defaulting to `no-cache` if no header exists)
- Updated `pipeWebResponse()` to set `Cache-Control` with `no-transform` to prevent gzip buffering in the compression middleware and intermediary proxies
- Added `X-Accel-Buffering: no` header to disable buffering in nginx-style reverse proxies
- Enhanced documentation explaining why these headers are necessary for SSE/streaming responses

## Implementation Details
- The `no-transform` directive instructs the Express `compression` middleware and proxies to skip gzipping the response, allowing chunks to be sent incrementally
- The solution handles both cases: when a `Cache-Control` header already exists (appends `no-transform`) and when it doesn't (defaults to `no-cache, no-transform`)
- Added a note that App Engine Standard has additional limitations and doesn't support real-time streaming regardless of these headers

https://claude.ai/code/session_01RdGE6wzWHzYvNFvbniNEzK