### PR TITLE
fix: add route import failure recovery with automatic page reload

### DIFF
--- a/.changeset/lazy-route-recovery.md
+++ b/.changeset/lazy-route-recovery.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: recover from route import failures after CMS rebuilds and redeploys

--- a/.changeset/lazy-route-recovery.md
+++ b/.changeset/lazy-route-recovery.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-fix: recover from route import failures after CMS rebuilds and redeploys
+fix: add route import failure recovery with automatic page reload

--- a/packages/root-cms/ui/components/RouteLoadError/RouteLoadError.css
+++ b/packages/root-cms/ui/components/RouteLoadError/RouteLoadError.css
@@ -1,0 +1,31 @@
+.RouteLoadError {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 100vh;
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.RouteLoadError__title {
+  font-size: 28px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.RouteLoadError__body {
+  font-size: 16px;
+  max-width: 480px;
+  font-weight: 400;
+}
+
+.RouteLoadError__error {
+  margin-top: 16px;
+  font-size: 12px;
+  color: #b00020;
+  max-width: 640px;
+  word-break: break-word;
+}

--- a/packages/root-cms/ui/components/RouteLoadError/RouteLoadError.tsx
+++ b/packages/root-cms/ui/components/RouteLoadError/RouteLoadError.tsx
@@ -1,0 +1,42 @@
+import {Button} from '@mantine/core';
+import {IconCloudOff, IconReload} from '@tabler/icons-preact';
+import './RouteLoadError.css';
+
+export interface RouteLoadErrorProps {
+  /** The error that caused the route to fail to load. */
+  error?: unknown;
+}
+
+/**
+ * Fallback screen rendered when the js for a route fails to load, e.g. when
+ * the server rebuilds or redeploys and the chunk files referenced by the
+ * version of the app running in the browser no longer exist on the server.
+ */
+export function RouteLoadError(props: RouteLoadErrorProps) {
+  const error = props.error;
+  const errorMessage =
+    error instanceof Error ? error.message : String(error || '');
+  return (
+    <div className="RouteLoadError">
+      <div className="RouteLoadError__icon">
+        <IconCloudOff size={60} />
+      </div>
+      <h2 className="RouteLoadError__title">Page failed to load</h2>
+      <p className="RouteLoadError__body">
+        The CMS may have been updated since this page was first opened. Reload
+        the page to fetch the latest version. If the problem persists, check
+        your network connection and try again.
+      </p>
+      <Button
+        color="dark"
+        leftIcon={<IconReload size={16} />}
+        onClick={() => window.location.reload()}
+      >
+        Reload page
+      </Button>
+      {errorMessage && (
+        <code className="RouteLoadError__error">{errorMessage}</code>
+      )}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -14,8 +14,8 @@ import {
   setDoc,
 } from 'firebase/firestore';
 import {getStorage} from 'firebase/storage';
-import {render, FunctionComponent} from 'preact';
-import {LocationProvider, Router, Route, lazy} from 'preact-iso';
+import {render} from 'preact';
+import {LocationProvider, Router, Route} from 'preact-iso';
 import type {CMSBuiltInSidebarTool} from '../core/plugin.js';
 import {Collection} from '../core/schema.js';
 import {AddToReleaseModal} from './components/AddToReleaseModal/AddToReleaseModal.js';
@@ -41,15 +41,7 @@ import {PendingReleasesProvider} from './hooks/usePendingReleases.js';
 import {SiteSettingsProvider} from './hooks/useSiteSettings.js';
 import {SSEProvider} from './hooks/useSSE.js';
 import {UserPreferencesProvider} from './hooks/useUserPreferences.js';
-
-/** Lazy-loads a named component export for use as a route component. */
-function lazyRoute<P>(
-  factory: () => Promise<FunctionComponent<P>>
-): FunctionComponent<P> {
-  return lazy(() =>
-    factory().then((component) => ({default: component}))
-  ) as unknown as FunctionComponent<P>;
-}
+import {lazyRoute} from './utils/lazy-route.js';
 
 const AIPage = lazyRoute(() =>
   import('./pages/AIPage/AIPage.js').then((m) => m.AIPage)

--- a/packages/root-cms/ui/utils/lazy-route.test.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.test.tsx
@@ -1,0 +1,78 @@
+import {render} from '@testing-library/preact';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {ROUTE_IMPORT_RELOAD_KEY, importRouteComponent} from './lazy-route.js';
+
+vi.mock('@mantine/core', async () => {
+  const actual: any = await vi.importActual('@mantine/core');
+  return {
+    ...actual,
+    Button: ({children, onClick}: any) => (
+      <button onClick={onClick}>{children}</button>
+    ),
+  };
+});
+
+function TestComponent() {
+  return <div>test page</div>;
+}
+
+describe('importRouteComponent', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  test('resolves with the component when the import succeeds', async () => {
+    const factory = vi.fn().mockResolvedValue(TestComponent);
+    const reload = vi.fn();
+    const component = await importRouteComponent(factory, {
+      retryDelayMs: 0,
+      reload,
+    });
+    expect(component).toBe(TestComponent);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('retries failed imports before succeeding', async () => {
+    const factory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue(TestComponent);
+    const reload = vi.fn();
+    const component = await importRouteComponent(factory, {
+      retryDelayMs: 0,
+      reload,
+    });
+    expect(component).toBe(TestComponent);
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('reloads the page when all import attempts fail', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const factory = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const reload = vi.fn();
+    // The returned promise intentionally never settles when reloading, so
+    // wait on the reload spy instead of awaiting the result.
+    void importRouteComponent(factory, {retryDelayMs: 0, reload});
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(factory).toHaveBeenCalledTimes(3);
+    expect(window.sessionStorage.getItem(ROUTE_IMPORT_RELOAD_KEY)).toBeTruthy();
+  });
+
+  test('falls back to an error screen if a reload was recently attempted', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.sessionStorage.setItem(ROUTE_IMPORT_RELOAD_KEY, String(Date.now()));
+    const factory = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const reload = vi.fn();
+    const ErrorComponent = await importRouteComponent(factory, {
+      retryDelayMs: 0,
+      reload,
+    });
+    expect(reload).not.toHaveBeenCalled();
+    const result = render(<ErrorComponent />);
+    expect(result.getByText('Page failed to load')).toBeTruthy();
+    expect(result.getByText('fetch failed')).toBeTruthy();
+  });
+});

--- a/packages/root-cms/ui/utils/lazy-route.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.tsx
@@ -1,0 +1,105 @@
+import {FunctionComponent} from 'preact';
+import {lazy} from 'preact-iso';
+import {RouteLoadError} from '../components/RouteLoadError/RouteLoadError.js';
+
+/** Number of times to attempt a route import before giving up. */
+const ROUTE_IMPORT_ATTEMPTS = 3;
+
+/** Base delay between route import retries (multiplied by attempt number). */
+const ROUTE_IMPORT_RETRY_DELAY_MS = 250;
+
+/**
+ * Storage key holding the timestamp of the last automatic reload triggered by
+ * a route import failure, used to guard against reload loops.
+ */
+export const ROUTE_IMPORT_RELOAD_KEY = 'root::lazyRoute::reloadedAt';
+
+/** Minimum time between automatic reloads triggered by route import failures. */
+const ROUTE_IMPORT_RELOAD_INTERVAL_MS = 60 * 1000;
+
+export interface ImportRouteComponentOptions {
+  /** Number of times to attempt the import before giving up. */
+  attempts?: number;
+  /** Base delay between retries (multiplied by the attempt number). */
+  retryDelayMs?: number;
+  /** Reloads the page. Overridable in tests. */
+  reload?: () => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Attempts a full page reload to recover from a route import failure, which
+ * typically happens when the server rebuilds or redeploys and the hashed
+ * chunk files referenced by the version of the app running in the browser no
+ * longer exist on the server. Returns `false` without reloading if a reload
+ * was already attempted recently (to avoid a reload loop) so callers can fall
+ * back to an error screen instead.
+ */
+function reloadOnRouteImportError(reload: () => void): boolean {
+  try {
+    const lastReloadAt = Number(
+      window.sessionStorage.getItem(ROUTE_IMPORT_RELOAD_KEY) || 0
+    );
+    if (Date.now() - lastReloadAt < ROUTE_IMPORT_RELOAD_INTERVAL_MS) {
+      return false;
+    }
+    window.sessionStorage.setItem(ROUTE_IMPORT_RELOAD_KEY, String(Date.now()));
+  } catch {
+    // If sessionStorage is unavailable there's no way to guard against a
+    // reload loop, so fall back to the error screen instead.
+    return false;
+  }
+  reload();
+  return true;
+}
+
+/**
+ * Imports a route component, retrying a few times on failure. Dynamic imports
+ * can fail when the server rebuilds or redeploys (the hashed chunk files
+ * change), when the login session expires, or due to flaky network requests.
+ * If the import still fails after all attempts, the page is automatically
+ * reloaded to fetch the latest version of the CMS. If a reload was already
+ * attempted recently, resolves to a `RouteLoadError` screen instead.
+ *
+ * NOTE: The returned promise never rejects. preact-iso treats a promise
+ * thrown during render as a suspension and only listens for it to resolve, so
+ * a rejected import would otherwise leave the router suspended forever.
+ */
+export async function importRouteComponent<P>(
+  factory: () => Promise<FunctionComponent<P>>,
+  options?: ImportRouteComponentOptions
+): Promise<FunctionComponent<P>> {
+  const attempts = options?.attempts ?? ROUTE_IMPORT_ATTEMPTS;
+  const retryDelayMs = options?.retryDelayMs ?? ROUTE_IMPORT_RETRY_DELAY_MS;
+  const reload = options?.reload ?? (() => window.location.reload());
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await factory();
+    } catch (err) {
+      lastError = err;
+      if (attempt < attempts) {
+        await sleep(retryDelayMs * attempt);
+      }
+    }
+  }
+  console.error('failed to import route component:', lastError);
+  if (reloadOnRouteImportError(reload)) {
+    // The page is about to reload; return a promise that never settles so the
+    // router stays in its current state until the reload occurs.
+    return new Promise(() => {});
+  }
+  return () => <RouteLoadError error={lastError} />;
+}
+
+/** Lazy-loads a named component export for use as a route component. */
+export function lazyRoute<P>(
+  factory: () => Promise<FunctionComponent<P>>
+): FunctionComponent<P> {
+  return lazy(() =>
+    importRouteComponent(factory).then((component) => ({default: component}))
+  ) as unknown as FunctionComponent<P>;
+}


### PR DESCRIPTION
## Summary
This PR adds resilient route loading with automatic recovery from import failures. When dynamic route imports fail (e.g., due to server rebuilds/redeploys), the system now retries the import and automatically reloads the page to fetch the latest version. If a reload was recently attempted, it falls back to an error screen instead of creating a reload loop.

## Key Changes
- **New `lazy-route.ts` utility**: Provides `importRouteComponent()` and `lazyRoute()` functions that wrap dynamic imports with retry logic and error recovery
  - Retries failed imports up to 3 times with exponential backoff (250ms base delay)
  - Automatically reloads the page on persistent failures to recover from stale chunk references
  - Guards against reload loops using sessionStorage to track recent reload attempts
  - Never rejects promises to prevent suspending the preact-iso router indefinitely
  
- **New `RouteLoadError` component**: Fallback UI displayed when route imports fail and automatic reload is not attempted
  - Shows user-friendly error message with cloud-off icon
  - Displays technical error details for debugging
  - Provides manual reload button
  
- **Updated `ui.tsx`**: Migrated from inline `lazyRoute()` implementation to use the new utility function

## Implementation Details
- The retry mechanism uses exponential backoff: delay = `retryDelayMs * attemptNumber`
- Reload attempts are throttled to once per 60 seconds to prevent infinite reload loops
- sessionStorage is used to track reload timestamps; if unavailable, falls back to error screen
- The returned promise intentionally never settles during reload to keep the router in its current state until the page reloads
- Comprehensive test coverage validates success paths, retry behavior, reload logic, and error fallback scenarios

https://claude.ai/code/session_013naiYxzHcCAtiuShZNqGTn