### PR TITLE
feat: add renderMode option to override JSX render mode per request

### DIFF
--- a/.changeset/red-words-knock.md
+++ b/.changeset/red-words-knock.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add renderMode option to override JSX render mode per request

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -6,7 +6,7 @@ import {
 } from 'express';
 import {ComponentType} from 'preact';
 import {ViteDevServer} from 'vite';
-import {JsxRenderOptions} from '../jsx/jsx-render.js';
+import {JsxRenderMode} from '../jsx/jsx-render.js';
 import {Hooks} from '../middleware/hooks.js';
 import {SaveSessionOptions, Session} from '../middleware/session.js';
 import {Renderer} from '../render/render.js';
@@ -245,7 +245,7 @@ export interface HandlerRenderOptions {
    * around block elements; `'minimal'` outputs compact HTML. If not provided,
    * defaults to the `jsxRenderer.mode` specified in `root.config.ts`.
    */
-  renderMode?: JsxRenderOptions['mode'];
+  renderMode?: JsxRenderMode;
 }
 
 export type HandlerRenderFn<Props = any> = (

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -6,6 +6,7 @@ import {
 } from 'express';
 import {ComponentType} from 'preact';
 import {ViteDevServer} from 'vite';
+import {JsxRenderOptions} from '../jsx/jsx-render.js';
 import {Hooks} from '../middleware/hooks.js';
 import {SaveSessionOptions, Session} from '../middleware/session.js';
 import {Renderer} from '../render/render.js';
@@ -239,6 +240,12 @@ export interface HandlerRenderOptions {
    * `/translations/{locale}.json`.
    */
   translations?: Record<string, string>;
+  /**
+   * Overrides the JSX render mode for this render. `'pretty'` adds newlines
+   * around block elements; `'minimal'` outputs compact HTML. If not provided,
+   * defaults to the `jsxRenderer.mode` specified in `root.config.ts`.
+   */
+  renderMode?: JsxRenderOptions['mode'];
 }
 
 export type HandlerRenderFn<Props = any> = (

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -348,9 +348,15 @@ function styleToString(style: Record<string, any>): string {
   return result;
 }
 
+/**
+ * JSX render mode. `'pretty'` adds newlines around block elements; `'minimal'`
+ * outputs compact HTML.
+ */
+export type JsxRenderMode = 'pretty' | 'minimal';
+
 export interface JsxRenderOptions {
   /** Render mode. `'pretty'` adds newlines around block elements; `'minimal'` outputs compact HTML. Default: `'pretty'`. */
-  mode?: 'pretty' | 'minimal';
+  mode?: JsxRenderMode;
   /** Additional tag names to treat as block-level elements in pretty mode. */
   blockElements?: string[];
 }

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -29,7 +29,11 @@ import {
   SitemapItem,
   Sitemap,
 } from '../core/types.js';
-import {JsxRenderOptions, renderJsxToString} from '../jsx/jsx-render.js';
+import {
+  JsxRenderMode,
+  JsxRenderOptions,
+  renderJsxToString,
+} from '../jsx/jsx-render.js';
 import type {ElementGraph} from '../node/element-graph.js';
 import {parseTagNames} from '../utils/elements.js';
 import {toHrefLang} from '../utils/i18n.js';
@@ -78,7 +82,7 @@ interface RenderHtmlOptions {
    * Overrides the JSX render mode. If not provided, defaults to the
    * `jsxRenderer.mode` specified in `root.config.ts`.
    */
-  renderMode?: JsxRenderOptions['mode'];
+  renderMode?: JsxRenderMode;
 }
 
 export class Renderer {
@@ -159,7 +163,7 @@ export class Renderer {
       locale: string;
       translations?: Record<string, string>;
       nonce?: string;
-      renderMode?: JsxRenderOptions['mode'];
+      renderMode?: JsxRenderMode;
     }
   ) {
     const {currentPath, route, routeParams, nonce} = options;
@@ -627,7 +631,7 @@ export class Renderer {
    * yielding to the event loop.
    */
   private async getJsxRenderFn(renderOptions?: {
-    mode?: JsxRenderOptions['mode'];
+    mode?: JsxRenderMode;
   }): Promise<(vnode: any) => string> {
     // Use the per-render mode override if provided, otherwise fall back to the
     // mode specified by the `jsxRenderer` config in `root.config.ts`.
@@ -652,7 +656,7 @@ export class Renderer {
    */
   private async renderJsx(
     vnode: any,
-    options?: {mode?: JsxRenderOptions['mode']}
+    options?: {mode?: JsxRenderMode}
   ) {
     const render = await this.getJsxRenderFn(options);
     return render(vnode);

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -74,6 +74,11 @@ interface RenderHtmlOptions {
   headComponents?: ComponentChildren[];
   /** Attrs passed to the <body> tag. */
   bodyAttrs?: preact.JSX.HTMLAttributes<HTMLBodyElement>;
+  /**
+   * Overrides the JSX render mode. If not provided, defaults to the
+   * `jsxRenderer.mode` specified in `root.config.ts`.
+   */
+  renderMode?: JsxRenderOptions['mode'];
 }
 
 export class Renderer {
@@ -154,6 +159,7 @@ export class Renderer {
       locale: string;
       translations?: Record<string, string>;
       nonce?: string;
+      renderMode?: JsxRenderOptions['mode'];
     }
   ) {
     const {currentPath, route, routeParams, nonce} = options;
@@ -196,7 +202,7 @@ export class Renderer {
     // occurs while the hook is swapped. Awaiting inside the swapped window
     // allows concurrent renders to interleave, leaking a stale hook (and its
     // nonce) into other requests.
-    const renderJsxFn = await this.getJsxRenderFn();
+    const renderJsxFn = await this.getJsxRenderFn({mode: options.renderMode});
     const preactHook = preactOptions.vnode;
     let mainHtml: string;
     try {
@@ -291,6 +297,7 @@ export class Renderer {
         ...styleTags,
         ...scriptTags,
       ],
+      renderMode: options.renderMode,
     });
     return {html};
   }
@@ -420,6 +427,7 @@ export class Renderer {
         locale,
         translations,
         nonce,
+        renderMode: options?.renderMode,
       });
 
       let html = await transformHtml(output.html, this.rootConfig);
@@ -610,14 +618,22 @@ export class Renderer {
    * `@blinkk/root/jsx` package or `preact-render-to-string` depending if the
    * `jsxRenderer` config is set up in `root.config.ts`.
    *
+   * A `mode` override may be passed to render in a specific mode for a single
+   * render, overriding the `jsxRenderer.mode` from `root.config.ts`.
+   *
    * Resolving the renderer up front (rather than awaiting inside the render
    * call) allows callers that temporarily swap global state (e.g. the
    * `preact.options.vnode` nonce hook) to render synchronously without
    * yielding to the event loop.
    */
-  private async getJsxRenderFn(): Promise<(vnode: any) => string> {
-    if (this.rootConfig.jsxRenderer?.mode) {
-      const options = this.getJsxRenderOptions();
+  private async getJsxRenderFn(renderOptions?: {
+    mode?: JsxRenderOptions['mode'];
+  }): Promise<(vnode: any) => string> {
+    // Use the per-render mode override if provided, otherwise fall back to the
+    // mode specified by the `jsxRenderer` config in `root.config.ts`.
+    const mode = renderOptions?.mode ?? this.rootConfig.jsxRenderer?.mode;
+    if (mode) {
+      const options = {...this.getJsxRenderOptions(), mode};
       return (vnode: any) => renderJsxToString(vnode, options);
     }
     const {renderToString} = await import('preact-render-to-string');
@@ -634,8 +650,11 @@ export class Renderer {
    * `preact-render-to-string` depending if the `jsxRenderer` config is set up
    * in `root.config.ts`.
    */
-  private async renderJsx(vnode: any) {
-    const render = await this.getJsxRenderFn();
+  private async renderJsx(
+    vnode: any,
+    options?: {mode?: JsxRenderOptions['mode']}
+  ) {
+    const render = await this.getJsxRenderFn(options);
     return render(vnode);
   }
 
@@ -664,7 +683,7 @@ export class Renderer {
         />
       </html>
     );
-    const content = await this.renderJsx(page);
+    const content = await this.renderJsx(page, {mode: options?.renderMode});
     return `<!doctype html>\n${content}`;
   }
 

--- a/packages/root/test/fixtures/render-mode/root.config.ts
+++ b/packages/root/test/fixtures/render-mode/root.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '../../../dist/core';
+
+export default defineConfig({
+  jsxRenderer: {
+    mode: 'pretty',
+  },
+});

--- a/packages/root/test/fixtures/render-mode/routes/index.tsx
+++ b/packages/root/test/fixtures/render-mode/routes/index.tsx
@@ -1,0 +1,7 @@
+export default function Index() {
+  return (
+    <main>
+      <h1>Default Mode</h1>
+    </main>
+  );
+}

--- a/packages/root/test/fixtures/render-mode/routes/minimal.tsx
+++ b/packages/root/test/fixtures/render-mode/routes/minimal.tsx
@@ -1,0 +1,18 @@
+import {Handler, HandlerContext, Request} from '../../../../dist/core';
+
+export default function MinimalPage() {
+  return (
+    <main>
+      <h1>Minimal Mode</h1>
+    </main>
+  );
+}
+
+/**
+ * SSR handler that overrides the JSX render mode to `'minimal'`, even though
+ * `root.config.ts` configures the default mode as `'pretty'`.
+ */
+export const handle: Handler = async (req: Request) => {
+  const ctx = req.handlerContext as HandlerContext;
+  return ctx.render({}, {renderMode: 'minimal'});
+};

--- a/packages/root/test/render-mode.test.ts
+++ b/packages/root/test/render-mode.test.ts
@@ -1,0 +1,50 @@
+import http from 'node:http';
+import path from 'node:path';
+import {afterAll, beforeAll, test, expect} from 'vitest';
+import {createDevServer} from '../dist/cli.js';
+
+const rootDir = path.resolve(__dirname, './fixtures/render-mode');
+let httpServer: http.Server;
+let app: any;
+const port = 14568;
+
+beforeAll(async () => {
+  app = await createDevServer({rootDir, port});
+  httpServer = app.listen(port);
+});
+
+afterAll(async () => {
+  if (httpServer) {
+    httpServer.close();
+  }
+  if (app) {
+    const viteServer = app.get('viteServer');
+    if (viteServer) {
+      await viteServer.close();
+    }
+  }
+});
+
+async function fetchPath(
+  urlPath: string
+): Promise<{status: number; body: string}> {
+  const res = await fetch(`http://localhost:${port}${urlPath}`);
+  const body = await res.text();
+  return {status: res.status, body};
+}
+
+test('ssr: defaults to the render mode from root.config.ts', async () => {
+  const {status, body} = await fetchPath('/');
+  expect(status).toBe(200);
+  // The config sets `mode: 'pretty'`, so block elements render on their own
+  // line with surrounding newlines.
+  expect(body).toContain('<main>\n<h1>Default Mode</h1>\n</main>');
+});
+
+test('ssr: render() can override the render mode', async () => {
+  const {status, body} = await fetchPath('/minimal');
+  expect(status).toBe(200);
+  // The route's `handle()` passes `{renderMode: 'minimal'}`, overriding the
+  // `'pretty'` default, so the output is compact with no extra whitespace.
+  expect(body).toContain('<main><h1>Minimal Mode</h1></main>');
+});


### PR DESCRIPTION
## Summary
This PR adds support for overriding the JSX render mode on a per-request basis, allowing individual routes to use a different render mode than the default configured in `root.config.ts`.

## Key Changes
- **Added `renderMode` option to `HandlerRenderOptions`**: Routes can now pass `{renderMode: 'minimal' | 'pretty'}` to `ctx.render()` to override the default mode for that specific request
- **Updated `Renderer` class**: Modified `render()`, `renderHtml()`, and `renderJsx()` methods to accept and propagate the `renderMode` option through the rendering pipeline
- **Enhanced `getJsxRenderFn()`**: Now accepts an optional `renderOptions` parameter to apply per-render mode overrides while maintaining backward compatibility with the config-level default
- **Added comprehensive tests**: New test file validates that routes can override the render mode, with fixtures demonstrating both default and overridden behavior

## Implementation Details
- The `renderMode` parameter flows through the rendering pipeline: `render()` → `renderHtml()` → `renderJsx()` → `getJsxRenderFn()`
- Per-render mode overrides take precedence over the `jsxRenderer.mode` configured in `root.config.ts`
- The implementation maintains backward compatibility—if no `renderMode` is provided, the configured default is used
- Test fixtures include a config with `mode: 'pretty'` and routes demonstrating both default behavior and mode override via the handler

https://claude.ai/code/session_01YKwfcoGqqJKxbYNZaXhJA1