### PR TITLE
feat: add source/reference support for select fields

### DIFF
--- a/.changeset/select-field-value-source.md
+++ b/.changeset/select-field-value-source.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add `source` (document-sourced options) and `creatable` to the select field (also available on multiselect) — bind a select's choices to a field in another CMS document via `source: {doc, field, valueKey?, labelKey?, helpKey?}`, with optional pick-or-create, per-option help text (`helpKey`), and an inline "open source doc" icon button

--- a/.changeset/select-field-value-source.md
+++ b/.changeset/select-field-value-source.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-feat: add `source` (document-sourced options) and `creatable` to the select field (also available on multiselect) — bind a select's choices to a field in another CMS document via `source: {doc, field, valueKey?, labelKey?, helpKey?}`, with optional pick-or-create, per-option help text (`helpKey`), and an inline "open source doc" icon button
+feat: add source/reference support for select fields

--- a/docs/collections/GlobalModules.schema.ts
+++ b/docs/collections/GlobalModules.schema.ts
@@ -1,0 +1,51 @@
+import {schema} from '@blinkk/root-cms';
+import {conditionsField} from '@/conditions/Conditions.schema.js';
+
+/**
+ * Global config docs (e.g. feature flags) that aren't tied to a single page.
+ *
+ * Create a doc with the slug `flags` (`GlobalModules/flags`) to define the
+ * site's feature flags. The `IsFeatureFlag` condition sources its pick-list of
+ * options from the `flags` field of that doc — see
+ * `/conditions/IsFeatureFlag/IsFeatureFlag.schema.ts`.
+ */
+export default schema.collection({
+  name: 'GlobalModules',
+  description: 'Global config docs (feature flags, etc.). Preview only.',
+  group: 'Global',
+  url: '/global-modules/[...slug]',
+  preview: {
+    title: ['{internalDesc}', 'Global Modules'],
+  },
+  fields: [
+    schema.string({
+      id: 'internalDesc',
+      label: '[INTERNAL] Description',
+      help: 'Internal description for this doc (not shown publicly).',
+      variant: 'textarea',
+    }),
+    schema.array({
+      id: 'flags',
+      label: 'Flags',
+      help: 'Feature flags for the site. A flag is enabled when all of its conditions are met.',
+      preview: ['{name}: {description}', '{name}'],
+      of: schema.object({
+        fields: [
+          schema.string({
+            id: 'name',
+            label: 'Name',
+            help: 'Unique flag id, e.g. EnableFooBar.',
+          }),
+          schema.string({
+            id: 'description',
+            label: 'Description',
+            variant: 'textarea',
+          }),
+          conditionsField({
+            help: 'The flag is enabled when all of these conditions pass.',
+          }),
+        ],
+      }),
+    }),
+  ],
+});

--- a/docs/conditions/Conditions.schema.ts
+++ b/docs/conditions/Conditions.schema.ts
@@ -1,0 +1,48 @@
+import {schema} from '@blinkk/root-cms';
+
+export interface ConditionsFieldOptions extends Partial<
+  Omit<schema.ArrayField, 'type' | 'of'>
+> {
+  /**
+   * Condition schema names to exclude from the dropdown, e.g.
+   * `{exclude: ['IsFeatureFlag']}`.
+   */
+  exclude?: string[];
+}
+
+/**
+ * Reusable "Conditions" array field. Each item is one of the condition schemas
+ * defined in `/conditions/<Name>/<Name>.schema.ts`. All conditions must pass
+ * for the parent to be considered "enabled" (see
+ * `/conditions/conditions.ts#testAllConditions`).
+ */
+export function conditionsField(options: ConditionsFieldOptions = {}) {
+  const {exclude, ...arrayOptions} = options;
+  return schema.array({
+    id: 'conditions',
+    label: 'Conditions',
+    preview: [
+      '{_type}: {internalDesc}',
+      '{_type}: {description}',
+      '{_type}: {flag}',
+      '{_type}',
+    ],
+    ...arrayOptions,
+    of: schema.oneOf({
+      types: schema.glob(
+        '/conditions/*/*.schema.ts',
+        exclude ? {exclude} : undefined
+      ),
+    }),
+  });
+}
+
+// This default export exists so that a `ConditionsFields` type is added to
+// `root-cms.d.ts`. It is not meant to be used as a collection directly.
+export default schema.define({
+  name: 'Conditions',
+  preview: {
+    title: ['{_type}: {internalDesc}', '{_type}: {flag}', '{_type}'],
+  },
+  fields: [conditionsField()],
+});

--- a/docs/conditions/IsFeatureFlag/IsFeatureFlag.schema.ts
+++ b/docs/conditions/IsFeatureFlag/IsFeatureFlag.schema.ts
@@ -1,0 +1,36 @@
+import {schema} from '@blinkk/root-cms';
+
+/**
+ * Condition that passes when a named feature flag is enabled.
+ *
+ * The `flag` field demonstrates a document-sourced select: instead of typing a
+ * free-form flag name, the editor picks from the flags defined in the
+ * `GlobalModules/flags` doc (or types a new one, since `creatable` is on). The
+ * options come from each `flags[].name`, with `flags[].description` shown as
+ * help text beneath each option.
+ */
+export default schema.define({
+  name: 'IsFeatureFlag',
+  preview: {
+    title: ['IsFeatureFlag: {flag}', 'IsFeatureFlag'],
+  },
+  fields: [
+    schema.string({
+      id: 'internalDesc',
+      label: '[INTERNAL] Description',
+      variant: 'textarea',
+    }),
+    schema.select({
+      id: 'flag',
+      label: 'Flag',
+      help: 'Pick a flag defined in GlobalModules/flags, or type a new one.',
+      creatable: true,
+      source: {
+        doc: 'GlobalModules/flags',
+        field: 'flags',
+        valueKey: 'name',
+        helpKey: 'description',
+      },
+    }),
+  ],
+});

--- a/docs/conditions/IsFeatureFlag/IsFeatureFlag.ts
+++ b/docs/conditions/IsFeatureFlag/IsFeatureFlag.ts
@@ -1,0 +1,10 @@
+import {useFeatureFlags} from '@/hooks/useFeatureFlags.js';
+import {IsFeatureFlagFields} from '@/root-cms.js';
+
+export function testIsFeatureFlag(condition: IsFeatureFlagFields): boolean {
+  if (!condition.flag) {
+    return false;
+  }
+  const flags = useFeatureFlags();
+  return flags.test(condition.flag);
+}

--- a/docs/conditions/IsLocale/IsLocale.schema.ts
+++ b/docs/conditions/IsLocale/IsLocale.schema.ts
@@ -1,0 +1,25 @@
+import {schema} from '@blinkk/root-cms';
+
+/**
+ * Example non-flag condition: passes when the current request locale is one of
+ * the selected locales. Useful for gating a feature flag to specific locales.
+ */
+export default schema.define({
+  name: 'IsLocale',
+  preview: {
+    title: ['IsLocale: {locales}', 'IsLocale'],
+  },
+  fields: [
+    schema.string({
+      id: 'internalDesc',
+      label: '[INTERNAL] Description',
+      variant: 'textarea',
+    }),
+    schema.multiselect({
+      id: 'locales',
+      label: 'Locale(s)',
+      help: 'Locales to match, e.g. "en", "de". Leave empty to match all.',
+      creatable: true,
+    }),
+  ],
+});

--- a/docs/conditions/IsLocale/IsLocale.ts
+++ b/docs/conditions/IsLocale/IsLocale.ts
@@ -1,0 +1,11 @@
+import {useRequestContext} from '@blinkk/root';
+import {IsLocaleFields} from '@/root-cms.js';
+
+export function testIsLocale(condition: IsLocaleFields): boolean {
+  const locales = condition.locales || [];
+  if (locales.length === 0) {
+    return true;
+  }
+  const ctx = useRequestContext();
+  return locales.includes(ctx.locale);
+}

--- a/docs/conditions/conditions.ts
+++ b/docs/conditions/conditions.ts
@@ -1,0 +1,60 @@
+import {ConditionsFields} from '@/root-cms.js';
+
+export type Condition = NonNullable<ConditionsFields['conditions']>[number];
+
+export type ConditionTestFn = (condition: Condition) => boolean;
+
+interface ConditionModule {
+  [key: string]: ConditionTestFn;
+}
+
+// Build a map of all `test<ConditionName>()` functions from
+// `/conditions/<ConditionName>/<ConditionName>.ts` files.
+const MODULES = import.meta.glob<ConditionModule>('/conditions/*/*.ts', {
+  eager: true,
+});
+
+const CONDITIONS_TEST_FNS: Record<string, ConditionTestFn> = {};
+for (const filepath in MODULES) {
+  const moduleId = moduleIdFromPath(filepath);
+  // Ignore `*.schema.ts` files (moduleId would include a ".") and files that
+  // start with "_".
+  if (moduleId.startsWith('_') || moduleId.includes('.')) {
+    continue;
+  }
+  // For a file like `IsLocale.ts`, the export should be `testIsLocale()`.
+  const testFn = MODULES[filepath][`test${moduleId}`];
+  if (testFn) {
+    CONDITIONS_TEST_FNS[moduleId] = testFn;
+  }
+}
+
+function moduleIdFromPath(filepath: string): string {
+  const base = filepath.split('/').pop() || '';
+  // Remove the final extension only (so `Foo.schema.ts` -> `Foo.schema`).
+  return base.replace(/\.[^.]+$/, '');
+}
+
+/** Returns `true` if all conditions pass (or there are no conditions). */
+export function testAllConditions(conditions?: Condition[]): boolean {
+  if (!conditions || conditions.length === 0) {
+    return true;
+  }
+  return conditions.every((condition) => testCondition(condition));
+}
+
+function testCondition(condition: Condition): boolean {
+  if (!condition?._type) {
+    console.warn('[conditions] no condition._type is selected.');
+    return false;
+  }
+  const testFn = CONDITIONS_TEST_FNS[condition._type];
+  if (!testFn) {
+    console.warn(
+      `[conditions] could not find test${condition._type}() fn. Export it from ` +
+        `@/conditions/${condition._type}/${condition._type}.ts`
+    );
+    return false;
+  }
+  return testFn(condition);
+}

--- a/docs/hooks/useFeatureFlags.ts
+++ b/docs/hooks/useFeatureFlags.ts
@@ -1,0 +1,51 @@
+import {createContext} from 'preact';
+import {useContext} from 'preact/hooks';
+import {testAllConditions} from '@/conditions/conditions.js';
+import {GlobalModulesFields} from '@/root-cms.js';
+
+export type FeatureFlag = NonNullable<GlobalModulesFields['flags']>[number];
+
+export interface FeatureFlags {
+  /** Returns a flag's configuration by name, if defined. */
+  get: (name: string) => FeatureFlag | undefined;
+  /** Returns `true` if the named flag is defined and all its conditions pass. */
+  test: (name: string) => boolean;
+}
+
+/**
+ * Provides the list of feature flags (from `GlobalModules/flags`) to the
+ * component tree so that `useFeatureFlags()` and the `IsFeatureFlag` condition
+ * can resolve flags during render.
+ */
+export const FeatureFlagsContext = createContext<FeatureFlag[]>([]);
+
+// Tracks flags currently being evaluated to guard against cyclic
+// IsFeatureFlag -> IsFeatureFlag references.
+const evaluating = new Set<string>();
+
+export function useFeatureFlags(): FeatureFlags {
+  const flags = useContext(FeatureFlagsContext) || [];
+
+  function get(name: string): FeatureFlag | undefined {
+    return flags.find((flag) => flag.name === name);
+  }
+
+  function test(name: string): boolean {
+    const flag = get(name);
+    if (!flag) {
+      return false;
+    }
+    if (evaluating.has(name)) {
+      // Cyclic reference — treat as not enabled to avoid infinite recursion.
+      return false;
+    }
+    evaluating.add(name);
+    try {
+      return testAllConditions(flag.conditions);
+    } finally {
+      evaluating.delete(name);
+    }
+  }
+
+  return {get, test};
+}

--- a/docs/root-cms.d.ts
+++ b/docs/root-cms.d.ts
@@ -170,6 +170,12 @@ export interface CodeBlockFields {
   code?: string;
 }
 
+/** Generated from `/conditions/Conditions.schema.ts`. */
+export interface ConditionsFields {
+  /** Conditions */
+  conditions?: RootCMSOneOf<RootCMSOneOfOption<'IsFeatureFlag', IsFeatureFlagFields> | RootCMSOneOfOption<'IsLocale', IsLocaleFields>>[];
+}
+
 /** Generated from `/blocks/CopyBlock/CopyBlock.schema.ts`. */
 export interface CopyBlockFields {
   /** ID. Used for deep linking, tracking, etc. */
@@ -209,6 +215,24 @@ export interface EmojiFields {
   emojiName?: string;
 }
 
+/** Generated from `/collections/GlobalModules.schema.ts`. */
+export interface GlobalModulesFields {
+  /** [INTERNAL] Description. Internal description for this doc (not shown publicly). */
+  internalDesc?: string;
+  /** Flags. Feature flags for the site. A flag is enabled when all of its conditions are met. */
+  flags?: {
+    /** Name. Unique flag id, e.g. EnableFooBar. */
+    name?: string;
+    /** Description */
+    description?: string;
+    /** Conditions. The flag is enabled when all of these conditions pass. */
+    conditions?: RootCMSOneOf<RootCMSOneOfOption<'IsFeatureFlag', IsFeatureFlagFields> | RootCMSOneOfOption<'IsLocale', IsLocaleFields>>[];
+  }[];
+}
+
+/** Generated from `/collections/GlobalModules.schema.ts`. */
+export type GlobalModulesDoc = RootCMSDoc<GlobalModulesFields>;
+
 /** Generated from `/collections/Guide.schema.ts`. */
 export interface GuideFields {
   /** Meta */
@@ -247,6 +271,18 @@ export interface GuideFields {
 /** Generated from `/collections/Guide.schema.ts`. */
 export type GuideDoc = RootCMSDoc<GuideFields>;
 
+/** Generated from `/templates/If/If.schema.ts`. */
+export interface IfFields {
+  /** [INTERNAL] Description. e.g. 'Show hero only when the EnableNewHero flag is on'. */
+  internalDesc?: string;
+  /** Conditions. Nested modules render only when all of these conditions pass. */
+  conditions?: RootCMSOneOf<RootCMSOneOfOption<'IsFeatureFlag', IsFeatureFlagFields> | RootCMSOneOfOption<'IsLocale', IsLocaleFields>>[];
+  /** Modules (if TRUE). Rendered when all conditions are satisfied. */
+  modulesIfTrue?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+  /** Modules (if FALSE). Rendered when the conditions are NOT satisfied. */
+  modulesIfFalse?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+}
+
 /** Generated from `/blocks/ImageBlock/ImageBlock.schema.ts`. */
 export interface ImageBlockFields {
   /** ID. Used for deep linking, tracking, etc. */
@@ -266,6 +302,22 @@ export interface ImageBlockFields {
   };
 }
 
+/** Generated from `/conditions/IsFeatureFlag/IsFeatureFlag.schema.ts`. */
+export interface IsFeatureFlagFields {
+  /** [INTERNAL] Description */
+  internalDesc?: string;
+  /** Flag. Pick a flag defined in GlobalModules/flags, or type a new one. */
+  flag?: string;
+}
+
+/** Generated from `/conditions/IsLocale/IsLocale.schema.ts`. */
+export interface IsLocaleFields {
+  /** [INTERNAL] Description */
+  internalDesc?: string;
+  /** Locale(s). Locales to match, e.g. 'en', 'de'. Leave empty to match all. */
+  locales?: string[];
+}
+
 /** Generated from `/collections/Pages.schema.ts`. */
 export interface PagesFields {
   /** Meta */
@@ -280,7 +332,7 @@ export interface PagesFields {
   /** Content */
   content?: {
     /** Modules. Compose the page by adding one or more modules. */
-    modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+    modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'If', IfFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
   };
 }
 
@@ -301,7 +353,7 @@ export interface SandboxFields {
   /** Content */
   content?: {
     /** Modules. Compose the page by adding one or more modules. */
-    modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+    modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'If', IfFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
   };
 }
 
@@ -317,7 +369,7 @@ export interface SectionFields {
   /** Module Options. Layout and display options. */
   options?: string[];
   /** Modules */
-  modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+  modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'If', IfFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
 }
 
 /** Generated from `/templates/Spacer/Spacer.schema.ts`. */
@@ -437,5 +489,5 @@ export interface TemplateSandboxFields {
   /** RichTextField */
   richtext?: RootCMSRichText;
   /** Modules */
-  modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
+  modules?: RootCMSOneOf<RootCMSOneOfOption<'Divider', DividerFields> | RootCMSOneOfOption<'If', IfFields> | RootCMSOneOfOption<'Section', SectionFields> | RootCMSOneOfOption<'Spacer', SpacerFields> | RootCMSOneOfOption<'Template50x50', Template50x50Fields> | RootCMSOneOfOption<'TemplateHeadline', TemplateHeadlineFields> | RootCMSOneOfOption<'TemplateImage', TemplateImageFields> | RootCMSOneOfOption<'TemplateJumplinks', TemplateJumplinksFields> | RootCMSOneOfOption<'TemplatePoweredBy', TemplatePoweredByFields> | RootCMSOneOfOption<'TemplateSandbox', TemplateSandboxFields>>[];
 }

--- a/docs/routes/global-modules/[[...slug]].tsx
+++ b/docs/routes/global-modules/[[...slug]].tsx
@@ -1,0 +1,85 @@
+import {Container} from '@/components/Container/Container.js';
+import {Text} from '@/components/Text/Text.js';
+import {UnstyledList} from '@/components/UnstyledList/UnstyledList.js';
+import {testAllConditions} from '@/conditions/conditions.js';
+import {FeatureFlag, FeatureFlagsContext} from '@/hooks/useFeatureFlags.js';
+import {BaseLayout} from '@/layouts/BaseLayout';
+import {GlobalModulesDoc} from '@/root-cms';
+import {cmsRoute} from '@/utils/cms-route';
+import styles from './global-modules.module.scss';
+
+export interface PageProps {
+  doc: GlobalModulesDoc;
+}
+
+export default function Page(props: PageProps) {
+  const fields = props.doc?.fields || {};
+  const flags: FeatureFlag[] = fields.flags || [];
+  return (
+    <BaseLayout title="Feature Flags" noindex>
+      <Container className={styles.wrap}>
+        <Text as="h1" size="h2">
+          Feature Flags
+        </Text>
+        <Text className={styles.intro} size="p">
+          Defined in <code>GlobalModules/flags</code>. A flag is enabled when
+          all of its conditions pass.
+        </Text>
+        <FeatureFlagsContext.Provider value={flags}>
+          {flags.length === 0 ? (
+            <Text size="p">No flags defined yet.</Text>
+          ) : (
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Flag</th>
+                  <th>Description</th>
+                  <th>Conditions</th>
+                  <th>Enabled?</th>
+                </tr>
+              </thead>
+              <tbody>
+                {flags.map((flag) => (
+                  <FlagRow flag={flag} />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </FeatureFlagsContext.Provider>
+      </Container>
+    </BaseLayout>
+  );
+}
+
+function FlagRow(props: {flag: FeatureFlag}) {
+  const flag = props.flag;
+  const conditions = flag.conditions || [];
+  const enabled = testAllConditions(conditions);
+  return (
+    <tr>
+      <td>{flag.name || ''}</td>
+      <td>{flag.description || ''}</td>
+      <td>
+        {conditions.length === 0 ? (
+          <span className={styles.muted}>(always enabled)</span>
+        ) : (
+          <UnstyledList>
+            {conditions.map((condition: any) => (
+              <li>
+                {condition._type}
+                {condition.flag ? `: ${condition.flag}` : ''}
+              </li>
+            ))}
+          </UnstyledList>
+        )}
+      </td>
+      <td className={styles.enabled}>{String(enabled)}</td>
+    </tr>
+  );
+}
+
+export const {handle} = cmsRoute({
+  collection: 'GlobalModules',
+  slugParam: 'slug',
+  previewOnly: true,
+});

--- a/docs/routes/global-modules/global-modules.module.scss
+++ b/docs/routes/global-modules/global-modules.module.scss
@@ -1,0 +1,29 @@
+.wrap {
+  padding: 48px 0 80px;
+}
+
+.intro {
+  margin-top: 8px;
+  margin-bottom: 24px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.enabled {
+  font-weight: 600;
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.5);
+}

--- a/docs/templates/If/If.schema.ts
+++ b/docs/templates/If/If.schema.ts
@@ -1,0 +1,51 @@
+import {schema} from '@blinkk/root-cms';
+import {conditionsField} from '@/conditions/Conditions.schema.js';
+
+/**
+ * Conditionally renders nested modules based on a set of conditions.
+ *
+ * This is a convenient place to exercise the `IsFeatureFlag` condition (and its
+ * document-sourced flag picker): add an `If` module to a page, open its
+ * Conditions, add `IsFeatureFlag`, and pick a flag defined in
+ * `GlobalModules/flags`.
+ */
+export default schema.define({
+  name: 'If',
+  description: 'Conditionally render nested modules based on conditions.',
+  preview: {
+    title: ['If: {internalDesc}', 'If'],
+  },
+  fields: [
+    schema.string({
+      id: 'internalDesc',
+      label: '[INTERNAL] Description',
+      help: 'e.g. "Show hero only when the EnableNewHero flag is on".',
+      variant: 'textarea',
+    }),
+    conditionsField({
+      help: 'Nested modules render only when all of these conditions pass.',
+    }),
+    schema.array({
+      id: 'modulesIfTrue',
+      label: 'Modules (if TRUE)',
+      help: 'Rendered when all conditions are satisfied.',
+      of: schema.oneOf({
+        types: schema.glob('/templates/*/*.schema.ts', {
+          exclude: ['If', 'Section'],
+        }),
+      }),
+      preview: ['{_type} (#{id})', '{_type}', '(empty)'],
+    }),
+    schema.array({
+      id: 'modulesIfFalse',
+      label: 'Modules (if FALSE)',
+      help: 'Rendered when the conditions are NOT satisfied.',
+      of: schema.oneOf({
+        types: schema.glob('/templates/*/*.schema.ts', {
+          exclude: ['If', 'Section'],
+        }),
+      }),
+      preview: ['{_type} (#{id})', '{_type}', '(empty)'],
+    }),
+  ],
+});

--- a/docs/templates/If/If.tsx
+++ b/docs/templates/If/If.tsx
@@ -1,0 +1,15 @@
+import {
+  PageModuleFields,
+  PageModules,
+} from '@/components/PageModules/PageModules.js';
+import {testAllConditions} from '@/conditions/conditions.js';
+import {IfFields} from '@/root-cms.js';
+
+export function If(props: IfFields) {
+  const conditions = props.conditions || [];
+  const passed = testAllConditions(conditions);
+  const modules: PageModuleFields[] =
+    (passed ? props.modulesIfTrue : props.modulesIfFalse) || [];
+  const fieldKey = passed ? 'modulesIfTrue' : 'modulesIfFalse';
+  return <PageModules modules={modules} fieldKey={fieldKey} />;
+}

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -18,6 +18,66 @@ export interface CommonFieldProps {
   hideLabel?: boolean;
 }
 
+/**
+ * Sources the selectable values for a field from a field within another CMS
+ * document.
+ *
+ * Use this when a set of allowed values is managed centrally in the CMS (e.g. a
+ * list of feature flags defined in a global module) and you want other fields
+ * to pick from that list instead of typing free-form strings.
+ *
+ * Example: source a `flag` select's options from the `name` of each item in
+ * the `flags` array of the `GlobalModules/flags` document.
+ *
+ * ```ts
+ * schema.select({
+ *   id: 'flag',
+ *   source: {
+ *     doc: 'GlobalModules/flags',
+ *     field: 'flags',
+ *     valueKey: 'name',
+ *     helpKey: 'description',
+ *   },
+ *   creatable: true,
+ * });
+ * ```
+ */
+export interface DocumentSource {
+  /**
+   * The document to source values from, in `<collection>/<slug>` format, e.g.
+   * `GlobalModules/flags`.
+   */
+  doc: string;
+  /**
+   * The field within the document that holds the values, e.g. `flags`. This is
+   * usually an array; for an array of objects use `valueKey`/`labelKey` to map
+   * each item, and for an array of strings each string is used directly.
+   */
+  field: string;
+  /**
+   * The key on each item to use as the stored value, e.g. `name`. Dot-paths are
+   * supported for nested keys (e.g. `meta.id`). Omit for arrays of strings.
+   */
+  valueKey?: string;
+  /**
+   * The key on each item to use as the display label, e.g. `name`. Dot-paths
+   * are supported. Defaults to `valueKey`.
+   */
+  labelKey?: string;
+  /**
+   * The key on each item to use as secondary help text, shown in a smaller,
+   * dimmed line beneath the label in the dropdown, e.g. `description`. Dot-paths
+   * are supported.
+   */
+  helpKey?: string;
+}
+
+/**
+ * The source of selectable values for a field. Currently only a CMS document
+ * source is supported; other source types may be added in the future.
+ */
+export type FieldValueSource = DocumentSource;
+
 export type StringField = CommonFieldProps & {
   type: 'string';
   default?: string;
@@ -106,7 +166,18 @@ export function boolean(field: Omit<BooleanField, 'type'>): BooleanField {
 export type SelectField = CommonFieldProps & {
   type: 'select';
   default?: string;
+  /** A static list of options to choose from. */
   options?: Array<{value: string; label?: string}> | string[];
+  /**
+   * Dynamically source the options from a field in another CMS document,
+   * instead of the static `options` list. See {@link DocumentSource}.
+   */
+  source?: FieldValueSource;
+  /**
+   * Whether to allow the user to enter arbitrary values that aren't in the
+   * options/source list. Defaults to `false`.
+   */
+  creatable?: boolean;
   translate?: boolean;
   searchable?: boolean;
 };
@@ -117,9 +188,6 @@ export function select(field: Omit<SelectField, 'type'>): SelectField {
 
 export type MultiSelectField = Omit<SelectField, 'type'> & {
   type: 'multiselect';
-  /** Set to `true` to allow users to create arbitrary values. */
-  creatable?: boolean;
-  translate?: boolean;
 };
 
 export function multiselect(

--- a/packages/root-cms/ui/components/DocEditor/fields/MultiSelectField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/MultiSelectField.tsx
@@ -1,14 +1,45 @@
-import {MultiSelect} from '@mantine/core';
-import {useMemo} from 'preact/hooks';
+import {Loader, MultiSelect} from '@mantine/core';
+import {useEffect, useMemo, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
+import {FieldOption, resolveFieldSource} from '../../../utils/field-source.js';
 import {FieldProps} from './FieldProps.js';
+import {FieldSourceItem, SourceDocButton} from './SourceField.js';
 
 export function MultiSelectField(props: FieldProps) {
   const field = props.field as schema.MultiSelectField;
   const [value, setValue] = useDraftDocValue<string[]>(props.deepKey, []);
+  const [sourceOptions, setSourceOptions] = useState<FieldOption[]>([]);
+  const [created, setCreated] = useState<FieldOption[]>([]);
+  const [loading, setLoading] = useState(Boolean(field.source));
 
-  const options = useMemo(() => {
+  // Resolve options from a document source, if configured.
+  useEffect(() => {
+    if (!field.source) {
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    resolveFieldSource(field.source)
+      .then((options) => {
+        if (active) {
+          setSourceOptions(options);
+        }
+      })
+      .catch((err) => {
+        console.error('failed to resolve field source:', err);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [field.source]);
+
+  const staticOptions = useMemo<FieldOption[]>(() => {
     return (field.options || []).map((option) => {
       // Mantine requires both label and value to be set.
       if (typeof option === 'string') {
@@ -21,21 +52,60 @@ export function MultiSelectField(props: FieldProps) {
     });
   }, [field.options]);
 
-  return (
-    <div className="DocEditor__MultiSelectField">
-      <MultiSelect
-        data={options}
-        size="xs"
-        radius={0}
-        placeholder={field.placeholder}
-        value={value}
-        searchable
-        creatable={field.creatable || false}
-        getCreateLabel={(query: string) => `+ Add "${query}"`}
-        onChange={(newValue: string[]) => setValue(newValue)}
-        // Due to issues with preact/compat, use a div for the dropdown el.
-        dropdownComponent="div"
-      />
-    </div>
+  const data = useMemo(() => {
+    const optionsByValue = new Map<string, FieldOption>();
+    const base = field.source ? sourceOptions : staticOptions;
+    for (const option of base) {
+      optionsByValue.set(option.value, option);
+    }
+    for (const option of created) {
+      if (!optionsByValue.has(option.value)) {
+        optionsByValue.set(option.value, option);
+      }
+    }
+    // Include any selected values not present in the options list.
+    for (const selected of value || []) {
+      if (selected && !optionsByValue.has(selected)) {
+        optionsByValue.set(selected, {value: selected, label: selected});
+      }
+    }
+    return Array.from(optionsByValue.values());
+  }, [field.source, sourceOptions, staticOptions, created, value]);
+
+  const multiSelect = (
+    <MultiSelect
+      data={data}
+      size="xs"
+      radius={0}
+      placeholder={field.placeholder}
+      value={value}
+      searchable
+      creatable={field.creatable || false}
+      getCreateLabel={(query: string) => `+ Add "${query}"`}
+      onCreate={(query: string) => {
+        const item = {value: query, label: query};
+        setCreated((current) => [...current, item]);
+        return item;
+      }}
+      onChange={(newValue: string[]) => setValue(newValue)}
+      itemComponent={field.source?.helpKey ? FieldSourceItem : undefined}
+      nothingFound={loading ? 'Loading…' : undefined}
+      rightSection={loading ? <Loader size="xs" /> : undefined}
+      // Due to issues with preact/compat, use a div for the dropdown el.
+      dropdownComponent="div"
+    />
   );
+
+  if (field.source?.doc) {
+    return (
+      <div
+        className="DocEditor__MultiSelectField"
+        style={{display: 'flex', alignItems: 'center', gap: 8}}
+      >
+        <div style={{flex: 1, minWidth: 0}}>{multiSelect}</div>
+        <SourceDocButton source={field.source} />
+      </div>
+    );
+  }
+  return <div className="DocEditor__MultiSelectField">{multiSelect}</div>;
 }

--- a/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/SelectField.tsx
@@ -1,14 +1,45 @@
-import {Select} from '@mantine/core';
-import {useMemo} from 'preact/hooks';
+import {Loader, Select} from '@mantine/core';
+import {useEffect, useMemo, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
+import {FieldOption, resolveFieldSource} from '../../../utils/field-source.js';
 import {FieldProps} from './FieldProps.js';
+import {FieldSourceItem, SourceDocButton} from './SourceField.js';
 
 export function SelectField(props: FieldProps) {
   const field = props.field as schema.SelectField;
   const [value, setValue] = useDraftDocValue(props.deepKey, '');
+  const [sourceOptions, setSourceOptions] = useState<FieldOption[]>([]);
+  const [created, setCreated] = useState<FieldOption[]>([]);
+  const [loading, setLoading] = useState(Boolean(field.source));
 
-  const options = useMemo(() => {
+  // Resolve options from a document source, if configured.
+  useEffect(() => {
+    if (!field.source) {
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    resolveFieldSource(field.source)
+      .then((options) => {
+        if (active) {
+          setSourceOptions(options);
+        }
+      })
+      .catch((err) => {
+        console.error('failed to resolve field source:', err);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [field.source]);
+
+  const staticOptions = useMemo<FieldOption[]>(() => {
     return (field.options || []).map((option) => {
       // Mantine requires both label and value to be set.
       if (typeof option === 'string') {
@@ -21,20 +52,60 @@ export function SelectField(props: FieldProps) {
     });
   }, [field.options]);
 
-  return (
-    <div className="DocEditor__SelectField">
-      <Select
-        data={options}
-        placeholder={field.placeholder}
-        value={value}
-        onChange={(e: string) => setValue(e || '')}
-        size="xs"
-        radius={0}
-        searchable={field.searchable ?? true}
-        clearable={true}
-        // Due to issues with preact/compat, use a div for the dropdown el.
-        dropdownComponent="div"
-      />
-    </div>
+  const data = useMemo(() => {
+    const optionsByValue = new Map<string, FieldOption>();
+    const base = field.source ? sourceOptions : staticOptions;
+    for (const option of base) {
+      optionsByValue.set(option.value, option);
+    }
+    for (const option of created) {
+      if (!optionsByValue.has(option.value)) {
+        optionsByValue.set(option.value, option);
+      }
+    }
+    // Always include the current value so its label renders, even if the source
+    // options haven't loaded yet or the value was removed from the list.
+    if (value && !optionsByValue.has(value)) {
+      optionsByValue.set(value, {value, label: value});
+    }
+    return Array.from(optionsByValue.values());
+  }, [field.source, sourceOptions, staticOptions, created, value]);
+
+  const select = (
+    <Select
+      data={data}
+      placeholder={field.placeholder}
+      value={value || null}
+      onChange={(e: string) => setValue(e || '')}
+      size="xs"
+      radius={0}
+      searchable={field.searchable ?? true}
+      clearable={true}
+      creatable={field.creatable || false}
+      getCreateLabel={(query: string) => `+ Add "${query}"`}
+      onCreate={(query: string) => {
+        const item = {value: query, label: query};
+        setCreated((current) => [...current, item]);
+        return item;
+      }}
+      itemComponent={field.source?.helpKey ? FieldSourceItem : undefined}
+      nothingFound={loading ? 'Loading…' : undefined}
+      rightSection={loading ? <Loader size="xs" /> : undefined}
+      // Due to issues with preact/compat, use a div for the dropdown el.
+      dropdownComponent="div"
+    />
   );
+
+  if (field.source?.doc) {
+    return (
+      <div
+        className="DocEditor__SelectField"
+        style={{display: 'flex', alignItems: 'center', gap: 8}}
+      >
+        <div style={{flex: 1, minWidth: 0}}>{select}</div>
+        <SourceDocButton source={field.source} />
+      </div>
+    );
+  }
+  return <div className="DocEditor__SelectField">{select}</div>;
 }

--- a/packages/root-cms/ui/components/DocEditor/fields/SourceField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/SourceField.tsx
@@ -1,0 +1,60 @@
+import {ActionIcon, Text, Tooltip} from '@mantine/core';
+import {IconExternalLink} from '@tabler/icons-preact';
+import {forwardRef} from 'preact/compat';
+import * as schema from '../../../../core/schema.js';
+
+/**
+ * Dropdown item for a document-sourced select/multiselect: shows the option
+ * label with optional smaller, dimmed help text beneath it (from `helpKey`).
+ */
+export const FieldSourceItem = forwardRef(
+  (props: {label: string; description?: string; ref: any}) => {
+    const {label, description, ...selectProps} = props;
+    return (
+      <div {...selectProps}>
+        <Text size="sm">{label}</Text>
+        {description && (
+          <Text size="xs" color="dimmed">
+            {description}
+          </Text>
+        )}
+      </div>
+    );
+  }
+);
+
+interface SourceDocButtonProps {
+  source?: schema.FieldValueSource;
+}
+
+/**
+ * Icon button that opens the source document's editor in a new tab. Renders
+ * nothing unless the field is sourced from a document.
+ */
+export function SourceDocButton(props: SourceDocButtonProps) {
+  const source = props.source;
+  if (!source || !source.doc) {
+    return null;
+  }
+  const label = `Open ${source.doc}`;
+  let href = `/cms/content/${source.doc}`;
+  if (source.field) {
+    // Deep-link to the source field within the doc editor, e.g.
+    // `?deeplink=fields.flags`.
+    const deepKey = `fields.${source.field}`;
+    href += `?deeplink=${encodeURIComponent(deepKey)}`;
+  }
+  return (
+    <Tooltip label={label} position="top" withArrow>
+      <ActionIcon
+        component="a"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={label}
+      >
+        <IconExternalLink size={16} />
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/packages/root-cms/ui/utils/doc-cache.test.ts
+++ b/packages/root-cms/ui/utils/doc-cache.test.ts
@@ -1,0 +1,78 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const getDocMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  getDoc: (ref: any) => getDocMock(ref),
+}));
+
+vi.mock('./doc.js', () => ({
+  getDraftDocRef: (docId: string) => ({docId}),
+}));
+
+import {
+  getDocFromCacheOrFetch,
+  removeDocFromCache,
+  setDocToCache,
+} from './doc-cache.js';
+
+describe('getDocFromCacheOrFetch', () => {
+  beforeEach(() => {
+    getDocMock.mockReset();
+    removeDocFromCache('Pages/foo');
+  });
+
+  it('dedupes concurrent fetches for the same doc into one request', async () => {
+    let resolveFetch: (data: any) => void = () => {};
+    getDocMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = (data: any) => resolve({data: () => data});
+      })
+    );
+
+    // Kick off several concurrent requests before the fetch resolves.
+    const p1 = getDocFromCacheOrFetch('Pages/foo');
+    const p2 = getDocFromCacheOrFetch('Pages/foo');
+    const p3 = getDocFromCacheOrFetch('Pages/foo');
+
+    resolveFetch({title: 'Foo'});
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(getDocMock).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual({title: 'Foo'});
+    expect(r2).toEqual({title: 'Foo'});
+    expect(r3).toEqual({title: 'Foo'});
+  });
+
+  it('serves subsequent reads from the cache without re-fetching', async () => {
+    getDocMock.mockResolvedValue({data: () => ({title: 'Bar'})});
+
+    const first = await getDocFromCacheOrFetch('Pages/foo');
+    const second = await getDocFromCacheOrFetch('Pages/foo');
+
+    expect(getDocMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({title: 'Bar'});
+    expect(second).toEqual({title: 'Bar'});
+  });
+
+  it('clears the in-flight promise on completion so errors can be retried', async () => {
+    getDocMock.mockRejectedValueOnce(new Error('network'));
+    await expect(getDocFromCacheOrFetch('Pages/foo')).rejects.toThrow(
+      'network'
+    );
+
+    getDocMock.mockResolvedValueOnce({data: () => ({title: 'Retry'})});
+    const retried = await getDocFromCacheOrFetch('Pages/foo');
+
+    expect(getDocMock).toHaveBeenCalledTimes(2);
+    expect(retried).toEqual({title: 'Retry'});
+  });
+
+  it('removeDocFromCache also clears any pending fetch', async () => {
+    setDocToCache('Pages/foo', {title: 'Cached'});
+    expect(await getDocFromCacheOrFetch('Pages/foo')).toEqual({
+      title: 'Cached',
+    });
+    expect(getDocMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/root-cms/ui/utils/doc-cache.ts
+++ b/packages/root-cms/ui/utils/doc-cache.ts
@@ -3,6 +3,13 @@ import {getDraftDocRef} from './doc.js';
 
 const DOC_CACHE: Map<string, any> = new Map();
 
+/**
+ * Tracks in-flight fetches so that concurrent requests for the same doc share a
+ * single network call. Without this, multiple fields that reference the same
+ * source doc would each issue their own fetch before the cache is populated.
+ */
+const PENDING_FETCHES: Map<string, Promise<any>> = new Map();
+
 export function getDocFromCache(docId: string) {
   return DOC_CACHE.get(docId) || null;
 }
@@ -12,11 +19,21 @@ export async function getDocFromCacheOrFetch(docId: string) {
   if (cachedValue) {
     return cachedValue;
   }
-  const docRef = getDraftDocRef(docId);
-  const snapshot = await getDoc(docRef);
-  const data = snapshot.data();
-  setDocToCache(docId, data);
-  return data;
+  const pending = PENDING_FETCHES.get(docId);
+  if (pending) {
+    return pending;
+  }
+  const fetchPromise = (async () => {
+    const docRef = getDraftDocRef(docId);
+    const snapshot = await getDoc(docRef);
+    const data = snapshot.data();
+    setDocToCache(docId, data);
+    return data;
+  })().finally(() => {
+    PENDING_FETCHES.delete(docId);
+  });
+  PENDING_FETCHES.set(docId, fetchPromise);
+  return fetchPromise;
 }
 
 export function setDocToCache(docId: string, data: any) {
@@ -25,6 +42,7 @@ export function setDocToCache(docId: string, data: any) {
 
 export function removeDocFromCache(docId: string) {
   DOC_CACHE.delete(docId);
+  PENDING_FETCHES.delete(docId);
 }
 
 export function removeDocsFromCache(docIds: string[]) {

--- a/packages/root-cms/ui/utils/field-source.test.ts
+++ b/packages/root-cms/ui/utils/field-source.test.ts
@@ -1,0 +1,112 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const getDocFromCacheOrFetchMock = vi.fn();
+
+vi.mock('./doc-cache.js', () => ({
+  getDocFromCacheOrFetch: (docId: string) => getDocFromCacheOrFetchMock(docId),
+}));
+
+import {resolveFieldSource} from './field-source.js';
+
+describe('resolveFieldSource', () => {
+  beforeEach(() => {
+    getDocFromCacheOrFetchMock.mockReset();
+  });
+
+  it('resolves document options from an array-of-objects field', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue({
+      fields: {
+        flags: {
+          _array: ['k1', 'k2'],
+          k1: {name: 'EnableFooBar', description: 'Foo bar'},
+          k2: {name: 'EnableBaz', description: 'Baz'},
+        },
+      },
+    });
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/flags',
+      field: 'flags',
+      valueKey: 'name',
+      labelKey: 'description',
+    });
+    expect(getDocFromCacheOrFetchMock).toHaveBeenCalledWith(
+      'GlobalModules/flags'
+    );
+    expect(options).toEqual([
+      {value: 'EnableFooBar', label: 'Foo bar'},
+      {value: 'EnableBaz', label: 'Baz'},
+    ]);
+  });
+
+  it('includes a description resolved from helpKey', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue({
+      fields: {
+        flags: {
+          _array: ['k1'],
+          k1: {name: 'EnableFooBar', description: 'Foo bar'},
+        },
+      },
+    });
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/flags',
+      field: 'flags',
+      valueKey: 'name',
+      helpKey: 'description',
+    });
+    expect(options).toEqual([
+      {value: 'EnableFooBar', label: 'EnableFooBar', description: 'Foo bar'},
+    ]);
+  });
+
+  it('uses the value as the label when no label sub-field resolves', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue({
+      fields: {
+        flags: {
+          _array: ['k1'],
+          k1: {name: 'EnableFooBar'},
+        },
+      },
+    });
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/flags',
+      field: 'flags',
+      valueKey: 'name',
+      labelKey: 'description',
+    });
+    expect(options).toEqual([{value: 'EnableFooBar', label: 'EnableFooBar'}]);
+  });
+
+  it('resolves document options from an array of strings', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue({
+      fields: {tags: ['typescript', 'javascript', 'typescript']},
+    });
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/tags',
+      field: 'tags',
+    });
+    expect(options).toEqual([
+      {value: 'typescript', label: 'typescript'},
+      {value: 'javascript', label: 'javascript'},
+    ]);
+  });
+
+  it('returns an empty list when the source field is missing', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue({fields: {}});
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/flags',
+      field: 'flags',
+      valueKey: 'name',
+    });
+    expect(options).toEqual([]);
+  });
+
+  it('returns an empty list when the document does not exist', async () => {
+    getDocFromCacheOrFetchMock.mockResolvedValue(undefined);
+    const options = await resolveFieldSource({
+      doc: 'GlobalModules/missing',
+      field: 'flags',
+      valueKey: 'name',
+    });
+    expect(options).toEqual([]);
+  });
+});

--- a/packages/root-cms/ui/utils/field-source.ts
+++ b/packages/root-cms/ui/utils/field-source.ts
@@ -1,0 +1,92 @@
+import * as schema from '../../core/schema.js';
+import {getDocFromCacheOrFetch} from './doc-cache.js';
+import {getNestedValue} from './objects.js';
+
+export interface FieldOption {
+  value: string;
+  label: string;
+  /** Optional secondary help text shown beneath the label in the dropdown. */
+  description?: string;
+}
+
+/**
+ * Resolves the selectable values for a field from its source. Currently only a
+ * CMS document source is supported (resolved from the referenced doc's field).
+ */
+export async function resolveFieldSource(
+  source: schema.FieldValueSource
+): Promise<FieldOption[]> {
+  if (source && source.doc) {
+    return resolveDocumentSource(source);
+  }
+  return [];
+}
+
+async function resolveDocumentSource(
+  source: schema.DocumentSource
+): Promise<FieldOption[]> {
+  if (!source.doc || !source.field) {
+    return [];
+  }
+  const rawDoc = await getDocFromCacheOrFetch(source.doc);
+  if (!rawDoc) {
+    return [];
+  }
+  const fields = rawDoc.fields || {};
+  const items = toArray(getNestedValue(fields, source.field));
+  const result: FieldOption[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    let rawValue: any;
+    let rawLabel: any;
+    let rawHelp: any;
+    if (item && typeof item === 'object') {
+      rawValue = source.valueKey
+        ? getNestedValue(item, source.valueKey)
+        : undefined;
+      rawLabel = source.labelKey
+        ? getNestedValue(item, source.labelKey)
+        : undefined;
+      rawHelp = source.helpKey
+        ? getNestedValue(item, source.helpKey)
+        : undefined;
+    } else {
+      rawValue = item;
+    }
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+      continue;
+    }
+    const value = String(rawValue);
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    const label =
+      rawLabel === undefined || rawLabel === null || rawLabel === ''
+        ? value
+        : String(rawLabel);
+    const description =
+      rawHelp === undefined || rawHelp === null || rawHelp === ''
+        ? undefined
+        : String(rawHelp);
+    result.push(description ? {value, label, description} : {value, label});
+  }
+  return result;
+}
+
+/**
+ * Converts a CMS array value to a plain array. CMS arrays are stored in the
+ * `{_array: [keys], <key>: <item>}` notation, so this normalizes that into an
+ * ordered list. Plain arrays are returned as-is.
+ */
+function toArray(value: any): any[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value && typeof value === 'object' && Array.isArray(value._array)) {
+    return value._array
+      .map((key: string) => value[key])
+      .filter((item: any) => item !== undefined && item !== null);
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

Adds **`source`** support to `select` (and `multiselect`) fields, letting a field's options be sourced from a field in another CMS document instead of (or alongside) a static `options` list. The stored value is still a plain string (`select`) / string array (`multiselect`).

```ts
schema.select({
  id: 'flag',
  source: {
    doc: 'GlobalModules/flags', // <collection>/<slug>
    field: 'flags',             // the (array) field to read
    valueKey: 'name',           // key on each item -> stored value
    helpKey: 'description',      // key on each item -> dimmed help line
  },
  creatable: true,              // optional pick-or-create
});
```

### Field changes (`packages/root-cms`)
- `SelectField` gains `source?: FieldValueSource` and `creatable?`. `MultiSelectField` inherits both.
- New `DocumentSource` / `FieldValueSource` types (`core/schema.ts`). `valueKey` / `labelKey` / `helpKey` are keys read from each item (dot-paths supported); the value stays a plain string, so generated `.d.ts` types are unchanged.
- Resolver util `ui/utils/field-source.ts` (`resolveFieldSource`) fetches the source doc via the existing doc cache and normalizes the `_array` storage format.
- `SelectField.tsx` / `MultiSelectField.tsx` async-resolve options, show a loading spinner, support `creatable`, and render per-option help text via a custom `itemComponent`.
- An inline "open source doc" icon button (tooltip `Open <docId>`) sits to the right of the field and deep-links to the source field: `/cms/content/<doc>?deeplink=fields.<field>`.

### Docs test bed (`docs/`)
A runnable example of the feature: a `GlobalModules` collection (feature flags), a small conditions system with an `IsFeatureFlag` condition whose `flag` field is the document-sourced picker, an `If` page-module template to exercise it in the editor, and a preview route that renders the flags table.

## Test plan
- `pnpm build:core` + `pnpm build:ui:bundle` in `packages/root-cms` (green)
- `pnpm exec vitest run ui/utils/field-source.test.ts` (6 passing)
- `pnpm exec root build --ssr-only` in `docs` (green)
- eslint clean on all changed files
- Includes a changeset.
