### PR TITLE
fix: limit translations fetched on doc translations page

### DIFF
--- a/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
+++ b/packages/root-cms/ui/pages/DocTranslationsPage/DocTranslationsPage.tsx
@@ -34,7 +34,8 @@ import {
   TranslationsMap,
   getTranslationForLanguage,
   isLocaleExcludedFromTranslations,
-  loadTranslations,
+  loadTranslationsByHashes,
+  sourceHash,
   toTranslationLanguages,
 } from '../../utils/l10n.js';
 import {notifyErrors} from '../../utils/notifications.js';
@@ -72,11 +73,16 @@ export function DocTranslationsPage(props: DocTranslationsPageProps) {
 
   async function init() {
     try {
-      const [sourceStrings, translationsMap, linkedSheet] = await Promise.all([
+      const [sourceStrings, linkedSheet] = await Promise.all([
         extractStringsForDoc(docId),
-        loadTranslations(),
         cmsGetLinkedGoogleSheetL10n(docId),
       ]);
+      // Hash each source string and load only the matching translations,
+      // instead of downloading the project's entire translations collection.
+      const hashes = await Promise.all(
+        sourceStrings.map((source) => sourceHash(source))
+      );
+      const translationsMap = await loadTranslationsByHashes(hashes);
       setSourceStrings(sourceStrings);
       setTranslationsMap(translationsMap);
       setLinkedSheet(linkedSheet);


### PR DESCRIPTION
## Summary
Refactored the translations loading mechanism in DocTranslationsPage to improve performance by only fetching translations for the specific source strings in the current document, rather than loading the entire project's translations collection.

## Key Changes
- Replaced `loadTranslations()` with `loadTranslationsByHashes()` to enable hash-based translation lookups
- Added `sourceHash` import from l10n utilities for hashing source strings
- Modified the initialization flow to:
  1. Extract source strings for the document
  2. Generate hashes for each source string
  3. Load only the translations matching those hashes
- Removed the full translations collection from the initial parallel Promise.all() call

## Implementation Details
- Source strings are now hashed individually using the `sourceHash()` function
- The hashes are collected and passed to `loadTranslationsByHashes()` for targeted translation retrieval
- This approach reduces the amount of data downloaded and processed, particularly beneficial for large translation projects with many documents

https://claude.ai/code/session_01WM1UHHz2c5U6ddprMqc9RG