### PR TITLE
fix: prevent CSP nonce race under concurrent renders

### DIFF
--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -190,6 +190,13 @@ export class Renderer {
 
     // Create a hook to auto-inject nonce values.
     // https://preactjs.com/guide/v10/options/
+    // NOTE: `preactOptions.vnode` is a global, so the hook must be installed
+    // and restored within a single synchronous block. Resolve the JSX
+    // renderer first (which may involve a dynamic import) so that no `await`
+    // occurs while the hook is swapped. Awaiting inside the swapped window
+    // allows concurrent renders to interleave, leaking a stale hook (and its
+    // nonce) into other requests.
+    const renderJsxFn = await this.getJsxRenderFn();
     const preactHook = preactOptions.vnode;
     let mainHtml: string;
     try {
@@ -215,11 +222,9 @@ export class Renderer {
           preactHook(vnode);
         }
       };
-      mainHtml = await this.renderJsx(vdom);
+      mainHtml = renderJsxFn(vdom);
+    } finally {
       preactOptions.vnode = preactHook;
-    } catch (err) {
-      preactOptions.vnode = preactHook;
-      throw err;
     }
 
     const jsDeps = new Set<string>();
@@ -601,13 +606,19 @@ export class Renderer {
   }
 
   /**
-   * Renders JSX via either the `@blinkk/root/jsx` package or
-   * `preact-render-to-string` depending if the `jsxRenderer` config is set up
-   * in `root.config.ts`.
+   * Resolves a synchronous JSX render function, using either the
+   * `@blinkk/root/jsx` package or `preact-render-to-string` depending if the
+   * `jsxRenderer` config is set up in `root.config.ts`.
+   *
+   * Resolving the renderer up front (rather than awaiting inside the render
+   * call) allows callers that temporarily swap global state (e.g. the
+   * `preact.options.vnode` nonce hook) to render synchronously without
+   * yielding to the event loop.
    */
-  private async renderJsx(vnode: any) {
+  private async getJsxRenderFn(): Promise<(vnode: any) => string> {
     if (this.rootConfig.jsxRenderer?.mode) {
-      return renderJsxToString(vnode, this.getJsxRenderOptions());
+      const options = this.getJsxRenderOptions();
+      return (vnode: any) => renderJsxToString(vnode, options);
     }
     const {renderToString} = await import('preact-render-to-string');
     if (!renderToString) {
@@ -615,7 +626,17 @@ export class Renderer {
         'failed to render jsx. either install preact-render-to-string or add the "jsxRenderer" config to root.config.ts'
       );
     }
-    return renderToString(vnode);
+    return (vnode: any) => renderToString(vnode);
+  }
+
+  /**
+   * Renders JSX via either the `@blinkk/root/jsx` package or
+   * `preact-render-to-string` depending if the `jsxRenderer` config is set up
+   * in `root.config.ts`.
+   */
+  private async renderJsx(vnode: any) {
+    const render = await this.getJsxRenderFn();
+    return render(vnode);
   }
 
   private getConfiguredStyleEntries() {


### PR DESCRIPTION
## Summary

Fixes a concurrency race in the CSP nonce injection that causes **every script and style on a page to be blocked** in production servers handling concurrent requests (e.g. Cloud Functions with `concurrency` > 1).

## Symptoms

- The `content-security-policy` header contains a fresh per-request nonce, but the HTML body contains a **different, stale** nonce on every `<script>`/`<style>`/`<link rel="stylesheet">` tag.
- Once triggered, the stale nonce is **constant for the lifetime of the server process** — every subsequent response is broken, even cache-busted requests hitting the origin directly.
- Browsers report errors like:

  ```
  Executing inline script violates the following Content Security Policy directive
  'script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http: 'nonce-...''.
  Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.
  ```

  and for external scripts:

  ```
  Note that 'strict-dynamic' is present, so host-based allowlisting is disabled.
  ```

  i.e. the presence of the (mismatched) nonce disables both `'unsafe-inline'` and host allowlisting, so nothing on the page executes.

## Root cause

`Renderer.renderComponent` injects nonces by temporarily swapping the **global** `preact.options.vnode` hook:

```ts
const preactHook = preactOptions.vnode;
preactOptions.vnode = (vnode) => { /* inject nonce */ };
mainHtml = await this.renderJsx(vdom);   // ⚠️ awaits while the global hook is swapped
preactOptions.vnode = preactHook;
```

In v2.x this was safe because the render was synchronous (`renderToString(vdom)`) — install/render/restore happened atomically within one event-loop tick.

#1005 (`3b1db9e`, first released in `@blinkk/root@3.0.1`) changed the call to `await this.renderJsx(vdom)`, and `renderJsx` performs `await import('preact-render-to-string')`. The `await` yields to the event loop **while the global hook is swapped**, so concurrent renders interleave:

1. Request A installs hook A (nonce A), then awaits.
2. Request B runs, captures hook A as its "previous" hook, installs hook B.
3. Restores happen out of order, leaving a stale hook closure — with an old nonce — installed **process-wide, permanently** (each new request's hook chains to the stale one and "restores" it afterward).

From then on, every rendered page gets the stale nonce in the body while `setSecurityHeaders` puts a fresh nonce in the header.

## Fix

Resolve the JSX render function (including the dynamic `import()`) **before** installing the hook, so the swapped-hook window is fully synchronous again — both render paths (`renderJsxToString` and `preact-render-to-string`'s `renderToString`) are synchronous once the module is loaded. The restore also moved to a `finally` block.

A longer-term improvement might be to thread the nonce through render context/options instead of a global hook, but this change restores the v2.x atomicity guarantee with minimal surface area.

## Testing

- `pnpm test` in `packages/root`: 32 files / 169 tests pass.
- Reproduced in production-like conditions (Cloud Functions, `concurrency: 80`): before the equivalent mitigation, concurrent requests reliably produced header/body nonce mismatches; with the hook window synchronous, 10/10 concurrent requests produce matching nonces.
