### PR TITLE
fix: show AI alt text button when top-level ai config is set

### DIFF
--- a/.changeset/shaggy-badgers-switch.md
+++ b/.changeset/shaggy-badgers-switch.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: show AI alt text button when top-level ai config is set

--- a/packages/root-cms/ui/components/DocDiffViewer/DocDiffViewer.tsx
+++ b/packages/root-cms/ui/components/DocDiffViewer/DocDiffViewer.tsx
@@ -3,6 +3,7 @@ import './DocDiffViewer.css';
 import {Button, Loader} from '@mantine/core';
 import {IconCircleCheckFilled} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
+import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {CMSDoc, cmsReadDocVersion, unmarshalData} from '../../utils/doc.js';
 import {stableJsonStringify} from '../../utils/objects.js';
@@ -33,9 +34,8 @@ export function DocDiffViewer(props: DocDiffViewerProps) {
   const [leftDoc, setLeftDoc] = useState<CMSDoc | null>(null);
   const [rightDoc, setRightDoc] = useState<CMSDoc | null>(null);
 
-  const experiments = (window as any).__ROOT_CTX?.experiments || {};
   const showAiSummary =
-    experiments.ai &&
+    testAiEnabled() &&
     left.docId === right.docId &&
     props.showAiSummary !== false;
 

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -75,6 +75,7 @@ import {
   ClipboardData,
   useVirtualClipboard,
 } from '../../hooks/useVirtualClipboard.js';
+import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {debounce} from '../../utils/debounce.js';
 import {
@@ -287,9 +288,7 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
       return false;
     }
   });
-  const aiAvailable = !!(
-    window.__ROOT_CTX.ai || window.__ROOT_CTX.experiments?.ai
-  );
+  const aiAvailable = testAiEnabled();
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -1330,7 +1329,6 @@ DocEditor.ArrayField = (props: FieldProps) => {
   const [value, dispatch] = useReducer(arrayReducer, {_array: []});
   const deeplink = useDeeplink();
   const virtualClipboard = useVirtualClipboard();
-  const experiments = window.__ROOT_CTX.experiments || {};
 
   const data = value ?? {};
   const order = data._array || [];
@@ -1672,7 +1670,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
                       !!field.defaultOpen
                     }
                     isCut={cutIndex === i}
-                    aiEnabled={!!experiments.ai}
+                    aiEnabled={testAiEnabled()}
                     onFocusHeader={focusFieldHeader}
                     onHeaderKeyDown={handleKeyDown}
                     onMoveUp={moveUp}

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -45,6 +45,7 @@ import {useContext, useMemo, useRef, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
 import {useGapiClient} from '../../../hooks/useGapiClient.js';
+import {testAiEnabled} from '../../../utils/ai.js';
 import {
   buildAssetFieldValue,
   getAsset,
@@ -772,7 +773,7 @@ FileField.Preview = () => {
   const ctx = useFileField();
   const [dragging, setDragging] = useState(false);
   const [copied, setCopied] = useState(false);
-  const experiments = window.__ROOT_CTX.experiments || {};
+  const aiEnabled = testAiEnabled();
 
   // Videos and images are the only files that get the canvas preview.
   // Other types just show the info panel. Videos with zero dimensions
@@ -1189,7 +1190,7 @@ FileField.Preview = () => {
                 ctx?.setAltText(e.currentTarget.value);
               }}
             />
-            {experiments.ai &&
+            {aiEnabled &&
               !ctx.altText &&
               ctx.value?.src?.startsWith('http') && (
                 <Tooltip

--- a/packages/root-cms/ui/components/DocEditor/fields/GenerateImageForm.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/GenerateImageForm.tsx
@@ -12,6 +12,7 @@ import {
 import {showNotification} from '@mantine/notifications';
 import {IconSparkles} from '@tabler/icons-preact';
 import {useState} from 'preact/hooks';
+import {testAiImageGenerationEnabled} from '../../../utils/ai.js';
 import {UploadedFile} from '../../../utils/gcs.js';
 
 interface GenerateImageFormProps {
@@ -65,9 +66,7 @@ export function GenerateImageForm(props: GenerateImageFormProps) {
   const [height, setHeight] = useState(props.initialHeight || 900);
   const [aspectRatio, setAspectRatio] = useState<string>('16:9');
 
-  const experiments = (window as any).__ROOT_CTX?.experiments || {};
-
-  const aiEnabled = !!experiments.ai;
+  const aiEnabled = testAiImageGenerationEnabled();
 
   async function handleGenerate() {
     if (!prompt) {

--- a/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
+++ b/packages/root-cms/ui/components/EditTranslationsModal/EditTranslationsModal.tsx
@@ -20,6 +20,7 @@ import {ChangeEvent} from 'preact/compat';
 import {useEffect, useState} from 'preact/hooks';
 import {DraftDocContext} from '../../hooks/useDraftDoc.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {CsvTranslation, cmsDocImportTranslations} from '../../utils/doc.js';
 import {GoogleSheetId, getSpreadsheetUrl} from '../../utils/gsheets.js';
@@ -246,10 +247,7 @@ export function EditTranslationsModal(
   }
 
   function shouldShowAiButton() {
-    const experiments = (window as any).__ROOT_CTX?.experiments || {};
-    const aiEnabled = !!experiments.ai;
-
-    if (!aiEnabled) return false;
+    if (!testAiEnabled()) return false;
 
     // Check if any translation fields are blank.
     for (const source of strings) {

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -42,6 +42,7 @@ import {DraftDocController} from '../../hooks/useDraftDoc.js';
 import {GapiClient, useGapiClient} from '../../hooks/useGapiClient.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {logAction} from '../../utils/actions.js';
+import {testAiEnabled} from '../../utils/ai.js';
 import {
   CsvTranslation,
   cmsDocImportTranslations,
@@ -435,9 +436,7 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
   }
 
   function shouldShowAiButton() {
-    const experiments = (window as any).__ROOT_CTX?.experiments || {};
-    const aiEnabled = !!experiments.ai;
-    if (!aiEnabled || !selectedLocale) return false;
+    if (!testAiEnabled() || !selectedLocale) return false;
     // Show if any translations are missing for the selected locale.
     return sourceStrings.some((source) => {
       const pending = pendingEdits[source]?.[selectedLocale];

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -7,6 +7,7 @@ import {IconGitCompare, IconPackage, IconSparkles} from '@tabler/icons-preact';
 import {useState, useRef, useEffect} from 'preact/hooks';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
+import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocFromCacheOrFetch} from '../../utils/doc-cache.js';
 import {cmsPublishDoc, cmsScheduleDoc} from '../../utils/doc.js';
@@ -57,9 +58,7 @@ export function PublishDocModal(
   const dateTimeRef = useRef<HTMLInputElement>(null);
   const modals = useModals();
   const modalTheme = useModalTheme();
-  const aiAvailable = !!(
-    window.__ROOT_CTX.ai || window.__ROOT_CTX.experiments?.ai
-  );
+  const aiAvailable = testAiEnabled();
 
   const {roles, loading: rolesLoading} = useProjectRoles();
   const currentUserEmail = window.firebase.user.email || '';

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -25,6 +25,7 @@ import type {CMSBuiltInSidebarTool} from '../../core/plugin.js';
 import packageJson from '../../package.json' assert {type: 'json'};
 import {RootCMSLogo} from '../components/RootCMSLogo/RootCMSLogo.js';
 import {SearchBar} from '../components/SearchBar/SearchBar.js';
+import {testAiEnabled} from '../utils/ai.js';
 import {joinClassNames} from '../utils/classes.js';
 import './Layout.css';
 
@@ -194,7 +195,7 @@ Layout.Side = () => {
           </Layout.SideButton>
         )}
 
-        {(experiments.ai || window.__ROOT_CTX.ai) && !isBuiltInHidden('ai') && (
+        {testAiEnabled() && !isBuiltInHidden('ai') && (
           <Layout.SideButton
             label="Root AI"
             url="/cms/ai"

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -28,6 +28,7 @@ import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {useStringParam} from '../../hooks/useQueryParam.js';
 import {Layout} from '../../layout/Layout.js';
+import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocPreviewPath, getDocServingPath} from '../../utils/doc-urls.js';
 import {testCanEdit} from '../../utils/permissions.js';
@@ -151,9 +152,7 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
   const isSearchVisibleRef = useRef(isSearchVisible);
   isSearchVisibleRef.current = isSearchVisible;
 
-  const isAiConfigured = !!(
-    window.__ROOT_CTX.ai || window.__ROOT_CTX.experiments?.ai
-  );
+  const isAiConfigured = testAiEnabled();
   const [isAiVisible, setIsAiVisible] = useLocalStorage<boolean>(
     'root::DocumentPage::aiVisible',
     false

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -194,6 +194,7 @@ declare global {
       };
       ai?: {
         defaultModel?: string;
+        imageGenerationEnabled?: boolean;
         models: Array<{
           id: string;
           label: string;

--- a/packages/root-cms/ui/utils/ai.ts
+++ b/packages/root-cms/ui/utils/ai.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns whether AI features are enabled for the project. AI is enabled when
+ * chat models are configured via the `ai` plugin option, or via the legacy
+ * `experiments.ai` flag.
+ */
+export function testAiEnabled(): boolean {
+  return !!(window.__ROOT_CTX.ai || window.__ROOT_CTX.experiments?.ai);
+}
+
+/**
+ * Returns whether AI image generation is enabled for the project, i.e. one or
+ * more `imageModels` are configured on the `ai` plugin option (or the legacy
+ * `experiments.ai` flag is set).
+ */
+export function testAiImageGenerationEnabled(): boolean {
+  return !!(
+    window.__ROOT_CTX.ai?.imageGenerationEnabled ||
+    window.__ROOT_CTX.experiments?.ai
+  );
+}


### PR DESCRIPTION
## Summary

The "Generate alt text with AI" button on image fields stopped appearing after migrating project config from the deprecated `experiments.ai` flag to the top-level `ai` plugin option. The button (and several other AI feature gates in the UI) still checked only `experiments.ai`, while the server endpoints already use the new `ai` config.

## Changes

- Add `ui/utils/ai.ts` with a shared `testAiEnabled()` helper (true when the `ai` plugin config or legacy `experiments.ai` flag is set) and `testAiImageGenerationEnabled()` (keyed on `imageGenerationEnabled`, since image generation requires `imageModels`).
- Update all AI feature gates to use the helpers:
  - `FileField.tsx` — alt text generate button (the reported bug)
  - `GenerateImageForm.tsx` — AI placeholder image generation
  - `EditTranslationsModal.tsx` / `LocalizationModal.tsx` — AI translate buttons
  - `DocDiffViewer.tsx` — AI diff summary
  - `DocEditor.tsx` — array-item "Edit with AI" (removes a now-unused `experiments` local)
  - `Layout.tsx`, `PublishDocModal.tsx`, `DocumentPage.tsx` — replace inline checks for consistency
- Declare `imageGenerationEnabled` on the `__ROOT_CTX.ai` type in `ui.tsx` (already sent by `serializeAiConfig`).

## Testing

- UI bundle compiles cleanly with esbuild; `tsc` reports no new errors in touched files.
- `vitest run ui/components/EditTranslationsModal ui/utils/extract.test.ts` — 19/19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)