### PR TITLE
feat: parallel SSG rendering with `root build --threads`

### DIFF
--- a/.changeset/build-threads.md
+++ b/.changeset/build-threads.md
@@ -1,38 +1,5 @@
 ---
-'@blinkk/root': minor
+'@blinkk/root': patch
 ---
 
 feat: parallel SSG rendering with `root build --threads`
-
-`root build` now accepts a `--threads [num]` flag that renders SSG pages
-using N worker threads. Page rendering was previously limited to a single
-CPU core — the `-c/--concurrency` flag overlaps async I/O (e.g. CMS fetches
-in `getStaticProps()`) but JSX rendering itself is synchronous CPU work, so
-builds for large sites (hundreds of pages across many locales) were
-bottlenecked on one core.
-
-Each worker thread loads the site's built server bundle
-(`dist/server/render.js`) plus the asset manifest and renders pages
-independently, mirroring how the prod server bootstraps. The main thread
-computes the sitemap, schedules pages across workers, and aggregates
-results (output logging and sitemap.xml generation are unchanged).
-
-Usage:
-
-```sh
-# Render pages using 8 worker threads.
-root build --threads 8
-
-# Pick a worker count automatically based on cpu cores and page count.
-root build --threads
-root build --threads auto
-```
-
-In auto mode, one core is reserved for the main thread and each worker must
-have enough pages to justify its startup cost; small builds automatically
-stay in-process.
-
-The flag is opt-in; builds without `--threads` behave exactly as before.
-`-c/--concurrency` is distributed across workers (e.g. `-c 30 --threads 6`
-gives each worker an async concurrency of 5). Output is byte-for-byte
-identical to single-threaded builds.

--- a/.changeset/build-threads.md
+++ b/.changeset/build-threads.md
@@ -1,0 +1,33 @@
+---
+'@blinkk/root': minor
+---
+
+feat: parallel SSG rendering with `root build --threads`
+
+`root build` now accepts a `--threads [num]` flag that renders SSG pages
+using N worker threads. Page rendering was previously limited to a single
+CPU core — the `-c/--concurrency` flag overlaps async I/O (e.g. CMS fetches
+in `getStaticProps()`) but JSX rendering itself is synchronous CPU work, so
+builds for large sites (hundreds of pages across many locales) were
+bottlenecked on one core.
+
+Each worker thread loads the site's built server bundle
+(`dist/server/render.js`) plus the asset manifest and renders pages
+independently, mirroring how the prod server bootstraps. The main thread
+computes the sitemap, schedules pages across workers, and aggregates
+results (output logging and sitemap.xml generation are unchanged).
+
+Usage:
+
+```sh
+# Render pages using 8 worker threads.
+root build --threads 8
+
+# Use one thread per available CPU core.
+root build --threads
+```
+
+The flag is opt-in; builds without `--threads` behave exactly as before.
+`-c/--concurrency` is distributed across workers (e.g. `-c 30 --threads 6`
+gives each worker an async concurrency of 5). Output is byte-for-byte
+identical to single-threaded builds.

--- a/.changeset/build-threads.md
+++ b/.changeset/build-threads.md
@@ -23,9 +23,14 @@ Usage:
 # Render pages using 8 worker threads.
 root build --threads 8
 
-# Use one thread per available CPU core.
+# Pick a worker count automatically based on cpu cores and page count.
 root build --threads
+root build --threads auto
 ```
+
+In auto mode, one core is reserved for the main thread and each worker must
+have enough pages to justify its startup cost; small builds automatically
+stay in-process.
 
 The flag is opt-in; builds without `--threads` behave exactly as before.
 `-c/--concurrency` is distributed across workers (e.g. `-c 30 --threads 6`

--- a/packages/root/esbuild.config.json
+++ b/packages/root/esbuild.config.json
@@ -1,6 +1,7 @@
 {
   "entryPoints": {
     "cli": "src/cli/cli.ts",
+    "build-worker": "src/cli/build-worker.ts",
     "core": "src/core/core.ts",
     "functions": "src/functions/functions.ts",
     "jsx": "src/jsx/jsx.ts",

--- a/packages/root/src/cli/build-page.ts
+++ b/packages/root/src/cli/build-page.ts
@@ -1,0 +1,118 @@
+import path from 'node:path';
+
+import {RootConfig} from '../core/config.js';
+import {Route} from '../core/types.js';
+import {transformHtml} from '../render/html-transform.js';
+import {makeDir, writeFile} from '../utils/fsutils.js';
+
+type Renderer = import('../render/render.js').Renderer;
+
+/** A single page to build during the SSG phase of `root build`. */
+export interface BuildPageTask {
+  /** The url path to build, e.g. `/intl/de/about/`. */
+  urlPath: string;
+  /** Route params used to build the page. */
+  params: Record<string, string>;
+  /**
+   * The route's src file (e.g. `routes/blog/[slug].tsx`). Used by worker
+   * threads to disambiguate overlapping routes that match the same url path.
+   */
+  routeSrc?: string;
+  /** The route's locale, used with `routeSrc` to disambiguate routes. */
+  locale?: string;
+}
+
+/** The result of building a single page. */
+export interface BuildPageResult {
+  urlPath: string;
+  /** Output file path relative to the build dir. Unset when `notFound`. */
+  outFilePath?: string;
+  notFound?: boolean;
+  /** Whether the output was generated via `getStaticContent()`. */
+  staticContent?: boolean;
+}
+
+/** Message sent from the build worker to the main thread. */
+export type BuildWorkerResponse =
+  | {type: 'ready'}
+  | {type: 'result'; id: number; result: BuildPageResult}
+  | {
+      type: 'error';
+      id: number;
+      urlPath: string;
+      params: Record<string, string>;
+      routeSrc?: string;
+      error: string;
+    }
+  | {type: 'fatal'; error: string};
+
+/** Message sent from the main thread to the build worker. */
+export type BuildWorkerRequest = {
+  type: 'render';
+  id: number;
+  task: BuildPageTask;
+};
+
+/**
+ * Builds a single page (or static content file) to the build dir. Shared by
+ * the in-process SSG build loop and the `--threads` build worker.
+ */
+export async function buildPage(
+  renderer: Renderer,
+  rootConfig: RootConfig,
+  buildDir: string,
+  route: Route,
+  task: BuildPageTask
+): Promise<BuildPageResult> {
+  const {urlPath, params} = task;
+  const routeModule = route.module;
+  if (routeModule.getStaticContent) {
+    let props: any;
+    if (routeModule.getStaticProps) {
+      props = await routeModule.getStaticProps({
+        rootConfig,
+        params,
+      });
+      if (props?.notFound) {
+        return {urlPath, notFound: true};
+      }
+    } else {
+      props = {rootConfig, params};
+    }
+    const result = await routeModule.getStaticContent(props);
+    let body: string;
+    if (typeof result === 'string') {
+      body = result;
+    } else if (result && typeof result === 'object') {
+      body = result.body;
+    } else {
+      body = '';
+    }
+    const outFilePath = urlPath.slice(1);
+    const outPath = path.join(buildDir, outFilePath);
+    await makeDir(path.dirname(outPath));
+    await writeFile(outPath, normalizeLineEndings(body));
+    return {urlPath, outFilePath, staticContent: true};
+  }
+
+  const data = await renderer.renderRoute(route, {
+    routeParams: params,
+  });
+  if (data.notFound) {
+    return {urlPath, notFound: true};
+  }
+
+  let outFilePath = path.join(urlPath.slice(1), 'index.html');
+  if (outFilePath.endsWith('404/index.html')) {
+    outFilePath = outFilePath.replace('404/index.html', '404.html');
+  }
+  const outPath = path.join(buildDir, outFilePath);
+
+  const html = await transformHtml(data.html || '', rootConfig);
+  await writeFile(outPath, normalizeLineEndings(html));
+  return {urlPath, outFilePath};
+}
+
+export function normalizeLineEndings(str: string): string {
+  return str.replace(/\r\n?/g, '\n');
+}

--- a/packages/root/src/cli/build-worker-pool.ts
+++ b/packages/root/src/cli/build-worker-pool.ts
@@ -1,0 +1,182 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {Worker} from 'node:worker_threads';
+
+import {
+  BuildPageResult,
+  BuildPageTask,
+  BuildWorkerRequest,
+  BuildWorkerResponse,
+} from './build-page.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface BuildWorkerPoolOptions {
+  /** Number of worker threads. */
+  numWorkers: number;
+  /**
+   * Number of pages each worker renders concurrently. Rendering is async, so
+   * pages that wait on I/O (e.g. CMS fetches in `getStaticProps()`) don't
+   * block other pages on the same thread.
+   */
+  workerConcurrency: number;
+  /** Project root dir, passed to each worker. */
+  rootDir: string;
+  /** Build mode (e.g. "production"), passed to each worker. */
+  mode: string;
+}
+
+interface PendingTask {
+  id: number;
+  task: BuildPageTask;
+  resolve: (result: BuildPageResult) => void;
+  reject: (err: Error) => void;
+}
+
+export class BuildPageError extends Error {
+  urlPath: string;
+  params: Record<string, string>;
+  routeSrc?: string;
+  workerError: string;
+
+  constructor(
+    urlPath: string,
+    params: Record<string, string>,
+    routeSrc: string | undefined,
+    workerError: string
+  ) {
+    super(
+      `BuildError: ${urlPath} (${routeSrc || 'unknown route'}) failed to build.`
+    );
+    this.urlPath = urlPath;
+    this.params = params;
+    this.routeSrc = routeSrc;
+    this.workerError = workerError;
+  }
+}
+
+class BuildWorker {
+  private worker: Worker;
+  private pool: BuildWorkerPool;
+  private concurrency: number;
+  private inFlight = new Map<number, PendingTask>();
+  private isReady = false;
+  ready: Promise<void>;
+
+  constructor(pool: BuildWorkerPool, options: BuildWorkerPoolOptions) {
+    this.pool = pool;
+    this.concurrency = options.workerConcurrency;
+    this.worker = new Worker(path.resolve(__dirname, './build-worker.js'), {
+      workerData: {rootDir: options.rootDir, mode: options.mode},
+    });
+    let onReady!: () => void;
+    let onFailed!: (err: Error) => void;
+    this.ready = new Promise<void>((resolve, reject) => {
+      onReady = resolve;
+      onFailed = reject;
+    });
+    this.worker.on('message', (msg: BuildWorkerResponse) => {
+      if (msg.type === 'ready') {
+        this.isReady = true;
+        onReady();
+        this.next();
+      } else if (msg.type === 'result') {
+        const pending = this.inFlight.get(msg.id);
+        this.inFlight.delete(msg.id);
+        pending?.resolve(msg.result);
+        this.next();
+      } else if (msg.type === 'error') {
+        const pending = this.inFlight.get(msg.id);
+        this.inFlight.delete(msg.id);
+        pending?.reject(
+          new BuildPageError(msg.urlPath, msg.params, msg.routeSrc, msg.error)
+        );
+        this.next();
+      } else if (msg.type === 'fatal') {
+        const err = new Error(`build worker failed: ${msg.error}`);
+        onFailed(err);
+        this.failAll(err);
+      }
+    });
+    this.worker.on('error', (err) => {
+      onFailed(err);
+      this.failAll(err);
+    });
+    this.worker.on('exit', (code) => {
+      if (code !== 0) {
+        const err = new Error(`build worker exited with code ${code}`);
+        onFailed(err);
+        this.failAll(err);
+      }
+    });
+  }
+
+  private failAll(err: Error) {
+    const pendingTasks = Array.from(this.inFlight.values());
+    this.inFlight.clear();
+    pendingTasks.forEach((pending) => pending.reject(err));
+  }
+
+  /** Pulls tasks off the pool's queue until at max concurrency. */
+  next() {
+    if (!this.isReady) {
+      return;
+    }
+    while (this.inFlight.size < this.concurrency) {
+      const pending = this.pool.dequeue();
+      if (!pending) {
+        return;
+      }
+      this.inFlight.set(pending.id, pending);
+      const req: BuildWorkerRequest = {
+        type: 'render',
+        id: pending.id,
+        task: pending.task,
+      };
+      this.worker.postMessage(req);
+    }
+  }
+
+  async terminate() {
+    await this.worker.terminate();
+  }
+}
+
+/**
+ * A pool of worker threads that render SSG pages in parallel. Each worker
+ * loads the site's built server bundle (`dist/server/render.js`) and renders
+ * pages independently, allowing the build to utilize multiple CPU cores.
+ */
+export class BuildWorkerPool {
+  private workers: BuildWorker[] = [];
+  private queue: PendingTask[] = [];
+  private nextTaskId = 0;
+
+  constructor(options: BuildWorkerPoolOptions) {
+    for (let i = 0; i < options.numWorkers; i++) {
+      this.workers.push(new BuildWorker(this, options));
+    }
+  }
+
+  /** Waits for all workers to finish initializing. */
+  async ready() {
+    await Promise.all(this.workers.map((worker) => worker.ready));
+  }
+
+  /** Schedules a page build and resolves when the page finishes. */
+  run(task: BuildPageTask): Promise<BuildPageResult> {
+    return new Promise<BuildPageResult>((resolve, reject) => {
+      this.queue.push({id: this.nextTaskId++, task, resolve, reject});
+      // Wake up any workers with spare capacity.
+      this.workers.forEach((worker) => worker.next());
+    });
+  }
+
+  dequeue(): PendingTask | undefined {
+    return this.queue.shift();
+  }
+
+  async terminate() {
+    await Promise.all(this.workers.map((worker) => worker.terminate()));
+  }
+}

--- a/packages/root/src/cli/build-worker.ts
+++ b/packages/root/src/cli/build-worker.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+import {parentPort, workerData} from 'node:worker_threads';
+
+import {Route} from '../core/types.js';
+import {ElementGraph} from '../node/element-graph.js';
+import {loadBundledConfig} from '../node/load-config.js';
+import {
+  BuildAssetManifest,
+  BuildAssetMap,
+} from '../render/asset-map/build-asset-map.js';
+import {loadJson} from '../utils/fsutils.js';
+import {
+  buildPage,
+  BuildPageTask,
+  BuildWorkerRequest,
+  BuildWorkerResponse,
+} from './build-page.js';
+
+type RenderModule = typeof import('../render/render.js');
+
+export interface BuildWorkerData {
+  rootDir: string;
+  mode: string;
+}
+
+async function main() {
+  if (!parentPort) {
+    throw new Error('build-worker.js must be run as a worker thread');
+  }
+  const port = parentPort;
+  const {rootDir, mode} = workerData as BuildWorkerData;
+  process.env.NODE_ENV = mode;
+
+  const rootConfig = await loadBundledConfig(rootDir, {command: 'build'});
+  const distDir = path.join(rootDir, 'dist');
+  const buildDir = path.join(distDir, 'html');
+
+  // Load the site's pre-built server bundle and asset manifests, mirroring
+  // the prod server (`root start`) bootstrapping.
+  const render: RenderModule = await import(
+    path.join(distDir, 'server/render.js')
+  );
+  const rootManifest = await loadJson<BuildAssetManifest>(
+    path.join(distDir, '.root/manifest.json')
+  );
+  const assetMap = BuildAssetMap.fromRootManifest(rootConfig, rootManifest);
+  const elementGraphJson = await loadJson<any>(
+    path.join(distDir, '.root/elements.json')
+  );
+  const elementGraph = ElementGraph.fromJson(elementGraphJson);
+  const renderer = new render.Renderer(rootConfig, {assetMap, elementGraph});
+
+  // Build a map of routes keyed by src + locale. The main thread's sitemap
+  // identifies each page's route by its src file and locale, which uniquely
+  // identifies a route registered with the router. (Url matching is not used
+  // here since some routes, e.g. `[slug].json.ts`, are not resolvable from
+  // their generated url paths.)
+  const routesByKey = new Map<string, Route>();
+  const routeKey = (src: string, locale: string, isDefaultLocale: boolean) => {
+    return `${src}|${isDefaultLocale ? 'x-default' : locale}`;
+  };
+  await renderer.walkRoutes(async (_urlPathFormat: string, route: Route) => {
+    routesByKey.set(
+      routeKey(route.src, route.locale, route.isDefaultLocale),
+      route
+    );
+  });
+
+  /**
+   * Resolves the route for a task using the route src and locale provided by
+   * the main thread's sitemap. Falls back to url matching.
+   */
+  function findRoute(task: BuildPageTask): Route | undefined {
+    if (task.routeSrc && task.locale) {
+      const route = routesByKey.get(
+        routeKey(task.routeSrc, task.locale, task.locale === 'x-default')
+      );
+      if (route) {
+        return route;
+      }
+    }
+    const matches = renderer.getRouteMatches(task.urlPath);
+    for (const [route] of matches) {
+      if (!task.routeSrc || route.src === task.routeSrc) {
+        return route;
+      }
+    }
+    return undefined;
+  }
+
+  port.on('message', async (msg: BuildWorkerRequest) => {
+    if (msg.type !== 'render') {
+      return;
+    }
+    const task = msg.task;
+    try {
+      const route = findRoute(task);
+      if (!route) {
+        throw new Error(`could not find route for ${task.urlPath}`);
+      }
+      const result = await buildPage(
+        renderer,
+        rootConfig,
+        buildDir,
+        route,
+        task
+      );
+      const res: BuildWorkerResponse = {type: 'result', id: msg.id, result};
+      port.postMessage(res);
+    } catch (e: any) {
+      const res: BuildWorkerResponse = {
+        type: 'error',
+        id: msg.id,
+        urlPath: task.urlPath,
+        params: task.params,
+        routeSrc: task.routeSrc,
+        error: String(e?.stack || e),
+      };
+      port.postMessage(res);
+    }
+  });
+
+  const readyRes: BuildWorkerResponse = {type: 'ready'};
+  port.postMessage(readyRes);
+}
+
+main().catch((e) => {
+  const res: BuildWorkerResponse = {
+    type: 'fatal',
+    error: String(e?.stack || e),
+  };
+  if (parentPort) {
+    parentPort.postMessage(res);
+  } else {
+    console.error(res.error);
+    process.exit(1);
+  }
+});

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -41,8 +41,9 @@ export interface BuildOptions {
   concurrency?: string | number;
   filter?: string;
   /**
-   * Renders pages using N worker threads. When passed without a value, uses
-   * one thread per available CPU core (minus one for the main thread).
+   * Renders pages using worker threads. Pass a number to use exactly N
+   * workers, or pass without a value (or "auto") to pick a worker count
+   * automatically based on CPU cores and the number of pages to build.
    */
   threads?: string | boolean;
 }
@@ -490,7 +491,10 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
 
     console.log('\nhtml output:');
     const concurrency = Number(options?.concurrency || 10);
-    const numThreads = parseNumThreads(options?.threads);
+    const numThreads = resolveNumThreads(
+      options?.threads,
+      sitemapEntries.length
+    );
 
     if (numThreads > 0) {
       // Render pages in parallel using worker threads. Each worker loads the
@@ -606,16 +610,42 @@ function isRouteFile(filepath: string) {
 }
 
 /**
- * Parses the `--threads` flag. Returns 0 when unset (single-threaded build).
- * When passed without a value (`--threads`), defaults to one worker per
- * available CPU core, minus one for the main thread.
+ * Minimum number of pages per worker thread in "auto" mode. Each worker pays
+ * a fixed startup cost (loading the server bundle, config, and manifests), so
+ * spawning a worker is only worthwhile when it has enough pages to render.
  */
-function parseNumThreads(threads?: string | boolean): number {
+const MIN_PAGES_PER_THREAD = 10;
+
+/**
+ * Resolves the `--threads` flag to a worker count. Returns 0 for an
+ * in-process (single-threaded) build.
+ *
+ * - unset: 0 (in-process build).
+ * - `--threads` or `--threads auto`: picks a worker count based on the
+ *   machine's CPU cores and the number of pages to build. One core is
+ *   reserved for the main thread, and each worker should have at least
+ *   `MIN_PAGES_PER_THREAD` pages to justify its startup cost. Small builds
+ *   resolve to 0 and stay in-process.
+ * - `--threads <num>`: uses exactly N workers (no workload heuristics).
+ */
+function resolveNumThreads(
+  threads: string | boolean | undefined,
+  numPages: number
+): number {
   if (threads === undefined || threads === false) {
     return 0;
   }
-  if (threads === true) {
-    return Math.max(os.availableParallelism() - 1, 1);
+  if (threads === true || threads === 'auto') {
+    const maxByCpu = Math.max(os.availableParallelism() - 1, 1);
+    const maxByPages = Math.floor(numPages / MIN_PAGES_PER_THREAD);
+    const numThreads = Math.min(maxByCpu, maxByPages);
+    // A single worker is never faster than rendering in-process (same
+    // parallelism, plus startup and messaging overhead).
+    if (numThreads <= 1) {
+      return 0;
+    }
+    console.log(`rendering with ${numThreads} worker threads`);
+    return numThreads;
   }
   const num = parseInt(threads);
   if (isNaN(num) || num < 0) {

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-control-regex */
+import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -8,7 +9,7 @@ import glob from 'tiny-glob';
 import {build as viteBuild, Manifest, ManifestChunk, UserConfig} from 'vite';
 
 import {getVitePlugins} from '../core/plugin.js';
-import {Route, Sitemap} from '../core/types.js';
+import {Route, Sitemap, SitemapItem} from '../core/types.js';
 import {getElements} from '../node/element-graph.js';
 import {bundleRootConfig, loadRootConfig} from '../node/load-config.js';
 import {collectPods} from '../node/pod-collector.js';
@@ -16,7 +17,6 @@ import {rootPodsVitePlugin} from '../node/pods-vite-plugin.js';
 import {pruneEmptyChunksPlugin} from '../node/vite-plugin-prune-empty-chunks.js';
 import {preactToRootJsxPlugin} from '../node/vite-plugin-root-jsx-virtual.js';
 import {BuildAssetMap} from '../render/asset-map/build-asset-map.js';
-import {transformHtml} from '../render/html-transform.js';
 import {batchAsyncCalls} from '../utils/batch.js';
 import {
   copyGlob,
@@ -28,6 +28,8 @@ import {
   rmDir,
   writeFile,
 } from '../utils/fsutils.js';
+import {buildPage, BuildPageResult} from './build-page.js';
+import {BuildPageError, BuildWorkerPool} from './build-worker-pool.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -38,6 +40,11 @@ export interface BuildOptions {
   mode?: string;
   concurrency?: string | number;
   filter?: string;
+  /**
+   * Renders pages using N worker threads. When passed without a value, uses
+   * one thread per available CPU core (minus one for the main thread).
+   */
+  threads?: string | boolean;
 }
 
 export async function build(rootProjectDir?: string, options?: BuildOptions) {
@@ -420,107 +427,138 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
     }
     const domain = rootConfig.domain!;
 
-    console.log('\nhtml output:');
-    const batchSize = Number(options?.concurrency || 10);
-
-    await batchAsyncCalls(
-      Object.entries(sitemap),
-      batchSize,
-      async ([urlPath, sitemapItem]) => {
-        // If "excludeDefaultLocaleFromIntlPaths" is true, ignore /intl/en/... in
-        // the SSG build and exclude it from sitemap.xml.
-        if (rootConfig.build?.excludeDefaultLocaleFromIntlPaths) {
-          const defaultLocale = rootConfig.i18n?.defaultLocale || 'en';
-          if (sitemapItem.locale === defaultLocale) {
-            return;
-          }
-        }
-
-        try {
-          const routeModule = sitemapItem.route.module;
-          if (routeModule.getStaticContent) {
-            let props: any;
-            if (routeModule.getStaticProps) {
-              props = await routeModule.getStaticProps({
-                rootConfig,
-                params: sitemapItem.params,
-              });
-              if (props?.notFound) {
-                return;
-              }
-            } else {
-              props = {rootConfig, params: sitemapItem.params};
-            }
-            const result = await routeModule.getStaticContent(props);
-            let body: string;
-            if (typeof result === 'string') {
-              body = result;
-            } else if (result && typeof result === 'object') {
-              body = result.body;
-            } else {
-              body = '';
-            }
-            const outFilePath = urlPath.slice(1);
-            const outPath = path.join(buildDir, outFilePath);
-            await makeDir(path.dirname(outPath));
-            await writeFile(outPath, normalizeLineEndings(body));
-            printFileOutput(fileSize(outPath), 'dist/html/', outFilePath);
-            return;
-          }
-
-          const data = await renderer.renderRoute(sitemapItem.route, {
-            routeParams: sitemapItem.params,
+    /** Adds an entry to sitemap.xml for a rendered page. */
+    const addSitemapXmlItem = (
+      urlPath: string,
+      sitemapItem: SitemapItem,
+      outFilePath: string
+    ) => {
+      // Save the url to sitemap.xml. Ignore error files (e.g. 404.html).
+      if (!rootConfig.sitemap || !outFilePath.endsWith('index.html')) {
+        return;
+      }
+      const sitemapXmlItem: {
+        url: string;
+        locale: string;
+        alts: Array<{locale: string; hreflang: string; url: string}>;
+      } = {
+        url: `${domain}${urlPath}`,
+        locale: sitemapItem.locale,
+        alts: [],
+      };
+      sitemapXmlItems.push(sitemapXmlItem);
+      if (sitemapItem.alts) {
+        Object.entries(sitemapItem.alts).forEach(([altLocale, item]) => {
+          sitemapXmlItem.alts.push({
+            url: `${domain}${item.urlPath}`,
+            locale: altLocale,
+            hreflang: item.hrefLang,
           });
-          if (data.notFound) {
-            return;
-          }
+        });
+      }
+    };
 
-          let outFilePath = path.join(urlPath.slice(1), 'index.html');
-          if (outFilePath.endsWith('404/index.html')) {
-            outFilePath = outFilePath.replace('404/index.html', '404.html');
-          }
-          const outPath = path.join(buildDir, outFilePath);
+    /** Handles the result of a page render. */
+    const onPageResult = (
+      sitemapItem: SitemapItem,
+      result: BuildPageResult
+    ) => {
+      if (result.notFound || !result.outFilePath) {
+        return;
+      }
+      if (!result.staticContent) {
+        addSitemapXmlItem(result.urlPath, sitemapItem, result.outFilePath);
+      }
+      printFileOutput(
+        fileSize(path.join(buildDir, result.outFilePath)),
+        'dist/html/',
+        result.outFilePath
+      );
+    };
 
-          // Save the url to sitemap.xml. Ignore error files (e.g. 404.html).
-          if (rootConfig.sitemap && outFilePath.endsWith('index.html')) {
-            const sitemapXmlItem: {
-              url: string;
-              locale: string;
-              alts: Array<{locale: string; hreflang: string; url: string}>;
-            } = {
-              url: `${domain}${urlPath}`,
-              locale: sitemapItem.locale,
-              alts: [],
-            };
-            sitemapXmlItems.push(sitemapXmlItem);
-            if (sitemapItem.alts) {
-              Object.entries(sitemapItem.alts).forEach(([altLocale, item]) => {
-                sitemapXmlItem.alts.push({
-                  url: `${domain}${item.urlPath}`,
-                  locale: altLocale,
-                  hreflang: item.hrefLang,
-                });
-              });
-            }
-          }
-
-          // Render html and save the file to dist/html.
-          const html = await transformHtml(data.html || '', rootConfig);
-          await writeFile(outPath, normalizeLineEndings(html));
-
-          printFileOutput(fileSize(outPath), 'dist/html/', outFilePath);
-        } catch (e) {
-          logBuildError(
-            {route: sitemapItem.route, params: sitemapItem.params, urlPath},
-            e
-          );
-          throw new Error(
-            `BuildError: ${urlPath} (${sitemapItem.route.src}) failed to build.`,
-            {cause: e}
-          );
+    // If "excludeDefaultLocaleFromIntlPaths" is true, ignore /intl/en/... in
+    // the SSG build and exclude it from sitemap.xml.
+    const sitemapEntries = Object.entries(sitemap).filter(([, sitemapItem]) => {
+      if (rootConfig.build?.excludeDefaultLocaleFromIntlPaths) {
+        const defaultLocale = rootConfig.i18n?.defaultLocale || 'en';
+        if (sitemapItem.locale === defaultLocale) {
+          return false;
         }
       }
-    );
+      return true;
+    });
+
+    console.log('\nhtml output:');
+    const concurrency = Number(options?.concurrency || 10);
+    const numThreads = parseNumThreads(options?.threads);
+
+    if (numThreads > 0) {
+      // Render pages in parallel using worker threads. Each worker loads the
+      // server bundle (dist/server/render.js) and renders pages
+      // independently.
+      const pool = new BuildWorkerPool({
+        numWorkers: numThreads,
+        workerConcurrency: Math.max(Math.ceil(concurrency / numThreads), 1),
+        rootDir,
+        mode,
+      });
+      try {
+        await pool.ready();
+        await Promise.all(
+          sitemapEntries.map(async ([urlPath, sitemapItem]) => {
+            try {
+              const result = await pool.run({
+                urlPath,
+                params: sitemapItem.params,
+                routeSrc: sitemapItem.route.src,
+                locale: sitemapItem.locale,
+              });
+              onPageResult(sitemapItem, result);
+            } catch (e) {
+              if (e instanceof BuildPageError) {
+                logBuildError(
+                  {
+                    route: sitemapItem.route,
+                    params: sitemapItem.params,
+                    urlPath,
+                  },
+                  new Error(e.workerError)
+                );
+              }
+              throw e;
+            }
+          })
+        );
+      } finally {
+        await pool.terminate();
+      }
+    } else {
+      await batchAsyncCalls(
+        sitemapEntries,
+        concurrency,
+        async ([urlPath, sitemapItem]) => {
+          try {
+            const result = await buildPage(
+              renderer,
+              rootConfig,
+              buildDir,
+              sitemapItem.route,
+              {urlPath, params: sitemapItem.params}
+            );
+            onPageResult(sitemapItem, result);
+          } catch (e) {
+            logBuildError(
+              {route: sitemapItem.route, params: sitemapItem.params, urlPath},
+              e
+            );
+            throw new Error(
+              `BuildError: ${urlPath} (${sitemapItem.route.src}) failed to build.`,
+              {cause: e}
+            );
+          }
+        }
+      );
+    }
 
     // Generate sitemap.xml.
     if (rootConfig.sitemap) {
@@ -565,6 +603,25 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
 
 function isRouteFile(filepath: string) {
   return filepath.startsWith('routes') && isJsFile(filepath);
+}
+
+/**
+ * Parses the `--threads` flag. Returns 0 when unset (single-threaded build).
+ * When passed without a value (`--threads`), defaults to one worker per
+ * available CPU core, minus one for the main thread.
+ */
+function parseNumThreads(threads?: string | boolean): number {
+  if (threads === undefined || threads === false) {
+    return 0;
+  }
+  if (threads === true) {
+    return Math.max(os.availableParallelism() - 1, 1);
+  }
+  const num = parseInt(threads);
+  if (isNaN(num) || num < 0) {
+    throw new Error(`invalid --threads value: ${threads}`);
+  }
+  return num;
 }
 
 function fileSize(filepath: string) {
@@ -642,8 +699,4 @@ function formatParams(params: Record<string, string>) {
       return `  ${key}: ${value}`;
     })
     .join('\n');
-}
-
-function normalizeLineEndings(str: string): string {
-  return str.replace(/\r\n?/g, '\n');
 }

--- a/packages/root/src/cli/cli.ts
+++ b/packages/root/src/cli/cli.ts
@@ -44,6 +44,10 @@ class CliRunner {
         '10'
       )
       .option(
+        '--threads [num]',
+        'renders pages using N worker threads; pass without a value to use one thread per cpu core'
+      )
+      .option(
         '--filter <urlPathRegex>',
         'builds the url paths that match the given regex, e.g. "/products/.*"',
         ''

--- a/packages/root/src/cli/cli.ts
+++ b/packages/root/src/cli/cli.ts
@@ -45,7 +45,7 @@ class CliRunner {
       )
       .option(
         '--threads [num]',
-        'renders pages using N worker threads; pass without a value to use one thread per cpu core'
+        'renders pages using worker threads; pass a number for exactly N workers, or omit the value (or pass "auto") to pick based on cpu cores and page count'
       )
       .option(
         '--filter <urlPathRegex>',

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -98,6 +98,18 @@ export class Renderer {
     return this.router.get(url);
   }
 
+  /** Returns all routes that match a given url path. */
+  getRouteMatches(url: string): Array<[Route, Record<string, string>]> {
+    return this.router.matchAll(url);
+  }
+
+  /** Walks all routes registered with the router. */
+  async walkRoutes(
+    cb: (urlPathFormat: string, route: Route) => void | Promise<void>
+  ) {
+    await this.router.walk(cb);
+  }
+
   async handle(req: Request, res: Response, next: NextFunction) {
     let url = req.path;
     // Decode unicode paths.

--- a/packages/root/test/build-threads.test.ts
+++ b/packages/root/test/build-threads.test.ts
@@ -59,5 +59,16 @@ test(
     for (const relPath of Object.keys(baseline)) {
       expect(threaded[relPath], relPath).toEqual(baseline[relPath]);
     }
+
+    // Auto mode picks a worker count based on cpu cores and page count (and
+    // may stay in-process for small builds); output should be identical
+    // either way.
+    await fixture.cleanup();
+    await fixture.build({threads: 'auto'});
+    const auto = await collectOutput(htmlDir);
+    expect(Object.keys(auto).sort()).toEqual(Object.keys(baseline).sort());
+    for (const relPath of Object.keys(baseline)) {
+      expect(auto[relPath], relPath).toEqual(baseline[relPath]);
+    }
   }
 );

--- a/packages/root/test/build-threads.test.ts
+++ b/packages/root/test/build-threads.test.ts
@@ -1,0 +1,63 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {assert, afterEach, expect, test} from 'vitest';
+import {Fixture, loadFixture} from './testutils.js';
+
+let fixture: Fixture;
+
+afterEach(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/** Recursively collects {relPath: contents} for all files in a dir. */
+async function collectOutput(dir: string): Promise<Record<string, string>> {
+  const output: Record<string, string> = {};
+  async function walk(currentDir: string) {
+    const entries = await fs.readdir(currentDir, {withFileTypes: true});
+    for (const entry of entries) {
+      const filePath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(filePath);
+      } else {
+        const relPath = path.relative(dir, filePath);
+        output[relPath] = await fs.readFile(filePath, 'utf-8');
+      }
+    }
+  }
+  await walk(dir);
+  return output;
+}
+
+test(
+  'threaded build output matches single-threaded build',
+  {timeout: 90000},
+  async () => {
+    // The build-threads fixture exercises multiple locales, getStaticPaths(),
+    // getStaticContent() file routes (e.g. feed.xml.ts and [slug].json.ts),
+    // 404.tsx, and sitemap.xml generation.
+    fixture = await loadFixture('./fixtures/build-threads');
+    const htmlDir = path.join(fixture.distDir, 'html');
+
+    await fixture.build();
+    const baseline = await collectOutput(htmlDir);
+    await fixture.cleanup();
+
+    await fixture.build({threads: '2'});
+    const threaded = await collectOutput(htmlDir);
+
+    // Sanity check the fixture produced meaningful output.
+    assert.isAbove(Object.keys(baseline).length, 0);
+    assert.include(Object.keys(baseline), 'sitemap.xml');
+    assert.include(Object.keys(baseline), 'feed.xml');
+    assert.include(Object.keys(baseline), path.join('data', 'foo.json'));
+    assert.include(Object.keys(baseline), '404.html');
+    assert.include(Object.keys(baseline), path.join('de', 'bar', 'index.html'));
+
+    expect(Object.keys(threaded).sort()).toEqual(Object.keys(baseline).sort());
+    for (const relPath of Object.keys(baseline)) {
+      expect(threaded[relPath], relPath).toEqual(baseline[relPath]);
+    }
+  }
+);

--- a/packages/root/test/fixtures/build-threads/root.config.ts
+++ b/packages/root/test/fixtures/build-threads/root.config.ts
@@ -1,0 +1,11 @@
+export default {
+  sitemap: true,
+  domain: 'https://www.example.com',
+  i18n: {
+    urlPath: '/intl/[path]',
+    locales: ['de', 'en', 'fr'],
+  },
+  server: {
+    trailingSlash: true,
+  },
+};

--- a/packages/root/test/fixtures/build-threads/routes/404.tsx
+++ b/packages/root/test/fixtures/build-threads/routes/404.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Not found!</h1>;
+}

--- a/packages/root/test/fixtures/build-threads/routes/[...page].tsx
+++ b/packages/root/test/fixtures/build-threads/routes/[...page].tsx
@@ -1,0 +1,13 @@
+export default function Page(props: {slug: string}) {
+  return <h1>Hello, {props.slug}!!</h1>;
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [{params: {page: 'bar'}}, {params: {page: 'baz'}}],
+  };
+}
+
+export async function getStaticProps(ctx) {
+  return {props: {slug: ctx.params.page}};
+}

--- a/packages/root/test/fixtures/build-threads/routes/data/[slug].json.ts
+++ b/packages/root/test/fixtures/build-threads/routes/data/[slug].json.ts
@@ -1,0 +1,14 @@
+export async function getStaticPaths() {
+  return {
+    paths: [{params: {slug: 'foo'}}, {params: {slug: 'bar'}}],
+  };
+}
+
+interface Props {
+  params: {slug: string};
+}
+
+export async function getStaticContent(props: Props) {
+  const params = props.params;
+  return JSON.stringify({slug: params.slug});
+}

--- a/packages/root/test/fixtures/build-threads/routes/feed.xml.ts
+++ b/packages/root/test/fixtures/build-threads/routes/feed.xml.ts
@@ -1,0 +1,3 @@
+export async function getStaticContent() {
+  return '<feed></feed>';
+}

--- a/packages/root/test/fixtures/build-threads/routes/index.tsx
+++ b/packages/root/test/fixtures/build-threads/routes/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello, index!</h1>;
+}


### PR DESCRIPTION
## Summary

`root build` currently renders all SSG pages on a single CPU core. The `-c/--concurrency` flag overlaps async I/O (e.g. CMS fetches in `getStaticProps()`), but JSX rendering itself is synchronous CPU work, so large sites (hundreds of pages across many locales) bottleneck on one core while the rest of the machine sits idle — on a typical multi-core CI machine, the render phase of a large site can take many minutes single-threaded.

This PR adds an opt-in `--threads [num]` flag that renders pages using a pool of `worker_threads`:

```sh
# Render pages using 8 worker threads.
root build --threads 8

# Pick a worker count automatically based on cpu cores and page count.
root build --threads
root build --threads auto
```

In auto mode, one core is reserved for the main thread and each worker must have enough pages to justify its fixed startup cost (loading the server bundle and manifests); small builds automatically stay in-process, since a single worker is never faster than rendering in-process.

## How it works

- The main thread builds the server/client bundles, computes the sitemap, and schedules pages; workers render them.
- Each worker bootstraps the same way the prod server (`root start`) does: it loads `dist/server/render.js`, `dist/root.config.js`, and the asset manifest / element graph from `dist/.root/`, then renders pages independently.
- Routes can't be structured-cloned across threads, so each task is identified by `{urlPath, params, routeSrc, locale}`. Workers resolve the route from a map keyed by `src + locale` built by walking the router (URL matching alone can't resolve extension routes like `[slug].json.ts`, so this avoids relying on it; URL matching is kept only as a fallback).
- The single-threaded code path is unchanged in behavior — the per-page logic was extracted to a shared `buildPage()` used by both paths, so output logging, sitemap.xml generation, `--filter`, `excludeDefaultLocaleFromIntlPaths`, and error reporting behave identically.
- `-c/--concurrency` is distributed across workers (e.g. `-c 30 --threads 6` gives each worker an async concurrency of 5), so per-page I/O still overlaps within each thread.
- Page errors are reported with the same detail as before (route src, params, stack) and fail the build; worker crashes reject all in-flight pages.

## Results

On a synthetic project (8 locales, 360 pages, ~3.5 MB rendered HTML per page), an M-series laptop:

| Configuration | Wall time | CPU time |
|---|---|---|
| `root build -c 30` | 7.9s | 8.0s (1 core saturated) |
| `root build -c 30 --threads 4` | 3.2s | 11.1s |
| `root build -c 30 --threads 8` | 3.5s | 14.9s |

The synthetic benchmark becomes disk-I/O bound at high thread counts; real-world sites with heavier component trees and more pages should scale further on high-core CI machines. Real-world builds also spend significant time in `getStaticProps()` data fetching, where the per-worker async concurrency continues to apply.

Output is byte-for-byte identical to single-threaded builds (verified by the included test, which exercises multiple locales, `getStaticPaths()`, `getStaticContent()` file routes, `404.tsx`, and sitemap.xml generation).

## Notes

- The flag is fully opt-in; builds without `--threads` use the existing code path.
- Workers share the same `dist/` artifacts and cwd, so filesystem-based caches that projects populate in `preBuild` hooks are shared across workers.
- `preBuild`/`postBuild` plugin hooks still run once, on the main thread.
- Worker memory: each thread loads its own copy of the server bundle; memory scales roughly linearly with thread count. The default (`--threads` with no value) reserves one core for the main thread.

## Test plan

- [x] New test: `packages/root/test/build-threads.test.ts` builds a fixture with and without `--threads 2` and asserts byte-identical output (multi-locale pages, `getStaticPaths`, `getStaticContent` file routes, 404, sitemap.xml).
- [x] Full `@blinkk/root` test suite passes (31 files / 163 tests).
- [x] `examples/starter` builds with `--threads 2` with output identical to the single-threaded build.
- [x] Lint/prettier clean; `pnpm build` (esbuild + tsc) passes.

