### PR TITLE
fix: short-circuit getDoc/getRawDoc for oversized slugs

### DIFF
--- a/.changeset/busy-dodos-drum.md
+++ b/.changeset/busy-dodos-drum.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: short-circuit getDoc/getRawDoc for oversized slugs

--- a/packages/root-cms/core/client.test.ts
+++ b/packages/root-cms/core/client.test.ts
@@ -718,6 +718,35 @@ describe('RootCMSClient Validation', () => {
         client.getRawDoc('Pages', '', {mode: 'draft'})
       ).rejects.toThrow(/slug is required/);
     });
+
+    it('returns null without querying when slug exceeds Firestore id byte limit', async () => {
+      const {RootCMSClient} = await import('./client.js');
+      const client = new RootCMSClient(mockRootConfig);
+
+      const mockDoc = vi.fn();
+      (client as any).db = {doc: mockDoc};
+
+      // A slug of 1501 ASCII chars is 1501 bytes, exceeding the 1500-byte limit.
+      const longSlug = 'a'.repeat(1501);
+      const result = await client.getRawDoc('Pages', longSlug, {mode: 'draft'});
+
+      expect(result).toBeNull();
+      expect(mockDoc).not.toHaveBeenCalled();
+    });
+
+    it('getDoc returns null when slug exceeds Firestore id byte limit', async () => {
+      const {RootCMSClient} = await import('./client.js');
+      const client = new RootCMSClient(mockRootConfig);
+
+      const mockDoc = vi.fn();
+      (client as any).db = {doc: mockDoc};
+
+      const longSlug = 'a'.repeat(1501);
+      const result = await client.getDoc('Pages', longSlug, {mode: 'draft'});
+
+      expect(result).toBeNull();
+      expect(mockDoc).not.toHaveBeenCalled();
+    });
   });
 
   describe('listDocs parameter validation', () => {

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -15,6 +15,13 @@ import {TranslationsManager} from './translations-manager.js';
 import {validateFields} from './validation.js';
 import {setValueAtPath} from './values.js';
 
+/**
+ * Maximum number of bytes allowed in a Firestore document id. Slugs are used
+ * as document ids, so a slug exceeding this limit cannot exist in the database.
+ * See https://firebase.google.com/docs/firestore/quotas#collections_documents_and_fields
+ */
+const FIRESTORE_DOC_ID_MAX_BYTES = 1500;
+
 export interface Doc<Fields = any> {
   /** The id of the doc, e.g. "Pages/foo-bar". */
   id: string;
@@ -281,6 +288,12 @@ export class RootCMSClient {
     const modeCollection = this.getModeCollection(options.mode);
     // Slugs with slashes are encoded as `--` in the DB.
     slug = normalizeSlug(slug);
+    // Firestore limits document ids (the slug) to 1500 bytes. A slug that
+    // exceeds this limit can never have been written, so short-circuit and
+    // return null instead of issuing a request that would throw.
+    if (Buffer.byteLength(slug, 'utf8') > FIRESTORE_DOC_ID_MAX_BYTES) {
+      return null;
+    }
     const dbPath = `Projects/${this.projectId}/Collections/${collectionId}/${modeCollection}/${slug}`;
     const docRef = this.db.doc(dbPath);
     const doc = await docRef.get();


### PR DESCRIPTION
## Summary
Added validation to prevent querying Firestore for documents with slugs that exceed the 1500-byte document ID limit, returning `null` early instead of issuing a request that would fail.

## Key Changes
- Added `FIRESTORE_DOC_ID_MAX_BYTES` constant (1500 bytes) with documentation referencing Firestore quotas
- Implemented byte length validation in `getRawDoc()` method to check slug size before database queries
- Returns `null` immediately if slug exceeds the byte limit, avoiding unnecessary Firestore requests
- Added comprehensive test coverage for both `getRawDoc()` and `getDoc()` methods with oversized slugs

## Implementation Details
- Validation uses `Buffer.byteLength(slug, 'utf8')` to accurately measure byte length, accounting for multi-byte UTF-8 characters
- The check is performed after slug normalization but before the database path is constructed
- This prevents potential errors from Firestore when document IDs exceed the platform's limits

https://claude.ai/code/session_01MAxVcj45hCArbpQbysr5HX

Fixes #1255 