### PR TITLE
fix: add popover to boolean attributes list

### DIFF
--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -46,6 +46,22 @@ test('renders disableRemotePlayback as a boolean attribute', () => {
   expect(output).toBe('<video disableremoteplayback></video>');
 });
 
+test('renders popover as a boolean attribute', () => {
+  // `<div popover />` should minimize to `popover` (treated as "auto" by the
+  // browser) rather than rendering an invalid `popover="true"` value.
+  expect(renderJsxToString(<div popover />, {mode: 'minimal'})).toBe(
+    '<div popover></div>'
+  );
+  // `popover={false}` removes the attribute.
+  expect(
+    renderJsxToString(<div popover={false} />, {mode: 'minimal'})
+  ).toBe('<div></div>');
+  // Explicit string values are preserved.
+  expect(
+    renderJsxToString(<div popover="manual" />, {mode: 'minimal'})
+  ).toBe('<div popover="manual"></div>');
+});
+
 test('handles falsy attribute values', () => {
   // true: boolean attrs are minimized, non-boolean attrs render as "true"
   expect(

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -131,6 +131,7 @@ const BOOLEAN_ATTRS = new Set([
   'novalidate',
   'open',
   'playsinline',
+  'popover',
   'readonly',
   'required',
   'reversed',


### PR DESCRIPTION
## Summary
Added support for the HTML `popover` attribute as a boolean attribute in JSX rendering, ensuring it's properly minimized when used without a value.

## Changes
- Added `'popover'` to the `BOOLEAN_ATTRS` set in `jsx-render.ts` to treat it as a boolean attribute
- Added comprehensive test coverage in `jsx-render.test.tsx` validating:
  - `<div popover />` renders as `<div popover></div>` (minimized form, treated as "auto" by browsers)
  - `<div popover={false} />` removes the attribute entirely
  - Explicit string values like `popover="manual"` are preserved as-is

## Implementation Details
The `popover` attribute is a boolean HTML attribute that should be minimized (rendered without a value) rather than rendered as `popover="true"`. This change ensures the JSX renderer handles it consistently with other boolean attributes like `disabled`, `readonly`, etc.

https://claude.ai/code/session_012i84G8UYoxLPojvJVuRs3X