### PR TITLE
feat: add --log flag to root build with progress indicator

### DIFF
--- a/.changeset/build-log-progress.md
+++ b/.changeset/build-log-progress.md
@@ -1,17 +1,5 @@
 ---
-'@blinkk/root': minor
+'@blinkk/root': patch
 ---
 
 feat: add `--log` flag to `root build` with progress indicator
-
-`root build` now shows a progress indicator by default instead of printing
-one line per output file. In interactive terminals this is a live progress
-bar (count, %, bytes written, elapsed, ETA); in non-interactive environments
-(e.g. CI) a progress line is printed at ~10% milestones, keeping logs to a
-handful of lines instead of one per page. A final summary lists the total
-page count, output size, build time, and the largest pages.
-
-- `--log progress` (default): progress indicator + summary.
-- `--log verbose`: one line per output file (previous behavior).
-- `--log quiet` (or the global `-q`): only the final summary; vite output is
-  reduced to warnings and errors.

--- a/.changeset/build-log-progress.md
+++ b/.changeset/build-log-progress.md
@@ -1,0 +1,17 @@
+---
+'@blinkk/root': minor
+---
+
+feat: add `--log` flag to `root build` with progress indicator
+
+`root build` now shows a progress indicator by default instead of printing
+one line per output file. In interactive terminals this is a live progress
+bar (count, %, bytes written, elapsed, ETA); in non-interactive environments
+(e.g. CI) a progress line is printed at ~10% milestones, keeping logs to a
+handful of lines instead of one per page. A final summary lists the total
+page count, output size, build time, and the largest pages.
+
+- `--log progress` (default): progress indicator + summary.
+- `--log verbose`: one line per output file (previous behavior).
+- `--log quiet` (or the global `-q`): only the final summary; vite output is
+  reduced to warnings and errors.

--- a/packages/root/src/cli/build-progress.test.ts
+++ b/packages/root/src/cli/build-progress.test.ts
@@ -1,0 +1,211 @@
+import {assert, test} from 'vitest';
+
+import {
+  BuildProgress,
+  formatBytes,
+  formatDuration,
+  parseBuildLogMode,
+} from './build-progress.js';
+
+/** Strips ANSI escape codes for assertions. */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+}
+
+class FakeStream {
+  isTTY: boolean;
+  chunks: string[] = [];
+
+  constructor(options?: {isTTY?: boolean}) {
+    this.isTTY = options?.isTTY ?? false;
+  }
+
+  write(str: string) {
+    this.chunks.push(str);
+    return true;
+  }
+
+  output(): string {
+    return stripAnsi(this.chunks.join(''));
+  }
+
+  lines(): string[] {
+    return this.output()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+  }
+}
+
+/** Fake clock, advanced manually by tests. */
+function fakeClock(startMs = 0) {
+  let now = startMs;
+  return {
+    now: () => now,
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+test('parseBuildLogMode accepts valid modes and defaults to progress', () => {
+  assert.equal(parseBuildLogMode(undefined), 'progress');
+  assert.equal(parseBuildLogMode(''), 'progress');
+  assert.equal(parseBuildLogMode('progress'), 'progress');
+  assert.equal(parseBuildLogMode('verbose'), 'verbose');
+  assert.equal(parseBuildLogMode('quiet'), 'quiet');
+  assert.throws(() => parseBuildLogMode('loud'), /invalid --log value/);
+});
+
+test('formatBytes formats sizes', () => {
+  assert.equal(formatBytes(174), '0.17 kB');
+  assert.equal(formatBytes(563056), '549.86 kB');
+  assert.equal(formatBytes(5 * 1024 * 1024), '5 MB');
+});
+
+test('formatDuration formats durations', () => {
+  assert.equal(formatDuration(45_200), '45.2s');
+  assert.equal(formatDuration(151_000), '2m31s');
+});
+
+test('verbose mode prints one line per file', () => {
+  const stream = new FakeStream();
+  const progress = new BuildProgress({
+    total: 2,
+    mode: 'verbose',
+    outputDirLabel: 'dist/html/',
+    stream,
+    now: fakeClock().now,
+  });
+  progress.add('index.html', 563056);
+  progress.add('about/index.html', 174);
+  progress.finish();
+  const lines = stream.lines();
+  assert.equal(lines.length, 3);
+  assert.match(lines[0], /549\.86 kB\s+dist\/html\/index\.html/);
+  assert.match(lines[1], /0\.17 kB\s+dist\/html\/about\/index\.html/);
+  assert.match(lines[2], /✓ 2 pages \(550\.03 kB\) in 0\.0s/);
+});
+
+test('progress mode in non-TTY prints milestone lines, not per-file lines', () => {
+  const stream = new FakeStream({isTTY: false});
+  const clock = fakeClock();
+  const progress = new BuildProgress({
+    total: 1000,
+    mode: 'progress',
+    stream,
+    now: clock.now,
+    intervalMs: 0,
+  });
+  for (let i = 0; i < 1000; i++) {
+    clock.advance(10);
+    progress.add(`page-${i}/index.html`, 1024);
+  }
+  progress.finish();
+  const lines = stream.lines();
+  // ~9 milestone lines (10%..90%) + summary + "largest pages:" + top 5.
+  assert.isBelow(lines.length, 20);
+  assert.match(lines[0], /100\/1000 pages \(10%\)/);
+  const summary = lines.find((line) => line.includes('✓'));
+  assert.isDefined(summary);
+  assert.match(summary!, /1000 pages \(1000 kB\) in 10\.0s/);
+});
+
+test('progress mode non-TTY throttles milestone lines by interval', () => {
+  const stream = new FakeStream({isTTY: false});
+  const clock = fakeClock();
+  const progress = new BuildProgress({
+    total: 100,
+    mode: 'progress',
+    stream,
+    now: clock.now,
+    intervalMs: 5000,
+  });
+  // All pages complete instantly; only milestones spaced >= 5s apart print.
+  for (let i = 0; i < 100; i++) {
+    progress.add(`page-${i}/index.html`, 1024);
+  }
+  progress.finish();
+  const milestoneLines = stream
+    .lines()
+    .filter((line) => line.includes('pages (') && !line.includes('✓'));
+  assert.equal(milestoneLines.length, 0);
+});
+
+test('progress mode lists largest pages in summary', () => {
+  const stream = new FakeStream({isTTY: false});
+  const progress = new BuildProgress({
+    total: 3,
+    mode: 'progress',
+    outputDirLabel: 'dist/html/',
+    stream,
+    now: fakeClock().now,
+    summaryTopN: 2,
+  });
+  progress.add('small/index.html', 100);
+  progress.add('large/index.html', 300000);
+  progress.add('medium/index.html', 2000);
+  progress.finish();
+  const output = stream.output();
+  const largeIdx = output.indexOf('large/index.html');
+  const mediumIdx = output.indexOf('medium/index.html');
+  assert.isAbove(largeIdx, -1);
+  assert.isAbove(mediumIdx, largeIdx);
+  assert.notInclude(output, 'small/index.html');
+});
+
+test('progress mode in TTY renders in-place and clears before summary', () => {
+  const stream = new FakeStream({isTTY: true});
+  const clock = fakeClock();
+  const progress = new BuildProgress({
+    total: 10,
+    mode: 'progress',
+    stream,
+    now: clock.now,
+    intervalMs: 0,
+  });
+  for (let i = 0; i < 10; i++) {
+    clock.advance(100);
+    progress.add(`page-${i}/index.html`, 1024);
+  }
+  const rawBeforeFinish = stream.chunks.join('');
+  assert.include(rawBeforeFinish, '\r');
+  progress.finish();
+  // Summary appears on its own line, with progress bar frames cleared.
+  const lines = stream.lines();
+  const summary = lines.find((line) => line.includes('✓'));
+  assert.isDefined(summary);
+  assert.match(summary!, /10 pages \(10 kB\) in 1\.0s/);
+});
+
+test('quiet mode prints only the summary', () => {
+  const stream = new FakeStream({isTTY: false});
+  const progress = new BuildProgress({
+    total: 50,
+    mode: 'quiet',
+    stream,
+    now: fakeClock().now,
+  });
+  for (let i = 0; i < 50; i++) {
+    progress.add(`page-${i}/index.html`, 2048);
+  }
+  progress.finish();
+  const lines = stream.lines();
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /✓ 50 pages \(100 kB\) in 0\.0s/);
+});
+
+test('abort suppresses the summary and clears the progress line', () => {
+  const stream = new FakeStream({isTTY: true});
+  const progress = new BuildProgress({
+    total: 10,
+    mode: 'progress',
+    stream,
+    now: fakeClock().now,
+    intervalMs: 0,
+  });
+  progress.add('page/index.html', 1024);
+  progress.abort();
+  progress.finish();
+  assert.notInclude(stream.output(), '✓');
+});

--- a/packages/root/src/cli/build-progress.ts
+++ b/packages/root/src/cli/build-progress.ts
@@ -1,0 +1,234 @@
+import {cyan, dim, green} from 'kleur/colors';
+
+/**
+ * Log output modes for `root build`:
+ *
+ * - `progress` (default): shows a progress indicator while pages render. In
+ *   interactive terminals this is a live single-line progress bar; in
+ *   non-interactive environments (e.g. CI) a progress line is printed at
+ *   ~10% intervals. A short summary (with the largest output files) is
+ *   printed at the end.
+ * - `verbose`: prints one line per output file (legacy behavior).
+ * - `quiet`: prints only the final summary line.
+ */
+export type BuildLogMode = 'progress' | 'verbose' | 'quiet';
+
+export function parseBuildLogMode(value: unknown): BuildLogMode {
+  if (value === undefined || value === null || value === '') {
+    return 'progress';
+  }
+  if (value === 'progress' || value === 'verbose' || value === 'quiet') {
+    return value;
+  }
+  throw new Error(
+    `invalid --log value: "${value}" (expected "progress", "verbose", or "quiet")`
+  );
+}
+
+/** Formats a byte count for display, e.g. `549.86 kB`. */
+export function formatBytes(bytes: number): string {
+  const k = 1024;
+  if (bytes < k) {
+    return (bytes / k).toFixed(2) + ' kB';
+  }
+  const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + units[i];
+}
+
+/** Formats a duration in ms for display, e.g. `45.2s` or `2m31s`. */
+export function formatDuration(ms: number): string {
+  const secs = ms / 1000;
+  if (secs < 60) {
+    return `${secs.toFixed(1)}s`;
+  }
+  const mins = Math.floor(secs / 60);
+  const rem = Math.round(secs - mins * 60);
+  return `${mins}m${String(rem).padStart(2, '0')}s`;
+}
+
+interface WritableStreamLike {
+  write(str: string): unknown;
+  isTTY?: boolean;
+}
+
+export interface BuildProgressOptions {
+  /** Total number of files expected. */
+  total: number;
+  /** Log output mode. */
+  mode: BuildLogMode;
+  /** Label for items in progress lines. Defaults to "pages". */
+  itemLabel?: string;
+  /** Path prefix shown before file paths, e.g. `dist/html/`. */
+  outputDirLabel?: string;
+  /** Output stream. Defaults to `process.stdout`. */
+  stream?: WritableStreamLike;
+  /** Clock function (injectable for tests). Defaults to `Date.now`. */
+  now?: () => number;
+  /**
+   * Minimum interval between progress updates, in ms. Defaults to 80ms for
+   * interactive terminals and 5000ms otherwise.
+   */
+  intervalMs?: number;
+  /** Number of largest files to list in the summary. Defaults to 5. */
+  summaryTopN?: number;
+}
+
+const BAR_WIDTH = 20;
+
+/**
+ * Reports progress for build output files.
+ *
+ * Tracks completed files and bytes written, and renders progress according
+ * to the configured `BuildLogMode`. Designed to keep CI logs readable: a
+ * 10,000-page build emits ~10 progress lines instead of 10,000.
+ */
+export class BuildProgress {
+  private readonly total: number;
+  private readonly mode: BuildLogMode;
+  private readonly itemLabel: string;
+  private readonly outputDirLabel: string;
+  private readonly stream: WritableStreamLike;
+  private readonly now: () => number;
+  private readonly intervalMs: number;
+  private readonly summaryTopN: number;
+  private readonly isTTY: boolean;
+  private readonly startedAt: number;
+
+  private completed = 0;
+  private totalBytes = 0;
+  private files: Array<{path: string; size: number}> = [];
+  private lastPrintAt = 0;
+  private lastMilestone = 0;
+  private ttyLineActive = false;
+  private done = false;
+
+  constructor(options: BuildProgressOptions) {
+    this.total = options.total;
+    this.mode = options.mode;
+    this.itemLabel = options.itemLabel ?? 'pages';
+    this.outputDirLabel = options.outputDirLabel ?? '';
+    this.stream = options.stream ?? process.stdout;
+    this.now = options.now ?? Date.now;
+    this.isTTY = !!this.stream.isTTY;
+    this.intervalMs = options.intervalMs ?? (this.isTTY ? 80 : 5000);
+    this.summaryTopN = options.summaryTopN ?? 5;
+    this.startedAt = this.now();
+  }
+
+  /** Records a completed output file. */
+  add(outputFile: string, sizeBytes: number) {
+    this.completed += 1;
+    this.totalBytes += sizeBytes;
+    this.files.push({path: outputFile, size: sizeBytes});
+    if (this.mode === 'verbose') {
+      const paddedSize = formatBytes(sizeBytes).padStart(9, ' ');
+      this.println(
+        `  ${dim(paddedSize)}  ${dim(this.outputDirLabel)}${cyan(outputFile)}`
+      );
+      return;
+    }
+    if (this.mode === 'progress') {
+      this.maybePrintProgress();
+    }
+  }
+
+  /** Clears any in-place progress line (call before printing errors). */
+  abort() {
+    this.clearTtyLine();
+    this.done = true;
+  }
+
+  /** Prints the final summary. */
+  finish() {
+    if (this.done) {
+      return;
+    }
+    this.done = true;
+    this.clearTtyLine();
+    const elapsed = formatDuration(this.now() - this.startedAt);
+    const summary = `${this.completed} ${this.itemLabel} (${formatBytes(
+      this.totalBytes
+    )}) in ${elapsed}`;
+    this.println(`  ${green('✓')} ${summary}`);
+    if (this.mode === 'progress' && this.summaryTopN > 0) {
+      const largest = [...this.files]
+        .sort((a, b) => b.size - a.size)
+        .slice(0, this.summaryTopN);
+      if (largest.length > 0) {
+        this.println(`  ${dim(`largest ${this.itemLabel}:`)}`);
+        for (const file of largest) {
+          const paddedSize = formatBytes(file.size).padStart(9, ' ');
+          this.println(
+            `  ${dim(paddedSize)}  ${dim(this.outputDirLabel)}${cyan(
+              file.path
+            )}`
+          );
+        }
+      }
+    }
+  }
+
+  private maybePrintProgress() {
+    const now = this.now();
+    if (this.isTTY) {
+      // Live single-line progress bar, throttled to avoid excessive redraws.
+      // The final state is always rendered by `finish()`.
+      if (now - this.lastPrintAt < this.intervalMs) {
+        return;
+      }
+      this.lastPrintAt = now;
+      this.renderTtyLine(now);
+      return;
+    }
+    // Non-interactive (e.g. CI): print a progress line at each ~10%
+    // milestone, throttled to at most one line per interval. The 100%
+    // state is reported by `finish()`.
+    const milestone = Math.floor((this.completed / this.total) * 10);
+    if (milestone <= this.lastMilestone || this.completed === this.total) {
+      return;
+    }
+    if (now - this.lastPrintAt < this.intervalMs) {
+      return;
+    }
+    this.lastMilestone = milestone;
+    this.lastPrintAt = now;
+    const pct = Math.floor((this.completed / this.total) * 100);
+    this.println(
+      `  ${this.completed}/${this.total} ${this.itemLabel} (${pct}%) · ${formatBytes(this.totalBytes)} · ${formatDuration(now - this.startedAt)}${this.eta(now)}`
+    );
+  }
+
+  private renderTtyLine(now: number) {
+    const ratio = this.total > 0 ? this.completed / this.total : 0;
+    const filled = Math.round(ratio * BAR_WIDTH);
+    const bar = '▕' + '█'.repeat(filled) + '░'.repeat(BAR_WIDTH - filled) + '▏';
+    const pct = String(Math.floor(ratio * 100)).padStart(3, ' ');
+    const line = `  ${bar} ${pct}% · ${this.completed}/${this.total} ${this.itemLabel} · ${formatBytes(this.totalBytes)} · ${formatDuration(now - this.startedAt)}${this.eta(now)}`;
+    this.stream.write(`\r\x1b[2K${line}`);
+    this.ttyLineActive = true;
+  }
+
+  /** Returns an " · eta 12.3s" suffix once enough progress exists to estimate. */
+  private eta(now: number): string {
+    if (this.completed < 10 || this.completed / this.total < 0.05) {
+      return '';
+    }
+    const elapsed = now - this.startedAt;
+    const remaining =
+      (elapsed / this.completed) * (this.total - this.completed);
+    return ` · eta ${formatDuration(remaining)}`;
+  }
+
+  private clearTtyLine() {
+    if (this.ttyLineActive) {
+      this.stream.write('\r\x1b[2K');
+      this.ttyLineActive = false;
+    }
+  }
+
+  private println(line: string) {
+    this.clearTtyLine();
+    this.stream.write(line + '\n');
+  }
+}

--- a/packages/root/src/cli/build-worker-pool.ts
+++ b/packages/root/src/cli/build-worker-pool.ts
@@ -128,10 +128,32 @@ class BuildWorker {
     });
   }
 
+  /**
+   * Rejects all in-flight tasks after a worker-level failure (fatal error,
+   * crash, or non-zero exit — e.g. an OOM kill).
+   *
+   * Each task is rejected with its own `BuildPageError` so the build log
+   * names every page that was in flight when the worker died. Without this,
+   * worker deaths surface as a single generic error with no route context,
+   * making OOM crashes impossible to trace back to pages. Note the in-flight
+   * pages are the OOM *suspects*, not necessarily the cause (memory pressure
+   * is cumulative), which is why the message says "while rendering".
+   */
   private failAll(err: Error) {
     const pendingTasks = Array.from(this.inFlight.values());
     this.inFlight.clear();
-    pendingTasks.forEach((pending) => pending.reject(err));
+    pendingTasks.forEach((pending) =>
+      pending.reject(
+        new BuildPageError(
+          pending.task.urlPath,
+          pending.task.params,
+          pending.task.routeSrc,
+          `worker thread died while rendering this page (` +
+            `${pendingTasks.length} page(s) were in flight): ` +
+            String(err.message || err)
+        )
+      )
+    );
   }
 
   /** Pulls tasks off the pool's queue until at max concurrency. */

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -29,6 +29,12 @@ import {
   writeFile,
 } from '../utils/fsutils.js';
 import {buildPage, BuildPageResult} from './build-page.js';
+import {
+  BuildLogMode,
+  BuildProgress,
+  formatBytes,
+  parseBuildLogMode,
+} from './build-progress.js';
 import {BuildPageError, BuildWorkerPool} from './build-worker-pool.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -46,22 +52,36 @@ export interface BuildOptions {
    * automatically based on CPU cores and the number of pages to build.
    */
   threads?: string | boolean;
+  /**
+   * Build log output mode: "progress" (default) shows a progress indicator
+   * and a final summary, "verbose" prints one line per output file, and
+   * "quiet" prints only the final summary.
+   */
+  log?: string;
+  /** Global `-q, --quiet` flag; equivalent to `log: 'quiet'`. */
+  quiet?: boolean;
 }
+
+/** Active log mode for the current build. */
+let activeLogMode: BuildLogMode = 'progress';
 
 export async function build(rootProjectDir?: string, options?: BuildOptions) {
   const mode = options?.mode || 'production';
   process.env.NODE_ENV = mode;
+  activeLogMode = options?.quiet ? 'quiet' : parseBuildLogMode(options?.log);
 
   const rootDir = path.resolve(rootProjectDir || process.cwd());
   const rootConfig = await loadRootConfig(rootDir, {command: 'build'});
   const distDir = path.join(rootDir, 'dist');
   const ssrOnly = options?.ssrOnly || false;
 
-  console.log();
-  console.log(`${dim('┃')} project:  ${rootDir}`);
-  console.log(`${dim('┃')} output:   ${distDir}/html`);
-  console.log(`${dim('┃')} mode:     ${mode}`);
-  console.log();
+  if (activeLogMode !== 'quiet') {
+    console.log();
+    console.log(`${dim('┃')} project:  ${rootDir}`);
+    console.log(`${dim('┃')} output:   ${distDir}/html`);
+    console.log(`${dim('┃')} mode:     ${mode}`);
+    console.log();
+  }
 
   await rmDir(distDir);
   await makeDir(distDir);
@@ -129,6 +149,8 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
     root: rootDir,
     mode: mode,
     plugins: vitePlugins,
+    // In quiet mode, only surface vite warnings and errors.
+    logLevel: activeLogMode === 'quiet' ? 'warn' : viteConfig.logLevel,
   };
 
   // Bundle the render.js file with vite along with any plugins `ssrInput()`
@@ -364,7 +386,9 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
 
   // Copy files from `dist/client/{assets,chunks}` to `dist/html` using the
   // root manifest. Ignore route files.
-  console.log('\njs/css output:');
+  if (activeLogMode !== 'quiet') {
+    console.log('\njs/css output:');
+  }
   await Promise.all(
     Object.keys(rootManifest).map(async (src) => {
       const assetData = rootManifest[src];
@@ -470,10 +494,9 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
       if (!result.staticContent) {
         addSitemapXmlItem(result.urlPath, sitemapItem, result.outFilePath);
       }
-      printFileOutput(
-        fileSize(path.join(buildDir, result.outFilePath)),
-        'dist/html/',
-        result.outFilePath
+      progress.add(
+        result.outFilePath,
+        fileSizeBytes(path.join(buildDir, result.outFilePath))
       );
     };
 
@@ -489,80 +512,96 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
       return true;
     });
 
-    console.log('\nhtml output:');
+    if (activeLogMode !== 'quiet') {
+      console.log('\nhtml output:');
+    }
     const concurrency = Number(options?.concurrency || 10);
     const numThreads = resolveNumThreads(
       options?.threads,
       sitemapEntries.length
     );
+    const progress = new BuildProgress({
+      total: sitemapEntries.length,
+      mode: activeLogMode,
+      itemLabel: 'pages',
+      outputDirLabel: 'dist/html/',
+    });
 
-    if (numThreads > 0) {
-      // Render pages in parallel using worker threads. Each worker loads the
-      // server bundle (dist/server/render.js) and renders pages
-      // independently.
-      const pool = new BuildWorkerPool({
-        numWorkers: numThreads,
-        workerConcurrency: Math.max(Math.ceil(concurrency / numThreads), 1),
-        rootDir,
-        mode,
-      });
-      try {
-        await pool.ready();
-        await Promise.all(
-          sitemapEntries.map(async ([urlPath, sitemapItem]) => {
+    try {
+      if (numThreads > 0) {
+        // Render pages in parallel using worker threads. Each worker loads the
+        // server bundle (dist/server/render.js) and renders pages
+        // independently.
+        const pool = new BuildWorkerPool({
+          numWorkers: numThreads,
+          workerConcurrency: Math.max(Math.ceil(concurrency / numThreads), 1),
+          rootDir,
+          mode,
+        });
+        try {
+          await pool.ready();
+          await Promise.all(
+            sitemapEntries.map(async ([urlPath, sitemapItem]) => {
+              try {
+                const result = await pool.run({
+                  urlPath,
+                  params: sitemapItem.params,
+                  routeSrc: sitemapItem.route.src,
+                  locale: sitemapItem.locale,
+                });
+                onPageResult(sitemapItem, result);
+              } catch (e) {
+                if (e instanceof BuildPageError) {
+                  progress.abort();
+                  logBuildError(
+                    {
+                      route: sitemapItem.route,
+                      params: sitemapItem.params,
+                      urlPath,
+                    },
+                    new Error(e.workerError)
+                  );
+                }
+                throw e;
+              }
+            })
+          );
+        } finally {
+          await pool.terminate();
+        }
+      } else {
+        await batchAsyncCalls(
+          sitemapEntries,
+          concurrency,
+          async ([urlPath, sitemapItem]) => {
             try {
-              const result = await pool.run({
-                urlPath,
-                params: sitemapItem.params,
-                routeSrc: sitemapItem.route.src,
-                locale: sitemapItem.locale,
-              });
+              const result = await buildPage(
+                renderer,
+                rootConfig,
+                buildDir,
+                sitemapItem.route,
+                {urlPath, params: sitemapItem.params}
+              );
               onPageResult(sitemapItem, result);
             } catch (e) {
-              if (e instanceof BuildPageError) {
-                logBuildError(
-                  {
-                    route: sitemapItem.route,
-                    params: sitemapItem.params,
-                    urlPath,
-                  },
-                  new Error(e.workerError)
-                );
-              }
-              throw e;
+              progress.abort();
+              logBuildError(
+                {route: sitemapItem.route, params: sitemapItem.params, urlPath},
+                e
+              );
+              throw new Error(
+                `BuildError: ${urlPath} (${sitemapItem.route.src}) failed to build.`,
+                {cause: e}
+              );
             }
-          })
-        );
-      } finally {
-        await pool.terminate();
-      }
-    } else {
-      await batchAsyncCalls(
-        sitemapEntries,
-        concurrency,
-        async ([urlPath, sitemapItem]) => {
-          try {
-            const result = await buildPage(
-              renderer,
-              rootConfig,
-              buildDir,
-              sitemapItem.route,
-              {urlPath, params: sitemapItem.params}
-            );
-            onPageResult(sitemapItem, result);
-          } catch (e) {
-            logBuildError(
-              {route: sitemapItem.route, params: sitemapItem.params, urlPath},
-              e
-            );
-            throw new Error(
-              `BuildError: ${urlPath} (${sitemapItem.route.src}) failed to build.`,
-              {cause: e}
-            );
           }
-        }
-      );
+        );
+      }
+    } catch (e) {
+      progress.abort();
+      throw e;
     }
+    progress.finish();
 
     // Generate sitemap.xml.
     if (rootConfig.sitemap) {
@@ -670,17 +709,12 @@ function resolveNumThreads(
   return num;
 }
 
-function fileSize(filepath: string) {
-  const stats = fsExtra.statSync(filepath);
-  const bytes = stats.size;
+function fileSizeBytes(filepath: string): number {
+  return fsExtra.statSync(filepath).size;
+}
 
-  const k = 1024;
-  if (bytes < k) {
-    return (bytes / k).toFixed(2) + ' kB';
-  }
-  const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + units[i];
+function fileSize(filepath: string) {
+  return formatBytes(fileSizeBytes(filepath));
 }
 
 function printFileOutput(
@@ -688,6 +722,9 @@ function printFileOutput(
   outputDir: string,
   outputFile: string
 ) {
+  if (activeLogMode === 'quiet') {
+    return;
+  }
   const indent = ' '.repeat(2);
   const paddedSize = fileSize.padStart(9, ' ');
   console.log(

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -516,10 +516,24 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
       console.log('\nhtml output:');
     }
     const concurrency = Number(options?.concurrency || 10);
-    const numThreads = resolveNumThreads(
+    const resolvedThreads = resolveNumThreads(
       options?.threads,
       sitemapEntries.length
     );
+    const numThreads = resolvedThreads.count;
+    const workerConcurrency =
+      numThreads > 0 ? Math.max(Math.ceil(concurrency / numThreads), 1) : 0;
+    // Log the render parallelism (helps troubleshoot what `--threads=auto`
+    // resolved to, e.g. when investigating OOM issues on CI builders).
+    if (activeLogMode !== 'quiet') {
+      const threadsDesc =
+        numThreads > 0
+          ? `${numThreads} workers x ${workerConcurrency} pages/worker`
+          : `in-process, ${concurrency} concurrent pages`;
+      console.log(
+        `  ${dim(`threads: ${threadsDesc} (${resolvedThreads.source})`)}`
+      );
+    }
     const progress = new BuildProgress({
       total: sitemapEntries.length,
       mode: activeLogMode,
@@ -534,7 +548,7 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
         // independently.
         const pool = new BuildWorkerPool({
           numWorkers: numThreads,
-          workerConcurrency: Math.max(Math.ceil(concurrency / numThreads), 1),
+          workerConcurrency,
           rootDir,
           mode,
         });
@@ -665,9 +679,17 @@ const MIN_PAGES_PER_THREAD = 10;
  */
 const MEMORY_PER_THREAD = 1024 * 1024 * 1024; // 1GB
 
+/** Result of resolving the `--threads` flag. */
+interface ResolvedThreads {
+  /** Number of worker threads to use (0 = in-process build). */
+  count: number;
+  /** Human-readable description of how the count was determined. */
+  source: string;
+}
+
 /**
- * Resolves the `--threads` flag to a worker count. Returns 0 for an
- * in-process (single-threaded) build.
+ * Resolves the `--threads` flag to a worker count. Returns a count of 0 for
+ * an in-process (single-threaded) build.
  *
  * - unset: 0 (in-process build).
  * - `--threads` or `--threads auto`: picks a worker count based on the
@@ -681,9 +703,9 @@ const MEMORY_PER_THREAD = 1024 * 1024 * 1024; // 1GB
 function resolveNumThreads(
   threads: string | boolean | undefined,
   numPages: number
-): number {
+): ResolvedThreads {
   if (threads === undefined || threads === false) {
-    return 0;
+    return {count: 0, source: '--threads not set'};
   }
   if (threads === true || threads === 'auto') {
     const maxByCpu = Math.max(os.availableParallelism() - 1, 1);
@@ -694,19 +716,21 @@ function resolveNumThreads(
       1
     );
     const numThreads = Math.min(maxByCpu, maxByPages, maxByMemory);
+    // Surface each limit so it's clear which one is binding, e.g.
+    // "auto = min(cpu 31, pages 212, memory 14)".
+    const source = `auto = min(cpu ${maxByCpu}, pages ${maxByPages}, memory ${maxByMemory})`;
     // A single worker is never faster than rendering in-process (same
     // parallelism, plus startup and messaging overhead).
     if (numThreads <= 1) {
-      return 0;
+      return {count: 0, source};
     }
-    console.log(`rendering with ${numThreads} worker threads`);
-    return numThreads;
+    return {count: numThreads, source};
   }
   const num = parseInt(threads);
   if (isNaN(num) || num < 0) {
     throw new Error(`invalid --threads value: ${threads}`);
   }
-  return num;
+  return {count: num, source: `--threads=${num}`};
 }
 
 function fileSizeBytes(filepath: string): number {

--- a/packages/root/src/cli/cli.ts
+++ b/packages/root/src/cli/cli.ts
@@ -1,4 +1,4 @@
-import {Command, InvalidArgumentError} from 'commander';
+import {Command, InvalidArgumentError, Option} from 'commander';
 import {bgGreen, black} from 'kleur/colors';
 import {build, BuildOptions} from './build.js';
 import {codegen} from './codegen.js';
@@ -52,7 +52,15 @@ class CliRunner {
         'builds the url paths that match the given regex, e.g. "/products/.*"',
         ''
       )
-      .action(build);
+      .addOption(
+        new Option(
+          '--log <mode>',
+          'build log output: "progress" (default) shows a progress indicator and a final summary, "verbose" prints one line per output file, "quiet" prints only the final summary'
+        ).choices(['progress', 'verbose', 'quiet'])
+      )
+      .action((rootProjectDir, options, cmd) =>
+        build(rootProjectDir, cmd.optsWithGlobals())
+      );
     program
       .command('codegen [type] [name]')
       .description('generates boilerplate code')


### PR DESCRIPTION
## Summary

Large SSG builds currently emit one log line per rendered page — a 10k-page site produces 10k+ lines, which bloats CI logs (and log streaming isn't free). This PR replaces the per-file lines with an adaptive progress indicator while keeping the useful information.

### Modes (`root build --log <mode>`)

- **`progress`** (default)
  - Interactive terminals: live single-line progress bar — page count, %, bytes written, elapsed, ETA.
  - Non-interactive (CI): one progress line per ~10% milestone, throttled to ≥5s apart (~10 lines total).
  - Both: final summary with page count, total output size, build time, and the **largest pages** (preserves the main diagnostic value of the old per-file output).
- **`verbose`**: previous behavior — one line per output file.
- **`quiet`** (or global `-q`): only the final summary; vite output reduced to warnings/errors.

### Example output (CI, progress mode)

```
html output:
  213/2126 pages (10%) · 71.2 MB · 5.1s · eta 45.8s
  428/2126 pages (20%) · 142.9 MB · 10.3s · eta 40.9s
  ...
  ✓ 2126 pages (716.4 MB) in 51.2s
  largest pages:
  549.86 kB  dist/html/index.html
  532.96 kB  dist/html/contact/index.html
  ...
```

### Implementation notes

- New `BuildProgress` reporter in `src/cli/build-progress.ts` (injectable clock/stream, unit tested — 10 tests).
- `--log` validated via commander `choices()`.
- On build errors, the in-place progress line is cleared before the error prints, and the summary is suppressed.
- `js/css output` section unchanged (small); hidden in quiet mode.
- The progress line is rendered with `\r` rewrite only when the stream is a TTY, so piped/CI output never contains control characters.

## Test plan

- `pnpm test` in `packages/root` (33 files, 179 tests) ✅
- e2e against `examples/starter`: default/verbose/quiet modes + invalid value handling ✅
- Verified non-TTY output contains no ANSI rewrite sequences ✅
