### PR TITLE
feat: add unsaved changes warning to settings page

### DIFF
--- a/packages/root-cms/ui/hooks/useUnsavedChangesWarning.ts
+++ b/packages/root-cms/ui/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,23 @@
+import {useEffect} from 'preact/hooks';
+import {registerNavigationGuard} from '../utils/navigation-guard.js';
+
+const CONFIRMATION_MESSAGE =
+  'You have unsaved changes. Are you sure you want to leave this page?';
+
+/**
+ * Warns the user before navigating away from the page when there are unsaved
+ * changes. Handles full page unloads (refresh, tab close, external links) as
+ * well as SPA navigations (internal link clicks and the browser back/forward
+ * buttons) via the global navigation guards installed in ui.tsx.
+ */
+export function useUnsavedChangesWarning(dirty: boolean) {
+  useEffect(() => {
+    if (!dirty) {
+      return;
+    }
+    return registerNavigationGuard({
+      message: CONFIRMATION_MESSAGE,
+      url: window.location.href,
+    });
+  }, [dirty]);
+}

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import './SettingsPage.css';
 import {Button, LoadingOverlay, Switch, Textarea} from '@mantine/core';
 import {showNotification} from '@mantine/notifications';
+import {IconCheck} from '@tabler/icons-preact';
 import {doc, getDoc, setDoc, updateDoc} from 'firebase/firestore';
 import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
@@ -13,6 +14,7 @@ import {useSearchIndexStatus} from '../../hooks/useGlobalSearch.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {SITE_SETTINGS, useSiteSettings} from '../../hooks/useSiteSettings.js';
+import {useUnsavedChangesWarning} from '../../hooks/useUnsavedChangesWarning.js';
 import {useUserPreferences} from '../../hooks/useUserPreferences.js';
 import {Layout} from '../../layout/Layout.js';
 import {logAction} from '../../utils/actions.js';
@@ -264,8 +266,10 @@ function ShareSection() {
       // derived `roles` field. Seed `globalRoles` from it so the admin sees the
       // same list; users that exist only via collection-scoped groups will be
       // dropped from the global section on the next save.
-      const globalRoles = (data.globalRoles ||
-        rolesField) as Record<string, UserRole>;
+      const globalRoles = (data.globalRoles || rolesField) as Record<
+        string,
+        UserRole
+      >;
       const initial: ShareDoc = {
         globalRoles,
         permissionGroups: (data.permissionGroups || []) as PermissionGroup[],
@@ -282,6 +286,7 @@ function ShareSection() {
 
   const currentUserIsAdmin = isCurrentUserAdmin(savedRoles);
   const dirty = !shareDocsEqual(savedState, draft);
+  useUnsavedChangesWarning(dirty);
 
   function setRoles(globalRoles: Record<string, UserRole>) {
     setDraft((prev) => ({...prev, globalRoles}));
@@ -438,7 +443,8 @@ function ShareSection() {
               <Button
                 size="xs"
                 radius={0}
-                color="dark"
+                color={dirty ? 'green' : 'dark'}
+                leftIcon={<IconCheck size={14} />}
                 loading={saving}
                 disabled={!dirty || !currentUserIsAdmin}
                 onClick={save}

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -42,6 +42,7 @@ import {SiteSettingsProvider} from './hooks/useSiteSettings.js';
 import {SSEProvider} from './hooks/useSSE.js';
 import {UserPreferencesProvider} from './hooks/useUserPreferences.js';
 import {lazyRoute} from './utils/lazy-route.js';
+import {installNavigationGuards} from './utils/navigation-guard.js';
 
 const AIPage = lazyRoute(() =>
   import('./pages/AIPage/AIPage.js').then((m) => m.AIPage)
@@ -410,6 +411,10 @@ function registerDevServerRedirectShortcut() {
 }
 
 registerDevServerRedirectShortcut();
+
+// Install the unsaved-changes navigation guards before the app renders so
+// the guard listeners run ahead of preact-iso's click/popstate listeners.
+installNavigationGuards();
 
 const root = document.getElementById('root')!;
 

--- a/packages/root-cms/ui/utils/navigation-guard.ts
+++ b/packages/root-cms/ui/utils/navigation-guard.ts
@@ -1,0 +1,124 @@
+/**
+ * Global navigation guards used to warn users before leaving a page with
+ * unsaved changes.
+ *
+ * preact-iso's `<LocationProvider>` performs SPA navigations by listening to
+ * `click` and `popstate` events on `window`. For `popstate` (back/forward
+ * button) the event target is `window` itself, so capture/bubble phases don't
+ * apply and listeners run in registration order. To run *before* the router,
+ * `installNavigationGuards()` must be called at app bootstrap, before the
+ * `<LocationProvider>` mounts (see ui.tsx).
+ */
+
+export interface NavigationGuard {
+  /** Confirmation message shown to the user. */
+  message: string;
+  /** URL to restore when the user cancels a back/forward navigation. */
+  url: string;
+}
+
+const guards = new Set<NavigationGuard>();
+let installed = false;
+
+function activeGuard(): NavigationGuard | undefined {
+  return guards.values().next().value;
+}
+
+/** Warns on full page unloads (refresh, tab close, external links). */
+function onBeforeUnload(e: BeforeUnloadEvent) {
+  if (!activeGuard()) {
+    return;
+  }
+  e.preventDefault();
+  // Required by some browsers to show the confirmation dialog.
+  e.returnValue = '';
+}
+
+/**
+ * Warns on SPA navigations triggered by internal link clicks. Registered in
+ * the capture phase so it runs before preact-iso's bubble-phase listener.
+ * Mirrors the router's own link detection so only clicks that would actually
+ * navigate trigger the warning.
+ */
+function onClickCapture(e: MouseEvent) {
+  const guard = activeGuard();
+  if (!guard) {
+    return;
+  }
+  if (
+    e.defaultPrevented ||
+    e.ctrlKey ||
+    e.metaKey ||
+    e.altKey ||
+    e.shiftKey ||
+    e.button !== 0
+  ) {
+    return;
+  }
+  const link = e
+    .composedPath()
+    .find(
+      (el): el is HTMLAnchorElement =>
+        el instanceof HTMLAnchorElement && !!el.href
+    );
+  if (
+    !link ||
+    (link.getAttribute('href') || '').startsWith('#') ||
+    link.download
+  ) {
+    return;
+  }
+  // Links that open in a new tab or go to an external origin trigger a full
+  // page unload (or no unload at all), which is handled by `beforeunload`.
+  if (
+    link.origin !== window.location.origin ||
+    !/^(_?self)?$/i.test(link.target)
+  ) {
+    return;
+  }
+  if (!window.confirm(guard.message)) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+  }
+}
+
+/**
+ * Warns on back/forward navigations. `popstate` fires *after* the history
+ * entry has already changed, so the navigation can't be prevented outright.
+ * Instead, when the user cancels, the guarded URL is pushed back onto the
+ * history stack and the event is stopped before preact-iso's listener
+ * re-renders the route.
+ */
+function onPopState(e: PopStateEvent) {
+  const guard = activeGuard();
+  if (!guard) {
+    return;
+  }
+  if (window.confirm(guard.message)) {
+    return;
+  }
+  e.stopImmediatePropagation();
+  window.history.pushState(null, '', guard.url);
+}
+
+/**
+ * Installs the global guard listeners. Must be called before the preact-iso
+ * `<LocationProvider>` mounts so the `popstate` listener runs first.
+ */
+export function installNavigationGuards() {
+  if (installed) {
+    return;
+  }
+  installed = true;
+  window.addEventListener('beforeunload', onBeforeUnload);
+  window.addEventListener('click', onClickCapture, {capture: true});
+  window.addEventListener('popstate', onPopState);
+}
+
+/**
+ * Registers a navigation guard. Returns a function that removes the guard.
+ */
+export function registerNavigationGuard(guard: NavigationGuard): () => void {
+  guards.add(guard);
+  return () => guards.delete(guard);
+}


### PR DESCRIPTION
## Background

We received a report from a user who edited the sharing settings on the Settings page and navigated away without clicking "Save changes". Since the page gave no indication that their edits were still pending, they assumed their changes had been saved — and later concluded the data had been lost when it never actually persisted. The edits were simply discarded on navigation without any warning.

## Changes

Two UX improvements to the Settings page share section to make the unsaved-changes state more obvious and harder to lose:

### 1. Green "Save changes" button when there are pending edits

The "Save changes" button now matches the green checkmark save buttons used elsewhere in the CMS (e.g. the AI edit modal and localization save bar). When the form is dirty, the button turns green with an `IconCheck` icon; otherwise it remains in its disabled state.

### 2. Warning when navigating away with unsaved changes

Added a reusable navigation guard system that warns before leaving a page with pending edits:

- **`ui/utils/navigation-guard.ts`** — a global guard registry with three listeners:
  - `beforeunload` for full page unloads (refresh, tab close, external links) — shows the browser's native confirmation.
  - Capture-phase `click` listener for internal SPA link navigations — runs ahead of preact-iso's bubble-phase router listener and cancels navigation if the user declines the confirm dialog.
  - `popstate` for browser back/forward — since the event fires *after* the history entry changes, declining restores the guarded URL via `pushState` and stops the event before the router re-renders, keeping in-progress edits intact.
- **`ui/hooks/useUnsavedChangesWarning.ts`** — a small hook that registers/unregisters a guard whenever the `dirty` flag changes.
- **`ui.tsx`** — installs the guard listeners at app bootstrap, *before* `<LocationProvider>` mounts. This ordering is required for the `popstate` guard: `popstate` targets `window` directly, so capture phase has no effect and listener registration order determines who runs first.

The hook is wired up to the share section's existing `dirty` flag, and can be reused by any other page that needs the same behavior.

## Screenshot

<img width="644" height="539" alt="image" src="https://github.com/user-attachments/assets/75ca71f8-2a71-4034-a412-98a8c72fcad0" />
