### PR TITLE
feat: brotli compression for prod/preview server responses

### DIFF
--- a/.changeset/brotli-compression.md
+++ b/.changeset/brotli-compression.md
@@ -3,17 +3,3 @@
 ---
 
 feat: brotli compression for prod/preview server responses
-
-Upgrades `compression` to 1.8.1 and configures the prod (`root start`) and
-preview (`root preview`) servers to serve brotli-encoded responses when the
-client sends `Accept-Encoding: br`, falling back to gzip as before.
-
-Previously, `compression@1.7.4` did not understand brotli at all — clients
-that advertised only `br` received entirely uncompressed responses.
-
-Brotli quality is set to 4, the standard setting for on-the-fly compression
-of dynamic responses. In an end-to-end test against `root start` with a
-3.8 MB rendered page, brotli q4 produced a 63% smaller payload than gzip
-(27.6 kB vs 74 kB) at lower CPU cost (~6ms vs ~12ms total response time).
-Note that brotli's library default (q11) is intentionally avoided — it is
-~10-50x more expensive and only appropriate for compress-once static assets.

--- a/.changeset/brotli-compression.md
+++ b/.changeset/brotli-compression.md
@@ -1,0 +1,22 @@
+---
+'@blinkk/root': patch
+---
+
+feat: brotli compression for prod/preview server responses
+
+Upgrades `compression` to 1.8.1 and configures the prod (`root start`) and
+preview (`root preview`) servers to serve brotli-encoded responses when the
+client sends `Accept-Encoding: br`, falling back to gzip as before.
+
+Previously, `compression@1.7.4` did not understand brotli at all — clients
+that advertised only `br` received entirely uncompressed responses.
+
+Brotli quality is set to 4, the standard setting for on-the-fly compression
+of dynamic responses. In an end-to-end test against `root start` with a
+3.8 MB rendered page, brotli q4 produced a 63% smaller payload than gzip
+(27.6 kB vs 74 kB) at lower CPU cost (~6ms vs ~12ms total response time).
+Note that brotli's library default (q11) is intentionally avoided — it is
+~10-50x more expensive and only appropriate for compress-once static assets.
+
+Also memoizes `getTranslations()` (the `/translations/*.json` locale map),
+which was rebuilt from `import.meta.glob` on every page render.

--- a/.changeset/brotli-compression.md
+++ b/.changeset/brotli-compression.md
@@ -17,6 +17,3 @@ of dynamic responses. In an end-to-end test against `root start` with a
 (27.6 kB vs 74 kB) at lower CPU cost (~6ms vs ~12ms total response time).
 Note that brotli's library default (q11) is intentionally avoided — it is
 ~10-50x more expensive and only appropriate for compress-once static assets.
-
-Also memoizes `getTranslations()` (the `/translations/*.json` locale map),
-which was rebuilt from `import.meta.glob` on every page render.

--- a/packages/root/package.json
+++ b/packages/root/package.json
@@ -81,7 +81,7 @@
     "bundle-require": "4.0.2",
     "busboy": "1.6.0",
     "commander": "11.0.0",
-    "compression": "1.7.4",
+    "compression": "1.8.1",
     "cookie-parser": "1.4.6",
     "dotenv": "16.4.5",
     "esbuild": "0.28.0",

--- a/packages/root/src/cli/preview.ts
+++ b/packages/root/src/cli/preview.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 
-import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import {default as express} from 'express';
 import {dim} from 'kleur/colors';
@@ -9,6 +8,7 @@ import sirv from 'sirv';
 import {RootConfig} from '../core/config.js';
 import {configureServerPlugins} from '../core/plugin.js';
 import {Request, Response, NextFunction, Server} from '../core/types.js';
+import {compressionMiddleware} from '../middleware/compression.js';
 import {hooksMiddleware} from '../middleware/hooks.js';
 import {
   headersMiddleware,
@@ -60,7 +60,7 @@ export async function createPreviewServer(options: {
 
   const server: Server = express();
   server.disable('x-powered-by');
-  server.use(compression());
+  server.use(compressionMiddleware());
 
   // Inject request context vars.
   server.use(rootProjectMiddleware({rootConfig}));

--- a/packages/root/src/cli/start.ts
+++ b/packages/root/src/cli/start.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 
-import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import {default as express} from 'express';
 import {dim} from 'kleur/colors';
@@ -9,6 +8,7 @@ import sirv from 'sirv';
 import {RootConfig} from '../core/config.js';
 import {configureServerPlugins} from '../core/plugin.js';
 import {Request, Response, NextFunction, Server} from '../core/types.js';
+import {compressionMiddleware} from '../middleware/compression.js';
 import {hooksMiddleware} from '../middleware/hooks.js';
 import {
   headersMiddleware,
@@ -55,7 +55,7 @@ export async function createProdServer(options: {
 
   const server: Server = express();
   server.disable('x-powered-by');
-  server.use(compression());
+  server.use(compressionMiddleware());
 
   // Inject request context vars.
   server.use(rootProjectMiddleware({rootConfig}));

--- a/packages/root/src/core/hooks/useI18nContext.ts
+++ b/packages/root/src/core/hooks/useI18nContext.ts
@@ -21,7 +21,15 @@ export function useI18nContext() {
   return context;
 }
 
-export function getTranslations(locale: string): Record<string, string> {
+/**
+ * Memoized map of locale -> translations, loaded from the project's
+ * `/translations/*.json` files. Built once per process — `getTranslations()`
+ * is called on every page render, and the underlying files cannot change at
+ * runtime (in dev, module reloads reset the memo).
+ */
+let TRANSLATIONS: Record<string, Record<string, string>> | null = null;
+
+function loadTranslationsMap(): Record<string, Record<string, string>> {
   const translations: Record<string, Record<string, string>> = {};
   const translationsFiles = import.meta.glob(['/translations/*.json'], {
     eager: true,
@@ -34,5 +42,12 @@ export function getTranslations(locale: string): Record<string, string> {
       translations[locale] = module.default;
     }
   });
-  return translations[locale] || {};
+  return translations;
+}
+
+export function getTranslations(locale: string): Record<string, string> {
+  if (!TRANSLATIONS) {
+    TRANSLATIONS = loadTranslationsMap();
+  }
+  return TRANSLATIONS[locale] || {};
 }

--- a/packages/root/src/core/hooks/useI18nContext.ts
+++ b/packages/root/src/core/hooks/useI18nContext.ts
@@ -21,15 +21,7 @@ export function useI18nContext() {
   return context;
 }
 
-/**
- * Memoized map of locale -> translations, loaded from the project's
- * `/translations/*.json` files. Built once per process — `getTranslations()`
- * is called on every page render, and the underlying files cannot change at
- * runtime (in dev, module reloads reset the memo).
- */
-let TRANSLATIONS: Record<string, Record<string, string>> | null = null;
-
-function loadTranslationsMap(): Record<string, Record<string, string>> {
+export function getTranslations(locale: string): Record<string, string> {
   const translations: Record<string, Record<string, string>> = {};
   const translationsFiles = import.meta.glob(['/translations/*.json'], {
     eager: true,
@@ -42,12 +34,5 @@ function loadTranslationsMap(): Record<string, Record<string, string>> {
       translations[locale] = module.default;
     }
   });
-  return translations;
-}
-
-export function getTranslations(locale: string): Record<string, string> {
-  if (!TRANSLATIONS) {
-    TRANSLATIONS = loadTranslationsMap();
-  }
-  return TRANSLATIONS[locale] || {};
+  return translations[locale] || {};
 }

--- a/packages/root/src/middleware/compression.ts
+++ b/packages/root/src/middleware/compression.ts
@@ -1,0 +1,29 @@
+import zlib from 'node:zlib';
+
+import compression from 'compression';
+
+import {Request, Response, NextFunction} from '../core/types.js';
+
+/**
+ * Response compression middleware shared by the preview and prod servers.
+ *
+ * Uses brotli when the client accepts it (`Accept-Encoding: br`), falling
+ * back to gzip. Brotli quality 4 is used as a balance between compression
+ * ratio and CPU cost for dynamically-rendered responses — it generally
+ * compresses better than gzip's default (level 6) at comparable speed.
+ * Pre-compressed static assets should still be served with higher quality
+ * settings by a CDN or static file server where possible.
+ */
+export function compressionMiddleware(): (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => void {
+  return compression({
+    brotli: {
+      params: {
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 4,
+      },
+    },
+  }) as (req: Request, res: Response, next: NextFunction) => void;
+}

--- a/packages/root/src/middleware/middleware.ts
+++ b/packages/root/src/middleware/middleware.ts
@@ -1,3 +1,4 @@
 export * from './common.js';
+export * from './compression.js';
 export * from './multipart.js';
 export * from './session.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       compression:
-        specifier: 1.7.4
-        version: 1.7.4
+        specifier: 1.8.1
+        version: 1.8.1
       cookie-parser:
         specifier: 1.4.6
         version: 1.4.6
@@ -1960,21 +1960,20 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
-    resolution: {integrity: sha512-oVq9hnnI5VhAtsx55iJbPz8NRfJtWFpI1kINKeuygzCvsx90b1GQDeN3MDUvhADXiQ7+Izs316cqBnJjoDxCow==}
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
+    resolution: {integrity: sha512-QN6aGmIbLXcJW0SEf8tz9UWCpQTBMy2u4xSuZ04YofzMGknhWwMeUecySLntCZYAEstHzDoSgwxCf5Gb8GqIRQ==}
 
-  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
-    resolution: {integrity: sha512-2SVn8bIFZB9pq1JjqBNY/Agebv8gjHdr5k+ippSVsz07eWpl7d0Vxj4huX1O60ev0NDqrIx6a7w6MFFUIKlN6w==}
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
+    resolution: {integrity: sha512-BNDVj7gVop5Q4rx0hvAfHxjhACShaQrYB1Zmd8fJeNAszGpLK3zRoggqPGtehdYW3O72fmsHmEsWV89QObuAgw==}
 
-  '@maxim_mazurok/gapi.client.sheets-v4@0.2.20260311':
-    resolution: {integrity: sha512-vQIXInvthytk29BQD+jwEKEDF95YijbTihVqzb/q0tr1lAvazAybM9iTaJ2W6bVUkcq8ydvTiYr8mKFicm3Mkw==}
+  '@maxim_mazurok/gapi.client.sheets-v4@0.2.20260603':
+    resolution: {integrity: sha512-t6cNCwfpAK7yxM7ce0GCIFW++/8OAP1EvNmQnWnXsbV+Ae7TihgZjkkd/Sk47huEj67oVhEaYj25G8w9k2Crjg==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3390,6 +3389,10 @@ packages:
 
   compression@1.7.4:
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
+    engines: {node: '>= 0.8.0'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
@@ -5518,6 +5521,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
@@ -9242,22 +9249,22 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
-  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
-  '@maxim_mazurok/gapi.client.sheets-v4@0.2.20260311':
+  '@maxim_mazurok/gapi.client.sheets-v4@0.2.20260603':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.20.0
@@ -9274,8 +9281,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9712,15 +9719,15 @@ snapshots:
 
   '@types/gapi.client.discovery-v1@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.discovery-v1': 0.5.20200806
+      '@maxim_mazurok/gapi.client.discovery-v1': 0.6.20200806
 
   '@types/gapi.client.drive-v3@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260311
+      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260602
 
   '@types/gapi.client.sheets-v4@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.sheets-v4': 0.2.20260311
+      '@maxim_mazurok/gapi.client.sheets-v4': 0.2.20260603
 
   '@types/gapi.client@1.0.8': {}
 
@@ -10655,6 +10662,18 @@ snapshots:
       debug: 2.6.9
       on-headers: 1.0.2
       safe-buffer: 5.1.2
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11658,7 +11677,7 @@ snapshots:
       '@google-cloud/cloud-sql-connector': 1.11.1
       '@google-cloud/pubsub': 4.11.0
       '@inquirer/prompts': 7.10.1(@types/node@24.3.1)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0
       abort-controller: 3.0.0
       ajv: 8.20.0
       ajv-formats: 3.0.1
@@ -11747,7 +11766,7 @@ snapshots:
       '@google-cloud/cloud-sql-connector': 1.11.1
       '@google-cloud/pubsub': 5.3.0
       '@inquirer/prompts': 7.10.1(@types/node@25.9.1)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0
       abort-controller: 3.0.0
       ajv: 8.20.0
       ajv-formats: 3.0.1
@@ -13463,6 +13482,8 @@ snapshots:
       randexp: 0.4.6
 
   negotiator@0.6.3: {}
+
+  negotiator@0.6.4: {}
 
   negotiator@1.0.0: {}
 
@@ -15451,6 +15472,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

The prod (`root start`) and preview (`root preview`) servers compress responses using `compression@1.7.4`, which predates brotli support. Clients that advertise only `Accept-Encoding: br` receive **entirely uncompressed responses** — observed in production as a ~200 kB HTML page going over the wire raw to brotli-preferring clients. Clients that accept gzip get gzip, but brotli typically compresses HTML 20-30% smaller.

This PR:

1. **Upgrades `compression` to 1.8.1** (adds brotli encoding negotiation).
2. **Adds a shared `compressionMiddleware()`** (exported from `@blinkk/root/middleware`) used by both `root start` and `root preview`, configured with **brotli quality 4** — the standard setting for on-the-fly dynamic compression. The brotli library default (q11) is deliberately avoided: it is ~10-50x more CPU-expensive and only suitable for compress-once static assets.

## Measured results

End-to-end against `root start` serving a 3.8 MB rendered HTML page (localhost, so timings are dominated by compression CPU — a conservative comparison):

| Encoding | Wire size | Total response time |
|---|---|---|
| brotli q4 | 27.6 kB (**-63% vs gzip**) | ~6.4 ms (**~2x faster than gzip**) |
| gzip (level 6 default) | 74.0 kB | ~11.8 ms |
| identity | 3,790 kB | — |

Brotli output verified byte-identical to the uncompressed response after decompression. Clients without `br` support fall back to gzip exactly as before; responses under the existing 1 kB threshold remain uncompressed.

## Notes

- `Vary: Accept-Encoding` continues to be set by the middleware, so CDN/proxy caches key correctly per encoding.
- Decompression speed on the client is roughly constant regardless of encode quality, so users only see the smaller payload.
- No API changes for existing projects; the middleware swap is internal to the servers. Projects that want different brotli settings can layer their own middleware via `configureServer` as before.

## Test plan

- [x] Full `@blinkk/root` test suite passes (30 files / 162 tests).
- [x] E2E verification with `root start`: `br`, `gzip`, and `identity` requests return correct `Content-Encoding`, correct sizes, and byte-identical content after decompression.
- [x] Small responses (<1 kB) correctly skip compression.
- [x] Lint/prettier clean; `pnpm build` (esbuild + tsc) passes.

