### PR TITLE
feat: add `@blinkk/root-cms/browser-client` for embedding cms tools

### DIFF
--- a/.changeset/browser-client.md
+++ b/.changeset/browser-client.md
@@ -1,5 +1,5 @@
 ---
-'@blinkk/root-cms': minor
+'@blinkk/root-cms': patch
 ---
 
-feat: add `@blinkk/root-cms/browser-client`, a typed client library for embedding the CMS (headless doc editor, Root AI, and preview field focus/highlight)
+feat: add `@blinkk/root-cms/browser-client` for embedding cms tools

--- a/.changeset/browser-client.md
+++ b/.changeset/browser-client.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: add `@blinkk/root-cms/browser-client`, a typed client library for embedding the CMS (headless doc editor, Root AI, and preview field focus/highlight)

--- a/docs/elements/root-node/root-node.ts
+++ b/docs/elements/root-node/root-node.ts
@@ -1,12 +1,7 @@
-/** Messages that can be sent from the CMS to the preview. */
-interface RootNodeEventData {
-  highlightNode?: {
-    deepKey: string | null;
-    options?: {
-      scroll: boolean;
-    };
-  };
-}
+import {
+  PreviewConnection,
+  RootCMSBrowserClient,
+} from '@blinkk/root-cms/browser-client';
 
 declare module 'preact' {
   namespace JSX {
@@ -16,6 +11,8 @@ declare module 'preact' {
   }
 }
 
+let preview: PreviewConnection;
+
 /** An element that represents actions associated with a CMS field. */
 class RootNodeElement extends HTMLElement {
   private deepKey: string;
@@ -24,8 +21,9 @@ class RootNodeElement extends HTMLElement {
   connectedCallback() {
     this.deepKey = this.getAttribute('data-deep-key');
     this.buttonElement = this.getSlotElement('button');
+    // "Click to edit": focus the field in the doc editor.
     this.buttonElement.addEventListener('click', () =>
-      RootNodeElement.requestDeepLinkScroll(this.deepKey)
+      preview.focusField(this.deepKey)
     );
   }
 
@@ -53,41 +51,16 @@ class RootNodeElement extends HTMLElement {
       this.scrollIntoView({behavior: 'smooth', block: 'center'});
     }
   }
-
-  /** Sends a message to the CMS requesting that the field associated with this node be focused. */
-  static requestDeepLinkScroll(deepKey: string) {
-    // TODO: This should be bundled into the CMS package so that sites can consume it.
-    window.parent.postMessage(
-      {
-        scrollToDeeplink: {
-          deepKey: deepKey,
-        },
-      },
-      '*'
-    );
-  }
-}
-
-/** Creates a listener to handle messages sent from the CMS. */
-function createMessageListener() {
-  const listener = (event: MessageEvent<RootNodeEventData>) => {
-    const {highlightNode} = event.data;
-    if (highlightNode) {
-      const {deepKey, options} = highlightNode;
-      RootNodeElement.clearAllHighlighted();
-      if (deepKey) {
-        const rootNode = RootNodeElement.getByDeepKey(deepKey);
-        if (rootNode) {
-          rootNode.setHighlighted(options?.scroll);
-        }
-      }
-    }
-  };
-  window.addEventListener('message', listener);
-  return listener;
 }
 
 if (!customElements.get('root-node')) {
   customElements.define('root-node', RootNodeElement);
-  createMessageListener();
+  // Highlight nodes when the doc editor hovers/focuses a field.
+  preview = RootCMSBrowserClient.connectPreview();
+  preview.on('highlight', ({deepKey, scroll}) => {
+    RootNodeElement.clearAllHighlighted();
+    if (deepKey) {
+      RootNodeElement.getByDeepKey(deepKey)?.setHighlighted(scroll);
+    }
+  });
 }

--- a/packages/root-cms/README.md
+++ b/packages/root-cms/README.md
@@ -142,7 +142,7 @@ Opens `/cms/embed/ai`, the compact Root AI chat, optionally with a doc as
 context:
 
 ```ts
-const ai = root.openAI({docId: 'Pages/about', mode: 'popup'});
+const ai = root.openRootAI({docId: 'Pages/about', mode: 'popup'});
 ai.on('ready', () => console.log('chat loaded'));
 ai.close();
 ```

--- a/packages/root-cms/README.md
+++ b/packages/root-cms/README.md
@@ -92,3 +92,80 @@ This is convenient for granting access to a whole workspace, but be aware:
   that grants access to anyone with a Google account.
 - Prefer explicit per-email grants for `ADMIN` and `EDITOR`; reserve the
   wildcard for `CONTRIBUTOR` or `VIEWER` if you use it at all.
+
+# Embedding the CMS (`@blinkk/root-cms/browser-client`)
+
+`@blinkk/root-cms/browser-client` is a dependency-free, framework-agnostic
+browser library for embedding Root CMS into another site. It wraps the
+underlying iframe/postMessage wiring behind a typed API, so the wire protocol
+can evolve without breaking your integration.
+
+For pop-up/iframe embedding (the doc editor and Root AI), the embedding page's
+origin must be allowlisted in the CMS plugin config:
+
+```ts
+// root.config.ts
+cmsPlugin({
+  // ...
+  allowedIframeOrigins: ['https://app.example.com'],
+});
+```
+
+## Headless doc editor (pop-up or iframe)
+
+Opens `/cms/embed/content/<collection>/<slug>`, a minimal version of the doc
+editor with explicit (non-auto) saving. In `popup` mode, call from a user
+gesture (e.g. a click handler) to avoid pop-up blockers. Closing the editor
+discards unsaved changes.
+
+```ts
+import {RootCMSBrowserClient} from '@blinkk/root-cms/browser-client';
+
+const root = new RootCMSBrowserClient({cmsOrigin: 'https://cms.example.com'});
+
+const editor = root.openEditor('Pages/about', {
+  mode: 'popup', // or 'iframe' (pass `container`)
+  deeplink: 'hero.title', // optional: field to scroll to on load
+});
+editor.on('ready', () => console.log('editor loaded'));
+editor.on('saved', () => location.reload());
+editor.on('published', () => editor.closeAndReload());
+editor.on('close', () => console.log('editor closed'));
+editor.focusField('hero.image'); // scroll the editor to a field
+editor.reload();
+editor.close(); // or editor.closeAndReload()
+```
+
+## Headless Root AI (pop-up or iframe)
+
+Opens `/cms/embed/ai`, the compact Root AI chat, optionally with a doc as
+context:
+
+```ts
+const ai = root.openAI({docId: 'Pages/about', mode: 'popup'});
+ai.on('ready', () => console.log('chat loaded'));
+ai.close();
+```
+
+## Field focus from the in-CMS preview pane ("click to edit")
+
+When your site is rendered inside the CMS preview pane, use a
+`PreviewConnection` to focus editor fields from the page and to highlight page
+nodes when the editor requests it. The preview pane is same-origin with the
+CMS, so no config is needed and the connection is inert when the page is not
+embedded:
+
+```ts
+import {RootCMSBrowserClient} from '@blinkk/root-cms/browser-client';
+
+const preview = RootCMSBrowserClient.connectPreview();
+if (preview.isEmbedded) {
+  // "Click to edit": focus the field in the doc editor.
+  el.addEventListener('click', () => preview.focusField('hero.title'));
+  // Highlight page nodes when the editor hovers/focuses a field.
+  preview.on('highlight', ({deepKey, scroll}) => {
+    clearHighlights();
+    if (deepKey) highlightNode(deepKey, {scroll});
+  });
+}
+```

--- a/packages/root-cms/browser-client/browser-client.test.ts
+++ b/packages/root-cms/browser-client/browser-client.test.ts
@@ -293,7 +293,7 @@ describe('openEditor (popup mode)', () => {
   });
 });
 
-describe('openAI', () => {
+describe('openRootAI', () => {
   let root: RootCMSBrowserClient;
   let container: HTMLElement;
 
@@ -308,13 +308,17 @@ describe('openAI', () => {
   });
 
   it('creates an iframe with the ai embed url', () => {
-    const ai = root.openAI({mode: 'iframe', container});
+    const ai = root.openRootAI({mode: 'iframe', container});
     expect(ai.element!.src).toEqual(`${CMS_ORIGIN}/cms/embed/ai`);
     ai.close();
   });
 
   it('adds the docId query param', () => {
-    const ai = root.openAI({mode: 'iframe', container, docId: 'Pages/about'});
+    const ai = root.openRootAI({
+      mode: 'iframe',
+      container,
+      docId: 'Pages/about',
+    });
     expect(ai.element!.src).toEqual(
       `${CMS_ORIGIN}/cms/embed/ai?docId=Pages%2Fabout`
     );

--- a/packages/root-cms/browser-client/browser-client.test.ts
+++ b/packages/root-cms/browser-client/browser-client.test.ts
@@ -1,0 +1,378 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {RootCMSBrowserClient} from './browser-client.js';
+
+const CMS_ORIGIN = 'https://cms.example.com';
+
+function dispatchMessage(data: unknown, origin: string, source: Window | null) {
+  window.dispatchEvent(new MessageEvent('message', {data, origin, source}));
+}
+
+describe('RootCMSBrowserClient', () => {
+  it('normalizes cmsOrigin to an origin', () => {
+    const root = new RootCMSBrowserClient({
+      cmsOrigin: 'https://cms.example.com/some/path',
+    });
+    expect(root.cmsOrigin).toEqual('https://cms.example.com');
+  });
+
+  it('throws on an invalid cmsOrigin', () => {
+    expect(() => new RootCMSBrowserClient({cmsOrigin: 'not a url'})).toThrow(
+      /invalid cmsOrigin/
+    );
+  });
+
+  it('throws on an invalid docId', () => {
+    const root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    expect(() => root.openEditor('Pages')).toThrow(/invalid docId/);
+    expect(() => root.openEditor('Pages/')).toThrow(/invalid docId/);
+    expect(() => root.openEditor('/about')).toThrow(/invalid docId/);
+  });
+
+  it('normalizes url-like slugs in the docId', () => {
+    const root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = root.openEditor('Pages/about/foo', {
+      mode: 'iframe',
+      container,
+    });
+    expect(editor.docId).toEqual('Pages/about--foo');
+    expect(editor.element!.src).toEqual(
+      `${CMS_ORIGIN}/cms/embed/content/Pages/about--foo`
+    );
+    editor.close();
+    container.remove();
+  });
+});
+
+describe('openEditor (iframe mode)', () => {
+  let root: RootCMSBrowserClient;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('requires a container', () => {
+    expect(() => root.openEditor('Pages/about', {mode: 'iframe'})).toThrow(
+      /container/
+    );
+  });
+
+  it('creates an iframe with the embed url', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    expect(editor.docId).toEqual('Pages/about');
+    expect(editor.element).toBeInstanceOf(HTMLIFrameElement);
+    expect(editor.element!.src).toEqual(
+      `${CMS_ORIGIN}/cms/embed/content/Pages/about`
+    );
+    expect(editor.element!.parentElement).toBe(container);
+    expect(editor.window).toBeNull();
+    editor.close();
+  });
+
+  it('adds the deeplink query param', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+      deeplink: 'hero.title',
+    });
+    expect(editor.element!.src).toEqual(
+      `${CMS_ORIGIN}/cms/embed/content/Pages/about?deeplink=hero.title`
+    );
+    editor.close();
+  });
+
+  it('close() removes the iframe and emits close exactly once', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    const onClose = vi.fn();
+    editor.on('close', onClose);
+    editor.close();
+    editor.close();
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches lifecycle messages from the cms origin', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    const onSaved = vi.fn();
+    editor.on('saved', onSaved);
+    dispatchMessage(
+      {root: {type: 'saved', docId: 'Pages/about'}},
+      CMS_ORIGIN,
+      editor.element!.contentWindow
+    );
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({docId: 'Pages/about'})
+    );
+    editor.close();
+  });
+
+  it('ignores messages from other origins', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    const onSaved = vi.fn();
+    editor.on('saved', onSaved);
+    dispatchMessage(
+      {root: {type: 'saved'}},
+      'https://evil.example.com',
+      editor.element!.contentWindow
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+    editor.close();
+  });
+
+  it('ignores messages from other windows', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    const onSaved = vi.fn();
+    editor.on('saved', onSaved);
+    // Right origin, but not this handle's iframe.
+    dispatchMessage({root: {type: 'saved'}}, CMS_ORIGIN, window);
+    dispatchMessage({root: {type: 'saved'}}, CMS_ORIGIN, null);
+    expect(onSaved).not.toHaveBeenCalled();
+    editor.close();
+  });
+
+  it('buffers focusField() until the editor is ready', () => {
+    const editor = root.openEditor('Pages/about', {
+      mode: 'iframe',
+      container,
+    });
+    const postMessage = vi.spyOn(editor.element!.contentWindow!, 'postMessage');
+    editor.focusField('hero.title');
+    expect(postMessage).not.toHaveBeenCalled();
+    dispatchMessage(
+      {root: {type: 'ready', docId: 'Pages/about'}},
+      CMS_ORIGIN,
+      editor.element!.contentWindow
+    );
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      {scrollToDeeplink: {deepKey: 'hero.title'}},
+      CMS_ORIGIN
+    );
+    // After ready, messages post immediately.
+    editor.focusField('hero.image');
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    editor.close();
+  });
+});
+
+describe('openEditor (popup mode)', () => {
+  let root: RootCMSBrowserClient;
+  let popup: {
+    closed: boolean;
+    close: () => void;
+    postMessage: (message: unknown, targetOrigin: string) => void;
+    location: {href: string};
+  };
+  let windowOpen: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    popup = {
+      closed: false,
+      close: vi.fn(() => {
+        popup.closed = true;
+      }),
+      postMessage: vi.fn(),
+      location: {href: ''},
+    };
+    windowOpen = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(popup as unknown as Window);
+  });
+
+  afterEach(() => {
+    windowOpen.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('opens a popup window with the embed url', () => {
+    const editor = root.openEditor('Pages/about', {width: 600, height: 800});
+    expect(windowOpen).toHaveBeenCalledWith(
+      `${CMS_ORIGIN}/cms/embed/content/Pages/about`,
+      '_blank',
+      'popup,width=600,height=800'
+    );
+    expect(editor.window).toBe(popup);
+    expect(editor.element).toBeNull();
+    editor.close();
+    expect(popup.close).toHaveBeenCalled();
+  });
+
+  it('emits close when the user closes the popup', () => {
+    vi.useFakeTimers();
+    const editor = root.openEditor('Pages/about');
+    const onClose = vi.fn();
+    editor.on('close', onClose);
+    popup.closed = true;
+    vi.advanceTimersByTime(500);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // The poll timer is cleared after close.
+    vi.advanceTimersByTime(5000);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits error when the popup is blocked', async () => {
+    windowOpen.mockReturnValue(null);
+    const editor = root.openEditor('Pages/about');
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    editor.on('error', onError);
+    editor.on('close', onClose);
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({error: expect.stringContaining('popup')})
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('reload() re-navigates the popup', () => {
+    const editor = root.openEditor('Pages/about');
+    editor.reload();
+    expect(popup.location.href).toEqual(
+      `${CMS_ORIGIN}/cms/embed/content/Pages/about`
+    );
+    editor.close();
+  });
+});
+
+describe('openAI', () => {
+  let root: RootCMSBrowserClient;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('creates an iframe with the ai embed url', () => {
+    const ai = root.openAI({mode: 'iframe', container});
+    expect(ai.element!.src).toEqual(`${CMS_ORIGIN}/cms/embed/ai`);
+    ai.close();
+  });
+
+  it('adds the docId query param', () => {
+    const ai = root.openAI({mode: 'iframe', container, docId: 'Pages/about'});
+    expect(ai.element!.src).toEqual(
+      `${CMS_ORIGIN}/cms/embed/ai?docId=Pages%2Fabout`
+    );
+    ai.close();
+  });
+});
+
+describe('connectPreview', () => {
+  const originalParent = Object.getOwnPropertyDescriptor(window, 'parent');
+
+  function mockParentWindow() {
+    const parentWindow = {postMessage: vi.fn()};
+    Object.defineProperty(window, 'parent', {
+      value: parentWindow,
+      configurable: true,
+    });
+    return parentWindow;
+  }
+
+  afterEach(() => {
+    if (originalParent) {
+      Object.defineProperty(window, 'parent', originalParent);
+    }
+  });
+
+  it('is inert at the top level', () => {
+    const preview = RootCMSBrowserClient.connectPreview();
+    expect(preview.isEmbedded).toBe(false);
+    // No parent to post to; should not throw.
+    preview.focusField('hero.title');
+    preview.disconnect();
+  });
+
+  it('focusField() posts scrollToDeeplink to the parent window', () => {
+    const parentWindow = mockParentWindow();
+    const preview = RootCMSBrowserClient.connectPreview();
+    preview.focusField('hero.title');
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      {scrollToDeeplink: {deepKey: 'hero.title'}},
+      window.location.origin
+    );
+    preview.disconnect();
+  });
+
+  it('emits highlight events for same-origin highlightNode messages', () => {
+    const preview = RootCMSBrowserClient.connectPreview();
+    const onHighlight = vi.fn();
+    preview.on('highlight', onHighlight);
+    dispatchMessage(
+      {highlightNode: {deepKey: 'hero.title', options: {scroll: true}}},
+      window.location.origin,
+      null
+    );
+    expect(onHighlight).toHaveBeenCalledTimes(1);
+    expect(onHighlight).toHaveBeenCalledWith({
+      deepKey: 'hero.title',
+      scroll: true,
+    });
+    // A null deepKey clears highlights.
+    dispatchMessage(
+      {highlightNode: {deepKey: null}},
+      window.location.origin,
+      null
+    );
+    expect(onHighlight).toHaveBeenCalledWith({deepKey: null, scroll: false});
+    preview.disconnect();
+  });
+
+  it('ignores highlightNode messages from other origins', () => {
+    const preview = RootCMSBrowserClient.connectPreview();
+    const onHighlight = vi.fn();
+    preview.on('highlight', onHighlight);
+    dispatchMessage(
+      {highlightNode: {deepKey: 'hero.title'}},
+      'https://evil.example.com',
+      null
+    );
+    expect(onHighlight).not.toHaveBeenCalled();
+    preview.disconnect();
+  });
+
+  it('disconnect() stops emitting events', () => {
+    const preview = RootCMSBrowserClient.connectPreview();
+    const onHighlight = vi.fn();
+    preview.on('highlight', onHighlight);
+    preview.disconnect();
+    dispatchMessage(
+      {highlightNode: {deepKey: 'hero.title'}},
+      window.location.origin,
+      null
+    );
+    expect(onHighlight).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/browser-client/browser-client.test.ts
+++ b/packages/root-cms/browser-client/browser-client.test.ts
@@ -21,11 +21,44 @@ describe('RootCMSBrowserClient', () => {
     );
   });
 
+  it('throws on a non-http(s) cmsOrigin', () => {
+    expect(
+      () => new RootCMSBrowserClient({cmsOrigin: 'javascript:alert(1)'})
+    ).toThrow(/invalid cmsOrigin/);
+    expect(
+      () => new RootCMSBrowserClient({cmsOrigin: 'data:text/html,hi'})
+    ).toThrow(/invalid cmsOrigin/);
+    expect(
+      () => new RootCMSBrowserClient({cmsOrigin: 'blob:https://x.example/123'})
+    ).toThrow(/invalid cmsOrigin/);
+  });
+
   it('throws on an invalid docId', () => {
     const root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
     expect(() => root.openEditor('Pages')).toThrow(/invalid docId/);
     expect(() => root.openEditor('Pages/')).toThrow(/invalid docId/);
     expect(() => root.openEditor('/about')).toThrow(/invalid docId/);
+    // Dot segments must not survive to traverse out of the embed path.
+    expect(() => root.openEditor('../about')).toThrow(/invalid docId/);
+    expect(() => root.openEditor('Pages/..')).toThrow(/invalid docId/);
+    expect(() => root.openEditor('./about')).toThrow(/invalid docId/);
+  });
+
+  it('encodes docId segments to prevent url injection', () => {
+    const root = new RootCMSBrowserClient({cmsOrigin: CMS_ORIGIN});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    // A `?` in the collection must not inject a query string.
+    const editor = root.openEditor('Pages?evil=1/about', {
+      mode: 'iframe',
+      container,
+    });
+    const src = new URL(editor.element!.src);
+    expect(src.origin).toEqual(CMS_ORIGIN);
+    expect(src.pathname).toEqual('/cms/embed/content/Pages%3Fevil%3D1/about');
+    expect(src.search).toEqual('');
+    editor.close();
+    container.remove();
   });
 
   it('normalizes url-like slugs in the docId', () => {

--- a/packages/root-cms/browser-client/browser-client.ts
+++ b/packages/root-cms/browser-client/browser-client.ts
@@ -1,0 +1,312 @@
+/**
+ * Browser client for embedding Root CMS into another site, exported as
+ * `@blinkk/root-cms/browser-client`. Framework-agnostic and dependency-free.
+ *
+ * Covers three scenarios:
+ * - Opening the headless doc editor in a pop-up or iframe
+ *   ({@link RootCMSBrowserClient.openEditor}).
+ * - Opening the headless Root AI chat in a pop-up or iframe
+ *   ({@link RootCMSBrowserClient.openAI}).
+ * - Communicating with the doc editor from a site rendered inside the in-CMS
+ *   preview pane ({@link RootCMSBrowserClient.connectPreview}).
+ *
+ * The first two require the embedding page's origin to be listed in the
+ * `allowedIframeOrigins` option of the CMS plugin config.
+ */
+
+import {
+  isHighlightNodeMessage,
+  ScrollToDeeplinkMessage,
+} from '../shared/embed-protocol.js';
+import {normalizeSlug} from '../shared/slug.js';
+import {EmbedWindow, EmbedWindowEvents} from './embed-window.js';
+import {Emitter} from './emitter.js';
+
+export {SaveState} from '../shared/embed-protocol.js';
+export type {
+  HighlightNodeMessage,
+  RootEmbedMessage,
+  ScrollToDeeplinkMessage,
+} from '../shared/embed-protocol.js';
+export type {EmbedWindowEvents} from './embed-window.js';
+
+export interface RootCMSBrowserClientOptions {
+  /** Origin of the Root CMS server, e.g. `https://cms.example.com`. */
+  cmsOrigin: string;
+}
+
+export interface OpenEditorOptions {
+  /** How to open the editor. Defaults to `popup`. */
+  mode?: 'popup' | 'iframe';
+  /** Container the iframe is appended to. Required when mode is `iframe`. */
+  container?: HTMLElement;
+  /** Deep key of a field to scroll to on load, e.g. `hero.title`. */
+  deeplink?: string;
+  /** Pop-up window width. Defaults to 480. */
+  width?: number;
+  /** Pop-up window height. Defaults to 720. */
+  height?: number;
+}
+
+export interface OpenAIOptions extends Omit<OpenEditorOptions, 'deeplink'> {
+  /** Doc to provide as context to the AI chat, e.g. `Pages/about`. */
+  docId?: string;
+}
+
+/** Events emitted by {@link EmbeddedEditor}. */
+export type EditorEvents = EmbedWindowEvents;
+
+/** Events emitted by {@link EmbeddedAI}. */
+export type AIEvents = Pick<EmbedWindowEvents, 'ready' | 'error' | 'close'>;
+
+/** Event emitted when the doc editor requests a field highlight. */
+export interface PreviewHighlightEvent {
+  /** Deep key of the field to highlight, or `null` to clear highlights. */
+  deepKey: string | null;
+  /** Whether to scroll the highlighted node into view. */
+  scroll: boolean;
+}
+
+/**
+ * Handle to a headless doc editor opened via {@link RootCMSBrowserClient.openEditor}.
+ *
+ * Note: the embedded editor does not autosave; closing it discards any
+ * unsaved changes.
+ */
+export class EmbeddedEditor {
+  /** The doc being edited, e.g. `Pages/about`. */
+  readonly docId: string;
+  private embedWindow: EmbedWindow;
+
+  constructor(docId: string, embedWindow: EmbedWindow) {
+    this.docId = docId;
+    this.embedWindow = embedWindow;
+  }
+
+  /** The iframe element (iframe mode only). */
+  get element(): HTMLIFrameElement | null {
+    return this.embedWindow.element;
+  }
+
+  /** The pop-up window (popup mode only). */
+  get window(): Window | null {
+    return this.embedWindow.window;
+  }
+
+  /** Subscribes to an editor event. Returns an unsubscribe function. */
+  on<K extends keyof EditorEvents>(
+    type: K,
+    cb: (payload: EditorEvents[K]) => void
+  ): () => void {
+    return this.embedWindow.on(type, cb);
+  }
+
+  /** Scrolls the editor to (focuses) a field, e.g. `hero.title`. */
+  focusField(deepKey: string) {
+    const message: ScrollToDeeplinkMessage = {scrollToDeeplink: {deepKey}};
+    this.embedWindow.post(message);
+  }
+
+  /** Reloads the embedded editor. */
+  reload() {
+    this.embedWindow.reload();
+  }
+
+  /** Closes the embedded editor, discarding any unsaved changes. */
+  close() {
+    this.embedWindow.close();
+  }
+
+  /** Closes the embedded editor and reloads the host page. */
+  closeAndReload() {
+    this.close();
+    window.location.reload();
+  }
+}
+
+/** Handle to a headless Root AI chat opened via {@link RootCMSBrowserClient.openAI}. */
+export class EmbeddedAI {
+  private embedWindow: EmbedWindow;
+
+  constructor(embedWindow: EmbedWindow) {
+    this.embedWindow = embedWindow;
+  }
+
+  /** The iframe element (iframe mode only). */
+  get element(): HTMLIFrameElement | null {
+    return this.embedWindow.element;
+  }
+
+  /** The pop-up window (popup mode only). */
+  get window(): Window | null {
+    return this.embedWindow.window;
+  }
+
+  /** Subscribes to an event. Returns an unsubscribe function. */
+  on<K extends keyof AIEvents>(
+    type: K,
+    cb: (payload: AIEvents[K]) => void
+  ): () => void {
+    return this.embedWindow.on(type, cb);
+  }
+
+  /** Reloads the embedded chat (starts a fresh chat). */
+  reload() {
+    this.embedWindow.reload();
+  }
+
+  /** Closes the embedded chat. */
+  close() {
+    this.embedWindow.close();
+  }
+
+  /** Closes the embedded chat and reloads the host page. */
+  closeAndReload() {
+    this.close();
+    window.location.reload();
+  }
+}
+
+/**
+ * Channel between a site rendered inside the in-CMS preview pane and the doc
+ * editor that frames it. The preview iframe is same-origin with the CMS, so
+ * no configuration is needed. Safe to construct unconditionally: outside the
+ * preview pane the connection is inert (`isEmbedded` is false).
+ */
+export class PreviewConnection {
+  /** Whether this page is rendered inside the in-CMS preview pane. */
+  readonly isEmbedded: boolean;
+  private emitter = new Emitter<{highlight: PreviewHighlightEvent}>();
+
+  constructor() {
+    this.isEmbedded = RootCMSBrowserClient.isInPreviewIframe();
+    window.addEventListener('message', this.onMessage);
+  }
+
+  /**
+   * Requests that the doc editor scroll to (focus) a field, e.g.
+   * `hero.title`. Used to implement "click to edit".
+   */
+  focusField(deepKey: string) {
+    if (window.parent === window) {
+      return;
+    }
+    const message: ScrollToDeeplinkMessage = {scrollToDeeplink: {deepKey}};
+    window.parent.postMessage(message, window.location.origin);
+  }
+
+  /**
+   * Subscribes to field highlight requests from the doc editor (sent when the
+   * user hovers/focuses a field). Returns an unsubscribe function.
+   */
+  on(
+    type: 'highlight',
+    cb: (event: PreviewHighlightEvent) => void
+  ): () => void {
+    return this.emitter.on(type, cb);
+  }
+
+  /** Removes the message listener and all subscriptions. */
+  disconnect() {
+    window.removeEventListener('message', this.onMessage);
+    this.emitter.removeAll();
+  }
+
+  private onMessage = (event: MessageEvent) => {
+    // The editor is same-origin with the preview iframe.
+    if (event.origin !== window.location.origin) {
+      return;
+    }
+    if (!isHighlightNodeMessage(event.data)) {
+      return;
+    }
+    const req = event.data.highlightNode;
+    this.emitter.emit('highlight', {
+      deepKey: req.deepKey,
+      scroll: req.options?.scroll ?? false,
+    });
+  };
+}
+
+/** Client for embedding Root CMS into another site. */
+export class RootCMSBrowserClient {
+  /** Normalized origin of the Root CMS server. */
+  readonly cmsOrigin: string;
+
+  constructor(options: RootCMSBrowserClientOptions) {
+    try {
+      this.cmsOrigin = new URL(options.cmsOrigin).origin;
+    } catch {
+      throw new Error(
+        `invalid cmsOrigin: "${options?.cmsOrigin}" (expected e.g. "https://cms.example.com")`
+      );
+    }
+  }
+
+  /**
+   * Opens the headless doc editor for a doc (e.g. `Pages/about`) in a pop-up
+   * or iframe. In popup mode, call from a user gesture (e.g. a click handler)
+   * to avoid pop-up blockers.
+   *
+   * The slug portion of the docId is normalized the same way the CMS
+   * normalizes slugs, so a URL-like path also works, e.g. `Pages/about/foo`
+   * -> `Pages/about--foo`.
+   */
+  openEditor(docId: string, options?: OpenEditorOptions): EmbeddedEditor {
+    const [collection, ...slugParts] = docId.split('/');
+    const slug = normalizeSlug(slugParts.join('/'));
+    if (!collection || !slug) {
+      throw new Error(
+        `invalid docId: "${docId}" (expected "<collection>/<slug>")`
+      );
+    }
+    const normalizedDocId = `${collection}/${slug}`;
+    const url = new URL(
+      `${this.cmsOrigin}/cms/embed/content/${collection}/${slug}`
+    );
+    if (options?.deeplink) {
+      url.searchParams.set('deeplink', options.deeplink);
+    }
+    const embedWindow = new EmbedWindow(
+      url.toString(),
+      this.cmsOrigin,
+      options
+    );
+    return new EmbeddedEditor(normalizedDocId, embedWindow);
+  }
+
+  /**
+   * Opens the headless Root AI chat in a pop-up or iframe, optionally with a
+   * doc as context. In popup mode, call from a user gesture (e.g. a click
+   * handler) to avoid pop-up blockers.
+   */
+  openAI(options?: OpenAIOptions): EmbeddedAI {
+    const url = new URL(`${this.cmsOrigin}/cms/embed/ai`);
+    if (options?.docId) {
+      url.searchParams.set('docId', options.docId);
+    }
+    const embedWindow = new EmbedWindow(
+      url.toString(),
+      this.cmsOrigin,
+      options
+    );
+    return new EmbeddedAI(embedWindow);
+  }
+
+  /**
+   * Connects to the doc editor from a site rendered inside the in-CMS preview
+   * pane, enabling "click to edit" ({@link PreviewConnection.focusField}) and
+   * field highlighting (`on('highlight', ...)`).
+   */
+  static connectPreview(): PreviewConnection {
+    return new PreviewConnection();
+  }
+
+  /** Returns whether this page is rendered inside the in-CMS preview pane. */
+  static isInPreviewIframe(): boolean {
+    if (window.parent === window) {
+      return false;
+    }
+    return document.referrer.startsWith(`${window.location.origin}/cms`);
+  }
+}

--- a/packages/root-cms/browser-client/browser-client.ts
+++ b/packages/root-cms/browser-client/browser-client.ts
@@ -30,6 +30,11 @@ export type {
 } from '../shared/embed-protocol.js';
 export type {EmbedWindowEvents} from './embed-window.js';
 
+/** Whether a path segment is a relative-traversal segment (`.` or `..`). */
+function isDotSegment(segment: string): boolean {
+  return segment === '.' || segment === '..';
+}
+
 export interface RootCMSBrowserClientOptions {
   /** Origin of the Root CMS server, e.g. `https://cms.example.com`. */
   cmsOrigin: string;
@@ -234,13 +239,23 @@ export class RootCMSBrowserClient {
   readonly cmsOrigin: string;
 
   constructor(options: RootCMSBrowserClientOptions) {
+    let url: URL;
     try {
-      this.cmsOrigin = new URL(options.cmsOrigin).origin;
+      url = new URL(options.cmsOrigin);
     } catch {
       throw new Error(
         `invalid cmsOrigin: "${options?.cmsOrigin}" (expected e.g. "https://cms.example.com")`
       );
     }
+    // Only http(s) origins are meaningful here. Reject other schemes (e.g.
+    // `javascript:`, `data:`, `blob:`) so the constructor doesn't silently
+    // accept an origin that can never serve the CMS.
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      throw new Error(
+        `invalid cmsOrigin: "${options?.cmsOrigin}" (expected an http(s) origin, e.g. "https://cms.example.com")`
+      );
+    }
+    this.cmsOrigin = url.origin;
   }
 
   /**
@@ -255,14 +270,27 @@ export class RootCMSBrowserClient {
   openEditor(docId: string, options?: OpenEditorOptions): EmbeddedEditor {
     const [collection, ...slugParts] = docId.split('/');
     const slug = normalizeSlug(slugParts.join('/'));
-    if (!collection || !slug) {
+    // Reject empty or dot segments (`.` / `..`). `normalizeSlug` strips
+    // slashes but not dots, and `encodeURIComponent` leaves dots intact, so a
+    // bare dot segment would otherwise survive path normalization and let a
+    // malicious docId traverse out of `/cms/embed/content/`.
+    if (
+      !collection ||
+      !slug ||
+      isDotSegment(collection) ||
+      isDotSegment(slug)
+    ) {
       throw new Error(
         `invalid docId: "${docId}" (expected "<collection>/<slug>")`
       );
     }
     const normalizedDocId = `${collection}/${slug}`;
+    // Encode each segment so characters like `?`, `#`, and `/` stay inside the
+    // path segment instead of injecting a query/fragment or new path part.
     const url = new URL(
-      `${this.cmsOrigin}/cms/embed/content/${collection}/${slug}`
+      `${this.cmsOrigin}/cms/embed/content/${encodeURIComponent(
+        collection
+      )}/${encodeURIComponent(slug)}`
     );
     if (options?.deeplink) {
       url.searchParams.set('deeplink', options.deeplink);

--- a/packages/root-cms/browser-client/browser-client.ts
+++ b/packages/root-cms/browser-client/browser-client.ts
@@ -6,7 +6,7 @@
  * - Opening the headless doc editor in a pop-up or iframe
  *   ({@link RootCMSBrowserClient.openEditor}).
  * - Opening the headless Root AI chat in a pop-up or iframe
- *   ({@link RootCMSBrowserClient.openAI}).
+ *   ({@link RootCMSBrowserClient.openRootAI}).
  * - Communicating with the doc editor from a site rendered inside the in-CMS
  *   preview pane ({@link RootCMSBrowserClient.connectPreview}).
  *
@@ -53,7 +53,7 @@ export interface OpenEditorOptions {
   height?: number;
 }
 
-export interface OpenAIOptions extends Omit<OpenEditorOptions, 'deeplink'> {
+export interface OpenRootAIOptions extends Omit<OpenEditorOptions, 'deeplink'> {
   /** Doc to provide as context to the AI chat, e.g. `Pages/about`. */
   docId?: string;
 }
@@ -129,7 +129,7 @@ export class EmbeddedEditor {
   }
 }
 
-/** Handle to a headless Root AI chat opened via {@link RootCMSBrowserClient.openAI}. */
+/** Handle to a headless Root AI chat opened via {@link RootCMSBrowserClient.openRootAI}. */
 export class EmbeddedAI {
   private embedWindow: EmbedWindow;
 
@@ -308,7 +308,7 @@ export class RootCMSBrowserClient {
    * doc as context. In popup mode, call from a user gesture (e.g. a click
    * handler) to avoid pop-up blockers.
    */
-  openAI(options?: OpenAIOptions): EmbeddedAI {
+  openRootAI(options?: OpenRootAIOptions): EmbeddedAI {
     const url = new URL(`${this.cmsOrigin}/cms/embed/ai`);
     if (options?.docId) {
       url.searchParams.set('docId', options.docId);

--- a/packages/root-cms/browser-client/embed-window.ts
+++ b/packages/root-cms/browser-client/embed-window.ts
@@ -1,0 +1,181 @@
+import {
+  isRootEmbedMessage,
+  RootEmbedMessage,
+  SaveState,
+} from '../shared/embed-protocol.js';
+import {Emitter} from './emitter.js';
+
+/** Events emitted by an embedded CMS window (iframe or pop-up). */
+export interface EmbedWindowEvents {
+  /** The embedded page finished loading. */
+  ready: {docId?: string};
+  /** The doc was saved. */
+  saved: {docId?: string; saveState?: SaveState};
+  /** The doc was published. */
+  published: {docId?: string; publishedAt?: number};
+  /** An error occurred (e.g. the pop-up was blocked). */
+  error: {error?: string};
+  /** The embedded window was closed (via `close()` or by the user). */
+  close: void;
+}
+
+export interface EmbedWindowOptions {
+  /** How to open the embedded page. Defaults to `popup`. */
+  mode?: 'popup' | 'iframe';
+  /** Container the iframe is appended to. Required when mode is `iframe`. */
+  container?: HTMLElement;
+  /** Pop-up window width. Defaults to 480. */
+  width?: number;
+  /** Pop-up window height. Defaults to 720. */
+  height?: number;
+}
+
+const POPUP_POLL_INTERVAL = 500;
+const DEFAULT_POPUP_WIDTH = 480;
+const DEFAULT_POPUP_HEIGHT = 720;
+
+/**
+ * Internal plumbing shared by the embedded doc editor and Root AI handles.
+ * Owns the iframe-or-popup lifecycle: opening, message routing (with origin
+ * and source validation), outbound message buffering until `ready`, reload,
+ * and close detection.
+ */
+export class EmbedWindow {
+  /** The iframe element (iframe mode only). */
+  readonly element: HTMLIFrameElement | null = null;
+  /** The pop-up window (popup mode only). */
+  readonly window: Window | null = null;
+
+  private url: string;
+  private cmsOrigin: string;
+  private emitter = new Emitter<EmbedWindowEvents>();
+  private ready = false;
+  private closed = false;
+  private outbox: unknown[] = [];
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(url: string, cmsOrigin: string, options?: EmbedWindowOptions) {
+    this.url = url;
+    this.cmsOrigin = cmsOrigin;
+    window.addEventListener('message', this.onMessage);
+    const mode = options?.mode || 'popup';
+    if (mode === 'iframe') {
+      if (!options?.container) {
+        throw new Error('`container` is required when mode is "iframe"');
+      }
+      const iframe = document.createElement('iframe');
+      iframe.className = 'root-cms-embed';
+      iframe.src = url;
+      options.container.appendChild(iframe);
+      this.element = iframe;
+    } else {
+      const width = options?.width ?? DEFAULT_POPUP_WIDTH;
+      const height = options?.height ?? DEFAULT_POPUP_HEIGHT;
+      const popup = window.open(
+        url,
+        '_blank',
+        `popup,width=${width},height=${height}`
+      );
+      if (!popup) {
+        // Pop-up blocked. Emit asynchronously so callers have a chance to
+        // attach listeners to the handle first.
+        queueMicrotask(() => {
+          this.emitter.emit('error', {
+            error:
+              'popup blocked (open the editor from a user gesture, e.g. a click handler)',
+          });
+          this.close();
+        });
+      } else {
+        this.window = popup;
+        this.pollTimer = setInterval(() => {
+          if (popup.closed) {
+            this.close();
+          }
+        }, POPUP_POLL_INTERVAL);
+      }
+    }
+  }
+
+  on<K extends keyof EmbedWindowEvents>(
+    type: K,
+    cb: (payload: EmbedWindowEvents[K]) => void
+  ): () => void {
+    return this.emitter.on(type, cb);
+  }
+
+  /**
+   * Posts a message to the embedded window, targeted at the CMS origin.
+   * Messages are buffered until the embedded page signals `ready`.
+   */
+  post(message: unknown) {
+    if (this.closed) {
+      return;
+    }
+    if (!this.ready) {
+      this.outbox.push(message);
+      return;
+    }
+    this.contentWindow()?.postMessage(message, this.cmsOrigin);
+  }
+
+  /** Reloads the embedded page. */
+  reload() {
+    if (this.closed) {
+      return;
+    }
+    // The embedded page is cross-origin, so reload by re-navigating to the
+    // url (navigation is permitted cross-origin; `location.reload()` is not).
+    this.ready = false;
+    if (this.element) {
+      this.element.src = this.url;
+    } else if (this.window) {
+      this.window.location.href = this.url;
+    }
+  }
+
+  /** Closes the embedded window. Safe to call multiple times. */
+  close() {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    window.removeEventListener('message', this.onMessage);
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.element?.remove();
+    if (this.window && !this.window.closed) {
+      this.window.close();
+    }
+    this.emitter.emit('close', undefined);
+    this.emitter.removeAll();
+  }
+
+  private contentWindow(): Window | null {
+    return this.element ? this.element.contentWindow : this.window;
+  }
+
+  private onMessage = (event: MessageEvent) => {
+    // Only accept messages from the CMS origin AND from this handle's own
+    // window (multiple embeds on one page each get their own listener).
+    if (event.origin !== this.cmsOrigin) {
+      return;
+    }
+    if (!event.source || event.source !== this.contentWindow()) {
+      return;
+    }
+    if (!isRootEmbedMessage(event.data)) {
+      return;
+    }
+    const root = (event.data as RootEmbedMessage).root;
+    if (root.type === 'ready') {
+      this.ready = true;
+      const outbox = this.outbox;
+      this.outbox = [];
+      outbox.forEach((message) => this.post(message));
+    }
+    this.emitter.emit(root.type, root);
+  };
+}

--- a/packages/root-cms/browser-client/emitter.test.ts
+++ b/packages/root-cms/browser-client/emitter.test.ts
@@ -1,0 +1,52 @@
+import {describe, it, expect, vi} from 'vitest';
+import {Emitter} from './emitter.js';
+
+describe('Emitter', () => {
+  it('notifies subscribers with the payload', () => {
+    const emitter = new Emitter<{foo: {value: number}}>();
+    const cb = vi.fn();
+    emitter.on('foo', cb);
+    emitter.emit('foo', {value: 42});
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith({value: 42});
+  });
+
+  it('on() returns an unsubscribe function', () => {
+    const emitter = new Emitter<{foo: void}>();
+    const cb = vi.fn();
+    const unsubscribe = emitter.on('foo', cb);
+    unsubscribe();
+    emitter.emit('foo', undefined);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('off() removes a subscriber', () => {
+    const emitter = new Emitter<{foo: void}>();
+    const cb = vi.fn();
+    emitter.on('foo', cb);
+    emitter.off('foo', cb);
+    emitter.emit('foo', undefined);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('removeAll() removes all subscribers', () => {
+    const emitter = new Emitter<{foo: void; bar: void}>();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    emitter.on('foo', cb1);
+    emitter.on('bar', cb2);
+    emitter.removeAll();
+    emitter.emit('foo', undefined);
+    emitter.emit('bar', undefined);
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).not.toHaveBeenCalled();
+  });
+
+  it('only notifies subscribers of the emitted event type', () => {
+    const emitter = new Emitter<{foo: void; bar: void}>();
+    const cb = vi.fn();
+    emitter.on('foo', cb);
+    emitter.emit('bar', undefined);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/browser-client/emitter.ts
+++ b/packages/root-cms/browser-client/emitter.ts
@@ -1,0 +1,29 @@
+type Listener<T> = (payload: T) => void;
+
+/** Minimal typed event emitter. */
+export class Emitter<Events extends Record<string, any>> {
+  private listeners = new Map<keyof Events, Set<Listener<any>>>();
+
+  /** Subscribes to an event. Returns an unsubscribe function. */
+  on<K extends keyof Events>(type: K, cb: Listener<Events[K]>): () => void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(cb);
+    return () => this.off(type, cb);
+  }
+
+  off<K extends keyof Events>(type: K, cb: Listener<Events[K]>) {
+    this.listeners.get(type)?.delete(cb);
+  }
+
+  emit<K extends keyof Events>(type: K, payload: Events[K]) {
+    this.listeners.get(type)?.forEach((cb) => cb(payload));
+  }
+
+  removeAll() {
+    this.listeners.clear();
+  }
+}

--- a/packages/root-cms/browser-client/tsconfig.json
+++ b/packages/root-cms/browser-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../core/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": []
+  },
+  "include": ["*.ts", "**/*.ts", "../shared/*.ts"]
+}

--- a/packages/root-cms/esbuild.config.json
+++ b/packages/root-cms/esbuild.config.json
@@ -2,6 +2,7 @@
   "clean": false,
   "entryPoints": {
     "app": "core/app.tsx",
+    "browser-client": "browser-client/browser-client.ts",
     "cli": "cli/cli.ts",
     "client": "core/client.ts",
     "core": "core/core.ts",

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/core/core.d.ts",
       "import": "./dist/core.js"
     },
+    "./browser-client": {
+      "types": "./dist/browser-client/browser-client.d.ts",
+      "import": "./dist/browser-client.js"
+    },
     "./client": {
       "types": "./dist/core/client.d.ts",
       "import": "./dist/client.js"

--- a/packages/root-cms/shared/embed-protocol.test.ts
+++ b/packages/root-cms/shared/embed-protocol.test.ts
@@ -1,0 +1,74 @@
+import {describe, it, expect} from 'vitest';
+import {
+  isHighlightNodeMessage,
+  isRootEmbedMessage,
+  isScrollToDeeplinkMessage,
+} from './embed-protocol.js';
+
+describe('isRootEmbedMessage', () => {
+  it('accepts lifecycle messages', () => {
+    expect(isRootEmbedMessage({root: {type: 'ready'}})).toBe(true);
+    expect(isRootEmbedMessage({root: {type: 'saved', docId: 'Pages/a'}})).toBe(
+      true
+    );
+    expect(
+      isRootEmbedMessage({root: {type: 'published', publishedAt: 123}})
+    ).toBe(true);
+    expect(isRootEmbedMessage({root: {type: 'error', error: 'oops'}})).toBe(
+      true
+    );
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(isRootEmbedMessage(null)).toBe(false);
+    expect(isRootEmbedMessage(undefined)).toBe(false);
+    expect(isRootEmbedMessage('ready')).toBe(false);
+    expect(isRootEmbedMessage({})).toBe(false);
+    expect(isRootEmbedMessage({root: null})).toBe(false);
+    expect(isRootEmbedMessage({root: 'ready'})).toBe(false);
+    expect(isRootEmbedMessage({root: {type: 'unknown'}})).toBe(false);
+    expect(isRootEmbedMessage({scrollToDeeplink: {deepKey: 'a'}})).toBe(false);
+  });
+});
+
+describe('isScrollToDeeplinkMessage', () => {
+  it('accepts scrollToDeeplink messages', () => {
+    expect(
+      isScrollToDeeplinkMessage({scrollToDeeplink: {deepKey: 'hero.title'}})
+    ).toBe(true);
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(isScrollToDeeplinkMessage(null)).toBe(false);
+    expect(isScrollToDeeplinkMessage({})).toBe(false);
+    expect(isScrollToDeeplinkMessage({scrollToDeeplink: null})).toBe(false);
+    expect(isScrollToDeeplinkMessage({scrollToDeeplink: {}})).toBe(false);
+    expect(isScrollToDeeplinkMessage({scrollToDeeplink: {deepKey: 1}})).toBe(
+      false
+    );
+    expect(isScrollToDeeplinkMessage({root: {type: 'ready'}})).toBe(false);
+  });
+});
+
+describe('isHighlightNodeMessage', () => {
+  it('accepts highlightNode messages', () => {
+    expect(
+      isHighlightNodeMessage({highlightNode: {deepKey: 'hero.title'}})
+    ).toBe(true);
+    expect(
+      isHighlightNodeMessage({
+        highlightNode: {deepKey: 'hero.title', options: {scroll: true}},
+      })
+    ).toBe(true);
+    // A null deepKey clears highlights.
+    expect(isHighlightNodeMessage({highlightNode: {deepKey: null}})).toBe(true);
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(isHighlightNodeMessage(null)).toBe(false);
+    expect(isHighlightNodeMessage({})).toBe(false);
+    expect(isHighlightNodeMessage({highlightNode: null})).toBe(false);
+    expect(isHighlightNodeMessage({highlightNode: {}})).toBe(false);
+    expect(isHighlightNodeMessage({highlightNode: {deepKey: 1}})).toBe(false);
+  });
+});

--- a/packages/root-cms/shared/embed-protocol.ts
+++ b/packages/root-cms/shared/embed-protocol.ts
@@ -1,0 +1,104 @@
+/**
+ * Wire protocol for the postMessage channels between the Root CMS UI and
+ * pages that embed it (or are embedded by it). This file IS the wire
+ * protocol: any change here must remain compatible with already-deployed CMS
+ * servers and published versions of `@blinkk/root-cms/browser-client`.
+ *
+ * Channels:
+ * - Embedded ("headless") pages -> parent window: lifecycle messages,
+ *   namespaced under `root` ({@link RootEmbedMessage}).
+ * - Parent window -> doc editor: field focus requests
+ *   ({@link ScrollToDeeplinkMessage}).
+ * - Doc editor -> in-CMS preview iframe: field highlight requests
+ *   ({@link HighlightNodeMessage}).
+ *
+ * The `scrollToDeeplink` / `highlightNode` messages predate the `root`
+ * namespace and are intentionally left un-namespaced for compatibility.
+ */
+
+/** Save state of the draft doc. */
+export enum SaveState {
+  NO_CHANGES = 'NO_CHANGES',
+  UPDATES_PENDING = 'UPDATE_PENDING',
+  SAVING = 'SAVING',
+  SAVED = 'SAVED',
+  ERROR = 'ERROR',
+}
+
+/**
+ * Lifecycle messages posted from the headless (embedded) pages (the doc
+ * editor and the Root AI panel) to the parent window that frames them. All
+ * messages are namespaced under `root` to avoid colliding with the
+ * un-namespaced `{scrollToDeeplink}` / `{highlightNode}` messages used by the
+ * in-CMS preview channel.
+ */
+export interface RootEmbedMessage {
+  root: {
+    /** The lifecycle event type. */
+    type: 'ready' | 'saved' | 'published' | 'error';
+    /** The doc being edited, e.g. "Pages/about" (when applicable). */
+    docId?: string;
+    /** Current save state (included on `saved`). */
+    saveState?: SaveState;
+    /** Epoch millis the doc was published (included on `published`). */
+    publishedAt?: number;
+    /** Error message (included on `error`). */
+    error?: string;
+  };
+}
+
+/** Requests that the doc editor scroll to (focus) a specific field. */
+export interface ScrollToDeeplinkMessage {
+  scrollToDeeplink: {
+    /** The deep key of the field to scroll to, e.g. "hero.title". */
+    deepKey: string;
+  };
+}
+
+/**
+ * Requests that the preview page highlight the node associated with a field.
+ * A `null` deepKey clears all highlights.
+ */
+export interface HighlightNodeMessage {
+  highlightNode: {
+    deepKey: string | null;
+    options?: {
+      /** Whether to scroll to the node in the preview. */
+      scroll: boolean;
+    };
+  };
+}
+
+const EMBED_MESSAGE_TYPES = ['ready', 'saved', 'published', 'error'];
+
+/** Returns whether a postMessage payload is a {@link RootEmbedMessage}. */
+export function isRootEmbedMessage(data: unknown): data is RootEmbedMessage {
+  const root = (data as RootEmbedMessage)?.root;
+  return (
+    typeof root === 'object' &&
+    root !== null &&
+    EMBED_MESSAGE_TYPES.includes(root.type)
+  );
+}
+
+/** Returns whether a postMessage payload is a {@link ScrollToDeeplinkMessage}. */
+export function isScrollToDeeplinkMessage(
+  data: unknown
+): data is ScrollToDeeplinkMessage {
+  const req = (data as ScrollToDeeplinkMessage)?.scrollToDeeplink;
+  return (
+    typeof req === 'object' && req !== null && typeof req.deepKey === 'string'
+  );
+}
+
+/** Returns whether a postMessage payload is a {@link HighlightNodeMessage}. */
+export function isHighlightNodeMessage(
+  data: unknown
+): data is HighlightNodeMessage {
+  const req = (data as HighlightNodeMessage)?.highlightNode;
+  return (
+    typeof req === 'object' &&
+    req !== null &&
+    (typeof req.deepKey === 'string' || req.deepKey === null)
+  );
+}

--- a/packages/root-cms/tsconfig.build.json
+++ b/packages/root-cms/tsconfig.build.json
@@ -3,11 +3,18 @@
   "compilerOptions": {
     "declarationMap": false,
     "emitDeclarationOnly": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
     "noCheck": true,
     "outDir": "dist",
     "rootDir": ".",
     "skipLibCheck": true
   },
-  "include": ["cli/**/*.ts", "core/**/*.ts", "core/**/*.tsx", "shared/**/*.ts"],
+  "include": [
+    "browser-client/**/*.ts",
+    "cli/**/*.ts",
+    "core/**/*.ts",
+    "core/**/*.tsx",
+    "shared/**/*.ts"
+  ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/root-cms/ui/hooks/useDeeplink.tsx
+++ b/packages/root-cms/ui/hooks/useDeeplink.tsx
@@ -1,19 +1,11 @@
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useEffect, useState} from 'preact/hooks';
+import {isScrollToDeeplinkMessage} from '../../shared/embed-protocol.js';
 import {isAllowedOrigin} from '../utils/embed-bridge.js';
 
 export interface DeeplinkContext {
   value: string;
   setValue: (value: string) => void;
-}
-
-/** Messages that can be sent to the DocEditor window. */
-interface DocEditorMessage {
-  /** Scrolls to a specific deeplink within the field editor. */
-  scrollToDeeplink?: {
-    /** The key of the field to scroll to. */
-    deepKey: string;
-  };
 }
 
 interface ScrollToDeeplinkOptions {
@@ -49,9 +41,8 @@ export function DeeplinkProvider(props: {children: ComponentChildren}) {
       if (!isAllowedOrigin(event.origin)) {
         return;
       }
-      const req = event.data as DocEditorMessage;
-      if (req.scrollToDeeplink) {
-        const deepKey = req.scrollToDeeplink.deepKey;
+      if (isScrollToDeeplinkMessage(event.data)) {
+        const deepKey = event.data.scrollToDeeplink.deepKey;
         const element = document.getElementById(deepKey);
         if (element) {
           setValue(deepKey);

--- a/packages/root-cms/ui/hooks/useDraftDoc.tsx
+++ b/packages/root-cms/ui/hooks/useDraftDoc.tsx
@@ -10,6 +10,7 @@ import {
 } from 'firebase/firestore';
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useEffect, useMemo, useState} from 'preact/hooks';
+import {SaveState} from '../../shared/embed-protocol.js';
 import {logAction} from '../utils/actions.js';
 import {containsAssetId, extractAssetIds} from '../utils/assets.js';
 import {debounce} from '../utils/debounce.js';
@@ -28,13 +29,7 @@ import {TIME_UNITS} from '../utils/time.js';
 const SAVE_DELAY = 3 * TIME_UNITS.second;
 const SAVE_ACTION_LOG_THROTTLE = 5 * TIME_UNITS.minute;
 
-export enum SaveState {
-  NO_CHANGES = 'NO_CHANGES',
-  UPDATES_PENDING = 'UPDATE_PENDING',
-  SAVING = 'SAVING',
-  SAVED = 'SAVED',
-  ERROR = 'ERROR',
-}
+export {SaveState} from '../../shared/embed-protocol.js';
 
 export enum DraftDocEventType {
   /** Changes made to the draft doc and are pending a save to the DB. */

--- a/packages/root-cms/ui/utils/embed-bridge.ts
+++ b/packages/root-cms/ui/utils/embed-bridge.ts
@@ -1,26 +1,6 @@
-import {SaveState} from '../hooks/useDraftDoc.js';
+import {RootEmbedMessage} from '../../shared/embed-protocol.js';
 
-/**
- * Lifecycle messages posted from the headless (embedded) pages (the doc
- * editor and the Root AI panel) to the parent window that frames them. All
- * messages are namespaced under `root` to avoid colliding with the
- * un-namespaced `{scrollToDeeplink}` / `{highlightNode}` messages used by the
- * in-CMS preview channel.
- */
-export interface RootEmbedMessage {
-  root: {
-    /** The lifecycle event type. */
-    type: 'ready' | 'saved' | 'published' | 'error';
-    /** The doc being edited, e.g. "Pages/about" (when applicable). */
-    docId?: string;
-    /** Current save state (included on `saved`). */
-    saveState?: SaveState;
-    /** Epoch millis the doc was published (included on `published`). */
-    publishedAt?: number;
-    /** Error message (included on `error`). */
-    error?: string;
-  };
-}
+export type {RootEmbedMessage} from '../../shared/embed-protocol.js';
 
 /**
  * Returns the origins allowed to embed the CMS, as configured via
@@ -62,14 +42,18 @@ function getReferrerOrigin(): string {
 }
 
 /**
- * Posts a lifecycle message to the parent window. Messages are targeted at the
- * configured allowed origins (never `'*'`), so a session-bearing editor never
- * leaks document content or events to an arbitrary parent. When no origins are
- * configured, falls back to the referrer origin; if that is also unavailable,
- * the message is dropped.
+ * Posts a lifecycle message to the window that framed this page: the parent
+ * window when iframed, or the opener when opened as a pop-up via
+ * `window.open()`. Messages are targeted at the configured allowed origins
+ * (never `'*'`), so a session-bearing editor never leaks document content or
+ * events to an arbitrary parent. When no origins are configured, falls back
+ * to the referrer origin; if that is also unavailable, the message is
+ * dropped.
  */
 export function postToParent(payload: RootEmbedMessage['root']) {
-  if (window.parent === window) {
+  const target: Window | null =
+    window.parent !== window ? window.parent : window.opener;
+  if (!target) {
     return;
   }
   const message: RootEmbedMessage = {root: payload};
@@ -77,11 +61,11 @@ export function postToParent(payload: RootEmbedMessage['root']) {
   if (targets.length === 0) {
     const referrerOrigin = getReferrerOrigin();
     if (referrerOrigin) {
-      window.parent.postMessage(message, referrerOrigin);
+      target.postMessage(message, referrerOrigin);
     }
     return;
   }
   targets.forEach((origin) => {
-    window.parent.postMessage(message, origin);
+    target.postMessage(message, origin);
   });
 }

--- a/packages/root-cms/ui/utils/iframe-preview.ts
+++ b/packages/root-cms/ui/utils/iframe-preview.ts
@@ -1,3 +1,5 @@
+import {HighlightNodeMessage} from '../../shared/embed-protocol.js';
+
 interface HighlightNodeOptions {
   /** Whether to scroll to the element in the preview. */
   scroll: boolean;
@@ -15,7 +17,10 @@ export function requestHighlightNode(
   if (!iframeEl) {
     return;
   }
-  iframeEl.contentWindow?.postMessage({highlightNode: {deepKey, options}}, '*');
+  const message: HighlightNodeMessage = {highlightNode: {deepKey, options}};
+  // The preview iframe is same-origin (preview URLs are relative paths served
+  // by the same root server).
+  iframeEl.contentWindow?.postMessage(message, window.location.origin);
 }
 
 /** Returns the iframe element used for previewing content. */


### PR DESCRIPTION
## Summary

Adds `@blinkk/root-cms/browser-client`, a zero-dependency, framework-agnostic browser library for embedding Root CMS into another site. It wraps the iframe/postMessage wiring introduced in #1204 and #1222 behind a typed API, so the wire protocol becomes an internal implementation detail that can evolve without breaking developer integrations.

```ts
import {RootCMSBrowserClient} from '@blinkk/root-cms/browser-client';

const root = new RootCMSBrowserClient({cmsOrigin: 'https://cms.example.com'});

// Headless doc editor (popup or iframe).
const editor = root.openEditor('Pages/about', {mode: 'popup', deeplink: 'hero.title'});
editor.on('saved', () => location.reload());
editor.on('published', () => editor.closeAndReload());
editor.focusField('hero.image');

// Headless Root AI.
const ai = root.openRootAI({docId: 'Pages/about'});

// Site inside the in-CMS preview pane ("click to edit" + highlight).
const preview = RootCMSBrowserClient.connectPreview();
preview.focusField('hero.title');
preview.on('highlight', ({deepKey, scroll}) => { /* ... */ });
```

## Changes

- **New subpath export** `@blinkk/root-cms/browser-client` (`packages/root-cms/browser-client/`): `RootCMSBrowserClient` with `openEditor()` / `openRootAI()` (popup or iframe, typed `ready`/`saved`/`published`/`error`/`close` events, `focusField()` buffered until ready, `reload()`, `close()`, `closeAndReload()`) and `connectPreview()` for the in-CMS preview channel.
- **Shared wire protocol** (`packages/root-cms/shared/embed-protocol.ts`): single source of truth for `RootEmbedMessage`, `scrollToDeeplink`, `highlightNode`, and `SaveState`, now used by both the CMS UI and the client library. Wire format unchanged — existing deployments stay compatible.
- **Pop-up lifecycle fix**: `postToParent()` early-returned when `window.parent === window`, which is always true in a `window.open()` pop-up, so lifecycle events never fired in popup mode. It now falls back to `window.opener`.
- **Security hardening**: the client validates inbound messages against both `event.origin` and `event.source`; outbound messages always target the CMS origin (never `'*'`). The in-CMS preview channel's `highlightNode` target tightened from `'*'` to same-origin.
- **Dogfooding**: the docs site's `root-node` element now uses `connectPreview()` instead of hand-rolled postMessage (resolving its long-standing TODO and fixing its unvalidated `event.origin`).
- README "Embedding the CMS" section + minor-bump changeset.

## Test plan

- [x] 558 tests pass under the Firebase emulator (48 files), including 33 new tests covering origin/source validation, `focusField` buffering, pop-up close detection, blocked-pop-up errors, and preview highlight routing
- [x] `pnpm build` emits browser-safe `dist/browser-client.js` (no node imports) + `dist/browser-client/browser-client.d.ts`; subpath import resolves from a consuming workspace package
- [x] Typecheck and lint clean for all changed files
- [x] Manual: click-to-edit/highlight on the docs site inside the CMS preview pane; popup `ready`/`saved`/`published` events from an `allowedIframeOrigins` page (exercises the `window.opener` fix)

Fixes #1223 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
