### PR TITLE
ci: restore verifyDepsBeforeRun=false for preview deploy

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -16,6 +16,13 @@ defaults:
 
 env:
   FORCE_COLOR: true
+  # The "Add preview package version suffix" step rewrites packages/*/package.json
+  # after install, which makes pnpm consider node_modules out of sync. With the
+  # repo's verifyDepsBeforeRun: warn setting, pnpm then prints an out-of-sync
+  # WARN to stdout on every `pnpm run`/`pnpm exec` — and FORCE_COLOR adds ANSI
+  # codes — which corrupts the captured `firebase --json` output below. Disable
+  # the check for this workflow so stdout only contains the command's own output.
+  PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
 
 jobs:
   preview:


### PR DESCRIPTION
## Problem

`/preview` deploys have failed every time since they were last exercised. The "Deploy preview to Firebase Hosting" step fails with:

```
SyntaxError: Unexpected token '', "[43m[33m"... is not valid JSON
    at JSON.parse (<anonymous>)
```

(e.g. run [27595487318](https://github.com/blinkk/rootjs/actions/runs/27595487318/job/81584835351)).

## Root cause

The deploy step captures `firebase hosting:channel:deploy --json` into a file and `JSON.parse`s it. The earlier **"Add preview package version suffix"** step rewrites `packages/*/package.json` *after* `pnpm install`, so pnpm considers `node_modules` out of sync. With the repo's `verifyDepsBeforeRun: warn` setting, the next `pnpm exec` prints a `[WARN] Your node_modules are out of sync...` line to **stdout**. Because `FORCE_COLOR: true` is set, that line is ANSI-colored, so it lands in the captured output *ahead of* the JSON and breaks `JSON.parse` (`Unexpected token '\u001b'`).

## Why this regressed "out of the blue"

This env var **used to exist** in the workflow. It was removed in **`8f9ee2ea`** ("ci: move verifyDepsBeforeRun to pnpm-workspace.yaml", 2026-06-04), which moved the setting into `pnpm-workspace.yaml` **and changed its value** from `false` (check off → silent) to `warn` (check on → prints to stdout). The `warn` default is desirable for local devs, but it reintroduced stdout noise in CI.

It went unnoticed because no `/preview` ran between the change (Jun 4) and the first failure (Jun 12) — last green preview was Jun 2.

## Fix

Re-add the workflow-scoped `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"` env so CI stdout stays clean, while keeping the helpful `warn` default in `pnpm-workspace.yaml` for local development.

## Scope check — is the fix needed elsewhere?

- **`docs.yml`** (production deploy): **not affected.** Its `JSON.parse` calls read `package.json` files from disk, and it runs `firebase deploy` directly without capturing `--json` stdout. The WARN is at most cosmetic there, so no change is made.
- Only `docs-preview.yml` captures command stdout as JSON, so it's the only file that needs the fix.

> Note: this workflow is triggered by `issue_comment`, so GitHub Actions runs the workflow definition from the **default branch**. That's why the fix must land on `main` to take effect.
