### PR TITLE
feat: add bulk operations to asset library

### DIFF
--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
@@ -59,6 +59,30 @@
   cursor: default;
 }
 
+.AssetBrowser__selectionBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--surface-border-radius);
+  background: var(--chip-background);
+}
+
+.AssetBrowser__selectionBar__count {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.AssetBrowser__selectionBar__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .AssetBrowser__listing {
   position: relative;
   border: 1px solid var(--color-border);
@@ -101,6 +125,15 @@
 
 .AssetBrowser__table th.AssetBrowser__table__modifiedCol {
   width: 200px;
+}
+
+.AssetBrowser__table th.AssetBrowser__table__checkboxCol {
+  width: 0;
+  white-space: nowrap;
+}
+
+.AssetBrowser__checkboxCell {
+  cursor: default;
 }
 
 .AssetBrowser__table th.AssetBrowser__table__actionsCol {
@@ -378,6 +411,27 @@
 
 .AssetBrowser__details__buttons__delete {
   margin-left: auto;
+}
+
+.AssetBrowser__details__alt__disabledNote {
+  font-size: 12px;
+  color: var(--color-text-gray);
+}
+
+.AssetBrowser__details__confirmReplace {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: #e67700;
+  background: #fff9db;
+  border-radius: 4px;
+  padding: 12px;
+}
+
+.AssetBrowser__details__confirmReplace__buttons {
+  display: flex;
+  gap: 8px;
 }
 
 .AssetBrowser__details__confirmDelete {

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -3,6 +3,7 @@ import './AssetBrowser.css';
 import {
   ActionIcon,
   Button,
+  Checkbox,
   Loader,
   Menu,
   Modal,
@@ -15,7 +16,6 @@ import {
   updateNotification,
 } from '@mantine/notifications';
 import {
-  IconArrowRight,
   IconChevronRight,
   IconCopy,
   IconDotsVertical,
@@ -48,9 +48,16 @@ import {
   moveAsset,
   parseFolderPath,
   renameAsset,
+  syncAssetToDocs,
+  updateAssetAltDisabled,
 } from '../../utils/assets.js';
 import {joinClassNames} from '../../utils/classes.js';
-import {testFileMatchesAccept, uploadFileToGCS} from '../../utils/gcs.js';
+import {
+  testFileMatchesAccept,
+  testIsImageFile,
+  testIsVideoFile,
+  uploadFileToGCS,
+} from '../../utils/gcs.js';
 import {notifyErrors} from '../../utils/notifications.js';
 import {testCanPublish} from '../../utils/permissions.js';
 import {getTimeAgo} from '../../utils/time.js';
@@ -109,9 +116,14 @@ export function AssetBrowser(props: AssetBrowserProps) {
 
   const [newFolderModalOpened, setNewFolderModalOpened] = useState(false);
   const [renameTarget, setRenameTarget] = useState<Asset | null>(null);
-  const [moveTarget, setMoveTarget] = useState<Asset | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<Asset | null>(null);
+  const [moveTarget, setMoveTarget] = useState<Asset[] | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Asset[] | null>(null);
+  const [disableAltTarget, setDisableAltTarget] = useState<AssetFile[] | null>(
+    null
+  );
   const [detailsTarget, setDetailsTarget] = useState<AssetFile | null>(null);
+  // Multi-select for bulk actions (manage mode), keyed by asset id.
+  const [selected, setSelected] = useState<Map<string, Asset>>(new Map());
 
   const {roles} = useProjectRoles();
   const currentUserEmail = window.firebase.user.email || '';
@@ -132,6 +144,7 @@ export function AssetBrowser(props: AssetBrowserProps) {
     setLoading(true);
     // Invalidate the search index so an active search refetches fresh data.
     setSearchIndex(null);
+    setSelected(new Map());
     await notifyErrors(async () => {
       const res = await listAssets(folderPath);
       setAssets(res);
@@ -285,6 +298,41 @@ export function AssetBrowser(props: AssetBrowserProps) {
 
   const showUpload = canManage;
 
+  // Multi-select for bulk actions (move, delete, disable alt text).
+  const showSelection = props.mode === 'manage' && canManage;
+  const selectedAssets = Array.from(selected.values());
+  // Alt text only applies to file assets that render as images/videos.
+  const selectedAltFiles = selectedAssets.filter(
+    (asset): asset is AssetFile =>
+      asset.type === 'file' &&
+      !asset.file?.altDisabled &&
+      (testIsImageFile(asset.file?.filename || asset.name) ||
+        testIsVideoFile(asset.file?.filename || asset.name))
+  );
+  const allSelected =
+    filteredAssets.length > 0 &&
+    filteredAssets.every((asset) => selected.has(asset.id));
+
+  function toggleSelected(asset: Asset) {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(asset.id)) {
+        next.delete(asset.id);
+      } else {
+        next.set(asset.id, asset);
+      }
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      setSelected(new Map());
+    } else {
+      setSelected(new Map(filteredAssets.map((asset) => [asset.id, asset])));
+    }
+  }
+
   return (
     <div
       className={joinClassNames(
@@ -329,6 +377,48 @@ export function AssetBrowser(props: AssetBrowserProps) {
           )}
         </div>
       </div>
+      {showSelection && selectedAssets.length > 0 && (
+        <div className="AssetBrowser__selectionBar">
+          <div className="AssetBrowser__selectionBar__count">
+            {selectedAssets.length} selected
+          </div>
+          <div className="AssetBrowser__selectionBar__actions">
+            <Button
+              variant="default"
+              size="xs"
+              leftIcon={<IconFolderSymlink size={14} />}
+              onClick={() => setMoveTarget(selectedAssets)}
+            >
+              Move
+            </Button>
+            {selectedAltFiles.length > 0 && (
+              <Button
+                variant="default"
+                size="xs"
+                onClick={() => setDisableAltTarget(selectedAltFiles)}
+              >
+                Disable alt text
+              </Button>
+            )}
+            <Button
+              color="red"
+              size="xs"
+              leftIcon={<IconTrash size={14} />}
+              onClick={() => setDeleteTarget(selectedAssets)}
+            >
+              Delete
+            </Button>
+            <Button
+              variant="subtle"
+              color="gray"
+              size="xs"
+              onClick={() => setSelected(new Map())}
+            >
+              Clear
+            </Button>
+          </div>
+        </div>
+      )}
       <div
         className={joinClassNames(
           'AssetBrowser__listing',
@@ -387,6 +477,17 @@ export function AssetBrowser(props: AssetBrowserProps) {
           >
             <thead>
               <tr>
+                {showSelection && (
+                  <th className="AssetBrowser__table__checkboxCol">
+                    <Checkbox
+                      size="xs"
+                      aria-label="Select all"
+                      checked={allSelected}
+                      indeterminate={!allSelected && selected.size > 0}
+                      onChange={() => toggleSelectAll()}
+                    />
+                  </th>
+                )}
                 <th>name</th>
                 <th className="AssetBrowser__table__modifiedCol">modified</th>
                 <th className="AssetBrowser__table__actionsCol"></th>
@@ -402,6 +503,19 @@ export function AssetBrowser(props: AssetBrowserProps) {
                       setFolder(joinFolderPath(asset.parent, asset.name))
                     }
                   >
+                    {showSelection && (
+                      <td
+                        className="AssetBrowser__checkboxCell"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Checkbox
+                          size="xs"
+                          aria-label={`Select ${asset.name}`}
+                          checked={selected.has(asset.id)}
+                          onChange={() => toggleSelected(asset)}
+                        />
+                      </td>
+                    )}
                     <td>
                       <div className="AssetBrowser__nameCell">
                         <div className="AssetBrowser__thumb">
@@ -444,14 +558,14 @@ export function AssetBrowser(props: AssetBrowserProps) {
                             </Menu.Item>
                             <Menu.Item
                               icon={<IconFolderSymlink size={14} />}
-                              onClick={() => setMoveTarget(asset)}
+                              onClick={() => setMoveTarget([asset])}
                             >
                               Move
                             </Menu.Item>
                             <Menu.Item
                               color="red"
                               icon={<IconTrash size={14} />}
-                              onClick={() => setDeleteTarget(asset)}
+                              onClick={() => setDeleteTarget([asset])}
                             >
                               Delete
                             </Menu.Item>
@@ -472,6 +586,19 @@ export function AssetBrowser(props: AssetBrowserProps) {
                       }
                     }}
                   >
+                    {showSelection && (
+                      <td
+                        className="AssetBrowser__checkboxCell"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Checkbox
+                          size="xs"
+                          aria-label={`Select ${asset.name}`}
+                          checked={selected.has(asset.id)}
+                          onChange={() => toggleSelected(asset)}
+                        />
+                      </td>
+                    )}
                     <td>
                       <div className="AssetBrowser__nameCell">
                         <AssetThumbnail file={asset.file} size={36} />
@@ -507,8 +634,8 @@ export function AssetBrowser(props: AssetBrowserProps) {
                             canManage={canManage}
                             onDetails={() => setDetailsTarget(asset)}
                             onRename={() => setRenameTarget(asset)}
-                            onMove={() => setMoveTarget(asset)}
-                            onDelete={() => setDeleteTarget(asset)}
+                            onMove={() => setMoveTarget([asset])}
+                            onDelete={() => setDeleteTarget([asset])}
                           />
                         )}
                       </div>
@@ -540,9 +667,9 @@ export function AssetBrowser(props: AssetBrowserProps) {
           }}
         />
       )}
-      {moveTarget && (
+      {moveTarget && moveTarget.length > 0 && (
         <MoveAssetModal
-          asset={moveTarget}
+          assets={moveTarget}
           onClose={() => setMoveTarget(null)}
           onMoved={() => {
             setMoveTarget(null);
@@ -550,12 +677,22 @@ export function AssetBrowser(props: AssetBrowserProps) {
           }}
         />
       )}
-      {deleteTarget && (
+      {deleteTarget && deleteTarget.length > 0 && (
         <DeleteAssetModal
-          asset={deleteTarget}
+          assets={deleteTarget}
           onClose={() => setDeleteTarget(null)}
           onDeleted={() => {
             setDeleteTarget(null);
+            reload(folder);
+          }}
+        />
+      )}
+      {disableAltTarget && disableAltTarget.length > 0 && (
+        <DisableAltTextModal
+          assets={disableAltTarget}
+          onClose={() => setDisableAltTarget(null)}
+          onDone={() => {
+            setDisableAltTarget(null);
             reload(folder);
           }}
         />
@@ -818,12 +955,12 @@ function RenameAssetModal(props: {
 }
 
 function MoveAssetModal(props: {
-  asset: Asset;
+  assets: Asset[];
   onClose: () => void;
   onMoved: () => void;
 }) {
-  const asset = props.asset;
-  const [path, setPath] = useState(asset.parent);
+  const assets = props.assets;
+  const [path, setPath] = useState(assets[0]?.parent || '');
   const [folders, setFolders] = useState<AssetFolder[]>([]);
   const [loading, setLoading] = useState(true);
   const [moving, setMoving] = useState(false);
@@ -836,35 +973,61 @@ function MoveAssetModal(props: {
     }).then(() => setLoading(false));
   }, [path]);
 
-  const assetPath =
-    asset.type === 'folder' ? joinFolderPath(asset.parent, asset.name) : '';
+  const folderAssetPaths = assets
+    .filter((asset) => asset.type === 'folder')
+    .map((asset) => joinFolderPath(asset.parent, asset.name));
 
   function isDisabledFolder(folderPath: string) {
     // A folder cannot be moved into itself or its own subtree.
-    if (asset.type !== 'folder') {
-      return false;
-    }
-    return folderPath === assetPath || folderPath.startsWith(`${assetPath}/`);
+    return folderAssetPaths.some(
+      (assetPath) =>
+        folderPath === assetPath || folderPath.startsWith(`${assetPath}/`)
+    );
   }
 
   async function onMove() {
     setMoving(true);
-    await notifyErrors(async () => {
-      await moveAsset(asset, path);
+    const failed: string[] = [];
+    let numMoved = 0;
+    for (const asset of assets) {
+      try {
+        await moveAsset(asset, path);
+        numMoved += 1;
+      } catch (err) {
+        console.error(`failed to move ${asset.name}:`, err);
+        failed.push(asset.name);
+      }
+    }
+    setMoving(false);
+    if (failed.length > 0) {
       showNotification({
-        message: `Moved "${asset.name}" to ${path || 'Assets'}.`,
+        title: 'Move failed',
+        message: `Failed to move: ${failed.join(', ')}`,
+        color: 'red',
+        autoClose: false,
+      });
+    }
+    if (numMoved > 0) {
+      showNotification({
+        message:
+          assets.length === 1
+            ? `Moved "${assets[0].name}" to ${path || 'Assets'}.`
+            : `Moved ${numMoved} item(s) to ${path || 'Assets'}.`,
         color: 'green',
       });
-      props.onMoved();
-    });
-    setMoving(false);
+    }
+    props.onMoved();
   }
 
   return (
     <Modal
       opened
       onClose={props.onClose}
-      title={`Move "${asset.name}"`}
+      title={
+        assets.length === 1
+          ? `Move "${assets[0].name}"`
+          : `Move ${assets.length} items`
+      }
       size="md"
       centered
     >
@@ -900,7 +1063,7 @@ function MoveAssetModal(props: {
           color="dark"
           fullWidth
           loading={moving}
-          disabled={path === asset.parent}
+          disabled={assets.every((asset) => asset.parent === path)}
           onClick={() => onMove()}
         >
           Move here
@@ -910,58 +1073,107 @@ function MoveAssetModal(props: {
   );
 }
 
+/**
+ * Max files for which doc usage is looked up before deleting. Usage requires
+ * a query per file per collection, so very large selections skip the check.
+ */
+const MAX_USAGE_LOOKUPS = 20;
+
 function DeleteAssetModal(props: {
-  asset: Asset;
+  assets: Asset[];
   onClose: () => void;
   onDeleted: () => void;
 }) {
-  const asset = props.asset;
+  const assets = props.assets;
   const [loading, setLoading] = useState(false);
   const [usageCount, setUsageCount] = useState<number | null>(null);
 
+  const files = assets.filter((asset) => asset.type === 'file');
+  const hasFolders = assets.some((asset) => asset.type === 'folder');
+
   useEffect(() => {
-    if (asset.type !== 'file') {
+    if (files.length === 0 || files.length > MAX_USAGE_LOOKUPS) {
       return;
     }
-    findDocsUsingAsset(asset.id)
-      .then((docs) => setUsageCount(docs.length))
+    Promise.all(files.map((asset) => findDocsUsingAsset(asset.id)))
+      .then((results) => {
+        const docIds = new Set(results.flat().map((cmsDoc) => cmsDoc.id));
+        setUsageCount(docIds.size);
+      })
       .catch(() => setUsageCount(null));
-  }, [asset.id]);
+  }, [assets.map((asset) => asset.id).join(',')]);
 
   async function onDelete() {
     setLoading(true);
-    await notifyErrors(async () => {
-      await deleteAsset(asset);
-      showNotification({message: `Deleted "${asset.name}".`, color: 'green'});
-      props.onDeleted();
-    });
+    const failed: string[] = [];
+    let numDeleted = 0;
+    for (const asset of assets) {
+      try {
+        await deleteAsset(asset);
+        numDeleted += 1;
+      } catch (err) {
+        console.error(`failed to delete ${asset.name}:`, err);
+        failed.push(asset.name);
+      }
+    }
     setLoading(false);
+    if (failed.length > 0) {
+      showNotification({
+        title: 'Delete failed',
+        message: `Failed to delete: ${failed.join(', ')}. Note that folders must be empty before they can be deleted.`,
+        color: 'red',
+        autoClose: false,
+      });
+    }
+    if (numDeleted > 0) {
+      showNotification({
+        message:
+          assets.length === 1
+            ? `Deleted "${assets[0].name}".`
+            : `Deleted ${numDeleted} item(s).`,
+        color: 'green',
+      });
+    }
+    props.onDeleted();
   }
 
   return (
     <Modal
       opened
       onClose={props.onClose}
-      title={`Delete ${asset.type}?`}
+      title={
+        assets.length === 1
+          ? `Delete ${assets[0].type}?`
+          : `Delete ${assets.length} items?`
+      }
       size="sm"
       centered
     >
       <div className="AssetBrowser__deleteModal">
         <div className="AssetBrowser__deleteModal__text">
-          Are you sure you want to delete <b>{asset.name}</b> from the asset
-          manager?
-          {asset.type === 'file' && (
+          Are you sure you want to delete{' '}
+          {assets.length === 1 ? (
+            <b>{assets[0].name}</b>
+          ) : (
+            <b>{assets.length} items</b>
+          )}{' '}
+          from the asset manager?
+          {files.length > 0 && (
             <>
               {' '}
-              The underlying file is not deleted from GCS, and docs that
-              currently use the asset keep their copy of the file.
+              The underlying files are not deleted from GCS, and docs that
+              currently use the assets keep their copy of the files.
             </>
           )}
+          {hasFolders && (
+            <> Folders must be empty before they can be deleted.</>
+          )}
         </div>
-        {asset.type === 'file' && usageCount !== null && usageCount > 0 && (
+        {usageCount !== null && usageCount > 0 && (
           <div className="AssetBrowser__deleteModal__warning">
-            This asset is currently used in {usageCount} doc(s). Those docs will
-            no longer receive updates when the asset changes.
+            {assets.length === 1 ? 'This asset is' : 'These assets are'}{' '}
+            currently used in {usageCount} doc(s). Those docs will no longer
+            receive updates when the asset changes.
           </div>
         )}
         <div className="AssetBrowser__deleteModal__buttons">
@@ -970,6 +1182,80 @@ function DeleteAssetModal(props: {
           </Button>
           <Button color="red" loading={loading} onClick={() => onDelete()}>
             Delete
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/**
+ * Confirmation modal for bulk-disabling alt text handling on file assets
+ * (e.g. decorative images). Each updated asset is synced to the draft docs
+ * that use it so their embedded alt text is cleared.
+ */
+function DisableAltTextModal(props: {
+  assets: AssetFile[];
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const assets = props.assets;
+  const [loading, setLoading] = useState(false);
+
+  async function onConfirm() {
+    setLoading(true);
+    const failed: string[] = [];
+    let numUpdated = 0;
+    for (const asset of assets) {
+      try {
+        const previousFile = asset.file;
+        const updated = await updateAssetAltDisabled(asset, true);
+        await syncAssetToDocs(updated, {previousFile});
+        numUpdated += 1;
+      } catch (err) {
+        console.error(`failed to disable alt text for ${asset.name}:`, err);
+        failed.push(asset.name);
+      }
+    }
+    setLoading(false);
+    if (failed.length > 0) {
+      showNotification({
+        title: 'Failed to disable alt text',
+        message: `Failed to update: ${failed.join(', ')}`,
+        color: 'red',
+        autoClose: false,
+      });
+    }
+    if (numUpdated > 0) {
+      showNotification({
+        message: `Disabled alt text for ${numUpdated} file(s).`,
+        color: 'green',
+      });
+    }
+    props.onDone();
+  }
+
+  return (
+    <Modal
+      opened
+      onClose={props.onClose}
+      title="Disable alt text?"
+      size="sm"
+      centered
+    >
+      <div className="AssetBrowser__deleteModal">
+        <div className="AssetBrowser__deleteModal__text">
+          Disable alt text for <b>{assets.length} file(s)</b>? The alt text
+          input is hidden in docs that use these assets and their embedded alt
+          text is cleared. Alt text can be re-enabled per asset from its
+          details.
+        </div>
+        <div className="AssetBrowser__deleteModal__buttons">
+          <Button variant="default" onClick={props.onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button color="dark" loading={loading} onClick={() => onConfirm()}>
+            Disable alt text
           </Button>
         </div>
       </div>

--- a/packages/root-cms/ui/components/AssetBrowser/AssetDetailsModal.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetDetailsModal.tsx
@@ -1,6 +1,7 @@
 import {
   ActionIcon,
   Button,
+  Checkbox,
   Loader,
   Modal,
   Table,
@@ -24,12 +25,15 @@ import {
   deleteAsset,
   findDocsUsingAsset,
   replaceAssetFile,
+  replaceFileExt,
   syncAssetToDocs,
+  updateAssetAltDisabled,
   updateAssetAltText,
 } from '../../utils/assets.js';
 import {CMSDoc} from '../../utils/doc.js';
 import {
   UploadedFile,
+  getFileExt,
   testIsImageFile,
   testIsVideoFile,
   uploadFileToGCS,
@@ -61,6 +65,7 @@ export function AssetDetailsModal(props: AssetDetailsModalProps) {
   const [altText, setAltText] = useState(props.asset.file?.alt || '');
   const [saving, setSaving] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [pendingReplace, setPendingReplace] = useState<File | null>(null);
   const [usageDocs, setUsageDocs] = useState<CMSDoc[] | null>(null);
 
   const file = asset.file || ({} as UploadedFile);
@@ -68,6 +73,7 @@ export function AssetDetailsModal(props: AssetDetailsModalProps) {
   const isImage = testIsImageFile(filename);
   const isVideo = testIsVideoFile(filename);
   const altDirty = altText !== (file.alt || '');
+  const altDisabled = file.altDisabled === true;
 
   useEffect(() => {
     findDocsUsingAsset(asset.id)
@@ -114,25 +120,51 @@ export function AssetDetailsModal(props: AssetDetailsModalProps) {
   function onReplaceFile() {
     const inputEl = document.createElement('input');
     inputEl.type = 'file';
-    inputEl.onchange = async () => {
+    inputEl.onchange = () => {
       const newFile = inputEl.files?.[0];
       if (!newFile) {
         return;
       }
-      setSaving(true);
-      await notifyErrors(async () => {
-        const previousFile = {...file};
-        const uploadedFile = await uploadFileToGCS(newFile);
-        const updated = await replaceAssetFile(asset, uploadedFile);
-        setAsset(updated);
-        setAltText(updated.file?.alt || '');
-        props.onChanged(updated);
-        await syncDocs(updated, previousFile);
-      });
-      setSaving(false);
+      // Replacing a file with a different extension changes the asset's file
+      // type and serving URL, so ask for confirmation first.
+      const oldExt = getFileExt(filename);
+      const newExt = getFileExt(newFile.name);
+      if (oldExt && newExt && oldExt !== newExt) {
+        setPendingReplace(newFile);
+        return;
+      }
+      replaceFile(newFile);
     };
     inputEl.click();
     inputEl.remove();
+  }
+
+  async function replaceFile(newFile: File) {
+    setPendingReplace(null);
+    setSaving(true);
+    await notifyErrors(async () => {
+      const previousFile = {...file};
+      const uploadedFile = await uploadFileToGCS(newFile);
+      const updated = await replaceAssetFile(asset, uploadedFile);
+      setAsset(updated);
+      setAltText(updated.file?.alt || '');
+      props.onChanged(updated);
+      await syncDocs(updated, previousFile);
+    });
+    setSaving(false);
+  }
+
+  async function onToggleAltDisabled(disabled: boolean) {
+    setSaving(true);
+    await notifyErrors(async () => {
+      const previousFile = {...file};
+      const updated = await updateAssetAltDisabled(asset, disabled);
+      setAsset(updated);
+      setAltText(updated.file?.alt || '');
+      props.onChanged(updated);
+      await syncDocs(updated, previousFile);
+    });
+    setSaving(false);
   }
 
   async function onDelete() {
@@ -246,28 +278,50 @@ export function AssetDetailsModal(props: AssetDetailsModalProps) {
 
         {(isImage || isVideo) && (
           <div className="AssetBrowser__details__alt">
-            <Textarea
-              label="Alt text"
-              description="Used as the default alt text when the asset is selected in a doc. Updating it syncs docs that use this asset."
-              autosize
-              minRows={1}
-              size="xs"
-              value={altText}
-              disabled={!props.canManage || saving}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-                setAltText(e.currentTarget.value)
-              }
-            />
-            {props.canManage && altDirty && (
-              <Button
+            {altDisabled ? (
+              <div className="AssetBrowser__details__alt__disabledNote">
+                Alt text is disabled for this asset. Docs that use it hide the
+                alt text input and render no alt text.
+              </div>
+            ) : (
+              <>
+                <Textarea
+                  label="Alt text"
+                  description="Used as the default alt text when the asset is selected in a doc. Updating it syncs docs that use this asset."
+                  autosize
+                  minRows={1}
+                  size="xs"
+                  value={altText}
+                  disabled={!props.canManage || saving}
+                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                    setAltText(e.currentTarget.value)
+                  }
+                />
+                {props.canManage && altDirty && (
+                  <Button
+                    size="xs"
+                    color="dark"
+                    mt={8}
+                    loading={saving}
+                    onClick={() => onSaveAltText()}
+                  >
+                    Save alt text
+                  </Button>
+                )}
+              </>
+            )}
+            {props.canManage && (
+              <Checkbox
+                className="AssetBrowser__details__alt__disableCheckbox"
+                label="Disable alt text (e.g. decorative images)"
                 size="xs"
-                color="dark"
                 mt={8}
-                loading={saving}
-                onClick={() => onSaveAltText()}
-              >
-                Save alt text
-              </Button>
+                checked={altDisabled}
+                disabled={saving}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  onToggleAltDisabled(e.currentTarget.checked)
+                }
+              />
             )}
           </div>
         )}
@@ -332,6 +386,46 @@ export function AssetDetailsModal(props: AssetDetailsModalProps) {
             </>
           )}
         </div>
+        {pendingReplace && (
+          <div className="AssetBrowser__details__confirmReplace">
+            <div>
+              The new file has a different type (<b>.{getFileExt(filename)}</b>{' '}
+              → <b>.{getFileExt(pendingReplace.name)}</b>). Replacing will
+              change the asset's file extension and serving URL
+              {replaceFileExt(asset.name, getFileExt(pendingReplace.name)) !==
+                asset.name && (
+                <>
+                  , and the asset will be renamed to{' '}
+                  <b>
+                    {replaceFileExt(
+                      asset.name,
+                      getFileExt(pendingReplace.name)
+                    )}
+                  </b>
+                </>
+              )}
+              . Docs that use this asset will be updated.
+            </div>
+            <div className="AssetBrowser__details__confirmReplace__buttons">
+              <Button
+                variant="default"
+                size="xs"
+                onClick={() => setPendingReplace(null)}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              <Button
+                color="dark"
+                size="xs"
+                loading={saving}
+                onClick={() => replaceFile(pendingReplace)}
+              >
+                Replace
+              </Button>
+            </div>
+          </div>
+        )}
         {confirmingDelete && (
           <div className="AssetBrowser__details__confirmDelete">
             <div>

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -176,7 +176,11 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
 
   const altText = value?.alt || '';
   const altDisabledByMetadata = props.altDisabledByMetadata === true;
-  const showAltText = field.alt !== false && !altDisabledByMetadata;
+  // Alt text can be disabled per field (schema), per instance (metadata) or
+  // per asset (asset library).
+  const altDisabledByAsset = value?.altDisabled === true;
+  const showAltText =
+    field.alt !== false && !altDisabledByMetadata && !altDisabledByAsset;
 
   async function uploadFile(
     file: File,

--- a/packages/root-cms/ui/utils/assets.test.ts
+++ b/packages/root-cms/ui/utils/assets.test.ts
@@ -10,6 +10,7 @@ import {
   getRelativeFolderPath,
   joinFolderPath,
   parseFolderPath,
+  replaceFileExt,
   validateAssetName,
 } from './assets.js';
 
@@ -162,6 +163,25 @@ describe('collectAssetFieldPaths', () => {
   });
 });
 
+describe('replaceFileExt', () => {
+  it('swaps a filename extension', () => {
+    expect(replaceFileExt('hero.png', 'webp')).toEqual('hero.webp');
+    expect(replaceFileExt('a.b.png', 'avif')).toEqual('a.b.avif');
+  });
+
+  it('returns the name unchanged when the ext matches', () => {
+    expect(replaceFileExt('hero.png', 'png')).toEqual('hero.png');
+    // `jpeg` normalizes to `jpg`.
+    expect(replaceFileExt('hero.jpeg', 'jpg')).toEqual('hero.jpeg');
+  });
+
+  it('returns names without an extension unchanged', () => {
+    expect(replaceFileExt('My Photo', 'png')).toEqual('My Photo');
+    expect(replaceFileExt('.gitignore', 'png')).toEqual('.gitignore');
+    expect(replaceFileExt('hero.png', '')).toEqual('hero.png');
+  });
+});
+
 describe('buildAssetFieldValue', () => {
   it('copies the file data and adds the assetId backlink', () => {
     const value = buildAssetFieldValue(testAsset());
@@ -178,6 +198,12 @@ describe('buildAssetFieldValue', () => {
   it('removes undefined values', () => {
     const value = buildAssetFieldValue(testAsset({width: undefined}));
     expect('width' in value).toBe(false);
+  });
+
+  it('clears alt text when alt is disabled for the asset', () => {
+    const value = buildAssetFieldValue(testAsset({altDisabled: true}));
+    expect(value.alt).toEqual('');
+    expect(value.altDisabled).toBe(true);
   });
 });
 
@@ -205,6 +231,22 @@ describe('buildSyncedFieldValue', () => {
     const previousFile = {src: 'https://example.com/old.png', alt: 'Old alt'};
     const value = buildSyncedFieldValue(testAsset(), existing, previousFile);
     expect(value.alt).toEqual('Custom doc alt');
+  });
+
+  it('drops doc-customized alt text when alt is disabled for the asset', () => {
+    const existing = {
+      src: 'https://example.com/old.png',
+      alt: 'Custom doc alt',
+      assetId: 'asset123',
+    };
+    const previousFile = {src: 'https://example.com/old.png', alt: 'Old alt'};
+    const value = buildSyncedFieldValue(
+      testAsset({altDisabled: true}),
+      existing,
+      previousFile
+    );
+    expect(value.alt).toEqual('');
+    expect(value.altDisabled).toBe(true);
   });
 
   it('preserves doc-customized canvas bg color', () => {

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -19,6 +19,7 @@ import {
   Timestamp,
   collection,
   deleteDoc,
+  deleteField,
   doc,
   getDoc,
   getDocs,
@@ -33,7 +34,7 @@ import {
 import {logAction} from './actions.js';
 import {removeDocsFromCache} from './doc-cache.js';
 import type {CMSDoc} from './doc.js';
-import {UploadedFile} from './gcs.js';
+import {UploadedFile, getFileExt} from './gcs.js';
 import {autokey} from './rand.js';
 
 export type AssetType = 'file' | 'folder';
@@ -522,14 +523,40 @@ export async function replaceAssetFile(
   if (!file.alt && asset.file?.alt) {
     file.alt = asset.file.alt;
   }
+  if (asset.file?.altDisabled) {
+    file.altDisabled = true;
+  }
   const docRef = doc(getAssetsDbCollection(), asset.id);
-  await updateDoc(docRef, {
+  const updates: Record<string, any> = {
     file: file,
     modifiedAt: serverTimestamp(),
     modifiedBy: window.firebase.user.email,
-  });
+  };
+  // When the new file has a different extension (e.g. replacing `hero.png`
+  // with a webp), update the asset's display name to match.
+  const newExt = getFileExt(file.filename || file.src || '');
+  const newName = replaceFileExt(asset.name, newExt);
+  if (newName !== asset.name) {
+    updates.name = newName;
+  }
+  await updateDoc(docRef, updates);
   logAction('asset.replace', {metadata: {assetId: asset.id, name: asset.name}});
   return (await getAsset(asset.id)) as AssetFile;
+}
+
+/**
+ * Swaps a filename's extension, e.g. `replaceFileExt('hero.png', 'webp')`
+ * returns `'hero.webp'`. Names without an extension are returned unchanged.
+ */
+export function replaceFileExt(name: string, newExt: string): string {
+  const dotIndex = (name || '').lastIndexOf('.');
+  if (!newExt || dotIndex <= 0) {
+    return name;
+  }
+  if (getFileExt(name) === newExt) {
+    return name;
+  }
+  return `${name.slice(0, dotIndex)}.${newExt}`;
 }
 
 /**
@@ -550,16 +577,45 @@ export async function updateAssetAltText(
 }
 
 /**
+ * Enables/disables alt text handling for an asset (e.g. for decorative
+ * images). The alt text stored on the asset is preserved so it can be
+ * restored when re-enabled, but it is no longer propagated to docs. Callers
+ * should follow up with {@link syncAssetToDocs} to fan the change out to docs
+ * that use the asset.
+ */
+export async function updateAssetAltDisabled(
+  asset: AssetFile,
+  disabled: boolean
+): Promise<AssetFile> {
+  const docRef = doc(getAssetsDbCollection(), asset.id);
+  await updateDoc(docRef, {
+    'file.altDisabled': disabled ? true : deleteField(),
+    modifiedAt: serverTimestamp(),
+    modifiedBy: window.firebase.user.email,
+  });
+  logAction('asset.alt_disabled', {
+    metadata: {assetId: asset.id, name: asset.name, disabled},
+  });
+  return (await getAsset(asset.id)) as AssetFile;
+}
+
+/**
  * Builds the field value to embed in a doc when an asset is selected from the
  * asset library. The full file data is copied into the doc (so fetching the
  * doc requires no extra RPCs) along with an `assetId` backlink used to keep
  * the copy in sync.
  */
 export function buildAssetFieldValue(asset: AssetFile): AssetFieldValue {
-  return {
+  const value: AssetFieldValue = {
     ...removeUndefinedValues(asset.file),
     assetId: asset.id,
   };
+  // When alt text handling is disabled, the alt text stored on the asset is
+  // kept on the asset itself but not propagated to docs.
+  if (value.altDisabled) {
+    value.alt = '';
+  }
+  return value;
 }
 
 /**
@@ -785,10 +841,14 @@ export function buildSyncedFieldValue(
   previousFile?: UploadedFile
 ): AssetFieldValue {
   const next = buildAssetFieldValue(asset);
-  const prevAlt = previousFile?.alt ?? asset.file?.alt ?? '';
-  const docAlt = existingValue?.alt || '';
-  if (docAlt && docAlt !== prevAlt) {
-    next.alt = docAlt;
+  // Doc-level alt customizations are dropped when the asset disables alt
+  // text handling.
+  if (!asset.file?.altDisabled) {
+    const prevAlt = previousFile?.alt ?? asset.file?.alt ?? '';
+    const docAlt = existingValue?.alt || '';
+    if (docAlt && docAlt !== prevAlt) {
+      next.alt = docAlt;
+    }
   }
   const prevBgColor = previousFile?.canvasBgColor ?? asset.file?.canvasBgColor;
   if (

--- a/packages/root-cms/ui/utils/gcs.test.ts
+++ b/packages/root-cms/ui/utils/gcs.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it} from 'vitest';
+import {
+  IMAGE_EXTS,
+  OPT_IN_IMAGE_EXTS,
+  PREVIEW_IMAGE_EXTS,
+  getFileExt,
+  testFileMatchesAccept,
+  testIsImageFile,
+} from './gcs.js';
+
+describe('image exts', () => {
+  it('excludes opt-in exts from the image field defaults', () => {
+    expect(IMAGE_EXTS).not.toContain('avif');
+    expect(OPT_IN_IMAGE_EXTS).toContain('avif');
+    expect(PREVIEW_IMAGE_EXTS).toContain('avif');
+  });
+});
+
+describe('getFileExt', () => {
+  it('normalizes extensions', () => {
+    expect(getFileExt('hero.PNG')).toEqual('png');
+    expect(getFileExt('hero.jpeg')).toEqual('jpg');
+    expect(getFileExt('hero.avif')).toEqual('avif');
+  });
+});
+
+describe('testIsImageFile', () => {
+  it('previews common image extensions', () => {
+    expect(testIsImageFile('https://example.com/a.png')).toBe(true);
+    expect(testIsImageFile('https://example.com/a.svg')).toBe(true);
+    expect(testIsImageFile('https://example.com/a.pdf')).toBe(false);
+  });
+
+  it('previews avif as an image', () => {
+    expect(testIsImageFile('https://example.com/a.avif')).toBe(true);
+  });
+});
+
+describe('testFileMatchesAccept', () => {
+  it('matches mime types and extensions', () => {
+    expect(testFileMatchesAccept('a.png', ['image/png'])).toBe(true);
+    expect(testFileMatchesAccept('a.png', ['.png'])).toBe(true);
+    expect(testFileMatchesAccept('a.png', ['image/webp'])).toBe(false);
+  });
+
+  it('excludes avif from the image/* wildcard (opt-in only)', () => {
+    expect(testFileMatchesAccept('a.avif', ['image/*'])).toBe(false);
+    expect(testFileMatchesAccept('a.png', ['image/*'])).toBe(true);
+  });
+
+  it('matches avif when a field opts in', () => {
+    expect(testFileMatchesAccept('a.avif', ['image/avif'])).toBe(true);
+    expect(testFileMatchesAccept('a.avif', ['.avif'])).toBe(true);
+    expect(testFileMatchesAccept('a.avif', ['*'])).toBe(true);
+  });
+});

--- a/packages/root-cms/ui/utils/gcs.ts
+++ b/packages/root-cms/ui/utils/gcs.ts
@@ -24,6 +24,16 @@ export const GCI_SUPPORTED_EXTS = [
 /** Extensions compatible with the image field. */
 export const IMAGE_EXTS = [...GCI_SUPPORTED_EXTS, 'svg'];
 
+/**
+ * Image extensions that preview as images in the CMS but are excluded from
+ * the image field's default accept list. To accept one of these, a field
+ * must opt in via its `exts` config, e.g. `exts: ['image/avif']`.
+ */
+export const OPT_IN_IMAGE_EXTS = ['avif'];
+
+/** All extensions that are previewed as images in the CMS UI. */
+export const PREVIEW_IMAGE_EXTS = [...IMAGE_EXTS, ...OPT_IN_IMAGE_EXTS];
+
 export const VIDEO_EXTS = ['mp4', 'webm'];
 
 export const GCI_URL_PREFIX = 'https://lh3.googleusercontent.com/';
@@ -53,6 +63,12 @@ export interface UploadedFile {
   uploadedBy?: string;
   uploadedAt?: string | number;
   canvasBgColor?: 'light' | 'dark';
+  /**
+   * When true, alt text handling is disabled for the file (e.g. decorative
+   * images). The alt text input is hidden in docs that use the file and no
+   * alt text is propagated from the asset library.
+   */
+  altDisabled?: boolean;
   /** The original source URL if the image has been edited. */
   originalSrc?: string;
   /**
@@ -189,7 +205,7 @@ async function finalizeUpload(
   meta.uploadedAt = String(Math.floor(new Date().getTime()));
   const gcsPath = `/${gcsRef.bucket}/${gcsRef.fullPath}`;
   let fileUrl = `https://storage.googleapis.com${gcsPath}`;
-  if (IMAGE_EXTS.includes(ext)) {
+  if (PREVIEW_IMAGE_EXTS.includes(ext)) {
     const dimens = await getImageDimensions(file);
     meta.width = dimens.width;
     meta.height = dimens.height;
@@ -341,7 +357,7 @@ export function testIsImageFile(src: string) {
     return true;
   }
   const ext = getFileExt(src);
-  return IMAGE_EXTS.includes(ext);
+  return PREVIEW_IMAGE_EXTS.includes(ext);
 }
 
 export function testIsGoogleCloudImageFile(src: string) {
@@ -380,6 +396,8 @@ export function testFileMatchesAccept(
     if (type.endsWith('/*')) {
       const prefix = type.split('/')[0];
       if (prefix === 'image') {
+        // Opt-in exts (e.g. avif) are excluded from the wildcard; they only
+        // match an explicit entry like `image/avif` or `.avif`.
         return IMAGE_EXTS.includes(ext);
       }
       if (prefix === 'video') {


### PR DESCRIPTION
## Summary
This PR adds multi-select functionality to the asset browser for bulk operations (move, delete) and introduces a new feature to disable alt text handling on assets (useful for decorative images). It also improves file replacement with extension change detection and confirmation.

## Key Changes

### Bulk Operations
- Added multi-select checkboxes to asset browser table (manage mode only)
- Implemented selection state management with `selected` Map keyed by asset ID
- Added selection bar showing count and bulk action buttons (Move, Delete, Disable alt text, Clear)
- Updated `MoveAssetModal` and `DeleteAssetModal` to handle multiple assets with individual error tracking
- Added "select all" checkbox in table header with indeterminate state support
- Bulk operations provide per-item error reporting while continuing to process remaining items

### Alt Text Disable Feature
- Added `DisableAltTextModal` for bulk disabling alt text on image/video files
- New `updateAssetAltDisabled()` utility function to toggle alt text handling per asset
- Added `altDisabled` field to `UploadedFile` interface
- Updated `buildAssetFieldValue()` to clear alt text when `altDisabled` is true
- Updated `buildSyncedFieldValue()` to drop doc-customized alt text when asset has alt disabled
- Asset details modal now shows disabled state and provides checkbox to toggle alt text handling
- Syncs changes to all docs using the asset when alt text is disabled/re-enabled

### File Replacement Improvements
- Added `getFileExt()` utility to normalize file extensions (handles case and jpeg→jpg normalization)
- Added `replaceFileExt()` utility to swap filename extensions
- File replacement now detects extension changes and shows confirmation modal
- When replacing with different extension, asset name is updated to match new extension
- Docs using the asset are automatically updated with new serving URL

### UI/UX Enhancements
- Added selection bar styling with count and action buttons
- Checkbox column in asset table with proper styling
- Alt text section in details modal shows disabled state with explanation
- File replacement confirmation shows old/new extensions and potential asset rename
- Improved error messaging for bulk operations with failed item lists

### Testing
- Added comprehensive test suite for `getFileExt()`, `testIsImageFile()`, and `testFileMatchesAccept()`
- Added tests for `replaceFileExt()` utility
- Added tests for `buildAssetFieldValue()` and `buildSyncedFieldValue()` with alt disabled scenarios

## Implementation Details
- Multi-select state is cleared when folder changes or assets are reloaded
- Bulk delete operations skip usage lookup for selections > 20 items (performance optimization)
- Alt text disable only applies to file assets that render as images/videos
- File extension normalization handles both uppercase and jpeg→jpg conversion
- Syncing to docs preserves doc-level customizations except when alt text is disabled

https://claude.ai/code/session_01Ni6EBqCW5eiwB7B5QsMMPH