### PR TITLE
fix: show AI summary in publish modal when top-level ai config is set

### DIFF
--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -57,7 +57,9 @@ export function PublishDocModal(
   const dateTimeRef = useRef<HTMLInputElement>(null);
   const modals = useModals();
   const modalTheme = useModalTheme();
-  const experiments = window.__ROOT_CTX.experiments || {};
+  const aiAvailable = !!(
+    window.__ROOT_CTX.ai || window.__ROOT_CTX.experiments?.ai
+  );
 
   const {roles, loading: rolesLoading} = useProjectRoles();
   const currentUserEmail = window.firebase.user.email || '';
@@ -283,7 +285,7 @@ export function PublishDocModal(
                   setPublishMessage(target.value);
                 }}
               />
-              {experiments.ai && (
+              {aiAvailable && (
                 <button
                   type="button"
                   className="PublishDocModal__form__publishMessage__sparkle"
@@ -332,7 +334,7 @@ export function PublishDocModal(
         </form>
         <div className="PublishDocModal__DiffWrapper">
           <ReferenceDocs docId={props.docId} />
-          {experiments.ai && (
+          {aiAvailable && (
             <AiSummary
               docId={props.docId}
               beforeVersion="published"


### PR DESCRIPTION
## Summary
Updated the AI feature flag detection logic in PublishDocModal to check for AI availability from multiple sources, improving flexibility in how the feature flag is configured.

## Key Changes
- Replaced direct `experiments.ai` reference with a new `aiAvailable` variable that checks both `window.__ROOT_CTX.ai` and `window.__ROOT_CTX.experiments?.ai`
- Updated all conditional renders that previously checked `experiments.ai` to use the new `aiAvailable` flag (2 locations: publish message sparkle button and AI summary section)
- Removed the unused `experiments` variable declaration

## Implementation Details
The new logic allows the AI feature to be enabled through either:
1. A direct `window.__ROOT_CTX.ai` property, or
2. The nested `window.__ROOT_CTX.experiments.ai` property

This provides more flexibility in feature flag configuration while maintaining backward compatibility with the existing experiments structure.

https://claude.ai/code/session_01FthYHaMtV1Cz6DvfeLYp2r