### PR TITLE
feat: add embeddable Root AI route for iframe/pop-up embedding

### DIFF
--- a/.changeset/embed-root-ai.md
+++ b/.changeset/embed-root-ai.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add embeddable Root AI route for iframe/pop-up embedding

--- a/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.css
+++ b/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.css
@@ -1,0 +1,6 @@
+.EmbeddedAIPage {
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  background: var(--mantine-color-body, #fff);
+}

--- a/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.tsx
+++ b/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.tsx
@@ -13,9 +13,9 @@ import {postToParent} from '../../utils/embed-bridge.js';
  * no chat history sidebar and a fresh chat per load.
  *
  * An optional `?docId=` query param (e.g. `?docId=Pages/about`) tells the AI
- * which document the user is editing. Clicking the panel's close button posts
- * a `close` lifecycle message to the parent window so the embedding page can
- * dismiss the iframe/pop-up.
+ * which document the user is editing. Unlike the document page panel, there
+ * is no close button -- dismissing the iframe/pop-up is up to the embedding
+ * page.
  */
 export function EmbeddedAIPage() {
   usePageTitle('Root AI');
@@ -33,11 +33,7 @@ export function EmbeddedAIPage() {
 
   return (
     <div className="EmbeddedAIPage">
-      <RootAIChat
-        variant="panel"
-        docContext={docId ? {docId} : undefined}
-        onClose={() => postToParent({type: 'close', docId: docId || undefined})}
-      />
+      <RootAIChat variant="panel" docContext={docId ? {docId} : undefined} />
     </div>
   );
 }

--- a/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.tsx
+++ b/packages/root-cms/ui/pages/EmbeddedAIPage/EmbeddedAIPage.tsx
@@ -1,0 +1,43 @@
+import './EmbeddedAIPage.css';
+
+import {useEffect, useRef} from 'preact/hooks';
+import {RootAIChat} from '../../components/RootAIChat/RootAIChat.js';
+import {usePageTitle} from '../../hooks/usePageTitle.js';
+import {useStringParam} from '../../hooks/useQueryParam.js';
+import {postToParent} from '../../utils/embed-bridge.js';
+
+/**
+ * Headless ("embedded") version of the Root AI chat, intended to be loaded
+ * inside an iframe / pop-up by a client previewing a page. Behaves like the
+ * Root AI side panel on the document page: the compact `panel` variant with
+ * no chat history sidebar and a fresh chat per load.
+ *
+ * An optional `?docId=` query param (e.g. `?docId=Pages/about`) tells the AI
+ * which document the user is editing. Clicking the panel's close button posts
+ * a `close` lifecycle message to the parent window so the embedding page can
+ * dismiss the iframe/pop-up.
+ */
+export function EmbeddedAIPage() {
+  usePageTitle('Root AI');
+  const [docId] = useStringParam('docId');
+
+  // Notify the parent window once mounted.
+  const readySentRef = useRef(false);
+  useEffect(() => {
+    if (readySentRef.current) {
+      return;
+    }
+    readySentRef.current = true;
+    postToParent({type: 'ready', docId: docId || undefined});
+  }, [docId]);
+
+  return (
+    <div className="EmbeddedAIPage">
+      <RootAIChat
+        variant="panel"
+        docContext={docId ? {docId} : undefined}
+        onClose={() => postToParent({type: 'close', docId: docId || undefined})}
+      />
+    </div>
+  );
+}

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -78,6 +78,11 @@ const EditDataSourcePage = lazyRoute(() =>
     (m) => m.EditDataSourcePage
   )
 );
+const EmbeddedAIPage = lazyRoute(() =>
+  import('./pages/EmbeddedAIPage/EmbeddedAIPage.js').then(
+    (m) => m.EmbeddedAIPage
+  )
+);
 const EmbeddedDocumentPage = lazyRoute(() =>
   import('./pages/EmbeddedDocumentPage/EmbeddedDocumentPage.js').then(
     (m) => m.EmbeddedDocumentPage
@@ -294,6 +299,10 @@ function App() {
                           <Route
                             path="/cms/embed/content/:collection/:slug"
                             component={EmbeddedDocumentPage}
+                          />
+                          <Route
+                            path="/cms/embed/ai"
+                            component={EmbeddedAIPage}
                           />
                           <Route path="/cms/data" component={DataPage} />
                           <Route

--- a/packages/root-cms/ui/utils/embed-bridge.ts
+++ b/packages/root-cms/ui/utils/embed-bridge.ts
@@ -1,17 +1,18 @@
 import {SaveState} from '../hooks/useDraftDoc.js';
 
 /**
- * Lifecycle messages posted from the headless (embedded) doc editor to the
- * parent window that frames it. All messages are namespaced under `root` to
- * avoid colliding with the un-namespaced `{scrollToDeeplink}` / `{highlightNode}`
- * messages used by the in-CMS preview channel.
+ * Lifecycle messages posted from the headless (embedded) pages (the doc
+ * editor and the Root AI panel) to the parent window that frames them. All
+ * messages are namespaced under `root` to avoid colliding with the
+ * un-namespaced `{scrollToDeeplink}` / `{highlightNode}` messages used by the
+ * in-CMS preview channel.
  */
 export interface RootEmbedMessage {
   root: {
     /** The lifecycle event type. */
-    type: 'ready' | 'saved' | 'published' | 'error';
-    /** The doc being edited, e.g. "Pages/about". */
-    docId: string;
+    type: 'ready' | 'saved' | 'published' | 'error' | 'close';
+    /** The doc being edited, e.g. "Pages/about" (when applicable). */
+    docId?: string;
     /** Current save state (included on `saved`). */
     saveState?: SaveState;
     /** Epoch millis the doc was published (included on `published`). */

--- a/packages/root-cms/ui/utils/embed-bridge.ts
+++ b/packages/root-cms/ui/utils/embed-bridge.ts
@@ -10,7 +10,7 @@ import {SaveState} from '../hooks/useDraftDoc.js';
 export interface RootEmbedMessage {
   root: {
     /** The lifecycle event type. */
-    type: 'ready' | 'saved' | 'published' | 'error' | 'close';
+    type: 'ready' | 'saved' | 'published' | 'error';
     /** The doc being edited, e.g. "Pages/about" (when applicable). */
     docId?: string;
     /** Current save state (included on `saved`). */


### PR DESCRIPTION
Adds a chrome-less Root AI chat route at `/cms/embed/ai` for embedding in an iframe/pop-up (e.g. alongside a page preview), following the embedded doc editor pattern from #1204.

## Changes

- New `EmbeddedAIPage` renders `RootAIChat` in the compact `panel` variant — the same component/mode as the Root AI side panel on the document page: no chat history sidebar, fresh chat per load, and the same not-configured fallback when AI isn't enabled. Unlike the document page panel, there is no close button — dismissing the iframe/pop-up is up to the embedding page.
- An optional `?docId=` query param (e.g. `/cms/embed/ai?docId=Pages/about`) passes the document context to the AI, same as the document page panel.
- A `ready` message is posted to the parent on mount, consistent with the embedded doc editor; `RootEmbedMessage.docId` becomes optional (the AI panel may have no doc context).

Outbound messages are targeted at the configured `allowedIframeOrigins` (never `'*'`), same as the embedded doc editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)