### PR TITLE
chore: switch to experimentalAutoDetectLongPolling

### DIFF
--- a/.changeset/five-bats-behave.md
+++ b/.changeset/five-bats-behave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+chore: switch to experimentalAutoDetectLongPolling

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -453,14 +453,19 @@ try {
   const databaseId = window.__ROOT_CTX.firebaseConfig.databaseId || '(default)';
   // const db = getFirestore(app);
   // NOTE(stevenle): the firestore web channel rpc sometimes has issues in
-  // collections with a large number of docs. Forcing long polling and disabling
-  // fetch streams seems to work for some people. This may cause performance
-  // issues however.
+  // collections with a large number of docs.
+  //
+  // We previously forced long polling (`experimentalForceLongPolling: true`)
+  // unconditionally as a workaround, but that transport can get into a stuck
+  // state where the `channel?gsessionid=...` long-poll session stalls and never
+  // completes, leaving requests like getDocs() pending forever (the CMS hangs
+  // on a loading spinner until a hard reload). Use auto-detect instead so the
+  // SDK prefers the more reliable WebChannel/fetch-stream transport and only
+  // falls back to long polling on networks that actually require it.
   const db = initializeFirestore(
     app,
     {
-      experimentalForceLongPolling: true,
-      useFetchStreams: false,
+      experimentalAutoDetectLongPolling: true,
     } as any,
     databaseId
   );


### PR DESCRIPTION
FYI: I've been experiencing stuck spinning and loading on the docs page today (not sure why). I worked with AI to come up with this solution; not sure how to test it though.

<img width="1446" height="840" alt="image" src="https://github.com/user-attachments/assets/20b51713-7e81-4d5f-ab7b-d8f4efa30fb2" />

FYI; I asked for an in-depth explanation from the AI, and here's what it said:

---

Here's the reasoning behind the original settings, per the SDK's documented behavior:

## `experimentalForceLongPolling: true`

Firestore has two web transports for its real-time/Listen channel:

- **WebChannel streaming** (default) — a single long-lived streaming connection (think server-sent-events style). Efficient and low-latency.
- **Long polling** — repeated short XHR round-trips (the `channel?gsessionid=...` requests you saw).

The streaming transport relies on the browser receiving a partially-buffered, still-open HTTP response. That breaks in environments that **buffer or terminate the response** before it completes:

- Corporate proxies, VPNs, and antivirus/TLS-inspection middleboxes that wait for a "complete" response before forwarding it.
- Some HTTP/2 setups, ad blockers, and aggressive caching layers.

When that happens, the streaming channel opens but never delivers data → Listen/getDocs requests hang. The original author (`stevenle`, per the comment) forced long polling to sidestep that — long polling uses normal complete request/response cycles that proxies handle fine, and the comment specifically notes it helped on "collections with a large number of docs."

The trade-off: long polling is chattier and higher-latency, and — ironically — has its own stuck-session failure mode (the gsession stall that was causing *your* hang). So it traded one network's problem for a reliability regression on healthy networks.

## `useFetchStreams: false`

This is paired with the long-polling decision. `useFetchStreams` controls whether the SDK reads responses using the modern **`fetch()` + ReadableStream** API instead of legacy `XMLHttpRequest`. Fetch streams are part of the *streaming* read path. There were known issues where fetch-based streaming misbehaved in some browsers/proxy setups (the same class of buffering problems), so disabling it forced the SDK back onto the older, more universally-compatible XHR path. Setting it to `false` was essentially "don't use the newer streaming read mechanism either" — belt-and-suspenders alongside forcing long polling.

## Why the new setting is better

`experimentalAutoDetectLongPolling: true` gives you the best of both: the SDK **starts with streaming** and automatically detects (via a probe) whether the connection is being buffered/broken, falling back to long polling **only when it actually is**. So:

- Healthy networks get fast streaming (no stuck gsession → fixes your hang).
- Proxy/VPN networks still get long polling automatically (preserves the original compatibility win).

I dropped `useFetchStreams: false` because it only made sense as part of the "force the legacy path" strategy; with auto-detect you want the SDK free to use its optimal path, and the modern fetch-stream defaults are stable in Firebase v12.