### PR TITLE
fix: limit translations fetched in the localization modal

### DIFF
--- a/.changeset/funny-mammals-shout.md
+++ b/.changeset/funny-mammals-shout.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: limit strings extracted in translations modal

--- a/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
+++ b/packages/root-cms/ui/components/LocalizationModal/LocalizationModal.tsx
@@ -69,7 +69,7 @@ import {
   sourceHash,
   toTranslationLanguages,
 } from '../../utils/l10n.js';
-import {TranslationsMap, loadTranslations} from '../../utils/l10n.js';
+import {TranslationsMap, loadTranslationsByHashes} from '../../utils/l10n.js';
 import {useExportSheetModal} from '../ExportSheetModal/ExportSheetModal.js';
 import {Heading} from '../Heading/Heading.js';
 import {ProgressiveLoader} from '../ProgressiveLoader/ProgressiveLoader.js';
@@ -613,11 +613,12 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
     setLoading(true);
     Promise.all([
       extractStringsForDoc(props.docId),
-      loadTranslations(),
       cmsGetLinkedGoogleSheetL10n(props.docId),
     ])
-      .then(async ([sourceStrings, translationsMap, linkedSheet]) => {
-        // Compute missing tags before showing the UI to prevent flash.
+      .then(async ([sourceStrings, linkedSheet]) => {
+        // Hash each source string and load only the matching translations,
+        // instead of downloading the project's entire translations collection
+        // (which can be very large and is the main cause of slow loads).
         const docTags = [props.docId];
         const hashesWithSources = await Promise.all(
           sourceStrings.map(async (source) => ({
@@ -625,6 +626,10 @@ LocalizationModal.Translations = (props: TranslationsProps) => {
             hash: await sourceHash(source),
           }))
         );
+        const translationsMap = await loadTranslationsByHashes(
+          hashesWithSources.map((item) => item.hash)
+        );
+        // Compute missing tags before showing the UI to prevent flash.
         const missing = new Set<string>();
         for (const {source, hash} of hashesWithSources) {
           if (translationsMap[hash]) {

--- a/packages/root-cms/ui/utils/l10n.test.ts
+++ b/packages/root-cms/ui/utils/l10n.test.ts
@@ -1,5 +1,10 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {batchUpdateTags, isLocaleExcludedFromTranslations} from './l10n.js';
+import type {Translation} from './l10n.js';
+import {
+  batchUpdateTags,
+  isLocaleExcludedFromTranslations,
+  loadTranslationsByHashes,
+} from './l10n.js';
 
 // Mock values used in the function.
 const mockProjectId = 'test-project-id';
@@ -21,6 +26,11 @@ const mockWriteBatch = vi.fn();
 const mockBatchUpdate = vi.fn();
 const mockBatchCommit = vi.fn();
 const mockDoc = vi.fn();
+const mockCollection = vi.fn();
+const mockDocumentId = vi.fn();
+const mockGetDocs = vi.fn();
+const mockQuery = vi.fn();
+const mockWhere = vi.fn();
 const mockArrayUnion = vi.fn((...args: any[]) => ({
   __type: 'arrayUnion',
   values: args,
@@ -30,13 +40,14 @@ vi.mock('firebase/firestore', () => ({
   arrayUnion: (...args: any[]) => mockArrayUnion(...args),
   writeBatch: (...args: any[]) => mockWriteBatch(...args),
   doc: (...args: any[]) => mockDoc(...args),
+  collection: (...args: any[]) => mockCollection(...args),
+  documentId: (...args: any[]) => mockDocumentId(...args),
+  getDocs: (...args: any[]) => mockGetDocs(...args),
+  query: (...args: any[]) => mockQuery(...args),
+  where: (...args: any[]) => mockWhere(...args),
   // Add other functions if they are imported but not used in the test path
-  collection: vi.fn(),
   getDoc: vi.fn(),
-  getDocs: vi.fn(),
-  query: vi.fn(),
   updateDoc: vi.fn(),
-  where: vi.fn(),
 }));
 
 describe('isLocaleExcludedFromTranslations', () => {
@@ -187,5 +198,95 @@ describe('batchUpdateTags', () => {
     expect(mockBatchUpdate).toHaveBeenCalledWith('doc-ref-1', {
       tags: {__type: 'arrayUnion', values: ['newTag']},
     });
+  });
+});
+
+describe('loadTranslationsByHashes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // documentId() is just a sentinel field path. query()/where() pass the
+    // requested chunk straight through so the fake db (getDocs) can resolve it.
+    mockDocumentId.mockReturnValue('__name__');
+    mockWhere.mockImplementation((_field: any, _op: any, chunk: string[]) => ({
+      chunk,
+    }));
+    mockQuery.mockImplementation(
+      (_colRef: any, whereClause: any) => whereClause
+    );
+  });
+
+  function setupFakeDb(docsByHash: Record<string, Partial<Translation>>) {
+    // Resolve a query by returning only the docs whose id is in the chunk,
+    // mirroring Firestore's `where(documentId(), 'in', chunk)` semantics.
+    mockGetDocs.mockImplementation((q: {chunk: string[]}) => {
+      const matched = q.chunk
+        .filter((hash) => docsByHash[hash] !== undefined)
+        .map((hash) => ({id: hash, data: () => docsByHash[hash]}));
+      return {
+        forEach: (cb: (doc: {id: string; data: () => any}) => void) =>
+          matched.forEach(cb),
+      };
+    });
+  }
+
+  it('returns docs by id regardless of their tags', async () => {
+    // The doc for `hash-other` is tagged for a *different* page, and
+    // `hash-untagged` has no tags at all. Both must still be returned (keyed by
+    // id), with their real tags intact, so the modal can detect missing tags.
+    setupFakeDb({
+      'hash-self': {source: 'Hello', tags: ['pages/this-page']},
+      'hash-other': {source: 'World', tags: ['pages/other-page']},
+      'hash-untagged': {source: 'Untagged'},
+    });
+
+    const result = await loadTranslationsByHashes([
+      'hash-self',
+      'hash-other',
+      'hash-untagged',
+    ]);
+
+    expect(result['hash-self']).toEqual({
+      source: 'Hello',
+      tags: ['pages/this-page'],
+    });
+    // The key guarantee: a translation tagged for another page is still loaded
+    // (it is fetched by id, never filtered by tag), so the modal can correctly
+    // flag that it is missing the current page's tag.
+    expect(result['hash-other']).toEqual({
+      source: 'World',
+      tags: ['pages/other-page'],
+    });
+    expect(result['hash-untagged']).toEqual({source: 'Untagged'});
+  });
+
+  it('omits hashes that have no translation doc', async () => {
+    setupFakeDb({'hash-1': {source: 'A', tags: []}});
+
+    const result = await loadTranslationsByHashes(['hash-1', 'hash-missing']);
+
+    expect(result['hash-1']).toEqual({source: 'A', tags: []});
+    expect(result['hash-missing']).toBeUndefined();
+  });
+
+  it('returns an empty map and issues no query for an empty hash list', async () => {
+    const result = await loadTranslationsByHashes([]);
+
+    expect(result).toEqual({});
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it('dedupes hashes and chunks `in` queries into batches of 30', async () => {
+    const hashes = Array.from({length: 65}, (_, i) => `hash-${i}`);
+    // Duplicate and empty values must be collapsed/dropped before chunking.
+    const hashesWithNoise = [...hashes, 'hash-0', 'hash-1', ''];
+    const docsByHash: Record<string, Partial<Translation>> = {};
+    hashes.forEach((h) => (docsByHash[h] = {source: h, tags: []}));
+    setupFakeDb(docsByHash);
+
+    const result = await loadTranslationsByHashes(hashesWithNoise);
+
+    // 65 unique hashes, chunked by 30 => 30 + 30 + 5 = 3 queries.
+    expect(mockGetDocs).toHaveBeenCalledTimes(3);
+    expect(Object.keys(result)).toHaveLength(65);
   });
 });

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -2,6 +2,7 @@ import {
   arrayUnion,
   collection,
   doc,
+  documentId,
   getDoc,
   getDocs,
   query,
@@ -71,6 +72,40 @@ export async function loadTranslations(options?: {
     const hash = doc.id;
     translationsMap[hash] = doc.data() as Translation;
   });
+  return translationsMap;
+}
+
+/**
+ * Loads translations for a specific set of source-string hashes. Only the
+ * matching translation docs are fetched (by id), instead of downloading the
+ * project's entire translations collection. This keeps doc-scoped localization
+ * UIs fast even when a project has a very large number of translated strings.
+ */
+export async function loadTranslationsByHashes(
+  hashes: string[]
+): Promise<TranslationsMap> {
+  const uniqueHashes = Array.from(new Set(hashes)).filter(Boolean);
+  const translationsMap: TranslationsMap = {};
+  if (uniqueHashes.length === 0) {
+    return translationsMap;
+  }
+  const colRef = getTranslationsCollection();
+  // Firestore allows a maximum of 30 values per `in` query, so fetch the
+  // matching docs in parallel chunks.
+  const CHUNK_SIZE = 30;
+  const chunks: string[][] = [];
+  for (let i = 0; i < uniqueHashes.length; i += CHUNK_SIZE) {
+    chunks.push(uniqueHashes.slice(i, i + CHUNK_SIZE));
+  }
+  await Promise.all(
+    chunks.map(async (chunk) => {
+      const q = query(colRef, where(documentId(), 'in', chunk));
+      const querySnapshot = await getDocs(q);
+      querySnapshot.forEach((doc) => {
+        translationsMap[doc.id] = doc.data() as Translation;
+      });
+    })
+  );
   return translationsMap;
 }
 

--- a/packages/root-cms/ui/utils/l10n.ts
+++ b/packages/root-cms/ui/utils/l10n.ts
@@ -99,6 +99,7 @@ export async function loadTranslationsByHashes(
   }
   await Promise.all(
     chunks.map(async (chunk) => {
+      // Fetch by doc id only (not by tag) so missing-tag detection still works.
       const q = query(colRef, where(documentId(), 'in', chunk));
       const querySnapshot = await getDocs(q);
       querySnapshot.forEach((doc) => {


### PR DESCRIPTION
- previously, the whole project's translations were extracted
- now, only the translations associated with the page are extracted
