### PR TITLE
feat: support markdown formatting in release descriptions

### DIFF
--- a/.changeset/markdown-release-descriptions.md
+++ b/.changeset/markdown-release-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: support markdown formatting in release descriptions

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
@@ -27,6 +27,19 @@
   margin-top: 4px;
 }
 
+.ReleasePage__header__description {
+  margin-top: 4px;
+  max-width: 800px;
+}
+
+.ReleasePage__header__description > :first-child {
+  margin-top: 0;
+}
+
+.ReleasePage__header__description > :last-child {
+  margin-bottom: 0;
+}
+
 .ReleasePage__header__controls {
   display: flex;
   align-items: center;

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
@@ -15,6 +15,7 @@ import {useEffect, useState} from 'preact/hooks';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {DocPreviewCard} from '../../components/DocPreviewCard/DocPreviewCard.js';
 import {Heading} from '../../components/Heading/Heading.js';
+import {Markdown} from '../../components/Markdown/Markdown.js';
 import {ReleaseStatusBadge} from '../../components/ReleaseStatusBadge/ReleaseStatusBadge.js';
 import {useScheduleReleaseModal} from '../../components/ScheduleReleaseModal/ScheduleReleaseModal.js';
 import {Surface} from '../../components/Surface/Surface.js';
@@ -80,7 +81,12 @@ export function ReleasePage(props: {id: string}) {
               </Tooltip>
             </div>
           </div>
-          {release?.description && <Text as="p">{release.description}</Text>}
+          {release?.description && (
+            <Markdown
+              className="ReleasePage__header__description"
+              code={release.description}
+            />
+          )}
         </div>
 
         {loading ? (


### PR DESCRIPTION
## Summary
Updated the ReleasePage to render release descriptions as markdown instead of plain text, allowing for richer formatting options.

## Changes
- Imported the `Markdown` component from the components library
- Replaced the plain text `<Text>` rendering of release descriptions with the `Markdown` component
- Added new CSS styles for `.ReleasePage__header__description` to:
  - Constrain the maximum width to 800px for better readability
  - Remove top margin from the first child element
  - Remove bottom margin from the last child element
  - Ensure proper spacing and layout of markdown-rendered content

## Implementation Details
The release description is now passed to the `Markdown` component via the `code` prop, which will parse and render any markdown syntax (bold, italic, links, lists, etc.) that users include in their release descriptions. The CSS adjustments ensure consistent spacing and prevent unwanted margins from nested markdown elements.

https://claude.ai/code/session_01GN7pVocVmG1JE9EPHNmpEA