### PR TITLE
feat: add pagination to asset library page

### DIFF
--- a/.changeset/lazy-streets-act.md
+++ b/.changeset/lazy-streets-act.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add pagination to asset library page

--- a/docs/scripts/seed_asset_library.mjs
+++ b/docs/scripts/seed_asset_library.mjs
@@ -1,0 +1,286 @@
+/**
+ * @fileoverview Seeds the asset library with test data to exercise pagination.
+ *
+ * Creates a `test-pagination` folder in the asset library and backfills it with
+ * N (default 200) image assets. Each asset is a self-contained `data:` URI SVG
+ * with a distinct, readable name like `foo-bar-baz.svg`, so no GCS upload is
+ * required. Because the asset library paginates at 100 assets per page, the
+ * default of 200 produces two full pages of results to page through.
+ *
+ * Run from the root of a Root.js CMS project (one with a `root.config.ts`),
+ * e.g. the `docs/` site:
+ *
+ *   node scripts/seed_asset_library.mjs
+ *   node scripts/seed_asset_library.mjs --count 250
+ *   node scripts/seed_asset_library.mjs --folder test-pagination
+ *   node scripts/seed_asset_library.mjs --clear   # remove existing files first
+ *
+ * Requires application-default credentials for the project's Firestore (the
+ * same auth used by the other root-cms admin scripts).
+ *
+ * Note: by default the script appends, so re-running adds another `--count`
+ * assets. Pass `--clear` to delete the folder's existing files before seeding.
+ */
+
+import {loadRootConfig} from '@blinkk/root/node';
+import {RootCMSClient} from '@blinkk/root-cms';
+import {Timestamp} from 'firebase-admin/firestore';
+
+/** Default number of assets to create. Two pages at 100 assets/page. */
+const DEFAULT_COUNT = 200;
+/** Default folder to seed into. */
+const DEFAULT_FOLDER = 'test-pagination';
+/** Email recorded as the creator/modifier of the seeded assets. */
+const SEED_USER = 'seed-asset-library@rootjs.dev';
+/** Max writes per Firestore batch (the hard limit is 500). */
+const BATCH_SIZE = 400;
+
+// Word lists combined to generate distinct, readable asset names. Three lists
+// of eight yield 8 * 8 * 8 = 512 unique three-word combinations, enough for the
+// default count without needing a numeric suffix.
+const ADJECTIVES = [
+  'foo',
+  'azure',
+  'crimson',
+  'golden',
+  'silent',
+  'cosmic',
+  'velvet',
+  'lunar',
+];
+const NOUNS = [
+  'bar',
+  'falcon',
+  'harbor',
+  'meadow',
+  'cipher',
+  'lantern',
+  'comet',
+  'willow',
+];
+const SUFFIXES = [
+  'baz',
+  'alpha',
+  'echo',
+  'nova',
+  'delta',
+  'prime',
+  'flux',
+  'zen',
+];
+
+/** Background colors cycled through so thumbnails are visually distinct. */
+const COLORS = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#06b6d4',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+];
+
+/** The id charset used by the CMS asset library (mirrors `autokey`). */
+const ID_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+/** Generates a random asset id, matching the CMS `autokey(12)` format. */
+function autokey(len = 12) {
+  let result = '';
+  for (let i = 0; i < len; i++) {
+    result += ID_CHARS.charAt(Math.floor(Math.random() * ID_CHARS.length));
+  }
+  return result;
+}
+
+/** Parses `--count`, `--folder` and `--clear` flags from argv. */
+function parseArgs(argv) {
+  const args = {
+    count: DEFAULT_COUNT,
+    folder: DEFAULT_FOLDER,
+    clear: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const [flag, inlineValue] = arg.split('=');
+    const nextValue = () => inlineValue ?? argv[++i];
+    if (flag === '--count') {
+      const count = parseInt(nextValue(), 10);
+      if (!Number.isInteger(count) || count <= 0) {
+        throw new Error(`invalid --count value: ${arg}`);
+      }
+      args.count = count;
+    } else if (flag === '--folder') {
+      const folder = nextValue();
+      if (!folder || /[/\\]/.test(folder)) {
+        throw new Error(`invalid --folder value: ${arg}`);
+      }
+      args.folder = folder;
+    } else if (flag === '--clear') {
+      args.clear = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+/**
+ * Builds a distinct, readable name for the asset at index `i`, e.g.
+ * `foo-bar-baz.svg`. Treats `i` as a mixed-radix number over the three word
+ * lists; if more assets are requested than there are unique combinations, a
+ * numeric suffix is appended to keep names unique.
+ */
+function buildName(i, usedNames) {
+  const idxA =
+    Math.floor(i / (NOUNS.length * SUFFIXES.length)) % ADJECTIVES.length;
+  const idxB = Math.floor(i / SUFFIXES.length) % NOUNS.length;
+  const idxC = i % SUFFIXES.length;
+  const base = `${ADJECTIVES[idxA]}-${NOUNS[idxB]}-${SUFFIXES[idxC]}`;
+  let name = `${base}.svg`;
+  // Once the unique combinations are exhausted, disambiguate with a suffix.
+  let dedupe = 2;
+  while (usedNames.has(name)) {
+    name = `${base}-${dedupe}.svg`;
+    dedupe++;
+  }
+  usedNames.add(name);
+  return name;
+}
+
+/** Escapes text for safe inclusion in SVG/XML markup. */
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Builds a `data:` URI for a 200x200 SVG labeled with the asset name. */
+function buildSvgDataUri(label, color) {
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" ' +
+    'viewBox="0 0 200 200">' +
+    `<rect width="200" height="200" fill="${color}"/>` +
+    '<text x="100" y="105" font-family="monospace" font-size="13" ' +
+    `fill="#ffffff" text-anchor="middle">${escapeXml(label)}</text>` +
+    '</svg>';
+  const base64 = Buffer.from(svg, 'utf8').toString('base64');
+  return `data:image/svg+xml;base64,${base64}`;
+}
+
+/** Deletes all file assets directly within `folder`. */
+async function clearFolder(db, assetsPath, folder) {
+  const snapshot = await db
+    .collection(assetsPath)
+    .where('parent', '==', folder)
+    .get();
+  if (snapshot.empty) {
+    return 0;
+  }
+  let batch = db.batch();
+  let ops = 0;
+  let deleted = 0;
+  for (const doc of snapshot.docs) {
+    batch.delete(doc.ref);
+    ops++;
+    deleted++;
+    if (ops >= BATCH_SIZE) {
+      await batch.commit();
+      batch = db.batch();
+      ops = 0;
+    }
+  }
+  if (ops > 0) {
+    await batch.commit();
+  }
+  return deleted;
+}
+
+async function main() {
+  const {count, folder, clear} = parseArgs(process.argv.slice(2));
+
+  const rootConfig = await loadRootConfig(process.cwd());
+  const client = new RootCMSClient(rootConfig);
+  const db = client.db;
+  const projectId = client.projectId;
+  const assetsPath = `Projects/${projectId}/Assets`;
+
+  console.log(`project: ${projectId}`);
+  console.log(`folder: ${folder}`);
+
+  if (clear) {
+    const deleted = await clearFolder(db, assetsPath, folder);
+    console.log(`cleared ${deleted} existing asset(s) from "${folder}"`);
+  }
+
+  // Create the folder doc. The id is derived from the path (mirroring the CMS)
+  // and merge:true keeps existing created metadata if it already exists.
+  const folderId = `folder-${encodeURIComponent(folder)}`;
+  const folderTs = Timestamp.now();
+  await db.doc(`${assetsPath}/${folderId}`).set(
+    {
+      id: folderId,
+      type: 'folder',
+      parent: '',
+      name: folder,
+      createdAt: folderTs,
+      createdBy: SEED_USER,
+      modifiedAt: folderTs,
+      modifiedBy: SEED_USER,
+    },
+    {merge: true}
+  );
+
+  // Backfill file assets in batches.
+  const usedNames = new Set();
+  let batch = db.batch();
+  let ops = 0;
+  for (let i = 0; i < count; i++) {
+    const name = buildName(i, usedNames);
+    const color = COLORS[i % COLORS.length];
+    const src = buildSvgDataUri(name, color);
+    const assetId = autokey(12);
+    const ts = Timestamp.now();
+    batch.set(db.doc(`${assetsPath}/${assetId}`), {
+      id: assetId,
+      type: 'file',
+      parent: folder,
+      name: name,
+      file: {
+        src: src,
+        filename: name,
+        width: 200,
+        height: 200,
+        alt: '',
+        uploadedBy: SEED_USER,
+        uploadedAt: ts.toMillis(),
+      },
+      createdAt: ts,
+      createdBy: SEED_USER,
+      modifiedAt: ts,
+      modifiedBy: SEED_USER,
+    });
+    ops++;
+    if (ops >= BATCH_SIZE) {
+      await batch.commit();
+      console.log(`seeded ${i + 1}/${count}...`);
+      batch = db.batch();
+      ops = 0;
+    }
+  }
+  if (ops > 0) {
+    await batch.commit();
+  }
+
+  console.log(`done: seeded ${count} asset(s) into "${folder}".`);
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Loader,
   MultiSelect,
-  Pagination,
   Select,
   Table,
   TextInput,
@@ -13,9 +12,11 @@ import {useDebouncedValue} from '@mantine/hooks';
 import {IconSearch} from '@tabler/icons-preact';
 import {Timestamp} from 'firebase/firestore';
 import {useEffect, useMemo, useState} from 'preact/hooks';
+import {usePagination} from '../../hooks/usePagination.js';
 import {Action, listActions} from '../../utils/actions.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getSpreadsheetUrl} from '../../utils/gsheets.js';
+import {Pagination, PaginationSummary} from '../Pagination/Pagination.js';
 import {Surface} from '../Surface/Surface.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 import './ActionsLogs.css';
@@ -78,9 +79,6 @@ export function ActionLogs(props: ActionLogsProps) {
   const [actionFilters, setActionFilters] = useState<string[]>([]);
   const [userFilters, setUserFilters] = useState<string[]>([]);
   const [timeFilter, setTimeFilter] = useState<string | null>('all');
-
-  // Pagination state.
-  const [currentPage, setCurrentPage] = useState(1);
 
   const {actions, loading} = useActions();
 
@@ -162,22 +160,12 @@ export function ActionLogs(props: ActionLogsProps) {
     });
   }, [actions, debouncedSearch, actionFilters, userFilters, timeFilter]);
 
-  // Paginate filtered actions (skip pagination in compact mode).
-  const totalPages = props.compact
-    ? 1
-    : Math.ceil(filteredActions.length / PAGE_SIZE);
-  const paginatedActions = useMemo(() => {
-    if (props.compact) {
-      return filteredActions;
-    }
-    const start = (currentPage - 1) * PAGE_SIZE;
-    return filteredActions.slice(start, start + PAGE_SIZE);
-  }, [filteredActions, currentPage, props.compact]);
-
-  // Reset to page 1 when filters change.
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [debouncedSearch, actionFilters, userFilters, timeFilter]);
+  // Paginate filtered actions, resetting to the first page when filters change.
+  const pagination = usePagination(filteredActions, {
+    pageSize: PAGE_SIZE,
+    resetDeps: [debouncedSearch, actionFilters, userFilters, timeFilter],
+  });
+  const paginatedActions = pagination.pageItems;
 
   if (loading) {
     return (
@@ -229,12 +217,17 @@ export function ActionLogs(props: ActionLogsProps) {
               onChange={setTimeFilter}
             />
           </div>
-          <div className="ActionsLog__summary">
-            Showing {paginatedActions.length} of {filteredActions.length}{' '}
-            actions
-            {filteredActions.length !== actions.length &&
-              ` (filtered from ${actions.length} total)`}
-          </div>
+          <PaginationSummary
+            start={pagination.start}
+            end={pagination.end}
+            total={pagination.totalItems}
+            noun="action"
+            note={
+              filteredActions.length !== actions.length
+                ? `filtered from ${actions.length} total`
+                : undefined
+            }
+          />
         </div>
       )}
 
@@ -294,16 +287,11 @@ export function ActionLogs(props: ActionLogsProps) {
         </Table>
       </Surface>
 
-      {!props.compact && totalPages > 1 && (
-        <div className="ActionsLog__pagination">
-          <Pagination
-            total={totalPages}
-            value={currentPage}
-            onChange={setCurrentPage}
-            size="sm"
-          />
-        </div>
-      )}
+      <Pagination
+        total={pagination.totalPages}
+        page={pagination.page}
+        onChange={pagination.setPage}
+      />
     </div>
   );
 }

--- a/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
+++ b/packages/root-cms/ui/components/ActionLogs/ActionsLogs.css
@@ -28,11 +28,6 @@
   min-width: 180px;
 }
 
-.ActionsLog__summary {
-  font-size: 13px;
-  color: var(--color-text-secondary);
-}
-
 .ActionsLog__tableHeader {
   display: flex;
   justify-content: space-between;
@@ -150,12 +145,6 @@
 .ActionsLogs__metadata__value {
   color: var(--color-text-primary);
   word-break: break-word;
-}
-
-.ActionsLog__pagination {
-  display: flex;
-  justify-content: center;
-  padding: 16px 0;
 }
 
 .ActionLogsCompact--loading {

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
@@ -118,6 +118,14 @@
   border: none;
 }
 
+.AssetBrowser__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .AssetBrowser__table td,
 .AssetBrowser__table th {
   border-left: none !important;

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -31,6 +31,7 @@ import {
 } from '@tabler/icons-preact';
 import {ChangeEvent} from 'preact/compat';
 import {useEffect, useMemo, useState} from 'preact/hooks';
+import {usePagination} from '../../hooks/usePagination.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {
   Asset,
@@ -61,6 +62,7 @@ import {
 import {notifyErrors} from '../../utils/notifications.js';
 import {testCanPublish} from '../../utils/permissions.js';
 import {getTimeAgo} from '../../utils/time.js';
+import {Pagination, PaginationSummary} from '../Pagination/Pagination.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 import {AssetDetailsModal} from './AssetDetailsModal.js';
 import {
@@ -94,6 +96,9 @@ export interface AssetBrowserProps {
   /** Manage mode: opens the details modal for an asset id on load (deep link). */
   initialAssetId?: string;
 }
+
+/** Number of assets to display per page. */
+const PAGE_SIZE = 100;
 
 /**
  * A Drive-like file browser for the project's asset library. Lists the
@@ -213,6 +218,14 @@ export function AssetBrowser(props: AssetBrowserProps) {
     return res;
   }, [assets, searchIndex, filter, props.mode, props.accept]);
 
+  // Paginate the listing, resetting to the first page when the folder or the
+  // search filter changes.
+  const pagination = usePagination(filteredAssets, {
+    pageSize: PAGE_SIZE,
+    resetDeps: [folder, filter],
+  });
+  const pageItems = pagination.pageItems;
+
   async function uploadFiles(files: File[]) {
     if (files.length === 0 || uploading) {
       return;
@@ -309,9 +322,10 @@ export function AssetBrowser(props: AssetBrowserProps) {
       (testIsImageFile(asset.file?.filename || asset.name) ||
         testIsVideoFile(asset.file?.filename || asset.name))
   );
+  // Select-all applies to the assets visible on the current page; selections
+  // made on other pages are preserved.
   const allSelected =
-    filteredAssets.length > 0 &&
-    filteredAssets.every((asset) => selected.has(asset.id));
+    pageItems.length > 0 && pageItems.every((asset) => selected.has(asset.id));
 
   function toggleSelected(asset: Asset) {
     setSelected((prev) => {
@@ -326,11 +340,15 @@ export function AssetBrowser(props: AssetBrowserProps) {
   }
 
   function toggleSelectAll() {
-    if (allSelected) {
-      setSelected(new Map());
-    } else {
-      setSelected(new Map(filteredAssets.map((asset) => [asset.id, asset])));
-    }
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (allSelected) {
+        pageItems.forEach((asset) => next.delete(asset.id));
+      } else {
+        pageItems.forEach((asset) => next.set(asset.id, asset));
+      }
+      return next;
+    });
   }
 
   return (
@@ -483,7 +501,10 @@ export function AssetBrowser(props: AssetBrowserProps) {
                       size="xs"
                       aria-label="Select all"
                       checked={allSelected}
-                      indeterminate={!allSelected && selected.size > 0}
+                      indeterminate={
+                        !allSelected &&
+                        pageItems.some((asset) => selected.has(asset.id))
+                      }
                       onChange={() => toggleSelectAll()}
                     />
                   </th>
@@ -494,7 +515,7 @@ export function AssetBrowser(props: AssetBrowserProps) {
               </tr>
             </thead>
             <tbody>
-              {filteredAssets.map((asset) =>
+              {pageItems.map((asset) =>
                 asset.type === 'folder' ? (
                   <tr
                     key={asset.id}
@@ -647,6 +668,22 @@ export function AssetBrowser(props: AssetBrowserProps) {
           </Table>
         )}
       </div>
+
+      {pagination.totalPages > 1 && (
+        <div className="AssetBrowser__footer">
+          <PaginationSummary
+            start={pagination.start}
+            end={pagination.end}
+            total={pagination.totalItems}
+            noun="asset"
+          />
+          <Pagination
+            total={pagination.totalPages}
+            page={pagination.page}
+            onChange={pagination.setPage}
+          />
+        </div>
+      )}
 
       <NewFolderModal
         opened={newFolderModalOpened}

--- a/packages/root-cms/ui/components/Pagination/Pagination.css
+++ b/packages/root-cms/ui/components/Pagination/Pagination.css
@@ -1,0 +1,10 @@
+.Pagination {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.Pagination__summary {
+  font-size: 13px;
+  color: var(--color-text-gray);
+}

--- a/packages/root-cms/ui/components/Pagination/Pagination.tsx
+++ b/packages/root-cms/ui/components/Pagination/Pagination.tsx
@@ -1,0 +1,70 @@
+import './Pagination.css';
+
+import {Pagination as MantinePagination} from '@mantine/core';
+import {joinClassNames} from '../../utils/classes.js';
+
+export interface PaginationProps {
+  className?: string;
+  /** Total number of pages. */
+  total: number;
+  /** The 1-based current page. */
+  page: number;
+  /** Called when the user selects a different page. */
+  onChange: (page: number) => void;
+}
+
+/**
+ * Shared pagination control used across CMS list views (e.g. the action logs
+ * and the asset library). Renders nothing when there is a single page or none.
+ */
+export function Pagination(props: PaginationProps) {
+  if (props.total <= 1) {
+    return null;
+  }
+  return (
+    <div className={joinClassNames(props.className, 'Pagination')}>
+      <MantinePagination
+        total={props.total}
+        value={props.page}
+        onChange={props.onChange}
+        size="sm"
+      />
+    </div>
+  );
+}
+
+export interface PaginationSummaryProps {
+  className?: string;
+  /** 1-based index of the first item shown on the current page. */
+  start: number;
+  /** 1-based index of the last item shown on the current page. */
+  end: number;
+  /** Total number of items across all pages. */
+  total: number;
+  /** Singular noun for the items, e.g. `asset` or `action`. */
+  noun: string;
+  /** Optional trailing note, e.g. `filtered from 500 total`. */
+  note?: string;
+}
+
+/**
+ * A short "Showing X–Y of Z" summary that pairs with {@link Pagination}.
+ */
+export function PaginationSummary(props: PaginationSummaryProps) {
+  const {start, end, total, noun, note} = props;
+  const nounLabel = total === 1 ? noun : `${noun}s`;
+  let text: string;
+  if (total === 0) {
+    text = `No ${noun}s`;
+  } else if (start === end) {
+    text = `Showing ${start} of ${total} ${nounLabel}`;
+  } else {
+    text = `Showing ${start}\u2013${end} of ${total} ${nounLabel}`;
+  }
+  return (
+    <div className={joinClassNames(props.className, 'Pagination__summary')}>
+      {text}
+      {note ? ` (${note})` : ''}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/hooks/usePagination.ts
+++ b/packages/root-cms/ui/hooks/usePagination.ts
@@ -1,0 +1,74 @@
+import {useEffect, useMemo, useState} from 'preact/hooks';
+
+export interface UsePaginationOptions {
+  /** Number of items per page. */
+  pageSize: number;
+  /**
+   * When any value in this list changes, the current page resets to 1. Use
+   * this for filter/search state so that changing a filter returns the user to
+   * the first page of results.
+   */
+  resetDeps?: unknown[];
+}
+
+export interface PaginationState<T> {
+  /** The 1-based current page number. */
+  page: number;
+  /** Navigates to the given 1-based page. */
+  setPage: (page: number) => void;
+  /** Total number of pages (always at least 1). */
+  totalPages: number;
+  /** The subset of items on the current page. */
+  pageItems: T[];
+  /** Total number of items across all pages. */
+  totalItems: number;
+  /** 1-based index of the first item on the current page (0 when empty). */
+  start: number;
+  /** 1-based index of the last item on the current page (0 when empty). */
+  end: number;
+}
+
+/**
+ * Client-side pagination for an in-memory list. Slices `items` into pages of
+ * `pageSize`, tracks the current page, clamps it whenever the result set
+ * shrinks, and resets to the first page when `resetDeps` change.
+ *
+ * Shared by list views such as the action logs and the asset library.
+ */
+export function usePagination<T>(
+  items: T[],
+  options: UsePaginationOptions
+): PaginationState<T> {
+  const {pageSize, resetDeps} = options;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalItems = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  // Clamp so a shrinking result set never strands the user on an empty page.
+  // The raw page state is only normalized on the next interaction or reset,
+  // but rendering always uses this clamped value.
+  const page = Math.min(Math.max(currentPage, 1), totalPages);
+
+  // Reset to the first page when the reset dependencies change (e.g. filters).
+  useEffect(() => {
+    setCurrentPage(1);
+  }, resetDeps ?? []);
+
+  const pageItems = useMemo(() => {
+    const startIndex = (page - 1) * pageSize;
+    return items.slice(startIndex, startIndex + pageSize);
+  }, [items, page, pageSize]);
+
+  const start = totalItems === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, totalItems);
+
+  return {
+    page,
+    setPage: setCurrentPage,
+    totalPages,
+    pageItems,
+    totalItems,
+    start,
+    end,
+  };
+}


### PR DESCRIPTION
- this extracts the pagination from action logs into a shared component
- reuse it on the asset browser page
- also add seed script to test lots of assets

<img width="1087" height="917" alt="image" src="https://github.com/user-attachments/assets/be31e900-adc7-4ef8-a06f-44cd68dedd24" />
