### PR TITLE
fix: opt SSE endpoint out of compression() buffering

### DIFF
--- a/packages/root-cms/core/sse.ts
+++ b/packages/root-cms/core/sse.ts
@@ -39,8 +39,13 @@ export function sse(server: Server) {
     // form would still receive non-auth-scoped events).
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
+      // `no-transform` opts out of the `compression()` middleware (used by
+      // `root start` / `root preview`), which would otherwise hold SSE chunks
+      // in a gzip/brotli window and never deliver them incrementally.
+      'Cache-Control': 'no-cache, no-transform',
       Connection: 'keep-alive',
+      // Disable buffering in nginx-style reverse proxies.
+      'X-Accel-Buffering': 'no',
     });
     sseClients.add(res);
     const connectedMessage = formatMessage<SSEConnectedEvent>(


### PR DESCRIPTION
## Summary

`/cms/api/sse.connect` only sent `Cache-Control: no-cache`, which the `compression()` middleware (registered first in `root start` / `root preview`) does not treat as an opt-out. Since `text/event-stream` is considered compressible and the response has no `Content-Length`, every SSE event was piped through a gzip/brotli window — and with nothing calling `res.flush()`, the `connected` event, heartbeats, and broadcasts sat in the compressor's buffer instead of reaching the client incrementally.

This adds `no-transform` to the `Cache-Control` header, which `compression@1.8.1` checks via `shouldTransform()` and skips the response entirely. Also adds `X-Accel-Buffering: no` for nginx-style reverse proxies, matching the approach already used by the streaming AI endpoints (`ai.chat` / `ai.edit_object`) via `pipeWebResponse()` in `packages/root-cms/core/api.ts`.

## Verification

- Confirmed against the installed `compression@1.8.1` source that the `no-transform` directive short-circuits compression at header-write time (`nocompress('no transform')`).
- Audited all other `ai.*` endpoints: the two streaming ones already opt out via `pipeWebResponse()`; the rest are one-shot JSON responses where compression is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)