### PR TITLE
feat: add `i18n.translationLanguages` config to map root locales to translation languages

### DIFF
--- a/.changeset/translation-languages-config.md
+++ b/.changeset/translation-languages-config.md
@@ -13,16 +13,19 @@ or edited:
 
 ```ts
 i18n: {
-  locales: ['en', 'es-419_mx', 'es-419_co'],
+  locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
   translationLanguages: {
-    'es-419_mx': 'es-419',
-    'es-419_co': 'es-419',
+    en_mx: 'es-419',
+    en_co: 'es-419',
+    en_gb: 'en-GB',
+    en_ca: 'en-GB',
+    fr_ca: 'fr-CA',
   },
 }
 ```
 
 With the config above, CSV and Google Sheets exports use a single `es-419`
-column, imports fan the `es-419` values out to both locales, the CMS
-translations pages show a single `es-419` field, and translation services
-receive rows keyed by `es-419` (plus a new `translationLanguages` field on
-`TranslationServiceContext`).
+column for the `en_mx` and `en_co` locales, imports fan the `es-419` values
+out to both locales, the CMS translations pages show a single `es-419` field,
+and translation services receive rows keyed by `es-419` (plus a new
+`translationLanguages` field on `TranslationServiceContext`).

--- a/.changeset/translation-languages-config.md
+++ b/.changeset/translation-languages-config.md
@@ -1,31 +1,6 @@
 ---
-'@blinkk/root': minor
-'@blinkk/root-cms': minor
+'@blinkk/root': patch
+'@blinkk/root-cms': patch
 ---
 
 feat: add `i18n.translationLanguages` config to map root locales to translation languages
-
-Translation systems often use different language identifiers than root
-locales, and multiple root locales may share the same translations. The new
-`i18n.translationLanguages` config in root.config.ts maps a root locale to
-the language identifier used wherever translations are imported, exported,
-or edited:
-
-```ts
-i18n: {
-  locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
-  translationLanguages: {
-    en_mx: 'es-419',
-    en_co: 'es-419',
-    en_gb: 'en-GB',
-    en_ca: 'en-GB',
-    fr_ca: 'fr-CA',
-  },
-}
-```
-
-With the config above, CSV and Google Sheets exports use a single `es-419`
-column for the `en_mx` and `en_co` locales, imports fan the `es-419` values
-out to both locales, the CMS translations pages show a single `es-419` field,
-and translation services receive rows keyed by `es-419` (plus a new
-`translationLanguages` field on `TranslationServiceContext`).

--- a/.changeset/translation-languages-config.md
+++ b/.changeset/translation-languages-config.md
@@ -1,0 +1,28 @@
+---
+'@blinkk/root': minor
+'@blinkk/root-cms': minor
+---
+
+feat: add `i18n.translationLanguages` config to map root locales to translation languages
+
+Translation systems often use different language identifiers than root
+locales, and multiple root locales may share the same translations. The new
+`i18n.translationLanguages` config in root.config.ts maps a root locale to
+the language identifier used wherever translations are imported, exported,
+or edited:
+
+```ts
+i18n: {
+  locales: ['en', 'es-419_mx', 'es-419_co'],
+  translationLanguages: {
+    'es-419_mx': 'es-419',
+    'es-419_co': 'es-419',
+  },
+}
+```
+
+With the config above, CSV and Google Sheets exports use a single `es-419`
+column, imports fan the `es-419` values out to both locales, the CMS
+translations pages show a single `es-419` field, and translation services
+receive rows keyed by `es-419` (plus a new `translationLanguages` field on
+`TranslationServiceContext`).

--- a/docs/plugins/crowdin-translations.ts
+++ b/docs/plugins/crowdin-translations.ts
@@ -366,7 +366,10 @@ export function crowdinTranslationService(
       data: TranslationRow[]
     ): Promise<TranslationExportResult> {
       const projectId = await getProjectId();
-      const {collectionId, slug, locales} = ctx;
+      const {collectionId, slug} = ctx;
+      // Translation languages may be shared by multiple root locales (per
+      // the `i18n.translationLanguages` config in root.config.ts).
+      const locales = ctx.translationLanguages || ctx.locales;
       const fileName = `${slug}.csv`;
 
       // Generate CSV with source column + context column + one column per locale.
@@ -439,7 +442,10 @@ export function crowdinTranslationService(
       data: TranslationRow[]
     ): Promise<TranslationRow[]> {
       const projectId = await getProjectId();
-      const {collectionId, slug, locales} = ctx;
+      const {collectionId, slug} = ctx;
+      // Translation languages may be shared by multiple root locales (per
+      // the `i18n.translationLanguages` config in root.config.ts).
+      const locales = ctx.translationLanguages || ctx.locales;
       const fileName = `${slug}.csv`;
 
       // Find directory and file in Crowdin.

--- a/docs/plugins/deepl-translations.ts
+++ b/docs/plugins/deepl-translations.ts
@@ -78,9 +78,12 @@ export function deeplTranslationService(
         return [];
       }
 
-      // Translate source texts to each locale in parallel.
+      // Translate source texts to each translation language in parallel.
+      // Translation languages may be shared by multiple root locales (per
+      // the `i18n.translationLanguages` config in root.config.ts).
+      const languages = ctx.translationLanguages || ctx.locales;
       const results = await Promise.all(
-        ctx.locales.map(async (locale) => {
+        languages.map(async (locale) => {
           const translated = await translateTexts(sourceTexts, locale, 'en');
           return {locale, translated};
         })

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {Server, Request, Response} from '@blinkk/root';
 import {multipartMiddleware} from '@blinkk/root/middleware';
 import {UIMessage} from 'ai';
+import {toTranslationLanguages} from '../shared/translation-languages.js';
 import {
   ChatStore,
   findModel,
@@ -1322,7 +1323,9 @@ export function api(server: Server, options: ApiOptions) {
 
     try {
       const cmsClient = new RootCMSClient(req.rootConfig!);
-      const locales = req.rootConfig?.i18n?.locales || [];
+      const i18nConfig = req.rootConfig?.i18n || {};
+      const locales = i18nConfig.locales || [];
+      const translationLanguages = toTranslationLanguages(i18nConfig, locales);
 
       const result = await handler(
         {
@@ -1332,6 +1335,7 @@ export function api(server: Server, options: ApiOptions) {
           collectionId,
           slug,
           locales,
+          translationLanguages,
           user: {email: req.user!.email},
         },
         data

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -49,8 +49,10 @@ export type {
 } from './services-notifications.js';
 export type {
   CMSTranslationService,
+  RootLocale,
   TranslationExportResult,
   TranslationImportResult,
+  TranslationLanguage,
   TranslationRow,
   TranslationServiceContext,
 } from './translations.js';

--- a/packages/root-cms/core/translations.ts
+++ b/packages/root-cms/core/translations.ts
@@ -1,4 +1,10 @@
+import type {
+  RootLocale,
+  TranslationLanguage,
+} from '../shared/translation-languages.js';
 import type {CMSService, CMSServiceContext} from './services.js';
+
+export type {RootLocale, TranslationLanguage};
 
 /** A row of translation data keyed by translation language. */
 export interface TranslationRow {
@@ -10,7 +16,7 @@ export interface TranslationRow {
    * config in root.config.ts; when no mapping is configured, the keys are the
    * locale ids themselves.
    */
-  translations: Record<string, string>;
+  translations: Record<TranslationLanguage, string>;
   /** Optional translator notes/context for the source string. */
   description?: string;
 }
@@ -24,7 +30,7 @@ export interface TranslationServiceContext extends CMSServiceContext {
   /** The slug, e.g. `index`. */
   slug: string;
   /** The locales configured for the project. */
-  locales: string[];
+  locales: RootLocale[];
   /**
    * The translation languages for the project, derived from `locales` via the
    * `i18n.translationLanguages` config in root.config.ts (deduped, since
@@ -32,7 +38,7 @@ export interface TranslationServiceContext extends CMSServiceContext {
    * when no mapping is configured. The `translations` keys in
    * `TranslationRow` data use these languages.
    */
-  translationLanguages: string[];
+  translationLanguages: TranslationLanguage[];
   /** The email of the user performing the action. */
   user: {email: string};
 }

--- a/packages/root-cms/core/translations.ts
+++ b/packages/root-cms/core/translations.ts
@@ -1,10 +1,15 @@
 import type {CMSService, CMSServiceContext} from './services.js';
 
-/** A row of translation data keyed by locale. */
+/** A row of translation data keyed by translation language. */
 export interface TranslationRow {
   /** The source string. */
   source: string;
-  /** Map of locale code to translated string. */
+  /**
+   * Map of translation language to translated string. Translation languages
+   * are derived from the project's locales via the `i18n.translationLanguages`
+   * config in root.config.ts; when no mapping is configured, the keys are the
+   * locale ids themselves.
+   */
   translations: Record<string, string>;
   /** Optional translator notes/context for the source string. */
   description?: string;
@@ -20,6 +25,14 @@ export interface TranslationServiceContext extends CMSServiceContext {
   slug: string;
   /** The locales configured for the project. */
   locales: string[];
+  /**
+   * The translation languages for the project, derived from `locales` via the
+   * `i18n.translationLanguages` config in root.config.ts (deduped, since
+   * multiple locales may share a translation language). Equal to `locales`
+   * when no mapping is configured. The `translations` keys in
+   * `TranslationRow` data use these languages.
+   */
+  translationLanguages: string[];
   /** The email of the user performing the action. */
   user: {email: string};
 }

--- a/packages/root-cms/shared/translation-languages.test.ts
+++ b/packages/root-cms/shared/translation-languages.test.ts
@@ -7,10 +7,10 @@ import {
 } from './translation-languages.js';
 
 const i18nConfig = {
-  locales: ['en', 'fr', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
+  locales: ['en', 'fr', 'es_mx', 'es_co', 'en_gb', 'en_ca', 'fr_ca'],
   translationLanguages: {
-    en_mx: 'es-419',
-    en_co: 'es-419',
+    es_mx: 'es-419',
+    es_co: 'es-419',
     en_gb: 'en-GB',
     en_ca: 'en-GB',
     fr_ca: 'fr-CA',
@@ -19,19 +19,19 @@ const i18nConfig = {
 
 describe('getTranslationLanguage', () => {
   it('returns the configured translation language for a locale', () => {
-    expect(getTranslationLanguage(i18nConfig, 'en_mx')).toEqual('es-419');
-    expect(getTranslationLanguage(i18nConfig, 'en_co')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'es_mx')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'es_co')).toEqual('es-419');
     expect(getTranslationLanguage(i18nConfig, 'en_gb')).toEqual('en-GB');
     expect(getTranslationLanguage(i18nConfig, 'fr_ca')).toEqual('fr-CA');
   });
 
   it('matches locales case-insensitively', () => {
-    expect(getTranslationLanguage(i18nConfig, 'EN_MX')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'ES_MX')).toEqual('es-419');
   });
 
   it('returns the locale itself when no mapping is configured', () => {
     expect(getTranslationLanguage(i18nConfig, 'fr')).toEqual('fr');
-    expect(getTranslationLanguage({}, 'en_mx')).toEqual('en_mx');
+    expect(getTranslationLanguage({}, 'es_mx')).toEqual('es_mx');
   });
 });
 
@@ -54,8 +54,8 @@ describe('toTranslationLanguages', () => {
 describe('getLocalesForTranslationLanguage', () => {
   it('expands a translation language to its root locales', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'es-419')).toEqual([
-      'en_mx',
-      'en_co',
+      'es_mx',
+      'es_co',
     ]);
     expect(getLocalesForTranslationLanguage(i18nConfig, 'en-GB')).toEqual([
       'en_gb',
@@ -68,26 +68,26 @@ describe('getLocalesForTranslationLanguage', () => {
 
   it('matches a root locale directly', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'fr')).toEqual(['fr']);
-    expect(getLocalesForTranslationLanguage(i18nConfig, 'en_mx')).toEqual([
-      'en_mx',
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'es_mx')).toEqual([
+      'es_mx',
     ]);
   });
 
   it('matches case-insensitively', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'ES-419')).toEqual([
-      'en_mx',
-      'en_co',
+      'es_mx',
+      'es_co',
     ]);
   });
 
   it('includes a root locale that matches the language id directly', () => {
     const config = {
-      locales: ['en', 'es-419', 'en_mx'],
-      translationLanguages: {en_mx: 'es-419'},
+      locales: ['en', 'es-419', 'es_mx'],
+      translationLanguages: {es_mx: 'es-419'},
     };
     expect(getLocalesForTranslationLanguage(config, 'es-419')).toEqual([
       'es-419',
-      'en_mx',
+      'es_mx',
     ]);
   });
 
@@ -98,7 +98,7 @@ describe('getLocalesForTranslationLanguage', () => {
 
 describe('getTranslationForLanguage', () => {
   it('returns the first non-empty translation across the locale group', () => {
-    const row = {source: 'Hello', en_mx: '', en_co: 'Hola'};
+    const row = {source: 'Hello', es_mx: '', es_co: 'Hola'};
     expect(getTranslationForLanguage(i18nConfig, row, 'es-419')).toEqual(
       'Hola'
     );

--- a/packages/root-cms/shared/translation-languages.test.ts
+++ b/packages/root-cms/shared/translation-languages.test.ts
@@ -1,0 +1,102 @@
+import {describe, it, expect} from 'vitest';
+import {
+  getLocalesForTranslationLanguage,
+  getTranslationForLanguage,
+  getTranslationLanguage,
+  toTranslationLanguages,
+} from './translation-languages.js';
+
+const i18nConfig = {
+  locales: ['en', 'fr', 'es-419_mx', 'es-419_co'],
+  translationLanguages: {
+    'es-419_mx': 'es-419',
+    'es-419_co': 'es-419',
+  },
+};
+
+describe('getTranslationLanguage', () => {
+  it('returns the configured translation language for a locale', () => {
+    expect(getTranslationLanguage(i18nConfig, 'es-419_mx')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'es-419_co')).toEqual('es-419');
+  });
+
+  it('matches locales case-insensitively', () => {
+    expect(getTranslationLanguage(i18nConfig, 'ES-419_MX')).toEqual('es-419');
+  });
+
+  it('returns the locale itself when no mapping is configured', () => {
+    expect(getTranslationLanguage(i18nConfig, 'fr')).toEqual('fr');
+    expect(getTranslationLanguage({}, 'es-419_mx')).toEqual('es-419_mx');
+  });
+});
+
+describe('toTranslationLanguages', () => {
+  it('dedupes locales that share a translation language', () => {
+    expect(toTranslationLanguages(i18nConfig, i18nConfig.locales)).toEqual([
+      'en',
+      'fr',
+      'es-419',
+    ]);
+  });
+
+  it('returns locales unchanged when no mapping is configured', () => {
+    expect(toTranslationLanguages({}, ['en', 'fr'])).toEqual(['en', 'fr']);
+  });
+});
+
+describe('getLocalesForTranslationLanguage', () => {
+  it('expands a translation language to its root locales', () => {
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'es-419')).toEqual([
+      'es-419_mx',
+      'es-419_co',
+    ]);
+  });
+
+  it('matches a root locale directly', () => {
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'fr')).toEqual(['fr']);
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'es-419_mx')).toEqual([
+      'es-419_mx',
+    ]);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'ES-419')).toEqual([
+      'es-419_mx',
+      'es-419_co',
+    ]);
+  });
+
+  it('includes a root locale that matches the language id directly', () => {
+    const config = {
+      locales: ['en', 'es-419', 'es-419_mx'],
+      translationLanguages: {'es-419_mx': 'es-419'},
+    };
+    expect(getLocalesForTranslationLanguage(config, 'es-419')).toEqual([
+      'es-419',
+      'es-419_mx',
+    ]);
+  });
+
+  it('returns an empty array for unknown values', () => {
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'de')).toEqual([]);
+  });
+});
+
+describe('getTranslationForLanguage', () => {
+  it('returns the first non-empty translation across the locale group', () => {
+    const row = {source: 'Hello', 'es-419_mx': '', 'es-419_co': 'Hola'};
+    expect(getTranslationForLanguage(i18nConfig, row, 'es-419')).toEqual(
+      'Hola'
+    );
+  });
+
+  it('reads a root locale directly', () => {
+    const row = {source: 'Hello', fr: 'Bonjour'};
+    expect(getTranslationForLanguage(i18nConfig, row, 'fr')).toEqual('Bonjour');
+  });
+
+  it('returns an empty string when no translation exists', () => {
+    expect(getTranslationForLanguage(i18nConfig, {}, 'es-419')).toEqual('');
+    expect(getTranslationForLanguage(i18nConfig, {}, 'de')).toEqual('');
+  });
+});

--- a/packages/root-cms/shared/translation-languages.test.ts
+++ b/packages/root-cms/shared/translation-languages.test.ts
@@ -7,26 +7,31 @@ import {
 } from './translation-languages.js';
 
 const i18nConfig = {
-  locales: ['en', 'fr', 'es-419_mx', 'es-419_co'],
+  locales: ['en', 'fr', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
   translationLanguages: {
-    'es-419_mx': 'es-419',
-    'es-419_co': 'es-419',
+    en_mx: 'es-419',
+    en_co: 'es-419',
+    en_gb: 'en-GB',
+    en_ca: 'en-GB',
+    fr_ca: 'fr-CA',
   },
 };
 
 describe('getTranslationLanguage', () => {
   it('returns the configured translation language for a locale', () => {
-    expect(getTranslationLanguage(i18nConfig, 'es-419_mx')).toEqual('es-419');
-    expect(getTranslationLanguage(i18nConfig, 'es-419_co')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'en_mx')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'en_co')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'en_gb')).toEqual('en-GB');
+    expect(getTranslationLanguage(i18nConfig, 'fr_ca')).toEqual('fr-CA');
   });
 
   it('matches locales case-insensitively', () => {
-    expect(getTranslationLanguage(i18nConfig, 'ES-419_MX')).toEqual('es-419');
+    expect(getTranslationLanguage(i18nConfig, 'EN_MX')).toEqual('es-419');
   });
 
   it('returns the locale itself when no mapping is configured', () => {
     expect(getTranslationLanguage(i18nConfig, 'fr')).toEqual('fr');
-    expect(getTranslationLanguage({}, 'es-419_mx')).toEqual('es-419_mx');
+    expect(getTranslationLanguage({}, 'en_mx')).toEqual('en_mx');
   });
 });
 
@@ -36,6 +41,8 @@ describe('toTranslationLanguages', () => {
       'en',
       'fr',
       'es-419',
+      'en-GB',
+      'fr-CA',
     ]);
   });
 
@@ -47,33 +54,40 @@ describe('toTranslationLanguages', () => {
 describe('getLocalesForTranslationLanguage', () => {
   it('expands a translation language to its root locales', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'es-419')).toEqual([
-      'es-419_mx',
-      'es-419_co',
+      'en_mx',
+      'en_co',
+    ]);
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'en-GB')).toEqual([
+      'en_gb',
+      'en_ca',
+    ]);
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'fr-CA')).toEqual([
+      'fr_ca',
     ]);
   });
 
   it('matches a root locale directly', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'fr')).toEqual(['fr']);
-    expect(getLocalesForTranslationLanguage(i18nConfig, 'es-419_mx')).toEqual([
-      'es-419_mx',
+    expect(getLocalesForTranslationLanguage(i18nConfig, 'en_mx')).toEqual([
+      'en_mx',
     ]);
   });
 
   it('matches case-insensitively', () => {
     expect(getLocalesForTranslationLanguage(i18nConfig, 'ES-419')).toEqual([
-      'es-419_mx',
-      'es-419_co',
+      'en_mx',
+      'en_co',
     ]);
   });
 
   it('includes a root locale that matches the language id directly', () => {
     const config = {
-      locales: ['en', 'es-419', 'es-419_mx'],
-      translationLanguages: {'es-419_mx': 'es-419'},
+      locales: ['en', 'es-419', 'en_mx'],
+      translationLanguages: {en_mx: 'es-419'},
     };
     expect(getLocalesForTranslationLanguage(config, 'es-419')).toEqual([
       'es-419',
-      'es-419_mx',
+      'en_mx',
     ]);
   });
 
@@ -84,7 +98,7 @@ describe('getLocalesForTranslationLanguage', () => {
 
 describe('getTranslationForLanguage', () => {
   it('returns the first non-empty translation across the locale group', () => {
-    const row = {source: 'Hello', 'es-419_mx': '', 'es-419_co': 'Hola'};
+    const row = {source: 'Hello', en_mx: '', en_co: 'Hola'};
     expect(getTranslationForLanguage(i18nConfig, row, 'es-419')).toEqual(
       'Hola'
     );

--- a/packages/root-cms/shared/translation-languages.ts
+++ b/packages/root-cms/shared/translation-languages.ts
@@ -11,10 +11,13 @@
  *
  * ```ts
  * i18n: {
- *   locales: ['en', 'es-419_mx', 'es-419_co'],
+ *   locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
  *   translationLanguages: {
- *     'es-419_mx': 'es-419',
- *     'es-419_co': 'es-419',
+ *     en_mx: 'es-419',
+ *     en_co: 'es-419',
+ *     en_gb: 'en-GB',
+ *     en_ca: 'en-GB',
+ *     fr_ca: 'fr-CA',
  *   },
  * }
  * ```
@@ -30,7 +33,7 @@ export interface TranslationLanguagesI18nConfig {
 
 /**
  * Returns the translation language for a root locale, e.g. `es-419` for the
- * `es-419_mx` locale. Returns the locale itself if no mapping is configured.
+ * `en_mx` locale. Returns the locale itself if no mapping is configured.
  */
 export function getTranslationLanguage(
   i18nConfig: TranslationLanguagesI18nConfig,
@@ -68,8 +71,8 @@ export function toTranslationLanguages(
 /**
  * Expands a translation language (or root locale) to the root locales it
  * covers. A value matches a root locale directly or via its configured
- * translation language, e.g. `es-419` returns both `es-419_mx` and
- * `es-419_co` with the example config above. Returns an empty array if the
+ * translation language, e.g. `es-419` returns both `en_mx` and `en_co` with
+ * the example config above. Returns an empty array if the
  * value doesn't match any configured locale.
  */
 export function getLocalesForTranslationLanguage(

--- a/packages/root-cms/shared/translation-languages.ts
+++ b/packages/root-cms/shared/translation-languages.ts
@@ -11,10 +11,10 @@
  *
  * ```ts
  * i18n: {
- *   locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
+ *   locales: ['en', 'es_mx', 'es_co', 'en_gb', 'en_ca', 'fr_ca'],
  *   translationLanguages: {
- *     en_mx: 'es-419',
- *     en_co: 'es-419',
+ *     es_mx: 'es-419',
+ *     es_co: 'es-419',
  *     en_gb: 'en-GB',
  *     en_ca: 'en-GB',
  *     fr_ca: 'fr-CA',
@@ -26,19 +26,32 @@
  * language. All matching is case-insensitive.
  */
 
+/**
+ * A site-defined locale identifier, as configured in `i18n.locales`.
+ * Root is agnostic to its format.
+ */
+export type RootLocale = string;
+
+/**
+ * The language identifier used by translation systems (CSV/Sheets columns,
+ * translation services, CMS translations pages), mapped from a root locale
+ * via `i18n.translationLanguages`. Defaults to the root locale id.
+ */
+export type TranslationLanguage = string;
+
 export interface TranslationLanguagesI18nConfig {
-  locales?: string[];
-  translationLanguages?: Record<string, string>;
+  locales?: RootLocale[];
+  translationLanguages?: Record<RootLocale, TranslationLanguage>;
 }
 
 /**
  * Returns the translation language for a root locale, e.g. `es-419` for the
- * `en_mx` locale. Returns the locale itself if no mapping is configured.
+ * `es_mx` locale. Returns the locale itself if no mapping is configured.
  */
 export function getTranslationLanguage(
   i18nConfig: TranslationLanguagesI18nConfig,
-  locale: string
-): string {
+  locale: RootLocale
+): TranslationLanguage {
   const mapping = i18nConfig.translationLanguages || {};
   const localeLower = String(locale).toLowerCase();
   for (const [key, lang] of Object.entries(mapping)) {
@@ -56,9 +69,9 @@ export function getTranslationLanguage(
  */
 export function toTranslationLanguages(
   i18nConfig: TranslationLanguagesI18nConfig,
-  locales: string[]
-): string[] {
-  const languages: string[] = [];
+  locales: RootLocale[]
+): TranslationLanguage[] {
+  const languages: TranslationLanguage[] = [];
   for (const locale of locales) {
     const lang = getTranslationLanguage(i18nConfig, locale);
     if (!languages.includes(lang)) {
@@ -71,17 +84,17 @@ export function toTranslationLanguages(
 /**
  * Expands a translation language (or root locale) to the root locales it
  * covers. A value matches a root locale directly or via its configured
- * translation language, e.g. `es-419` returns both `en_mx` and `en_co` with
+ * translation language, e.g. `es-419` returns both `es_mx` and `es_co` with
  * the example config above. Returns an empty array if the
  * value doesn't match any configured locale.
  */
 export function getLocalesForTranslationLanguage(
   i18nConfig: TranslationLanguagesI18nConfig,
-  lang: string
-): string[] {
+  lang: TranslationLanguage | RootLocale
+): RootLocale[] {
   const i18nLocales = i18nConfig.locales || ['en'];
   const langLower = String(lang).toLowerCase();
-  const locales: string[] = [];
+  const locales: RootLocale[] = [];
   for (const locale of i18nLocales) {
     if (
       String(locale).toLowerCase() === langLower ||
@@ -100,8 +113,8 @@ export function getLocalesForTranslationLanguage(
  */
 export function getTranslationForLanguage(
   i18nConfig: TranslationLanguagesI18nConfig,
-  translations: Record<string, unknown>,
-  lang: string
+  translations: Record<RootLocale, unknown>,
+  lang: TranslationLanguage | RootLocale
 ): string {
   for (const locale of getLocalesForTranslationLanguage(i18nConfig, lang)) {
     const value = translations[locale];

--- a/packages/root-cms/shared/translation-languages.ts
+++ b/packages/root-cms/shared/translation-languages.ts
@@ -1,0 +1,110 @@
+/**
+ * Utilities for converting between a "root locale" and a "translation
+ * language".
+ *
+ * Translation systems often use different language identifiers than root
+ * locales, and multiple root locales may share the same translations. The
+ * `i18n.translationLanguages` config in root.config.ts maps a root locale to
+ * the language identifier used wherever translations are imported, exported,
+ * or edited (CSV, Google Sheets, translation services, and the CMS
+ * translations pages). For example:
+ *
+ * ```ts
+ * i18n: {
+ *   locales: ['en', 'es-419_mx', 'es-419_co'],
+ *   translationLanguages: {
+ *     'es-419_mx': 'es-419',
+ *     'es-419_co': 'es-419',
+ *   },
+ * }
+ * ```
+ *
+ * Locales not listed in the mapping use the locale id as the translation
+ * language. All matching is case-insensitive.
+ */
+
+export interface TranslationLanguagesI18nConfig {
+  locales?: string[];
+  translationLanguages?: Record<string, string>;
+}
+
+/**
+ * Returns the translation language for a root locale, e.g. `es-419` for the
+ * `es-419_mx` locale. Returns the locale itself if no mapping is configured.
+ */
+export function getTranslationLanguage(
+  i18nConfig: TranslationLanguagesI18nConfig,
+  locale: string
+): string {
+  const mapping = i18nConfig.translationLanguages || {};
+  const localeLower = String(locale).toLowerCase();
+  for (const [key, lang] of Object.entries(mapping)) {
+    if (key.toLowerCase() === localeLower) {
+      return lang;
+    }
+  }
+  return locale;
+}
+
+/**
+ * Converts a list of root locales to translation languages, removing
+ * duplicates (multiple root locales may share a translation language) while
+ * preserving order.
+ */
+export function toTranslationLanguages(
+  i18nConfig: TranslationLanguagesI18nConfig,
+  locales: string[]
+): string[] {
+  const languages: string[] = [];
+  for (const locale of locales) {
+    const lang = getTranslationLanguage(i18nConfig, locale);
+    if (!languages.includes(lang)) {
+      languages.push(lang);
+    }
+  }
+  return languages;
+}
+
+/**
+ * Expands a translation language (or root locale) to the root locales it
+ * covers. A value matches a root locale directly or via its configured
+ * translation language, e.g. `es-419` returns both `es-419_mx` and
+ * `es-419_co` with the example config above. Returns an empty array if the
+ * value doesn't match any configured locale.
+ */
+export function getLocalesForTranslationLanguage(
+  i18nConfig: TranslationLanguagesI18nConfig,
+  lang: string
+): string[] {
+  const i18nLocales = i18nConfig.locales || ['en'];
+  const langLower = String(lang).toLowerCase();
+  const locales: string[] = [];
+  for (const locale of i18nLocales) {
+    if (
+      String(locale).toLowerCase() === langLower ||
+      getTranslationLanguage(i18nConfig, locale).toLowerCase() === langLower
+    ) {
+      locales.push(locale);
+    }
+  }
+  return locales;
+}
+
+/**
+ * Reads the translation for a translation language (or root locale) from a
+ * map keyed by root locale, checking all root locales that share the
+ * language and returning the first non-empty value.
+ */
+export function getTranslationForLanguage(
+  i18nConfig: TranslationLanguagesI18nConfig,
+  translations: Record<string, unknown>,
+  lang: string
+): string {
+  for (const locale of getLocalesForTranslationLanguage(i18nConfig, lang)) {
+    const value = translations[locale];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+  }
+  return '';
+}

--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.test.tsx
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.test.tsx
@@ -8,6 +8,11 @@ const mockCmsDocImportTranslations = vi.fn();
 
 vi.mock('../../utils/l10n.js', () => ({
   loadTranslations: (...args: any[]) => mockLoadTranslations(...args),
+  toTranslationLanguages: (locales: string[]) => locales,
+  getTranslationForLanguage: (
+    translations: Record<string, string>,
+    lang: string
+  ) => translations?.[lang] || '',
 }));
 
 vi.mock('../../utils/doc.js', () => ({

--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
@@ -23,7 +23,11 @@ import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {CsvTranslation, cmsDocImportTranslations} from '../../utils/doc.js';
 import {GoogleSheetId, getSpreadsheetUrl} from '../../utils/gsheets.js';
-import {loadTranslations} from '../../utils/l10n.js';
+import {
+  getTranslationForLanguage,
+  loadTranslations,
+  toTranslationLanguages,
+} from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
 import {FieldHistory} from '../FieldHistory/FieldHistory.js';
 import {Heading} from '../Heading/Heading.js';
@@ -70,7 +74,9 @@ export function EditTranslationsModal(
   const {innerProps: props, context, id} = modalProps;
   const strings = props.strings || [];
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const i18nLocales = i18nConfig.locales || ['en'];
+  // Edits are keyed by "translation language", which may be shared by
+  // multiple root locales (per the `i18n.translationLanguages` config).
+  const i18nLocales = toTranslationLanguages(i18nConfig.locales || ['en']);
   const [translationsMap, setTranslationsMap] = useState<
     Record<string, Record<string, string>>
   >({});
@@ -102,7 +108,16 @@ export function EditTranslationsModal(
     loadTranslations({tags: [props.docId]}).then((res) => {
       const translationsMap: Record<string, Record<string, string>> = {};
       Object.values(res).forEach((row) => {
-        translationsMap[row.source] = row;
+        // Re-key rows from root locales to translation languages so edits
+        // and saves apply to every root locale that shares the language.
+        const langRow: Record<string, string> = {source: row.source};
+        i18nLocales.forEach((lang) => {
+          const value = getTranslationForLanguage(row, lang);
+          if (value) {
+            langRow[lang] = value;
+          }
+        });
+        translationsMap[row.source] = langRow;
       });
       setTranslationsMap(translationsMap);
       setLoading(false);

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -334,8 +334,8 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   const [sourceStrings, setSourceStrings] = useState<string[]>([]);
   const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
   // The translations UI operates on "translation languages", which may be
-  // shared by multiple root locales (e.g. `es-419` covering `en_mx` and
-  // `en_co`, per the `i18n.translationLanguages` config).
+  // shared by multiple root locales (e.g. `es-419` covering `es_mx` and
+  // `es_co`, per the `i18n.translationLanguages` config).
   const translationLanguages = toTranslationLanguages(locales);
   const defaultLocale =
     (props.locale && getTranslationLanguage(props.locale)) ||

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -61,8 +61,12 @@ import {
 import {
   batchSaveTranslations,
   batchUpdateTags,
+  getLocalesForTranslationLanguage,
+  getTranslationForLanguage,
+  getTranslationLanguage,
   isLocaleExcludedFromTranslations,
   sourceHash,
+  toTranslationLanguages,
 } from '../../utils/l10n.js';
 import {TranslationsMap, loadTranslations} from '../../utils/l10n.js';
 import {useExportSheetModal} from '../ExportSheetModal/ExportSheetModal.js';
@@ -329,7 +333,14 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   const [loading, setLoading] = useState(true);
   const [sourceStrings, setSourceStrings] = useState<string[]>([]);
   const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
-  const defaultLocale = props.locale || locales.find((l) => l !== 'en') || 'en';
+  // The translations UI operates on "translation languages", which may be
+  // shared by multiple root locales (e.g. `es-419` covering `es-419_mx` and
+  // `es-419_co`, per the `i18n.translationLanguages` config).
+  const translationLanguages = toTranslationLanguages(locales);
+  const defaultLocale =
+    (props.locale && getTranslationLanguage(props.locale)) ||
+    translationLanguages.find((l) => l !== 'en') ||
+    'en';
   const [selectedLocale, setSelectedLocale] = useState(defaultLocale);
   const [filterMissing, setFilterMissing] = useState(false);
   const [translationsMap, setTranslationsMap] = useState<TranslationsMap>({});
@@ -338,7 +349,10 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
     const result: Record<string, string> = {};
     Object.values(translationsMap).forEach(
       (translation: Record<string, string>) => {
-        result[translation.source] = translation[selectedLocale] || '';
+        result[translation.source] = getTranslationForLanguage(
+          translation,
+          selectedLocale
+        );
       }
     );
     return result;
@@ -581,7 +595,7 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
     return results;
   }, [translationsMap]);
 
-  const localeOptions = locales.map((locale) => ({
+  const localeOptions = translationLanguages.map((locale) => ({
     value: locale,
     label: getLocaleLabel(locale),
   }));
@@ -644,23 +658,23 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   function getTranslation(source: string, locale: string): string {
     const row = sourceToTranslationsMap[source];
     if (row) {
-      return row[locale] || '';
+      return getTranslationForLanguage(row, locale);
     }
     return '';
   }
 
   function formatCsvData() {
-    const nonEnLocales = locales.filter(
-      (l) => l !== 'en' && !isLocaleExcludedFromTranslations(l)
-    );
-    const headers = ['source', 'en', ...nonEnLocales];
+    const nonEnLanguages = toTranslationLanguages(
+      locales.filter((l) => !isLocaleExcludedFromTranslations(l))
+    ).filter((lang) => lang !== 'en');
+    const headers = ['source', 'en', ...nonEnLanguages];
     const rows: Array<Record<string, string>> = [];
     sourceStrings.forEach((source) => {
       const row: Record<string, string> = {
         source: source,
         en: getTranslation(source, 'en') || source,
       };
-      nonEnLocales.forEach((l) => {
+      nonEnLanguages.forEach((l) => {
         row[l] = getTranslation(source, l);
       });
       rows.push(row);
@@ -770,7 +784,7 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
         // When exporting strings, avoid overwriting cells where there is an
         // existing translation. If users want to export translations from the
         // CMS to the sheet, they should clear those cells first.
-        preserveColumns: locales,
+        preserveColumns: translationLanguages,
       });
     }
     logAction('doc.export_to_sheet', {
@@ -908,7 +922,7 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
         exportSheetModal.open({
           docId: props.docId,
           csvData: formatCsvData(),
-          locales: locales,
+          locales: translationLanguages,
         });
         return;
       }
@@ -946,10 +960,11 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
           ? await extractStringsWithMetadataForDoc(props.docId)
           : null;
 
-      // Build translation row data from current source strings.
+      // Build translation row data from current source strings, keyed by
+      // translation language.
       const data = sourceStrings.map((source) => {
         const translations: Record<string, string> = {};
-        locales.forEach((locale) => {
+        translationLanguages.forEach((locale) => {
           translations[locale] = getTranslation(source, locale) ?? '';
         });
         const description = stringsWithMeta?.get(source)?.description;
@@ -1017,13 +1032,19 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
                 };
                 const translations = row?.translations;
                 if (translations && typeof translations === 'object') {
-                  locales.forEach((locale) => {
-                    const value = (translations as Record<string, unknown>)[
-                      locale
-                    ];
-                    if (value !== null && value !== undefined) {
-                      safeRow[locale] = String(value);
+                  // Keys may be root locales or translation languages;
+                  // `cmsDocImportTranslations()` expands languages to the
+                  // root locales they cover.
+                  Object.entries(
+                    translations as Record<string, unknown>
+                  ).forEach(([key, value]) => {
+                    if (value === null || value === undefined) {
+                      return;
                     }
+                    if (getLocalesForTranslationLanguage(key).length === 0) {
+                      return;
+                    }
+                    safeRow[key] = String(value);
                   });
                 }
                 return safeRow;

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -334,8 +334,8 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   const [sourceStrings, setSourceStrings] = useState<string[]>([]);
   const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
   // The translations UI operates on "translation languages", which may be
-  // shared by multiple root locales (e.g. `es-419` covering `es-419_mx` and
-  // `es-419_co`, per the `i18n.translationLanguages` config).
+  // shared by multiple root locales (e.g. `es-419` covering `en_mx` and
+  // `en_co`, per the `i18n.translationLanguages` config).
   const translationLanguages = toTranslationLanguages(locales);
   const defaultLocale =
     (props.locale && getTranslationLanguage(props.locale)) ||

--- a/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.tsx
+++ b/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.tsx
@@ -38,8 +38,10 @@ import {useArrayParam, useStringParam} from '../../hooks/useQueryParam.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {
   batchUpdateTags,
+  getTranslationForLanguage,
   isLocaleExcludedFromTranslations,
   loadTranslations,
+  toTranslationLanguages,
 } from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
 
@@ -59,12 +61,16 @@ export function TranslationsTable() {
   >({});
 
   const locales = window.__ROOT_CTX.rootConfig.i18n?.locales || [];
+  // Columns are "translation languages", which may be shared by multiple
+  // root locales (per the `i18n.translationLanguages` config).
   const allLocales = [
     'en',
-    ...locales
-      .filter(
+    ...toTranslationLanguages(
+      locales.filter(
         (l: string) => l !== 'en' && !isLocaleExcludedFromTranslations(l)
       )
+    )
+      .filter((lang: string) => lang !== 'en')
       .sort(),
   ];
 
@@ -235,15 +241,15 @@ export function TranslationsTable() {
           matchesSource = source.toLowerCase() === query;
           matchesHash = hashStr.toLowerCase() === query;
           matchesTranslation = allLocales.some((locale) => {
-            const translation = translations[locale];
-            return (translation || '').toLowerCase() === query;
+            const translation = getTranslationForLanguage(translations, locale);
+            return translation.toLowerCase() === query;
           });
         } else {
           matchesSource = source.toLowerCase().includes(query);
           matchesHash = hashStr.toLowerCase().includes(query);
           matchesTranslation = allLocales.some((locale) => {
-            const translation = translations[locale];
-            return (translation || '').toLowerCase().includes(query);
+            const translation = getTranslationForLanguage(translations, locale);
+            return translation.toLowerCase().includes(query);
           });
         }
 
@@ -258,7 +264,7 @@ export function TranslationsTable() {
         tags: rowTags,
       };
       allLocales.forEach((locale) => {
-        row[locale] = translations[locale] || '';
+        row[locale] = getTranslationForLanguage(translations, locale);
       });
       data.push(row);
     });

--- a/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.visual.test.tsx
+++ b/packages/root-cms/ui/components/TranslationsTable/TranslationsTable.visual.test.tsx
@@ -12,6 +12,12 @@ import {TranslationsTable} from './TranslationsTable.js';
 vi.mock('../../utils/l10n.js', () => ({
   loadTranslations: vi.fn(),
   batchUpdateTags: vi.fn(),
+  isLocaleExcludedFromTranslations: () => false,
+  toTranslationLanguages: (locales: string[]) => locales,
+  getTranslationForLanguage: (
+    translations: Record<string, string>,
+    lang: string
+  ) => translations?.[lang] || '',
 }));
 
 // Mock notifications.

--- a/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
+++ b/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
@@ -32,8 +32,10 @@ import {GoogleSheetId, getSpreadsheetUrl} from '../../utils/gsheets.js';
 import {
   Translation,
   TranslationsMap,
+  getTranslationForLanguage,
   isLocaleExcludedFromTranslations,
   loadTranslations,
+  toTranslationLanguages,
 } from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
 import './DocTranslationsPage.css';
@@ -59,8 +61,12 @@ export function DocTranslationsPage(props: DocTranslationsPageProps) {
   const pruneModal = usePruneTranslationsModal();
 
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const defaultLocales = (i18nConfig.locales || []).filter(
-    (l) => !isLocaleExcludedFromTranslations(l)
+  // Columns are "translation languages", which may be shared by multiple
+  // root locales (per the `i18n.translationLanguages` config).
+  const defaultLocales = toTranslationLanguages(
+    (i18nConfig.locales || []).filter(
+      (l) => !isLocaleExcludedFromTranslations(l)
+    )
   );
   const [i18nLocales, setI18nLocales] = useArrayParam('locale', defaultLocales);
 
@@ -286,8 +292,10 @@ interface DocTranslationsPageTableProps {
 
 DocTranslationsPage.Table = (props: DocTranslationsPageTableProps) => {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const allLocales = (i18nConfig.locales || []).filter(
-    (l) => !isLocaleExcludedFromTranslations(l)
+  const allLocales = toTranslationLanguages(
+    (i18nConfig.locales || []).filter(
+      (l) => !isLocaleExcludedFromTranslations(l)
+    )
   );
   const sourceToTranslationsMap = useMemo(() => {
     const results: {[source: string]: Record<string, string>} = {};
@@ -301,7 +309,7 @@ DocTranslationsPage.Table = (props: DocTranslationsPageTableProps) => {
 
   function getTranslation(source: string, locale: string) {
     const sourceTranslations = sourceToTranslationsMap[source] || {};
-    const translation = sourceTranslations[locale] || '';
+    const translation = getTranslationForLanguage(sourceTranslations, locale);
     return {
       translation: translation,
       hasChanges: false,

--- a/packages/root-cms/ui/pages/TranslationsEditPage/TranslationsEditPage.tsx
+++ b/packages/root-cms/ui/pages/TranslationsEditPage/TranslationsEditPage.tsx
@@ -14,7 +14,9 @@ import {Layout} from '../../layout/Layout.js';
 import {
   Translation,
   getTranslationByHash,
+  getTranslationForLanguage,
   normalizeString,
+  toTranslationLanguages,
   updateTranslationByHash,
 } from '../../utils/l10n.js';
 
@@ -97,7 +99,11 @@ interface TranslationsEditPagePropsForm {
 TranslationsEditPage.Form = (props: TranslationsEditPagePropsForm) => {
   const translations = props.translations;
   const locales = window.__ROOT_CTX.rootConfig.i18n.locales || [];
-  const nonEnLocales = locales.filter((l) => l !== 'en');
+  // Fields are keyed by "translation language", which may be shared by
+  // multiple root locales (per the `i18n.translationLanguages` config).
+  const nonEnLocales = toTranslationLanguages(locales).filter(
+    (l) => l !== 'en'
+  );
   const [tags, setTags] = useState<string[]>(translations.tags || []);
   const [saving, setSaving] = useState<'translations' | 'tags' | null>(null);
 
@@ -164,7 +170,7 @@ TranslationsEditPage.Form = (props: TranslationsEditPagePropsForm) => {
             radius={0}
             name={locale}
             label={locale}
-            value={translations[locale] || ''}
+            value={getTranslationForLanguage(translations, locale)}
             autosize
             disabled={!!saving}
           />

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -164,6 +164,7 @@ declare global {
           locales?: string[];
           urlFormat?: string;
           groups?: Record<string, {label?: string; locales: string[]}>;
+          translationLanguages?: Record<string, string>;
         };
         server: {
           trailingSlash?: boolean;

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -662,7 +662,7 @@ export async function cmsDocImportTranslations(
       source: normalizeString(row.source),
     };
     // A column may be a root locale or a translation language shared by
-    // multiple root locales (e.g. `es-419` covering `en_mx` and `en_co`).
+    // multiple root locales (e.g. `es-419` covering `es_mx` and `es_co`).
     // Language columns fan out to every locale in the group,
     // but a column that names a root locale directly takes precedence.
     const fromLanguageColumns: Record<string, string> = {};

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -28,8 +28,10 @@ import {extractAssetIds} from './assets.js';
 import {removeDocFromCache, removeDocsFromCache} from './doc-cache.js';
 import {GoogleSheetId} from './gsheets.js';
 import {
+  getLocalesForTranslationLanguage,
   getTranslationsCollection,
   isLocaleExcludedFromTranslations,
+  normalizeLocale,
   normalizeString,
   sourceHash,
 } from './l10n.js';
@@ -651,19 +653,6 @@ export async function cmsDocImportTranslations(
     actionLinks?: Array<{label: string; url: string; target?: string}>;
   }
 ) {
-  const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
-  const i18nLocales = i18nConfig.locales || ['en'];
-
-  function normalizeLocale(locale: string) {
-    for (const l of i18nLocales) {
-      if (String(l).toLowerCase() === locale.toLowerCase()) {
-        return l;
-      }
-    }
-    // Ignore locales that are not in the root config.
-    return null;
-  }
-
   const translationsMap: Record<string, CsvTranslation> = {};
   for (const row of csvData) {
     if (!row.source) {
@@ -672,16 +661,28 @@ export async function cmsDocImportTranslations(
     const translation: CsvTranslation = {
       source: normalizeString(row.source),
     };
+    // A column may be a root locale or a translation language shared by
+    // multiple root locales (e.g. `es-419` covering `es-419_mx` and
+    // `es-419_co`). Language columns fan out to every locale in the group,
+    // but a column that names a root locale directly takes precedence.
+    const fromLanguageColumns: Record<string, string> = {};
+    const fromLocaleColumns: Record<string, string> = {};
     Object.entries(row).forEach(([column, str]) => {
       if (column === 'source') {
         return;
       }
-      const locale = normalizeLocale(column);
-      // Skip locales excluded from translation import/export (e.g. `ALL_*`).
-      if (locale && !isLocaleExcludedFromTranslations(locale)) {
-        translation[locale] = normalizeString(str || '');
+      const exactLocale = normalizeLocale(column);
+      for (const locale of getLocalesForTranslationLanguage(column)) {
+        // Skip locales excluded from translation import/export (e.g. `ALL_*`).
+        if (isLocaleExcludedFromTranslations(locale)) {
+          continue;
+        }
+        const target =
+          locale === exactLocale ? fromLocaleColumns : fromLanguageColumns;
+        target[locale] = normalizeString(str || '');
       }
     });
+    Object.assign(translation, fromLanguageColumns, fromLocaleColumns);
 
     const hash = await sourceHash(translation.source);
     translationsMap[hash] = translation;

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -662,8 +662,8 @@ export async function cmsDocImportTranslations(
       source: normalizeString(row.source),
     };
     // A column may be a root locale or a translation language shared by
-    // multiple root locales (e.g. `es-419` covering `es-419_mx` and
-    // `es-419_co`). Language columns fan out to every locale in the group,
+    // multiple root locales (e.g. `es-419` covering `en_mx` and `en_co`).
+    // Language columns fan out to every locale in the group,
     // but a column that names a root locale directly takes precedence.
     const fromLanguageColumns: Record<string, string> = {};
     const fromLocaleColumns: Record<string, string> = {};

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -9,6 +9,12 @@ import {
   where,
   writeBatch,
 } from 'firebase/firestore';
+import {
+  getLocalesForTranslationLanguage as sharedGetLocalesForTranslationLanguage,
+  getTranslationForLanguage as sharedGetTranslationForLanguage,
+  getTranslationLanguage as sharedGetTranslationLanguage,
+  toTranslationLanguages as sharedToTranslationLanguages,
+} from '../../shared/translation-languages.js';
 import {logAction} from './actions.js';
 import {TIME_UNITS} from './time.js';
 
@@ -94,8 +100,9 @@ export async function updateTranslationByHash(
       updates.tags = translations.tags;
       continue;
     }
-    const locale = normalizeLocale(key);
-    if (locale) {
+    // A key may be a root locale or a translation language shared by multiple
+    // root locales (e.g. `es-419` covering `es-419_mx` and `es-419_co`).
+    for (const locale of getLocalesForTranslationLanguage(key)) {
       updates[locale] = translations[key];
     }
   }
@@ -208,8 +215,7 @@ function wildcardToRegExp(pattern: string): RegExp {
  * Patterns support wildcards, e.g. `ALL_*`.
  */
 export function isLocaleExcludedFromTranslations(locale: string): boolean {
-  const patterns =
-    window.__ROOT_CTX.excludeLocalesFromTranslations || [];
+  const patterns = window.__ROOT_CTX.excludeLocalesFromTranslations || [];
   return patterns.some((pattern) => wildcardToRegExp(pattern).test(locale));
 }
 
@@ -223,6 +229,49 @@ export function normalizeLocale(locale: string) {
   }
   // Ignore locales that are not in the root config.
   return null;
+}
+
+/**
+ * Returns the "translation language" for a root locale, as configured in
+ * `i18n.translationLanguages` (e.g. `es-419` for the `es-419_mx` locale).
+ * Returns the locale itself if no mapping is configured.
+ */
+export function getTranslationLanguage(locale: string): string {
+  const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
+  return sharedGetTranslationLanguage(i18nConfig, locale);
+}
+
+/**
+ * Converts a list of root locales to translation languages, removing
+ * duplicates (multiple root locales may share a translation language) while
+ * preserving order.
+ */
+export function toTranslationLanguages(locales: string[]): string[] {
+  const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
+  return sharedToTranslationLanguages(i18nConfig, locales);
+}
+
+/**
+ * Expands a translation language (or root locale) to the root locales it
+ * covers, e.g. `es-419` may return `['es-419_mx', 'es-419_co']`. Returns an
+ * empty array if the value doesn't match any locale in the root config.
+ */
+export function getLocalesForTranslationLanguage(lang: string): string[] {
+  const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
+  return sharedGetLocalesForTranslationLanguage(i18nConfig, lang);
+}
+
+/**
+ * Reads the translation for a translation language (or root locale) from a
+ * translations map keyed by root locale, checking all root locales that
+ * share the language and returning the first non-empty value.
+ */
+export function getTranslationForLanguage(
+  translations: Record<string, unknown>,
+  lang: string
+): string {
+  const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
+  return sharedGetTranslationForLanguage(i18nConfig, translations, lang);
 }
 
 /**
@@ -256,8 +305,9 @@ export async function batchSaveTranslations(
       const docRef = doc(db, 'Projects', projectId, 'Translations', entry.hash);
       const updates: Record<string, any> = {source: entry.source};
       for (const [locale, value] of Object.entries(entry.locales)) {
-        const normalized = normalizeLocale(locale);
-        if (normalized) {
+        // A key may be a root locale or a translation language shared by
+        // multiple root locales (e.g. `es-419` covering `es-419_mx`).
+        for (const normalized of getLocalesForTranslationLanguage(locale)) {
           updates[normalized] = normalizeString(value);
         }
       }

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -10,6 +10,8 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import {
+  type RootLocale,
+  type TranslationLanguage,
   getLocalesForTranslationLanguage as sharedGetLocalesForTranslationLanguage,
   getTranslationForLanguage as sharedGetTranslationForLanguage,
   getTranslationLanguage as sharedGetTranslationLanguage,
@@ -101,7 +103,7 @@ export async function updateTranslationByHash(
       continue;
     }
     // A key may be a root locale or a translation language shared by multiple
-    // root locales (e.g. `es-419` covering `en_mx` and `en_co`).
+    // root locales (e.g. `es-419` covering `es_mx` and `es_co`).
     for (const locale of getLocalesForTranslationLanguage(key)) {
       updates[locale] = translations[key];
     }
@@ -233,10 +235,12 @@ export function normalizeLocale(locale: string) {
 
 /**
  * Returns the "translation language" for a root locale, as configured in
- * `i18n.translationLanguages` (e.g. `es-419` for the `en_mx` locale).
+ * `i18n.translationLanguages` (e.g. `es-419` for the `es_mx` locale).
  * Returns the locale itself if no mapping is configured.
  */
-export function getTranslationLanguage(locale: string): string {
+export function getTranslationLanguage(
+  locale: RootLocale
+): TranslationLanguage {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
   return sharedGetTranslationLanguage(i18nConfig, locale);
 }
@@ -246,17 +250,21 @@ export function getTranslationLanguage(locale: string): string {
  * duplicates (multiple root locales may share a translation language) while
  * preserving order.
  */
-export function toTranslationLanguages(locales: string[]): string[] {
+export function toTranslationLanguages(
+  locales: RootLocale[]
+): TranslationLanguage[] {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
   return sharedToTranslationLanguages(i18nConfig, locales);
 }
 
 /**
  * Expands a translation language (or root locale) to the root locales it
- * covers, e.g. `es-419` may return `['en_mx', 'en_co']`. Returns an
+ * covers, e.g. `es-419` may return `['es_mx', 'es_co']`. Returns an
  * empty array if the value doesn't match any locale in the root config.
  */
-export function getLocalesForTranslationLanguage(lang: string): string[] {
+export function getLocalesForTranslationLanguage(
+  lang: TranslationLanguage | RootLocale
+): RootLocale[] {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
   return sharedGetLocalesForTranslationLanguage(i18nConfig, lang);
 }
@@ -267,8 +275,8 @@ export function getLocalesForTranslationLanguage(lang: string): string[] {
  * share the language and returning the first non-empty value.
  */
 export function getTranslationForLanguage(
-  translations: Record<string, unknown>,
-  lang: string
+  translations: Record<RootLocale, unknown>,
+  lang: TranslationLanguage | RootLocale
 ): string {
   const i18nConfig = window.__ROOT_CTX.rootConfig.i18n || {};
   return sharedGetTranslationForLanguage(i18nConfig, translations, lang);
@@ -306,7 +314,7 @@ export async function batchSaveTranslations(
       const updates: Record<string, any> = {source: entry.source};
       for (const [locale, value] of Object.entries(entry.locales)) {
         // A key may be a root locale or a translation language shared by
-        // multiple root locales (e.g. `es-419` covering `en_mx`).
+        // multiple root locales (e.g. `es-419` covering `es_mx`).
         for (const normalized of getLocalesForTranslationLanguage(locale)) {
           updates[normalized] = normalizeString(value);
         }

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -101,7 +101,7 @@ export async function updateTranslationByHash(
       continue;
     }
     // A key may be a root locale or a translation language shared by multiple
-    // root locales (e.g. `es-419` covering `es-419_mx` and `es-419_co`).
+    // root locales (e.g. `es-419` covering `en_mx` and `en_co`).
     for (const locale of getLocalesForTranslationLanguage(key)) {
       updates[locale] = translations[key];
     }
@@ -233,7 +233,7 @@ export function normalizeLocale(locale: string) {
 
 /**
  * Returns the "translation language" for a root locale, as configured in
- * `i18n.translationLanguages` (e.g. `es-419` for the `es-419_mx` locale).
+ * `i18n.translationLanguages` (e.g. `es-419` for the `en_mx` locale).
  * Returns the locale itself if no mapping is configured.
  */
 export function getTranslationLanguage(locale: string): string {
@@ -253,7 +253,7 @@ export function toTranslationLanguages(locales: string[]): string[] {
 
 /**
  * Expands a translation language (or root locale) to the root locales it
- * covers, e.g. `es-419` may return `['es-419_mx', 'es-419_co']`. Returns an
+ * covers, e.g. `es-419` may return `['en_mx', 'en_co']`. Returns an
  * empty array if the value doesn't match any locale in the root config.
  */
 export function getLocalesForTranslationLanguage(lang: string): string[] {
@@ -306,7 +306,7 @@ export async function batchSaveTranslations(
       const updates: Record<string, any> = {source: entry.source};
       for (const [locale, value] of Object.entries(entry.locales)) {
         // A key may be a root locale or a translation language shared by
-        // multiple root locales (e.g. `es-419` covering `es-419_mx`).
+        // multiple root locales (e.g. `es-419` covering `en_mx`).
         for (const normalized of getLocalesForTranslationLanguage(locale)) {
           updates[normalized] = normalizeString(value);
         }

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -190,16 +190,19 @@ export interface RootI18nConfig {
    *
    * ```
    * i18n: {
-   *   locales: ['en', 'es-419_mx', 'es-419_co'],
+   *   locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
    *   translationLanguages: {
-   *     'es-419_mx': 'es-419',
-   *     'es-419_co': 'es-419',
+   *     en_mx: 'es-419',
+   *     en_co: 'es-419',
+   *     en_gb: 'en-GB',
+   *     en_ca: 'en-GB',
+   *     fr_ca: 'fr-CA',
    *   },
    * }
    * ```
    *
-   * With the config above, translations for the `es-419_mx` and `es-419_co`
-   * locales are imported and exported using a single `es-419` language. The
+   * With the config above, translations for the `en_mx` and `en_co` locales
+   * are imported and exported using a single `es-419` language. The
    * conversion applies anywhere translations are used, e.g. CSV and Google
    * Sheets import/export, translation services, and the CMS translations
    * pages. Locales not listed here use the locale id as the translation

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -157,19 +157,32 @@ export type RootConfig = RootUserConfig & {
 
 export interface LocaleGroup {
   label?: string;
-  locales: string[];
+  locales: RootLocale[];
 }
+
+/**
+ * A site-defined locale identifier, as configured in `i18n.locales`.
+ * Root is agnostic to its format.
+ */
+export type RootLocale = string;
+
+/**
+ * The language identifier used by translation systems (CSV/Sheets columns,
+ * translation services, CMS translations pages), mapped from a root locale
+ * via `i18n.translationLanguages`. Defaults to the root locale id.
+ */
+export type TranslationLanguage = string;
 
 export interface RootI18nConfig {
   /**
    * Locales enabled for the site.
    */
-  locales?: string[];
+  locales?: RootLocale[];
 
   /**
    * The default locale to use. Defaults is `en`.
    */
-  defaultLocale?: string;
+  defaultLocale?: RootLocale;
 
   /**
    * URL format for localized content. Default is `/[locale]/[base]/[path]`.
@@ -190,10 +203,10 @@ export interface RootI18nConfig {
    *
    * ```
    * i18n: {
-   *   locales: ['en', 'en_mx', 'en_co', 'en_gb', 'en_ca', 'fr_ca'],
+   *   locales: ['en', 'es_mx', 'es_co', 'en_gb', 'en_ca', 'fr_ca'],
    *   translationLanguages: {
-   *     en_mx: 'es-419',
-   *     en_co: 'es-419',
+   *     es_mx: 'es-419',
+   *     es_co: 'es-419',
    *     en_gb: 'en-GB',
    *     en_ca: 'en-GB',
    *     fr_ca: 'fr-CA',
@@ -201,14 +214,14 @@ export interface RootI18nConfig {
    * }
    * ```
    *
-   * With the config above, translations for the `en_mx` and `en_co` locales
+   * With the config above, translations for the `es_mx` and `es_co` locales
    * are imported and exported using a single `es-419` language. The
    * conversion applies anywhere translations are used, e.g. CSV and Google
    * Sheets import/export, translation services, and the CMS translations
    * pages. Locales not listed here use the locale id as the translation
    * language.
    */
-  translationLanguages?: Record<string, string>;
+  translationLanguages?: Record<RootLocale, TranslationLanguage>;
 }
 
 export interface RootBuildConfig {

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -181,6 +181,31 @@ export interface RootI18nConfig {
    * locales.
    */
   groups?: Record<string, LocaleGroup>;
+
+  /**
+   * Maps a root locale to the "translation language" used by translation
+   * systems. Translation systems often use different language identifiers
+   * than root locales, and multiple root locales may share the same
+   * translations. For example:
+   *
+   * ```
+   * i18n: {
+   *   locales: ['en', 'es-419_mx', 'es-419_co'],
+   *   translationLanguages: {
+   *     'es-419_mx': 'es-419',
+   *     'es-419_co': 'es-419',
+   *   },
+   * }
+   * ```
+   *
+   * With the config above, translations for the `es-419_mx` and `es-419_co`
+   * locales are imported and exported using a single `es-419` language. The
+   * conversion applies anywhere translations are used, e.g. CSV and Google
+   * Sheets import/export, translation services, and the CMS translations
+   * pages. Locales not listed here use the locale id as the translation
+   * language.
+   */
+  translationLanguages?: Record<string, string>;
 }
 
 export interface RootBuildConfig {


### PR DESCRIPTION
## Summary

This PR introduces a new `i18n.translationLanguages` configuration option that allows mapping root locales to translation language identifiers. This enables multiple root locales to share the same translations (e.g., `es-419_mx` and `es-419_co` both using `es-419` translations).

## Key Changes

- **New shared utilities** (`packages/root-cms/shared/translation-languages.ts`):
  - `getTranslationLanguage()` - converts a root locale to its translation language
  - `toTranslationLanguages()` - dedupes locales that share a translation language
  - `getLocalesForTranslationLanguage()` - expands a translation language to all matching root locales
  - `getTranslationForLanguage()` - reads translations from a map, checking all locales in a language group

- **UI layer wrappers** (`packages/root-cms/ui/utils/l10n.ts`):
  - Added wrapper functions that read the i18n config from `window.__ROOT_CTX`
  - Updated `updateTranslationByHash()` and `batchSaveTranslations()` to use `getLocalesForTranslationLanguage()` for expanding language columns to root locales

- **CMS components updated** to operate on translation languages instead of root locales:
  - `LocalizationModal` - shows translation language options, uses `getTranslationForLanguage()` to read values
  - `EditTranslationsModal` - re-keys translation rows from root locales to translation languages
  - `TranslationsTable` - displays translation language columns
  - `DocTranslationsPage` - filters and displays translation languages
  - `TranslationsEditPage` - edits keyed by translation language

- **Import/export logic** (`packages/root-cms/ui/utils/doc.ts`):
  - Updated `cmsDocImportTranslations()` to handle both root locale and translation language columns
  - Language columns fan out to all matching root locales, with direct locale columns taking precedence

- **Translation service context** (`packages/root-cms/core/translations.ts`):
  - Added `translationLanguages` field to `TranslationServiceContext`
  - Updated documentation to clarify that `TranslationRow.translations` keys are translation languages

- **Config schema** (`packages/root/src/core/config.ts`):
  - Added `translationLanguages?: Record<string, string>` to `RootI18nConfig`

- **Translation service plugins** updated to use `ctx.translationLanguages` when available (Crowdin, DeepL)

- **Test mocks** updated to support the new translation language utilities

## Implementation Details

- All matching is case-insensitive for locale/language identifiers
- When no mapping is configured, locale IDs are used as translation languages
- The conversion applies consistently across CSV/Google Sheets import/export, CMS UI, and translation service integrations
- Locales excluded from translations (e.g., `ALL_*` patterns) are properly filtered during import/export

Fixes #1216

https://claude.ai/code/session_01Wd2wVeaYVy66fF91KKgBeC