### PR TITLE
feat: add experimental Firestore streaming for buffered SSE responses

### DIFF
--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -17,16 +17,19 @@ import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
 import {RootConfig} from '@blinkk/root';
 import {
   convertToModelMessages,
+  createUIMessageStreamResponse,
   generateImage as generateImageSdk,
   generateText,
   ImageModel,
   LanguageModel,
+  readUIMessageStream,
   stepCountIs,
   streamText,
   ToolSet,
   UIMessage,
+  UIMessageChunk,
 } from 'ai';
-import {Timestamp} from 'firebase-admin/firestore';
+import {FieldValue, Timestamp} from 'firebase-admin/firestore';
 import {
   CmsToolContext,
   createCmsTools,
@@ -122,6 +125,13 @@ interface ChatRecord {
   modelId?: string;
   title?: string;
   messages: UIMessage[];
+  /**
+   * Experimental (`AiFirestoreStream`): snapshot of the in-progress assistant
+   * message while a response is streaming, mirrored here so clients behind
+   * SSE-buffering proxies can render it via `onSnapshot`. Deleted when the
+   * stream ends — `messages` remains the source of truth.
+   */
+  streamingMessage?: UIMessage;
 }
 
 /** Resolves an `AiModelConfig` to an AI SDK `LanguageModel` instance. */
@@ -388,6 +398,16 @@ export class ChatStore {
       updates.title = options.title;
     }
     await this.collection().doc(id).update(updates);
+  }
+
+  async setStreamingMessage(id: string, message: UIMessage): Promise<void> {
+    await this.collection().doc(id).update({streamingMessage: message});
+  }
+
+  async clearStreamingMessage(id: string): Promise<void> {
+    await this.collection()
+      .doc(id)
+      .update({streamingMessage: FieldValue.delete()});
   }
 }
 
@@ -705,6 +725,14 @@ export interface RunChatStreamOptions {
   loadCollection: (collectionId: string) => Promise<Collection | null>;
   /** Loads every project collection keyed by id. */
   loadAllCollections: () => Promise<Record<string, Collection>>;
+  /**
+   * Experimental (`AiFirestoreStream`): also mirrors the in-progress
+   * assistant message to the chat's Firestore doc (throttled) so clients
+   * behind SSE-buffering proxies (Firebase Hosting rewrites, App Engine
+   * standard) can render the stream via `onSnapshot` instead of waiting for
+   * the buffered HTTP response.
+   */
+  mirrorStreamToFirestore?: boolean;
 }
 
 /**
@@ -914,10 +942,10 @@ export async function runChatStream(
     stopWhen: stepCountIs(config.maxSteps ?? 10),
   });
 
-  return result.toUIMessageStreamResponse({
+  const streamOptions = {
     sendReasoning: model.capabilities?.reasoning ?? false,
     originalMessages: sanitizedMessages,
-    onFinish: async ({messages: finalMessages}) => {
+    onFinish: async ({messages: finalMessages}: {messages: UIMessage[]}) => {
       const store = new ChatStore(cmsClient, user);
       // Generate a title only on the first assistant response. Once a chat
       // has a saved title we keep it stable so follow-up messages do not
@@ -942,7 +970,79 @@ export async function runChatStream(
         console.error('failed to persist chat history:', err);
       }
     },
+  };
+  if (!options.mirrorStreamToFirestore) {
+    return result.toUIMessageStreamResponse(streamOptions);
+  }
+  // Tee the UI message stream: one branch becomes the HTTP response (which
+  // may be buffered by upstream proxies), the other is mirrored to Firestore
+  // so the client can render incremental output via `onSnapshot`.
+  const [responseStream, mirrorStream] = result
+    .toUIMessageStream(streamOptions)
+    .tee();
+  const lastMessage = sanitizedMessages.at(-1);
+  void mirrorStreamingMessageToFirestore({
+    stream: mirrorStream,
+    store: new ChatStore(cmsClient, user),
+    chatId,
+    // Tool-result resubmits continue the previous assistant message (same
+    // id), so seed the reader with it to keep snapshots complete.
+    resumeMessage:
+      lastMessage?.role === 'assistant'
+        ? (structuredClone(lastMessage) as UIMessage)
+        : undefined,
   });
+  return createUIMessageStreamResponse({stream: responseStream});
+}
+
+/**
+ * Minimum interval between Firestore writes while mirroring a streaming
+ * response. Firestore sustains ~1 write/sec per document; intermediate
+ * snapshots are complete message states, so skipped ones are never missed.
+ */
+const STREAMING_MESSAGE_WRITE_INTERVAL_MS = 500;
+
+/**
+ * Consumes a UI message stream and periodically writes the assembled
+ * in-progress assistant message to the chat doc's `streamingMessage` field
+ * (see `RunChatStreamOptions.mirrorStreamToFirestore`). The field is deleted
+ * when the stream ends; `onFinish` persists the final messages separately.
+ * Mirroring is best-effort — failures are logged, never surfaced to the
+ * HTTP response branch.
+ */
+async function mirrorStreamingMessageToFirestore(options: {
+  stream: ReadableStream<UIMessageChunk>;
+  store: ChatStore;
+  chatId: string;
+  resumeMessage?: UIMessage;
+}) {
+  const {stream, store, chatId, resumeMessage} = options;
+  let lastWriteAt = 0;
+  try {
+    const messageStates = readUIMessageStream({
+      stream,
+      message: resumeMessage,
+      onError: (err) => {
+        console.error('[root-cms ai] stream mirror error:', err);
+      },
+    });
+    for await (const message of messageStates) {
+      const now = Date.now();
+      if (now - lastWriteAt < STREAMING_MESSAGE_WRITE_INTERVAL_MS) {
+        continue;
+      }
+      lastWriteAt = now;
+      await store.setStreamingMessage(chatId, stripUndefined(message));
+    }
+  } catch (err) {
+    console.error('[root-cms ai] failed to mirror stream to firestore:', err);
+  } finally {
+    try {
+      await store.clearStreamingMessage(chatId);
+    } catch (err) {
+      console.error('[root-cms ai] failed to clear streaming message:', err);
+    }
+  }
 }
 
 export interface RunEditObjectStreamOptions {

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -825,6 +825,11 @@ export function api(server: Server, options: ApiOptions) {
       typeof body.docId === 'string' && body.docId.trim()
         ? body.docId.trim()
         : undefined;
+    // Experimental (`AiFirestoreStream`): opted into per-request by clients
+    // running with `?e=AiFirestoreStream`. Mirrors in-progress output to the
+    // chat's Firestore doc so the stream renders incrementally even when an
+    // upstream proxy buffers the SSE response (see `pipeWebResponse` notes).
+    const mirrorStreamToFirestore = body.experiments?.firestoreStream === true;
 
     const cmsClient = new RootCMSClient(req.rootConfig!);
     // Require the user to have an assigned role on this project. Write tools
@@ -922,6 +927,7 @@ export function api(server: Server, options: ApiOptions) {
         executionMode,
         existingTitle,
         activeDocId,
+        mirrorStreamToFirestore,
         loadCollection: (collectionId) =>
           getCollectionSchema(req, collectionId),
         loadAllCollections: async () =>

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -36,6 +36,7 @@ import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
+import {doc, onSnapshot} from 'firebase/firestore';
 import {marked} from 'marked';
 import type {ComponentChildren} from 'preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
@@ -43,6 +44,7 @@ import {useLocation} from 'preact-iso';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {stableJsonStringify} from '../../utils/objects.js';
+import {testHasExperimentParam} from '../../utils/url-params.js';
 import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
 import {JsDiff} from '../JsDiff/JsDiff.js';
 import {Markdown} from '../Markdown/Markdown.js';
@@ -211,6 +213,15 @@ interface ToolApprovalControls {
 }
 
 const NEW_CHAT_ID = '';
+
+/**
+ * Experiment (`?e=AiFirestoreStream`): some hosting setups buffer SSE
+ * responses and deliver the whole AI reply at once (Firebase Hosting
+ * rewrites, App Engine standard). When enabled, the server mirrors the
+ * in-progress assistant message to the chat's Firestore doc and the client
+ * renders it via `onSnapshot` while the HTTP response is held upstream.
+ */
+const EXPERIMENT_FIRESTORE_STREAM = testHasExperimentParam('AiFirestoreStream');
 
 export function RootAIChat(props: RootAIChatProps) {
   const [config, setConfig] = useState<AiConfigResponse | null>(null);
@@ -836,6 +847,9 @@ function ChatPane(props: {
             modelId: modelRef.current,
             executionMode: executionModeRef.current,
             docId: docContextRef.current?.docId,
+            ...(EXPERIMENT_FIRESTORE_STREAM
+              ? {experiments: {firestoreStream: true}}
+              : undefined),
           },
         }),
       }),
@@ -866,10 +880,62 @@ function ChatPane(props: {
 
   const isStreaming = status === 'streaming' || status === 'submitted';
 
+  // Experiment (`AiFirestoreStream`): while a response is in flight, watch
+  // the chat doc's `streamingMessage` field and overlay it on the transcript
+  // so output renders incrementally even when the SSE response is buffered
+  // upstream. The overlay is dropped once `useChat` receives the real
+  // response and `status` leaves the streaming state.
+  const [streamingOverlay, setStreamingOverlay] = useState<UIMessage | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!EXPERIMENT_FIRESTORE_STREAM || !isStreaming) {
+      setStreamingOverlay(null);
+      return;
+    }
+    const projectId = window.__ROOT_CTX.rootConfig.projectId;
+    const chatDocRef = doc(
+      window.firebase.db,
+      'Projects',
+      projectId,
+      'AiChats',
+      effectiveChatId
+    );
+    return onSnapshot(chatDocRef, (snapshot) => {
+      const message = snapshot.data()?.streamingMessage as
+        | UIMessage
+        | undefined;
+      // The server deletes the field when the stream ends; keep the last
+      // snapshot so the text doesn't flicker away before the buffered HTTP
+      // response arrives.
+      if (message?.id) {
+        setStreamingOverlay(message);
+      }
+    });
+  }, [isStreaming, effectiveChatId]);
+
+  const displayMessages = useMemo(() => {
+    if (!streamingOverlay || !isStreaming) {
+      return messages;
+    }
+    // Tool-result resubmits continue the previous assistant message under
+    // the same id; the overlay snapshot is seeded from the persisted message
+    // on the server, so it supersedes the local copy. Otherwise the overlay
+    // is a brand new assistant turn — append it.
+    const index = messages.findIndex((m) => m.id === streamingOverlay.id);
+    if (index === -1) {
+      return [...messages, streamingOverlay];
+    }
+    const merged = messages.slice();
+    merged[index] = streamingOverlay;
+    return merged;
+  }, [messages, streamingOverlay, isStreaming]);
+
   return (
     <>
       <ChatTranscript
-        messages={messages}
+        messages={displayMessages}
         isStreaming={isStreaming}
         emptyMessage={!props.model ? 'Select a model to start.' : undefined}
         toolApprovals={{


### PR DESCRIPTION
## Summary
Adds experimental support for mirroring in-progress AI chat responses to Firestore, enabling incremental rendering on clients behind SSE-buffering proxies (Firebase Hosting rewrites, App Engine standard). When enabled, the server writes streaming message updates to the chat document, and the client renders them via `onSnapshot` while waiting for the buffered HTTP response.

## Key Changes

- **Server-side streaming mirror** (`core/ai.ts`):
  - Added `mirrorStreamToFirestore` option to `RunChatStreamOptions`
  - Implemented `mirrorStreamingMessageToFirestore()` function that consumes the UI message stream and periodically writes the in-progress assistant message to Firestore (throttled to 500ms intervals)
  - Added `setStreamingMessage()` and `clearStreamingMessage()` methods to `ChatStore` for managing the temporary `streamingMessage` field
  - Updated `ChatRecord` interface to include optional `streamingMessage` field with documentation
  - Modified `runChatStream()` to tee the message stream when mirroring is enabled, routing one branch to the HTTP response and the other to Firestore

- **Client-side rendering** (`ui/components/RootAIChat/RootAIChat.tsx`):
  - Added `EXPERIMENT_FIRESTORE_STREAM` flag controlled by `?e=AiFirestoreStream` URL parameter
  - Implemented `useEffect` hook to watch the chat document's `streamingMessage` field via `onSnapshot` when streaming is active
  - Added `displayMessages` computed state that merges the streaming overlay with local messages, handling both new assistant turns and tool-result continuations
  - Passes experiment flag to the chat request body

- **API integration** (`core/api.ts`):
  - Extracts `experiments.firestoreStream` flag from request body
  - Passes `mirrorStreamToFirestore` to `runChatStream()`

## Implementation Details

- The `streamingMessage` field is temporary and deleted when the stream ends; `messages` remains the source of truth for persisted chat history
- Firestore writes are throttled to 500ms intervals to respect document write limits (~1 write/sec)
- Tool-result resubmits continue the previous assistant message under the same ID; the server seeds the mirror reader with the persisted message to keep snapshots complete
- Mirroring failures are logged but never surfaced to the HTTP response, ensuring graceful degradation
- The streaming overlay is dropped once the buffered HTTP response arrives and `useChat` updates the local state

https://claude.ai/code/session_01TirYGxDUTcBkkP2h29NKVp