### PR TITLE
fix: prevent worker thread OOM crashes in `root build --threads`

### DIFF
--- a/.changeset/threads-memory-aware.md
+++ b/.changeset/threads-memory-aware.md
@@ -1,0 +1,13 @@
+---
+'@blinkk/root': patch
+---
+
+fix: prevent worker thread OOM crashes in `root build --threads`
+
+Worker threads now inherit the main thread's heap size limit (e.g. from
+`--max-old-space-size`) via `resourceLimits`, instead of falling back to v8's
+default sizing, which can collapse to a few hundred MB when many workers spawn
+concurrently. Additionally, `--threads=auto` now caps the worker count based
+on available memory (budgeting 1GB per worker) in addition to CPU cores and
+page count, preventing high-core machines from spawning more workers than the
+machine's RAM supports.

--- a/.changeset/threads-memory-aware.md
+++ b/.changeset/threads-memory-aware.md
@@ -3,11 +3,3 @@
 ---
 
 fix: prevent worker thread OOM crashes in `root build --threads`
-
-Worker threads now inherit the main thread's heap size limit (e.g. from
-`--max-old-space-size`) via `resourceLimits`, instead of falling back to v8's
-default sizing, which can collapse to a few hundred MB when many workers spawn
-concurrently. Additionally, `--threads=auto` now caps the worker count based
-on available memory (budgeting 1GB per worker) in addition to CPU cores and
-page count, preventing high-core machines from spawning more workers than the
-machine's RAM supports.

--- a/packages/root/src/cli/build-worker-pool.ts
+++ b/packages/root/src/cli/build-worker-pool.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import v8 from 'node:v8';
 import {Worker} from 'node:worker_threads';
 
 import {
@@ -10,6 +11,21 @@ import {
 } from './build-page.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Heap size limit (in MB) for each worker thread.
+ *
+ * Worker threads do not inherit the main thread's heap size limit (e.g. from
+ * `NODE_OPTIONS=--max-old-space-size=...`). When `resourceLimits` is unset,
+ * v8 sizes each worker's heap from the memory available at spawn time, which
+ * can collapse to a few hundred MB when many workers start concurrently —
+ * causing "JavaScript heap out of memory" crashes on large builds even on
+ * machines with plenty of RAM. Give each worker the same heap limit as the
+ * main thread so flags like `--max-old-space-size` apply to workers too.
+ */
+const WORKER_HEAP_LIMIT_MB = Math.ceil(
+  v8.getHeapStatistics().heap_size_limit / (1024 * 1024)
+);
 
 export interface BuildWorkerPoolOptions {
   /** Number of worker threads. */
@@ -68,6 +84,7 @@ class BuildWorker {
     this.concurrency = options.workerConcurrency;
     this.worker = new Worker(path.resolve(__dirname, './build-worker.js'), {
       workerData: {rootDir: options.rootDir, mode: options.mode},
+      resourceLimits: {maxOldGenerationSizeMb: WORKER_HEAP_LIMIT_MB},
     });
     let onReady!: () => void;
     let onFailed!: (err: Error) => void;

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -617,13 +617,24 @@ function isRouteFile(filepath: string) {
 const MIN_PAGES_PER_THREAD = 10;
 
 /**
+ * Estimated memory footprint per worker thread (in bytes), used to cap the
+ * worker count in "auto" mode. Each worker loads the site's server bundle,
+ * config, and manifests, and holds in-flight renders, which can add up to
+ * hundreds of MB on large sites. Without a memory cap, high-core machines
+ * (e.g. 32-core CI runners) can spawn more workers than the machine's RAM
+ * supports, leading to out-of-memory crashes.
+ */
+const MEMORY_PER_THREAD = 1024 * 1024 * 1024; // 1GB
+
+/**
  * Resolves the `--threads` flag to a worker count. Returns 0 for an
  * in-process (single-threaded) build.
  *
  * - unset: 0 (in-process build).
  * - `--threads` or `--threads auto`: picks a worker count based on the
- *   machine's CPU cores and the number of pages to build. One core is
- *   reserved for the main thread, and each worker should have at least
+ *   machine's CPU cores, free memory, and the number of pages to build. One
+ *   core is reserved for the main thread, each worker is budgeted
+ *   `MEMORY_PER_THREAD` of free memory, and each worker should have at least
  *   `MIN_PAGES_PER_THREAD` pages to justify its startup cost. Small builds
  *   resolve to 0 and stay in-process.
  * - `--threads <num>`: uses exactly N workers (no workload heuristics).
@@ -638,7 +649,12 @@ function resolveNumThreads(
   if (threads === true || threads === 'auto') {
     const maxByCpu = Math.max(os.availableParallelism() - 1, 1);
     const maxByPages = Math.floor(numPages / MIN_PAGES_PER_THREAD);
-    const numThreads = Math.min(maxByCpu, maxByPages);
+    // Reserve 1 worker's worth of memory for the main thread.
+    const maxByMemory = Math.max(
+      Math.floor(os.freemem() / MEMORY_PER_THREAD) - 1,
+      1
+    );
+    const numThreads = Math.min(maxByCpu, maxByPages, maxByMemory);
     // A single worker is never faster than rendering in-process (same
     // parallelism, plus startup and messaging overhead).
     if (numThreads <= 1) {


### PR DESCRIPTION
## Problem

On a high-core CI machine (32 vCPU / 32GB RAM), `root build --threads=auto` for a large production site (~3,000 pages) crashed with:

```
FATAL ERROR: NewSpace::EnsureCurrentCapacity Allocation failed - JavaScript heap out of memory
```

Two root causes:

1. **Worker threads don't inherit the main thread's heap limit.** `NODE_OPTIONS=--max-old-space-size=8192` only applies to the main thread. With `resourceLimits` unset, v8 sizes each worker's heap from memory available at spawn time — with 31 workers starting concurrently, each worker's heap collapsed to ~512MB and crashed mid-build, even though the machine had plenty of RAM overall.
2. **Auto mode only considered CPU cores**, not memory. Each worker loads the full server bundle, config, and manifests (hundreds of MB for large sites), so a 32-core machine spawning 31 workers can easily exceed available RAM.

## Fix

- `BuildWorkerPool` now passes `resourceLimits: {maxOldGenerationSizeMb}` to each `Worker`, derived from the main thread's own heap limit (`v8.getHeapStatistics().heap_size_limit`), so flags like `--max-old-space-size` apply to workers too.
- `resolveNumThreads()` auto mode now also caps the worker count by free memory, budgeting 1GB per worker and reserving one budget for the main thread: `min(maxByCpu, maxByPages, maxByMemory)`.

Explicit `--threads <num>` behavior is unchanged (no heuristics applied).

## Testing

- `pnpm vitest run` in `packages/root`: 32 files / 169 tests pass, including the `build-threads` parity test which exercises the new `resourceLimits` path with real workers.
