### PR TITLE
feat: add error boundary to DocEditor

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -108,6 +108,7 @@ import {
 } from '../DocStatusBadges/DocStatusBadges.js';
 import {useEditJsonModal} from '../EditJsonModal/EditJsonModal.js';
 import {useEditTranslationsModal} from '../EditTranslationsModal/EditTranslationsModal.js';
+import {FieldErrorBoundary} from '../FieldErrorBoundary/FieldErrorBoundary.js';
 import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {useLocalizationModal} from '../LocalizationModal/LocalizationModal.js';
 import {useLockPublishingModal} from '../LockPublishingModal/LockPublishingModal.js';
@@ -579,41 +580,43 @@ DocEditor.FieldBody = (props: FieldProps) => {
     >
       {showFieldHeader && <DocEditor.FieldHeader {...props} />}
       <div className="DocEditor__field__input">
-        {field.type === 'array' ? (
-          <DocEditor.ArrayField {...props} />
-        ) : field.type === 'boolean' ? (
-          <BooleanField {...props} />
-        ) : field.type === 'date' ? (
-          <DateField {...props} />
-        ) : field.type === 'datetime' ? (
-          <DateTimeField {...props} />
-        ) : field.type === 'file' ? (
-          <FileField {...props} />
-        ) : field.type === 'image' ? (
-          <ImageField {...props} />
-        ) : field.type === 'multiselect' ? (
-          <MultiSelectField {...props} />
-        ) : field.type === 'number' ? (
-          <NumberField {...props} />
-        ) : field.type === 'object' ? (
-          <DocEditor.ObjectField {...props} />
-        ) : field.type === 'oneof' ? (
-          <DocEditor.OneOfField {...props} />
-        ) : field.type === 'reference' ? (
-          <ReferenceField {...props} />
-        ) : field.type === 'references' ? (
-          <ReferencesField {...props} />
-        ) : field.type === 'richtext' ? (
-          <RichTextField {...props} />
-        ) : field.type === 'select' ? (
-          <SelectField {...props} />
-        ) : field.type === 'string' ? (
-          <StringField {...props} />
-        ) : (
-          <div className="DocEditor__field__input__unknown">
-            Unknown field type: {(field as any).type}
-          </div>
-        )}
+        <FieldErrorBoundary deepKey={props.deepKey}>
+          {field.type === 'array' ? (
+            <DocEditor.ArrayField {...props} />
+          ) : field.type === 'boolean' ? (
+            <BooleanField {...props} />
+          ) : field.type === 'date' ? (
+            <DateField {...props} />
+          ) : field.type === 'datetime' ? (
+            <DateTimeField {...props} />
+          ) : field.type === 'file' ? (
+            <FileField {...props} />
+          ) : field.type === 'image' ? (
+            <ImageField {...props} />
+          ) : field.type === 'multiselect' ? (
+            <MultiSelectField {...props} />
+          ) : field.type === 'number' ? (
+            <NumberField {...props} />
+          ) : field.type === 'object' ? (
+            <DocEditor.ObjectField {...props} />
+          ) : field.type === 'oneof' ? (
+            <DocEditor.OneOfField {...props} />
+          ) : field.type === 'reference' ? (
+            <ReferenceField {...props} />
+          ) : field.type === 'references' ? (
+            <ReferencesField {...props} />
+          ) : field.type === 'richtext' ? (
+            <RichTextField {...props} />
+          ) : field.type === 'select' ? (
+            <SelectField {...props} />
+          ) : field.type === 'string' ? (
+            <StringField {...props} />
+          ) : (
+            <div className="DocEditor__field__input__unknown">
+              Unknown field type: {(field as any).type}
+            </div>
+          )}
+        </FieldErrorBoundary>
       </div>
     </div>
   );

--- a/packages/root-cms/ui/components/DocEditor/fields/StringField.test.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/StringField.test.tsx
@@ -1,0 +1,75 @@
+import {cleanup, render, screen} from '@testing-library/preact';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import * as schema from '../../../../core/schema.js';
+import {FieldErrorBoundary} from '../../FieldErrorBoundary/FieldErrorBoundary.js';
+import {FieldProps} from './FieldProps.js';
+
+// Mock Mantine inputs. The real components require a MantineProvider context
+// that isn't available under @preact/compat in jsdom; these stubs keep the
+// test focused on StringField's own value-handling logic.
+vi.mock('@mantine/core', () => ({
+  TextInput: ({value}: any) => <input value={value} readOnly />,
+  Textarea: ({value}: any) => <textarea value={value} readOnly />,
+}));
+
+// Mock useDraftDocValue so the field can be rendered without the full draft
+// doc controller/context. The mocked value is controlled per-test.
+let mockValue: any = '';
+vi.mock('../../../hooks/useDraftDoc.js', () => ({
+  useDraftDocValue: () => [mockValue, vi.fn()] as const,
+}));
+
+// Mock iframe-preview to avoid touching window messaging.
+vi.mock('../../../utils/iframe-preview.js', () => ({
+  requestHighlightNode: vi.fn(),
+}));
+
+// Import after mocks are registered.
+const {StringField} = await import('./StringField.js');
+
+function renderField(value: any) {
+  mockValue = value;
+  const field: schema.StringField = {
+    type: 'string',
+    id: 'title',
+  };
+  const props: FieldProps = {
+    field,
+    deepKey: 'meta.title',
+  };
+  return render(
+    <FieldErrorBoundary deepKey={props.deepKey}>
+      <StringField {...props} />
+    </FieldErrorBoundary>
+  );
+}
+
+describe('StringField', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('renders a string value without error', () => {
+    renderField('Hello world');
+    expect(screen.queryByText('This field failed to render.')).toBeNull();
+  });
+
+  test('renders an empty string value without error', () => {
+    renderField('');
+    expect(screen.queryByText('This field failed to render.')).toBeNull();
+  });
+
+  test('shows the field error boundary for a non-string value', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    renderField({foo: 'bar'});
+
+    expect(screen.getByText('This field failed to render.')).toBeTruthy();
+    expect(consoleError).toHaveBeenCalled();
+    // The garbled "[object Object]" string should NOT be rendered.
+    expect(screen.queryByDisplayValue('[object Object]')).toBeNull();
+  });
+});

--- a/packages/root-cms/ui/components/DocEditor/fields/StringField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/StringField.tsx
@@ -16,7 +16,8 @@ interface HighlighterProps {
 }
 
 function Highlighter(props: HighlighterProps) {
-  const {value, variant, scrollRef} = props;
+  const {variant, scrollRef} = props;
+  const value = typeof props.value === 'string' ? props.value : '';
   const parts = value.split(/([\u00A0\u2011])/g);
   return (
     <div
@@ -45,6 +46,16 @@ export function StringField(props: FieldProps) {
   const highlighterRef = useRef<HTMLDivElement>(null);
   const inputHighlighterRef = useRef<HTMLDivElement>(null);
   const [jsonError, setJsonError] = useState<string | null>(null);
+
+  // Surface mismatched data instead of silently rendering "[object Object]".
+  // The FieldErrorBoundary catches this and shows an inline error, while the
+  // rest of the editor keeps working.
+  if (value !== null && value !== undefined && typeof value !== 'string') {
+    throw new Error(
+      `Expected a string value but got ${typeof value}. The stored data for ` +
+        'this field may be corrupted. Fix it using "Edit JSON" or restore a previous version.'
+    );
+  }
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(e.currentTarget.value);

--- a/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.css
+++ b/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.css
@@ -1,0 +1,35 @@
+.FieldErrorBoundary {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid #f3c2c2;
+  border-radius: 4px;
+  background: #fdf2f2;
+  color: #b00020;
+}
+
+.FieldErrorBoundary__icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.FieldErrorBoundary__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.FieldErrorBoundary__title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.FieldErrorBoundary__message {
+  font-size: 12px;
+  font-family: var(--font-family-monospace, monospace);
+  word-break: break-word;
+}

--- a/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.test.tsx
+++ b/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.test.tsx
@@ -1,0 +1,72 @@
+import {cleanup, render, screen} from '@testing-library/preact';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {FieldErrorBoundary} from './FieldErrorBoundary.js';
+
+/**
+ * Test fixture: a component that throws while rendering. This simulates a
+ * field whose stored value has an unexpected type (e.g. the `e.split is not a
+ * function` crash that takes down the whole doc editor).
+ */
+function ThrowingField(props: {message?: string}) {
+  throw new Error(props.message || 'field render failed');
+
+  return null;
+}
+
+/** Test fixture: a field that renders normally. */
+function HealthyField() {
+  return <div>healthy field</div>;
+}
+
+describe('FieldErrorBoundary', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('renders children when no error is thrown', () => {
+    render(
+      <FieldErrorBoundary deepKey="meta.title">
+        <HealthyField />
+      </FieldErrorBoundary>
+    );
+    expect(screen.getByText('healthy field')).toBeTruthy();
+  });
+
+  test('renders a fallback message when a child throws', () => {
+    // Suppress the expected error log from the boundary.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <FieldErrorBoundary deepKey="meta.title">
+        <ThrowingField message="e.split is not a function" />
+      </FieldErrorBoundary>
+    );
+
+    expect(screen.getByText('This field failed to render.')).toBeTruthy();
+    expect(screen.getByText('e.split is not a function')).toBeTruthy();
+    expect(screen.queryByText('healthy field')).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  test('includes the deepKey in the logged error', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <FieldErrorBoundary deepKey="fields.0.body">
+        <ThrowingField />
+      </FieldErrorBoundary>
+    );
+
+    const loggedMessages = consoleError.mock.calls.map((call) =>
+      String(call[0])
+    );
+    expect(loggedMessages.some((msg) => msg.includes('fields.0.body'))).toBe(
+      true
+    );
+  });
+});

--- a/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.tsx
+++ b/packages/root-cms/ui/components/FieldErrorBoundary/FieldErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import './FieldErrorBoundary.css';
+
+import {IconAlertTriangle} from '@tabler/icons-preact';
+import {Component, ComponentChildren} from 'preact';
+
+export interface FieldErrorBoundaryProps {
+  /** The deepKey of the field being rendered, used for error reporting. */
+  deepKey?: string;
+  children?: ComponentChildren;
+}
+
+interface FieldErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Error boundary that isolates a single field in the doc editor. If a field
+ * throws while rendering (e.g. because its stored value has an unexpected
+ * type), the error is caught and an inline message is shown instead of
+ * crashing the entire editor.
+ */
+export class FieldErrorBoundary extends Component<
+  FieldErrorBoundaryProps,
+  FieldErrorBoundaryState
+> {
+  state: FieldErrorBoundaryState = {error: null};
+
+  static getDerivedStateFromError(error: Error): FieldErrorBoundaryState {
+    return {error};
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(
+      `Error rendering field${
+        this.props.deepKey ? ` "${this.props.deepKey}"` : ''
+      }:`,
+      error
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      const message =
+        this.state.error instanceof Error
+          ? this.state.error.message
+          : String(this.state.error);
+      return (
+        <div className="FieldErrorBoundary">
+          <div className="FieldErrorBoundary__icon">
+            <IconAlertTriangle size={16} />
+          </div>
+          <div className="FieldErrorBoundary__body">
+            <div className="FieldErrorBoundary__title">
+              This field failed to render.
+            </div>
+            <div className="FieldErrorBoundary__message">{message}</div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
- if a developer makes a mistake or if there's a field/content mismatch, we now show an error instead of killing the CMS UI
- this is a UI only change, it doesn't change the underlying data or save flow (we can address that later if needed)

<img width="621" height="270" alt="image" src="https://github.com/user-attachments/assets/f6b31de0-3ad6-4be5-bfa4-79a4666f5c81" />

