### PR TITLE
chore: replace preact-iso lazy with custom hook-based route loading

### DIFF
--- a/packages/root-cms/ui/components/RouteLoading/RouteLoading.css
+++ b/packages/root-cms/ui/components/RouteLoading/RouteLoading.css
@@ -1,0 +1,18 @@
+.RouteLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 100vh;
+  opacity: 0;
+  animation: RouteLoading-fade-in 150ms ease 150ms forwards;
+}
+
+@keyframes RouteLoading-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/packages/root-cms/ui/components/RouteLoading/RouteLoading.css
+++ b/packages/root-cms/ui/components/RouteLoading/RouteLoading.css
@@ -3,7 +3,19 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
+}
+
+/* When rendered within the app frame, the `.Layout__main > *:first-child`
+   rule sizes the element to the content area (below the topbar, beside the
+   sidebar), which uses the standard page background. */
+.RouteLoading--framed {
+  background: var(--page-background);
+}
+
+/* Fade the spinner in after a short delay so it doesn't flash when the
+   import resolves quickly. */
+.RouteLoading > * {
   opacity: 0;
   animation: RouteLoading-fade-in 150ms ease 150ms forwards;
 }

--- a/packages/root-cms/ui/components/RouteLoading/RouteLoading.tsx
+++ b/packages/root-cms/ui/components/RouteLoading/RouteLoading.tsx
@@ -1,0 +1,14 @@
+import {Loader} from '@mantine/core';
+import './RouteLoading.css';
+
+/**
+ * Loading screen rendered while the js for a route is being fetched. Fades in
+ * after a short delay so it doesn't flash when the import resolves quickly.
+ */
+export function RouteLoading() {
+  return (
+    <div className="RouteLoading">
+      <Loader color="gray" size="xl" />
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/RouteLoading/RouteLoading.tsx
+++ b/packages/root-cms/ui/components/RouteLoading/RouteLoading.tsx
@@ -1,14 +1,35 @@
 import {Loader} from '@mantine/core';
+import {Layout} from '../../layout/Layout.js';
+import {joinClassNames} from '../../utils/classes.js';
 import './RouteLoading.css';
 
+export interface RouteLoadingProps {
+  /**
+   * Whether to render within the app frame (topbar, sidebar). Disable for
+   * routes that render outside the frame, e.g. the embedded pages.
+   */
+  frame?: boolean;
+}
+
 /**
- * Loading screen rendered while the js for a route is being fetched. Fades in
- * after a short delay so it doesn't flash when the import resolves quickly.
+ * Loading screen rendered while the js for a route is being fetched. The
+ * spinner fades in after a short delay so it doesn't flash when the import
+ * resolves quickly.
  */
-export function RouteLoading() {
-  return (
-    <div className="RouteLoading">
+export function RouteLoading(props: RouteLoadingProps) {
+  const frame = props.frame ?? true;
+  const loader = (
+    <div
+      className={joinClassNames(
+        'RouteLoading',
+        frame && 'RouteLoading--framed'
+      )}
+    >
       <Loader color="gray" size="xl" />
     </div>
   );
+  if (!frame) {
+    return loader;
+  }
+  return <Layout>{loader}</Layout>;
 }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -79,15 +79,19 @@ const EditDataSourcePage = lazyRoute(() =>
     (m) => m.EditDataSourcePage
   )
 );
-const EmbeddedAIPage = lazyRoute(() =>
-  import('./pages/EmbeddedAIPage/EmbeddedAIPage.js').then(
-    (m) => m.EmbeddedAIPage
-  )
+const EmbeddedAIPage = lazyRoute(
+  () =>
+    import('./pages/EmbeddedAIPage/EmbeddedAIPage.js').then(
+      (m) => m.EmbeddedAIPage
+    ),
+  {frame: false}
 );
-const EmbeddedDocumentPage = lazyRoute(() =>
-  import('./pages/EmbeddedDocumentPage/EmbeddedDocumentPage.js').then(
-    (m) => m.EmbeddedDocumentPage
-  )
+const EmbeddedDocumentPage = lazyRoute(
+  () =>
+    import('./pages/EmbeddedDocumentPage/EmbeddedDocumentPage.js').then(
+      (m) => m.EmbeddedDocumentPage
+    ),
+  {frame: false}
 );
 const EditReleasePage = lazyRoute(() =>
   import('./pages/EditReleasePage/EditReleasePage.js').then(

--- a/packages/root-cms/ui/utils/lazy-route.test.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.test.tsx
@@ -1,6 +1,11 @@
 import {render} from '@testing-library/preact';
+import {FunctionComponent} from 'preact';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
-import {ROUTE_IMPORT_RELOAD_KEY, importRouteComponent} from './lazy-route.js';
+import {
+  ROUTE_IMPORT_RELOAD_KEY,
+  importRouteComponent,
+  lazyRoute,
+} from './lazy-route.js';
 
 vi.mock('@mantine/core', async () => {
   const actual: any = await vi.importActual('@mantine/core');
@@ -9,6 +14,7 @@ vi.mock('@mantine/core', async () => {
     Button: ({children, onClick}: any) => (
       <button onClick={onClick}>{children}</button>
     ),
+    Loader: () => <div>loading...</div>,
   };
 });
 
@@ -74,5 +80,53 @@ describe('importRouteComponent', () => {
     const result = render(<ErrorComponent />);
     expect(result.getByText('Page failed to load')).toBeTruthy();
     expect(result.getByText('fetch failed')).toBeTruthy();
+  });
+});
+
+describe('lazyRoute', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  test('shows a loading indicator until the import resolves', async () => {
+    let resolveImport!: (component: FunctionComponent) => void;
+    const factory = vi.fn(
+      () =>
+        new Promise<FunctionComponent>((resolve) => {
+          resolveImport = resolve;
+        })
+    );
+    const LazyComponent = lazyRoute(factory);
+    const result = render(<LazyComponent />);
+    expect(result.container.querySelector('.RouteLoading')).toBeTruthy();
+    resolveImport(TestComponent);
+    await result.findByText('test page');
+    expect(result.container.querySelector('.RouteLoading')).toBeFalsy();
+  });
+
+  test('renders immediately once the import has resolved', async () => {
+    const factory = vi.fn().mockResolvedValue(TestComponent);
+    const LazyComponent = lazyRoute(factory);
+    const first = render(<LazyComponent />);
+    await first.findByText('test page');
+    first.unmount();
+
+    const second = render(<LazyComponent />);
+    expect(second.container.querySelector('.RouteLoading')).toBeFalsy();
+    expect(second.container.textContent).toContain('test page');
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders the error screen when the import fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.sessionStorage.setItem(ROUTE_IMPORT_RELOAD_KEY, String(Date.now()));
+    const factory = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const reload = vi.fn();
+    const LazyComponent = lazyRoute(factory, {retryDelayMs: 0, reload});
+    const result = render(<LazyComponent />);
+    expect(result.container.querySelector('.RouteLoading')).toBeTruthy();
+    await result.findByText('Page failed to load');
+    expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/packages/root-cms/ui/utils/lazy-route.test.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.test.tsx
@@ -18,6 +18,14 @@ vi.mock('@mantine/core', async () => {
   };
 });
 
+// The app frame requires the router location context and the global firebase
+// objects, which aren't available in tests.
+vi.mock('../layout/Layout.js', () => {
+  return {
+    Layout: ({children}: any) => <div className="Layout">{children}</div>,
+  };
+});
+
 function TestComponent() {
   return <div>test page</div>;
 }
@@ -99,10 +107,21 @@ describe('lazyRoute', () => {
     );
     const LazyComponent = lazyRoute(factory);
     const result = render(<LazyComponent />);
-    expect(result.container.querySelector('.RouteLoading')).toBeTruthy();
+    // The loading screen renders within the app frame by default.
+    expect(
+      result.container.querySelector('.Layout .RouteLoading')
+    ).toBeTruthy();
     resolveImport(TestComponent);
     await result.findByText('test page');
     expect(result.container.querySelector('.RouteLoading')).toBeFalsy();
+  });
+
+  test('shows a frameless loading indicator for frameless routes', () => {
+    const factory = vi.fn(() => new Promise<FunctionComponent>(() => {}));
+    const LazyComponent = lazyRoute(factory, {frame: false});
+    const result = render(<LazyComponent />);
+    expect(result.container.querySelector('.RouteLoading')).toBeTruthy();
+    expect(result.container.querySelector('.Layout')).toBeFalsy();
   });
 
   test('renders immediately once the import has resolved', async () => {

--- a/packages/root-cms/ui/utils/lazy-route.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.tsx
@@ -1,6 +1,7 @@
 import {FunctionComponent} from 'preact';
-import {lazy} from 'preact-iso';
+import {useEffect, useState} from 'preact/hooks';
 import {RouteLoadError} from '../components/RouteLoadError/RouteLoadError.js';
+import {RouteLoading} from '../components/RouteLoading/RouteLoading.js';
 
 /** Number of times to attempt a route import before giving up. */
 const ROUTE_IMPORT_ATTEMPTS = 3;
@@ -64,9 +65,8 @@ function reloadOnRouteImportError(reload: () => void): boolean {
  * reloaded to fetch the latest version of the CMS. If a reload was already
  * attempted recently, resolves to a `RouteLoadError` screen instead.
  *
- * NOTE: The returned promise never rejects. preact-iso treats a promise
- * thrown during render as a suspension and only listens for it to resolve, so
- * a rejected import would otherwise leave the router suspended forever.
+ * NOTE: The returned promise never rejects; failures resolve to a component
+ * that renders the error screen, so callers can render the result directly.
  */
 export async function importRouteComponent<P>(
   factory: () => Promise<FunctionComponent<P>>,
@@ -95,11 +95,51 @@ export async function importRouteComponent<P>(
   return () => <RouteLoadError error={lastError} />;
 }
 
-/** Lazy-loads a named component export for use as a route component. */
+/**
+ * Lazy-loads a named component export for use as a route component. While the
+ * import is pending a loading screen is rendered, and once it resolves the
+ * component is cached so subsequent navigations to the route render
+ * immediately without a loading state.
+ */
 export function lazyRoute<P>(
-  factory: () => Promise<FunctionComponent<P>>
+  factory: () => Promise<FunctionComponent<P>>,
+  options?: ImportRouteComponentOptions
 ): FunctionComponent<P> {
-  return lazy(() =>
-    importRouteComponent(factory).then((component) => ({default: component}))
-  ) as unknown as FunctionComponent<P>;
+  let component: FunctionComponent<P> | null = null;
+  let promise: Promise<void> | null = null;
+
+  function load(): Promise<void> {
+    if (!promise) {
+      promise = importRouteComponent(factory, options).then((c) => {
+        component = c;
+      });
+    }
+    return promise;
+  }
+
+  return function LazyRoute(props: P) {
+    const [, setLoaded] = useState(component !== null);
+    useEffect(() => {
+      if (component) {
+        return;
+      }
+      let cancelled = false;
+      load().then(() => {
+        if (!cancelled) {
+          setLoaded(true);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, []);
+    if (!component) {
+      // Start the import during render (rather than waiting for the effect)
+      // so the chunk request goes out as early as possible.
+      load();
+      return <RouteLoading />;
+    }
+    const Component = component;
+    return <Component {...(props as any)} />;
+  };
 }

--- a/packages/root-cms/ui/utils/lazy-route.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.tsx
@@ -27,6 +27,15 @@ export interface ImportRouteComponentOptions {
   reload?: () => void;
 }
 
+export interface LazyRouteOptions extends ImportRouteComponentOptions {
+  /**
+   * Whether the loading screen renders within the app frame (topbar,
+   * sidebar). Defaults to true. Disable for routes that render outside the
+   * frame, e.g. the embedded pages.
+   */
+  frame?: boolean;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -103,7 +112,7 @@ export async function importRouteComponent<P>(
  */
 export function lazyRoute<P>(
   factory: () => Promise<FunctionComponent<P>>,
-  options?: ImportRouteComponentOptions
+  options?: LazyRouteOptions
 ): FunctionComponent<P> {
   let component: FunctionComponent<P> | null = null;
   let promise: Promise<void> | null = null;
@@ -137,7 +146,7 @@ export function lazyRoute<P>(
       // Start the import during render (rather than waiting for the effect)
       // so the chunk request goes out as early as possible.
       load();
-      return <RouteLoading />;
+      return <RouteLoading frame={options?.frame} />;
     }
     const Component = component;
     return <Component {...(props as any)} />;


### PR DESCRIPTION
## Summary
Replaced the `preact-iso` lazy loading implementation with a custom hook-based solution that provides better control over loading states and error handling for route components.

## Key Changes
- **Removed dependency on `preact-iso`'s `lazy` function** and replaced it with a custom implementation using `useState` and `useEffect` hooks
- **Added `RouteLoading` component** that displays a centered spinner with a fade-in animation while route chunks are being fetched
- **Improved loading UX** by showing a loading indicator during import, with a 150ms delay to prevent flashing on fast imports
- **Enhanced caching behavior** where route components are cached after first load, allowing subsequent navigations to render immediately without loading state
- **Updated `lazyRoute` function** to accept optional `ImportRouteComponentOptions` parameter for customization
- **Simplified error handling** by ensuring the promise never rejects, allowing callers to render results directly
- **Added comprehensive test coverage** for the new `lazyRoute` implementation, including loading states, caching, and error scenarios

## Implementation Details
- The custom `lazyRoute` implementation uses closure to maintain component and promise state across renders
- Import is initiated during render (not just in effect) to start chunk requests as early as possible
- Loading screen fades in after 150ms to avoid visual flashing for quick imports
- Cancellation logic prevents state updates after unmount
- All tests mock the `@mantine/core` Loader component and verify loading/error states

https://claude.ai/code/session_011Y2WUEiYe29ezqn7fxP2KS