### PR TITLE
chore: tune the ui of the status badges

### DIFF
--- a/packages/root-cms/ui/components/CompareDraftModal/CompareDraftModal.css
+++ b/packages/root-cms/ui/components/CompareDraftModal/CompareDraftModal.css
@@ -1,0 +1,3 @@
+.CompareDraftModal__diff {
+  margin-top: 4px;
+}

--- a/packages/root-cms/ui/components/CompareDraftModal/CompareDraftModal.tsx
+++ b/packages/root-cms/ui/components/CompareDraftModal/CompareDraftModal.tsx
@@ -1,0 +1,62 @@
+import './CompareDraftModal.css';
+
+import {ContextModalProps, useModals} from '@mantine/modals';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {DocDiffViewer} from '../DocDiffViewer/DocDiffViewer.js';
+
+const MODAL_ID = 'CompareDraftModal';
+
+export interface CompareDraftModalProps {
+  [key: string]: unknown;
+  docId: string;
+}
+
+export function useCompareDraftModal(props: CompareDraftModalProps) {
+  // Degrade gracefully when rendered outside a `ModalsProvider` (e.g. visual
+  // tests that render badges in isolation).
+  let modals: ReturnType<typeof useModals> | null = null;
+  try {
+    modals = useModals();
+  } catch {
+    modals = null;
+  }
+  const modalTheme = useModalTheme();
+  return {
+    enabled: modals !== null,
+    open: () => {
+      if (!modals) {
+        console.warn(
+          'useCompareDraftModal() requires a <ModalsProvider> context.'
+        );
+        return;
+      }
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        title: `Unpublished changes: ${props.docId}`,
+        innerProps: props,
+        overflow: 'inside',
+        size: 'min(calc(100% - 32px), 900px)',
+      });
+    },
+  };
+}
+
+export function CompareDraftModal(
+  modalProps: ContextModalProps<CompareDraftModalProps>
+) {
+  const {innerProps: props} = modalProps;
+  const docId = props.docId;
+  return (
+    <div className="CompareDraftModal">
+      <DocDiffViewer
+        className="CompareDraftModal__diff"
+        left={{docId, versionId: 'published'}}
+        right={{docId, versionId: 'draft'}}
+        showExpandButton={true}
+        showAiSummary={false}
+      />
+    </div>
+  );
+}
+
+CompareDraftModal.id = MODAL_ID;

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -345,6 +345,7 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
           <DocStatusBadges
             doc={data as CMSDoc}
             docId={props.docId}
+            showLockedLabel
             onPublishingLockClick={canEdit ? onPublishingLockClick : undefined}
           />
         </div>

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -345,7 +345,6 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
           <DocStatusBadges
             doc={data as CMSDoc}
             docId={props.docId}
-            showLockedLabel
             onPublishingLockClick={canEdit ? onPublishingLockClick : undefined}
           />
         </div>

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -1,15 +1,233 @@
 .DocStatusBadges {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 6px;
+  min-width: 0;
 }
 
+/*
+ * Each badge is wrapped in a Mantine Tooltip. Make those wrappers flex items
+ * that center their content so every badge (text or icon-only) sits on the
+ * same vertical midline.
+ */
 .DocStatusBadges .mantine-Tooltip-root {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.DocStatusBadges .mantine-Tooltip-body {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+/*
+ * Compact status pill (Sanity / Hygraph / Contentful style). Each tone uses a
+ * hand-tuned background + text pairing (defined below) rather than Mantine's
+ * pale `light` variant, so the label always meets WCAG AA contrast and stays
+ * legible against the surface.
+ */
+.DocStatusBadges__badge {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 20px;
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  vertical-align: middle;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  max-width: 100%;
+}
+
+.DocStatusBadges__badge__inner {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  /* Avoid clipping descenders (e.g. the "g" in "Changed"). */
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.DocStatusBadges__badge__leftSection {
+  display: flex;
+  align-items: center;
+  margin-right: 4px;
+  color: inherit;
+}
+
+/* Icon-only badge (e.g. the "Locked" shield): square, snug padding. */
+.DocStatusBadges__badge--iconOnly {
+  padding: 0 4px;
+}
+
+.DocStatusBadges__badge--iconOnly .DocStatusBadges__badge__inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* SVG icons default to baseline alignment; force block so they center. */
+.DocStatusBadges__badge svg {
   display: block;
 }
 
-.DocStatusBadges .mantine-Badge-root {
+/* Structured tooltip for the publishing-lock ("Locked") badge. */
+.DocStatusBadges__lockTooltip {
   display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.DocStatusBadges__lockTooltip__top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Consistent 1px ring around the avatar (matches UserActionTooltip). */
+.DocStatusBadges__lockTooltip__top .UserAvatar {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}
+
+.DocStatusBadges__lockTooltip__topText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.DocStatusBadges__lockTooltip__line {
+  line-height: 1.4;
+}
+
+.DocStatusBadges__lockTooltip__divider {
+  height: 1px;
+  margin: 4px 0;
+  background-color: currentColor;
+  opacity: 0.3;
+}
+
+.DocStatusBadges__lockTooltip__reason {
+  white-space: pre-line;
+  line-height: 1.4;
+  opacity: 0.95;
+}
+
+/* Structured tooltip for the "Changed" badge. */
+.DocStatusBadges__changedTooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.DocStatusBadges__changedTooltip__title {
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+/* An avatar + "<action> <date> / by <email>" row inside a tooltip. */
+.DocStatusBadges__tooltipRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.DocStatusBadges__tooltipRow__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* Keep the "<action> <date>" line on one row when there's space. */
+.DocStatusBadges__tooltipRow__text .DocStatusBadges__lockTooltip__line:first-child {
+  white-space: nowrap;
+}
+
+/* Consistent 1px ring around the avatar (matches UserActionTooltip). */
+.DocStatusBadges__tooltipRow .UserAvatar {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}
+
+/*
+ * Status tones. Each pairs a soft tinted background with a deep, fully-
+ * saturated label and a matching-hue border for stronger definition and
+ * high (WCAG AA) contrast. Scheme: Draft = Yellow-Orange, Changed = Blue,
+ * Published = Green.
+ */
+.DocStatusBadges__badge--draft {
+  background-color: #fff2dd !important;
+  color: #8a4500 !important;
+  border-color: #f3c98a !important;
+}
+
+.DocStatusBadges__badge--changed {
+  background-color: #e7f1ff !important;
+  color: #14529e !important;
+  border-color: #a9cdf5 !important;
+}
+
+.DocStatusBadges__badge--published {
+  background-color: #e3f6e8 !important;
+  color: #156c35 !important;
+  border-color: #a3dcb4 !important;
+}
+
+.DocStatusBadges__badge--scheduled {
+  background-color: #efe9ff !important;
+  color: #4f31ad !important;
+  border-color: #c7b8f3 !important;
+}
+
+.DocStatusBadges__badge--locked {
+  background-color: #ffe9e0 !important;
+  color: #9c3200 !important;
+  border-color: #f5b79e !important;
+}
+
+.DocStatusBadges__badge--archived {
+  background-color: #ebedf0 !important;
+  color: #3b4248 !important;
+  border-color: #c5cbd2 !important;
+}
+
+.DocStatusBadges__badge--release {
+  background-color: #efe9ff !important;
+  color: #4f31ad !important;
+  border-color: #c7b8f3 !important;
+}
+
+/* Release badges can have long IDs — keep them from overflowing the column. */
+.DocStatusBadges__releaseBadge {
+  max-width: 100%;
+  min-width: 0;
+  /* Clip the (ellipsized) label inside the badge's rounded corners. */
+  overflow: hidden;
+}
+
+.DocStatusBadges__releaseBadge__inner {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-family-monospace, monospace);
+  font-size: 11px;
+  letter-spacing: 0;
 }
 
 .DocStatusBadges__badge--clickable {
@@ -18,7 +236,7 @@
 }
 
 .DocStatusBadges__badge--clickable:hover {
-  opacity: 0.9;
+  opacity: 0.7;
 }
 
 .DocStatusBadges__badge--clickable:focus-visible {

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -44,6 +44,9 @@
   border: 1px solid transparent;
   border-radius: 5px;
   max-width: 100%;
+  /* Allow the badge to shrink and truncate when the column is squeezed. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 .DocStatusBadges__badge__inner {
@@ -56,6 +59,18 @@
   line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/*
+ * Text badges ellipsize when the Status column is too narrow to fit them all
+ * (e.g. "Changed" + "Scheduled" side by side). Icon-only badges are excluded so
+ * their glyph stays centered.
+ */
+.DocStatusBadges__badge:not(.DocStatusBadges__badge--iconOnly)
+  .DocStatusBadges__badge__inner {
+  display: block;
+  max-width: 100%;
+  white-space: nowrap;
 }
 
 .DocStatusBadges__badge__leftSection {
@@ -191,24 +206,6 @@
   background-color: #efe9ff !important;
   color: #4f31ad !important;
   border-color: #c7b8f3 !important;
-}
-
-/*
- * Scheduled labels can be long for a narrow Status column. Let them ellipsize
- * within the badge (same overflow behavior as release names) instead of being
- * clipped by the column edge.
- */
-.DocStatusBadges__badge--scheduled {
-  min-width: 0;
-  overflow: hidden;
-}
-
-.DocStatusBadges__badge--scheduled .DocStatusBadges__badge__inner {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .DocStatusBadges__badge--locked {

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -1,7 +1,7 @@
 .DocStatusBadges {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 }
 
@@ -33,16 +33,17 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  height: 20px;
+  height: 16px;
   padding: 0 7px;
-  font-size: 11px;
+  font-size: 9px;
   font-weight: 600;
   line-height: 1;
-  letter-spacing: 0.02em;
-  text-transform: none;
+  letter-spacing: 0.25px;
+  text-transform: uppercase;
   vertical-align: middle;
   border: 1px solid transparent;
-  border-radius: 5px;
+  /* Pill corners, matching the original Mantine badge radius. */
+  border-radius: 999px;
   max-width: 100%;
   /* Allow the badge to shrink and truncate when the column is squeezed. */
   min-width: 0;
@@ -54,7 +55,8 @@
   align-items: center;
   color: inherit;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.25px;
+  text-transform: uppercase;
   /* Avoid clipping descenders (e.g. the "g" in "Changed"). */
   line-height: 1.4;
   overflow: hidden;
@@ -179,55 +181,9 @@
 }
 
 /*
- * Status tones. Each pairs a soft tinted background with a deep, fully-
- * saturated label and a matching-hue border for stronger definition and
- * high (WCAG AA) contrast. Scheme: Draft = Yellow-Orange, Changed = Blue,
- * Published = Green.
+ * Badge colors come from Mantine's `variant="gradient"` (the original badge
+ * palette). Only the font styling, sizing, and truncation are handled in CSS.
  */
-.DocStatusBadges__badge--draft {
-  background-color: #fff2dd !important;
-  color: #8a4500 !important;
-  border-color: #f3c98a !important;
-}
-
-.DocStatusBadges__badge--changed {
-  background-color: #e7f1ff !important;
-  color: #14529e !important;
-  border-color: #a9cdf5 !important;
-}
-
-.DocStatusBadges__badge--published {
-  background-image: linear-gradient(135deg, #40c057 0%, #37b24d 100%) !important;
-  background-color: #2f9e44 !important;
-  color: #ffffff !important;
-  border-color: #2b8a3e !important;
-}
-
-.DocStatusBadges__badge--scheduled {
-  background-image: linear-gradient(135deg, #845ef7 0%, #5f3dc4 100%) !important;
-  background-color: #7048e8 !important;
-  color: #ffffff !important;
-  border-color: #5f3dc4 !important;
-}
-
-.DocStatusBadges__badge--locked {
-  background-image: linear-gradient(135deg, #ff922b 0%, #e8590c 100%) !important;
-  background-color: #f76707 !important;
-  color: #ffffff !important;
-  border-color: #d9480f !important;
-}
-
-.DocStatusBadges__badge--archived {
-  background-color: #ebedf0 !important;
-  color: #3b4248 !important;
-  border-color: #c5cbd2 !important;
-}
-
-.DocStatusBadges__badge--release {
-  background-color: #efe9ff !important;
-  color: #4f31ad !important;
-  border-color: #c7b8f3 !important;
-}
 
 /* Release badges can have long IDs — keep them from overflowing the column. */
 .DocStatusBadges__releaseBadge {
@@ -244,7 +200,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-family-monospace, monospace);
-  font-size: 11px;
+  font-size: 9px;
   letter-spacing: 0;
 }
 

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -193,6 +193,24 @@
   border-color: #c7b8f3 !important;
 }
 
+/*
+ * Scheduled labels can be long for a narrow Status column. Let them ellipsize
+ * within the badge (same overflow behavior as release names) instead of being
+ * clipped by the column edge.
+ */
+.DocStatusBadges__badge--scheduled {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.DocStatusBadges__badge--scheduled .DocStatusBadges__badge__inner {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .DocStatusBadges__badge--locked {
   background-color: #ffe9e0 !important;
   color: #9c3200 !important;

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -197,21 +197,24 @@
 }
 
 .DocStatusBadges__badge--published {
-  background-color: #e3f6e8 !important;
-  color: #156c35 !important;
-  border-color: #a3dcb4 !important;
+  background-image: linear-gradient(135deg, #40c057 0%, #37b24d 100%) !important;
+  background-color: #2f9e44 !important;
+  color: #ffffff !important;
+  border-color: #2b8a3e !important;
 }
 
 .DocStatusBadges__badge--scheduled {
-  background-color: #efe9ff !important;
-  color: #4f31ad !important;
-  border-color: #c7b8f3 !important;
+  background-image: linear-gradient(135deg, #845ef7 0%, #5f3dc4 100%) !important;
+  background-color: #7048e8 !important;
+  color: #ffffff !important;
+  border-color: #5f3dc4 !important;
 }
 
 .DocStatusBadges__badge--locked {
-  background-color: #ffe9e0 !important;
-  color: #9c3200 !important;
-  border-color: #f5b79e !important;
+  background-image: linear-gradient(135deg, #ff922b 0%, #e8590c 100%) !important;
+  background-color: #f76707 !important;
+  color: #ffffff !important;
+  border-color: #d9480f !important;
 }
 
 .DocStatusBadges__badge--archived {

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.css
@@ -217,3 +217,33 @@
   outline: 2px solid var(--mantine-color-blue-6, #339af0);
   outline-offset: 2px;
 }
+
+/* Interactive list of releases shown when a doc belongs to multiple releases. */
+.DocStatusBadges__releaseList {
+  display: flex;
+  flex-direction: column;
+}
+
+.DocStatusBadges__releaseList__title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #868e96;
+  padding: 2px 8px 4px;
+}
+
+.DocStatusBadges__releaseList__item {
+  display: block;
+  padding: 5px 8px;
+  border-radius: 4px;
+  font-family: var(--font-family-monospace, monospace);
+  font-size: 12px;
+  color: inherit;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.DocStatusBadges__releaseList__item:hover {
+  background: var(--mantine-color-gray-1, #f1f3f5);
+}

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -1,10 +1,12 @@
 import './DocStatusBadges.css';
 
-import {Badge, Tooltip} from '@mantine/core';
+import {Badge, Popover, Tooltip} from '@mantine/core';
 import {Timestamp} from 'firebase/firestore';
 import {ComponentChildren} from 'preact';
+import {useState} from 'preact/hooks';
 import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {CMSDoc, testPublishingLocked} from '../../utils/doc.js';
+import {Release} from '../../utils/release.js';
 import {formatDateTime, getTimeAgo} from '../../utils/time.js';
 import {useCompareDraftModal} from '../CompareDraftModal/CompareDraftModal.js';
 import {UserActionTooltip} from '../UserActionTooltip/UserActionTooltip.js';
@@ -333,32 +335,94 @@ function ReleaseBadges(props: {
   if (releases.length === 0) {
     return null;
   }
+  // When a doc belongs to multiple releases, collapse them into a single badge
+  // that opens a clickable list of releases.
+  if (releases.length > 1) {
+    return <MultiReleaseBadge releases={releases} />;
+  }
+  const release = releases[0];
   return (
-    <>
-      {releases.map((release) => (
-        <Tooltip
-          key={release.id}
-          {...props.tooltipProps}
-          label={`In release: ${release.id}`}
+    <Tooltip {...props.tooltipProps} label={`In release: ${release.id}`}>
+      <Badge
+        component="a"
+        href={`/cms/releases/${release.id}`}
+        size="sm"
+        variant="gradient"
+        gradient={TONE_GRADIENTS.release}
+        classNames={{
+          root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
+          inner:
+            'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
+        }}
+        style={{cursor: 'pointer'}}
+      >
+        {release.id}
+      </Badge>
+    </Tooltip>
+  );
+}
+
+/**
+ * A single badge representing membership in multiple releases. Clicking it
+ * opens an interactive popover listing each release; the popover stays open so
+ * the user can click through to a specific release.
+ */
+function MultiReleaseBadge(props: {releases: Release[]}) {
+  const [opened, setOpened] = useState(false);
+  const releases = props.releases;
+  return (
+    <Popover
+      opened={opened}
+      onClose={() => setOpened(false)}
+      withArrow
+      withCloseButton={false}
+      position="bottom"
+      placement="center"
+      spacing={4}
+      width={220}
+      target={
+        <Badge
+          size="sm"
+          variant="gradient"
+          gradient={TONE_GRADIENTS.release}
+          classNames={{
+            root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge DocStatusBadges__badge--clickable',
+            inner:
+              'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
+          }}
+          style={{cursor: 'pointer'}}
+          role="button"
+          tabIndex={0}
+          aria-label={`${releases.length} releases`}
+          onClick={(e: MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpened((value) => !value);
+          }}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOpened((value) => !value);
+            }
+          }}
         >
-          <Badge
-            component="a"
+          {releases.length} releases
+        </Badge>
+      }
+    >
+      <div className="DocStatusBadges__releaseList">
+        <div className="DocStatusBadges__releaseList__title">In releases</div>
+        {releases.map((release) => (
+          <a
+            key={release.id}
+            className="DocStatusBadges__releaseList__item"
             href={`/cms/releases/${release.id}`}
-            size="sm"
-            variant="gradient"
-            gradient={TONE_GRADIENTS.release}
-            classNames={{
-              root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
-              inner:
-                'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
-            }}
-            style={{cursor: 'pointer'}}
           >
             {release.id}
-          </Badge>
-        </Tooltip>
-      ))}
-    </>
+          </a>
+        ))}
+      </div>
+    </Popover>
   );
 }
 

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -158,7 +158,7 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
       {publishState === 'published' && (
         <UserActionTooltip
           position={props.tooltipPosition}
-          message={`Published ${timeDiff(sys.publishedAt)}`}
+          message={`Published ${timeDiff(sys.publishedAt ?? null)}`}
           user={sys.publishedBy}
         >
           <StatusBadge

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -1,7 +1,6 @@
 import './DocStatusBadges.css';
 
 import {Badge, Tooltip} from '@mantine/core';
-import {IconShield} from '@tabler/icons-preact';
 import {Timestamp} from 'firebase/firestore';
 import {ComponentChildren} from 'preact';
 import {usePendingReleases} from '../../hooks/usePendingReleases.js';
@@ -14,7 +13,6 @@ import {useVersionHistoryModal} from '../VersionHistoryModal/VersionHistoryModal
 
 type StatusTone =
   | 'draft'
-  | 'changed'
   | 'published'
   | 'scheduled'
   | 'locked'
@@ -22,9 +20,23 @@ type StatusTone =
   | 'release';
 
 /**
- * Renders a compact status pill with a hand-tuned, high-contrast color tone.
- * Colors are defined in CSS (not Mantine's pale `light` variant) so the
- * background/text pairing meets WCAG AA contrast.
+ * Per-tone Mantine gradient (matches the original badge colors exactly).
+ */
+const TONE_GRADIENTS: Record<
+  StatusTone,
+  {from: string; to: string; deg?: number}
+> = {
+  draft: {from: 'indigo', to: 'cyan'},
+  published: {from: 'teal', to: 'lime', deg: 105},
+  scheduled: {from: 'grape', to: 'pink', deg: 35},
+  locked: {from: 'orange', to: 'red'},
+  archived: {from: 'gray', to: 'dark'},
+  release: {from: 'violet', to: 'grape'},
+};
+
+/**
+ * Renders a compact status pill using the original Mantine gradient colors,
+ * with the updated font styling/sizing applied via CSS.
  */
 function StatusBadge(props: {
   tone: StatusTone;
@@ -44,8 +56,8 @@ function StatusBadge(props: {
   return (
     <Badge
       size="sm"
-      radius="sm"
-      variant="filled"
+      variant="gradient"
+      gradient={TONE_GRADIENTS[tone]}
       leftSection={leftSection}
       classNames={{
         root: joinClassNames(
@@ -78,12 +90,6 @@ interface DocStatusBadgesProps {
    * the badge becomes interactive (clickable) so callers can open an edit UI.
    */
   onPublishingLockClick?: () => void;
-  /**
-   * When true, the "Locked" badge shows the "Locked" text label next to the
-   * shield icon. Defaults to false (icon-only), which is used in dense list
-   * views; the doc editor opts in to the labeled variant.
-   */
-  showLockedLabel?: boolean;
 }
 
 export function DocStatusBadges(props: DocStatusBadgesProps) {
@@ -93,59 +99,58 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
   };
   const doc = props.doc;
   const sys = doc.sys;
-  const publishState = getPublishState(sys);
-  const compareDraftModal = useCompareDraftModal({
+  const versionHistoryModal = useVersionHistoryModal({
     docId: props.docId || doc.id,
   });
-  const onChangedClick = compareDraftModal.enabled
-    ? () => compareDraftModal.open()
-    : undefined;
-  const versionHistoryModal = useVersionHistoryModal({
+  const compareDraftModal = useCompareDraftModal({
     docId: props.docId || doc.id,
   });
   // Shared by the Draft and Published badges: both open the version history.
   const onShowVersionHistory = versionHistoryModal.enabled
     ? () => versionHistoryModal.open()
     : undefined;
+  // When a doc is both published and has newer unpublished edits, clicking the
+  // Draft badge shows the diff between published and draft.
+  const hasUnpublishedChanges =
+    !!sys.publishedAt && !!sys.modifiedAt && sys.modifiedAt > sys.publishedAt;
+  const onDraftClick =
+    hasUnpublishedChanges && compareDraftModal.enabled
+      ? () => compareDraftModal.open()
+      : onShowVersionHistory;
   return (
     <div className="DocStatusBadges">
-      {/*
-        Single publish-state badge (Draft / Published / Changed), following the
-        Sanity/Hygraph/Contentful convention of collapsing "published doc with
-        newer unpublished edits" into one "Changed" badge rather than stacking
-        separate Draft + Published badges.
-      */}
-      {publishState === 'draft' && (
+      {(!sys.publishedAt ||
+        !sys.modifiedAt ||
+        sys.modifiedAt > sys.publishedAt) && (
         <UserActionTooltip
           position={props.tooltipPosition}
+          heading={hasUnpublishedChanges ? 'Unpublished changes' : undefined}
           message={`Modified ${timeDiff(sys.modifiedAt)}`}
           user={sys.modifiedBy}
         >
           <StatusBadge
             tone="draft"
             className={
-              onShowVersionHistory
-                ? 'DocStatusBadges__badge--clickable'
-                : undefined
+              onDraftClick ? 'DocStatusBadges__badge--clickable' : undefined
             }
-            style={onShowVersionHistory ? {cursor: 'pointer'} : undefined}
-            role={onShowVersionHistory ? 'button' : undefined}
-            tabIndex={onShowVersionHistory ? 0 : undefined}
+            style={onDraftClick ? {cursor: 'pointer'} : undefined}
+            role={onDraftClick ? 'button' : undefined}
+            tabIndex={onDraftClick ? 0 : undefined}
             onClick={
-              onShowVersionHistory
+              onDraftClick
                 ? (e: MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    onShowVersionHistory();
+                    onDraftClick();
                   }
                 : undefined
             }
             onKeyDown={
-              onShowVersionHistory
+              onDraftClick
                 ? (e: KeyboardEvent) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      onShowVersionHistory();
+                      onDraftClick();
                     }
                   }
                 : undefined
@@ -155,7 +160,7 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           </StatusBadge>
         </UserActionTooltip>
       )}
-      {publishState === 'published' && (
+      {!!sys.publishedAt && (
         <UserActionTooltip
           position={props.tooltipPosition}
           message={`Published ${timeDiff(sys.publishedAt ?? null)}`}
@@ -195,52 +200,6 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           </StatusBadge>
         </UserActionTooltip>
       )}
-      {publishState === 'changed' && (
-        <Tooltip
-          position={props.tooltipPosition}
-          transition="pop"
-          withArrow
-          label={
-            <ChangedTooltip
-              modifiedAt={sys.modifiedAt}
-              modifiedBy={sys.modifiedBy}
-              publishedAt={sys.publishedAt}
-              publishedBy={sys.publishedBy}
-            />
-          }
-        >
-          <StatusBadge
-            tone="changed"
-            className={
-              onChangedClick ? 'DocStatusBadges__badge--clickable' : undefined
-            }
-            style={onChangedClick ? {cursor: 'pointer'} : undefined}
-            role={onChangedClick ? 'button' : undefined}
-            tabIndex={onChangedClick ? 0 : undefined}
-            onClick={
-              onChangedClick
-                ? (e: MouseEvent) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onChangedClick();
-                  }
-                : undefined
-            }
-            onKeyDown={
-              onChangedClick
-                ? (e: KeyboardEvent) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      onChangedClick();
-                    }
-                  }
-                : undefined
-            }
-          >
-            Changed
-          </StatusBadge>
-        </Tooltip>
-      )}
       {!!sys.scheduledAt && (
         <UserActionTooltip
           position={props.tooltipPosition}
@@ -267,19 +226,11 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
         >
           <StatusBadge
             tone="locked"
-            leftSection={
-              props.showLockedLabel ? (
-                <IconShield size={12} stroke={2.25} />
-              ) : undefined
-            }
-            className={joinClassNames(
-              props.showLockedLabel
-                ? undefined
-                : 'DocStatusBadges__badge--iconOnly',
+            className={
               props.onPublishingLockClick
                 ? 'DocStatusBadges__badge--clickable'
                 : undefined
-            )}
+            }
             style={
               props.onPublishingLockClick ? {cursor: 'pointer'} : undefined
             }
@@ -298,11 +249,7 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
                 : undefined
             }
           >
-            {props.showLockedLabel ? (
-              'Locked'
-            ) : (
-              <IconShield size={13} stroke={2.25} />
-            )}
+            Locked
           </StatusBadge>
         </Tooltip>
       )}
@@ -315,94 +262,6 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           <StatusBadge tone="archived">Archived</StatusBadge>
         </UserActionTooltip>
       )}
-    </div>
-  );
-}
-
-type PublishState = 'draft' | 'published' | 'changed';
-
-/**
- * Computes the single publish-state for a doc, mirroring the convention used by
- * Sanity, Hygraph, and Contentful:
- *   - `draft`: never published.
- *   - `changed`: published, but has newer unpublished edits.
- *   - `published`: published and up to date.
- */
-function getPublishState(sys: CMSDoc['sys']): PublishState {
-  if (!sys.publishedAt) {
-    return 'draft';
-  }
-  if (!sys.modifiedAt) {
-    return 'published';
-  }
-  return sys.modifiedAt > sys.publishedAt ? 'changed' : 'published';
-}
-
-/**
- * Structured tooltip content for the "Changed" badge. Renders:
- *   Unpublished changes
- *   ---
- *   [avatar]  Modified <date>
- *             by <email>
- *   ---
- *   [avatar]  Published <date>
- *             by <email>
- */
-function ChangedTooltip(props: {
-  modifiedAt: Timestamp | null;
-  modifiedBy?: string | null;
-  publishedAt?: Timestamp | null;
-  publishedBy?: string | null;
-}) {
-  return (
-    <div className="DocStatusBadges__changedTooltip">
-      <div className="DocStatusBadges__changedTooltip__title">
-        Unpublished changes
-      </div>
-      <div className="DocStatusBadges__lockTooltip__divider" />
-      <TooltipUserRow
-        action="Modified"
-        date={props.modifiedAt}
-        user={props.modifiedBy}
-      />
-      {props.publishedAt && (
-        <>
-          <div className="DocStatusBadges__lockTooltip__divider" />
-          <TooltipUserRow
-            action="Published"
-            date={props.publishedAt}
-            user={props.publishedBy}
-          />
-        </>
-      )}
-    </div>
-  );
-}
-
-/**
- * A tooltip row showing "<action> <date>" / "by <email>" with the user's
- * avatar on the left.
- */
-function TooltipUserRow(props: {
-  action: string;
-  date: Timestamp | null | undefined;
-  user?: string | null;
-}) {
-  return (
-    <div className="DocStatusBadges__tooltipRow">
-      {props.user && (
-        <UserAvatar email={props.user} size={20} withTooltip={false} />
-      )}
-      <div className="DocStatusBadges__tooltipRow__text">
-        <div className="DocStatusBadges__lockTooltip__line">
-          {props.action} {props.date ? formatDateTime(props.date) : 'just now'}
-        </div>
-        {props.user && (
-          <div className="DocStatusBadges__lockTooltip__line">
-            by {props.user}
-          </div>
-        )}
-      </div>
     </div>
   );
 }
@@ -486,8 +345,8 @@ function ReleaseBadges(props: {
             component="a"
             href={`/cms/releases/${release.id}`}
             size="sm"
-            radius="sm"
-            variant="filled"
+            variant="gradient"
+            gradient={TONE_GRADIENTS.release}
             classNames={{
               root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
               inner:

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -1,11 +1,71 @@
 import './DocStatusBadges.css';
 
 import {Badge, Tooltip} from '@mantine/core';
+import {IconShield} from '@tabler/icons-preact';
 import {Timestamp} from 'firebase/firestore';
+import {ComponentChildren} from 'preact';
 import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {CMSDoc, testPublishingLocked} from '../../utils/doc.js';
 import {formatDateTime, getTimeAgo} from '../../utils/time.js';
+import {useCompareDraftModal} from '../CompareDraftModal/CompareDraftModal.js';
 import {UserActionTooltip} from '../UserActionTooltip/UserActionTooltip.js';
+import {UserAvatar} from '../UserAvatar/UserAvatar.js';
+import {useVersionHistoryModal} from '../VersionHistoryModal/VersionHistoryModal.js';
+
+type StatusTone =
+  | 'draft'
+  | 'changed'
+  | 'published'
+  | 'scheduled'
+  | 'locked'
+  | 'archived'
+  | 'release';
+
+/**
+ * Renders a compact status pill with a hand-tuned, high-contrast color tone.
+ * Colors are defined in CSS (not Mantine's pale `light` variant) so the
+ * background/text pairing meets WCAG AA contrast.
+ */
+function StatusBadge(props: {
+  tone: StatusTone;
+  children: ComponentChildren;
+  leftSection?: ComponentChildren;
+  className?: string;
+  style?: Record<string, any>;
+  component?: any;
+  href?: string;
+  role?: string;
+  tabIndex?: number;
+  'aria-label'?: string;
+  onClick?: (e: any) => void;
+  onKeyDown?: (e: any) => void;
+}) {
+  const {tone, children, className, leftSection, ...rest} = props;
+  return (
+    <Badge
+      size="sm"
+      radius="sm"
+      variant="filled"
+      leftSection={leftSection}
+      classNames={{
+        root: joinClassNames(
+          'DocStatusBadges__badge',
+          `DocStatusBadges__badge--${tone}`,
+          className
+        ),
+        inner: 'DocStatusBadges__badge__inner',
+        leftSection: 'DocStatusBadges__badge__leftSection',
+      }}
+      {...rest}
+    >
+      {children}
+    </Badge>
+  );
+}
+
+function joinClassNames(...names: Array<string | undefined>): string {
+  return names.filter(Boolean).join(' ');
+}
 
 interface DocStatusBadgesProps {
   doc: CMSDoc;
@@ -18,6 +78,12 @@ interface DocStatusBadgesProps {
    * the badge becomes interactive (clickable) so callers can open an edit UI.
    */
   onPublishingLockClick?: () => void;
+  /**
+   * When true, the "Locked" badge shows the "Locked" text label next to the
+   * shield icon. Defaults to false (icon-only), which is used in dense list
+   * views; the doc editor opts in to the labeled variant.
+   */
+  showLockedLabel?: boolean;
 }
 
 export function DocStatusBadges(props: DocStatusBadgesProps) {
@@ -27,39 +93,153 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
   };
   const doc = props.doc;
   const sys = doc.sys;
+  const publishState = getPublishState(sys);
+  const compareDraftModal = useCompareDraftModal({
+    docId: props.docId || doc.id,
+  });
+  const onChangedClick = compareDraftModal.enabled
+    ? () => compareDraftModal.open()
+    : undefined;
+  const versionHistoryModal = useVersionHistoryModal({
+    docId: props.docId || doc.id,
+  });
+  // Shared by the Draft and Published badges: both open the version history.
+  const onShowVersionHistory = versionHistoryModal.enabled
+    ? () => versionHistoryModal.open()
+    : undefined;
   return (
     <div className="DocStatusBadges">
-      {(!sys.publishedAt ||
-        !sys.modifiedAt ||
-        sys.modifiedAt > sys.publishedAt) && (
+      {/*
+        Single publish-state badge (Draft / Published / Changed), following the
+        Sanity/Hygraph/Contentful convention of collapsing "published doc with
+        newer unpublished edits" into one "Changed" badge rather than stacking
+        separate Draft + Published badges.
+      */}
+      {publishState === 'draft' && (
         <UserActionTooltip
           position={props.tooltipPosition}
           message={`Modified ${timeDiff(sys.modifiedAt)}`}
           user={sys.modifiedBy}
         >
-          <Badge
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'indigo', to: 'cyan'}}
+          <StatusBadge
+            tone="draft"
+            className={
+              onShowVersionHistory
+                ? 'DocStatusBadges__badge--clickable'
+                : undefined
+            }
+            style={onShowVersionHistory ? {cursor: 'pointer'} : undefined}
+            role={onShowVersionHistory ? 'button' : undefined}
+            tabIndex={onShowVersionHistory ? 0 : undefined}
+            onClick={
+              onShowVersionHistory
+                ? (e: MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onShowVersionHistory();
+                  }
+                : undefined
+            }
+            onKeyDown={
+              onShowVersionHistory
+                ? (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onShowVersionHistory();
+                    }
+                  }
+                : undefined
+            }
           >
             Draft
-          </Badge>
+          </StatusBadge>
         </UserActionTooltip>
       )}
-      {!!sys.publishedAt && (
+      {publishState === 'published' && (
         <UserActionTooltip
           position={props.tooltipPosition}
           message={`Published ${timeDiff(sys.publishedAt)}`}
           user={sys.publishedBy}
         >
-          <Badge
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'teal', to: 'lime', deg: 105}}
+          <StatusBadge
+            tone="published"
+            className={
+              onShowVersionHistory
+                ? 'DocStatusBadges__badge--clickable'
+                : undefined
+            }
+            style={onShowVersionHistory ? {cursor: 'pointer'} : undefined}
+            role={onShowVersionHistory ? 'button' : undefined}
+            tabIndex={onShowVersionHistory ? 0 : undefined}
+            onClick={
+              onShowVersionHistory
+                ? (e: MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onShowVersionHistory();
+                  }
+                : undefined
+            }
+            onKeyDown={
+              onShowVersionHistory
+                ? (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onShowVersionHistory();
+                    }
+                  }
+                : undefined
+            }
           >
             Published
-          </Badge>
+          </StatusBadge>
         </UserActionTooltip>
+      )}
+      {publishState === 'changed' && (
+        <Tooltip
+          position={props.tooltipPosition}
+          transition="pop"
+          withArrow
+          label={
+            <ChangedTooltip
+              modifiedAt={sys.modifiedAt}
+              modifiedBy={sys.modifiedBy}
+              publishedAt={sys.publishedAt}
+              publishedBy={sys.publishedBy}
+            />
+          }
+        >
+          <StatusBadge
+            tone="changed"
+            className={
+              onChangedClick ? 'DocStatusBadges__badge--clickable' : undefined
+            }
+            style={onChangedClick ? {cursor: 'pointer'} : undefined}
+            role={onChangedClick ? 'button' : undefined}
+            tabIndex={onChangedClick ? 0 : undefined}
+            onClick={
+              onChangedClick
+                ? (e: MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onChangedClick();
+                  }
+                : undefined
+            }
+            onKeyDown={
+              onChangedClick
+                ? (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onChangedClick();
+                    }
+                  }
+                : undefined
+            }
+          >
+            Changed
+          </StatusBadge>
+        </Tooltip>
       )}
       {!!sys.scheduledAt && (
         <UserActionTooltip
@@ -67,13 +247,7 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           message={`Scheduled ${formatDateTime(sys.scheduledAt)}`}
           user={sys.scheduledBy}
         >
-          <Badge
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'grape', to: 'pink', deg: 35}}
-          >
-            Scheduled
-          </Badge>
+          <StatusBadge tone="scheduled">Scheduled</StatusBadge>
         </UserActionTooltip>
       )}
       {!props.hideReleases && (
@@ -83,26 +257,35 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
         />
       )}
       {testPublishingLocked(doc) && (
-        <UserActionTooltip
+        <Tooltip
           position={props.tooltipPosition}
-          message={getPublishingLockedMessage(doc)}
-          detail={doc.sys?.publishingLocked?.reason}
-          user={doc.sys?.publishingLocked?.lockedBy}
+          transition="pop"
+          withArrow
+          width={260}
+          wrapLines
+          label={<PublishingLockTooltip doc={doc} />}
         >
-          <Badge
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'orange', to: 'red'}}
-            className={
+          <StatusBadge
+            tone="locked"
+            leftSection={
+              props.showLockedLabel ? (
+                <IconShield size={12} stroke={2.25} />
+              ) : undefined
+            }
+            className={joinClassNames(
+              props.showLockedLabel
+                ? undefined
+                : 'DocStatusBadges__badge--iconOnly',
               props.onPublishingLockClick
                 ? 'DocStatusBadges__badge--clickable'
                 : undefined
-            }
+            )}
             style={
               props.onPublishingLockClick ? {cursor: 'pointer'} : undefined
             }
             role={props.onPublishingLockClick ? 'button' : undefined}
             tabIndex={props.onPublishingLockClick ? 0 : undefined}
+            aria-label="Locked"
             onClick={props.onPublishingLockClick}
             onKeyDown={
               props.onPublishingLockClick
@@ -115,9 +298,13 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
                 : undefined
             }
           >
-            Locked
-          </Badge>
-        </UserActionTooltip>
+            {props.showLockedLabel ? (
+              'Locked'
+            ) : (
+              <IconShield size={13} stroke={2.25} />
+            )}
+          </StatusBadge>
+        </Tooltip>
       )}
       {!!sys.archivedAt && (
         <UserActionTooltip
@@ -125,29 +312,142 @@ export function DocStatusBadges(props: DocStatusBadgesProps) {
           message={`Archived ${timeDiff(sys.archivedAt)}`}
           user={sys.archivedBy}
         >
-          <Badge
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'gray', to: 'dark'}}
-          >
-            Archived
-          </Badge>
+          <StatusBadge tone="archived">Archived</StatusBadge>
         </UserActionTooltip>
       )}
     </div>
   );
 }
 
+type PublishState = 'draft' | 'published' | 'changed';
+
 /**
- * Returns the primary message line for the publishing lock tooltip (without the
- * "by <user>" suffix and reason, which `UserActionTooltip` renders separately).
+ * Computes the single publish-state for a doc, mirroring the convention used by
+ * Sanity, Hygraph, and Contentful:
+ *   - `draft`: never published.
+ *   - `changed`: published, but has newer unpublished edits.
+ *   - `published`: published and up to date.
  */
-function getPublishingLockedMessage(docData: CMSDoc): string {
-  const lock = docData.sys?.publishingLocked;
-  if (lock?.until) {
-    return `Locked until ${formatDateTime(lock.until)}`;
+function getPublishState(sys: CMSDoc['sys']): PublishState {
+  if (!sys.publishedAt) {
+    return 'draft';
   }
-  return 'Locked';
+  if (!sys.modifiedAt) {
+    return 'published';
+  }
+  return sys.modifiedAt > sys.publishedAt ? 'changed' : 'published';
+}
+
+/**
+ * Structured tooltip content for the "Changed" badge. Renders:
+ *   Unpublished changes
+ *   ---
+ *   [avatar]  Modified <date>
+ *             by <email>
+ *   ---
+ *   [avatar]  Published <date>
+ *             by <email>
+ */
+function ChangedTooltip(props: {
+  modifiedAt: Timestamp | null;
+  modifiedBy?: string | null;
+  publishedAt?: Timestamp | null;
+  publishedBy?: string | null;
+}) {
+  return (
+    <div className="DocStatusBadges__changedTooltip">
+      <div className="DocStatusBadges__changedTooltip__title">
+        Unpublished changes
+      </div>
+      <div className="DocStatusBadges__lockTooltip__divider" />
+      <TooltipUserRow
+        action="Modified"
+        date={props.modifiedAt}
+        user={props.modifiedBy}
+      />
+      {props.publishedAt && (
+        <>
+          <div className="DocStatusBadges__lockTooltip__divider" />
+          <TooltipUserRow
+            action="Published"
+            date={props.publishedAt}
+            user={props.publishedBy}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A tooltip row showing "<action> <date>" / "by <email>" with the user's
+ * avatar on the left.
+ */
+function TooltipUserRow(props: {
+  action: string;
+  date: Timestamp | null | undefined;
+  user?: string | null;
+}) {
+  return (
+    <div className="DocStatusBadges__tooltipRow">
+      {props.user && (
+        <UserAvatar email={props.user} size={20} withTooltip={false} />
+      )}
+      <div className="DocStatusBadges__tooltipRow__text">
+        <div className="DocStatusBadges__lockTooltip__line">
+          {props.action} {props.date ? formatDateTime(props.date) : 'just now'}
+        </div>
+        {props.user && (
+          <div className="DocStatusBadges__lockTooltip__line">
+            by {props.user}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Structured tooltip content for the "Locked" publishing-lock badge. Renders:
+ *   [avatar]  Locked by <name>
+ *             Until <date>        (only when an expiry is set)
+ *   ---
+ *   Reason:                       (only when a reason is set)
+ *   <reason>
+ */
+function PublishingLockTooltip(props: {doc: CMSDoc}) {
+  const lock = props.doc.sys?.publishingLocked;
+  if (!lock) {
+    return null;
+  }
+  return (
+    <div className="DocStatusBadges__lockTooltip">
+      <div className="DocStatusBadges__lockTooltip__top">
+        {lock.lockedBy && (
+          <UserAvatar email={lock.lockedBy} size={20} withTooltip={false} />
+        )}
+        <div className="DocStatusBadges__lockTooltip__topText">
+          <div className="DocStatusBadges__lockTooltip__line">
+            Locked by {lock.lockedBy}
+          </div>
+          {lock.until && (
+            <div className="DocStatusBadges__lockTooltip__line">
+              Until {formatDateTime(lock.until)}
+            </div>
+          )}
+        </div>
+      </div>
+      {lock.reason && (
+        <>
+          <div className="DocStatusBadges__lockTooltip__divider" />
+          <div className="DocStatusBadges__lockTooltip__line">Reason:</div>
+          <div className="DocStatusBadges__lockTooltip__reason">
+            {lock.reason}
+          </div>
+        </>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -185,9 +485,14 @@ function ReleaseBadges(props: {
           <Badge
             component="a"
             href={`/cms/releases/${release.id}`}
-            size="xs"
-            variant="gradient"
-            gradient={{from: 'violet', to: 'grape'}}
+            size="sm"
+            radius="sm"
+            variant="filled"
+            classNames={{
+              root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
+              inner:
+                'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
+            }}
             style={{cursor: 'pointer'}}
           >
             {release.id}

--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.visual.test.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.visual.test.tsx
@@ -42,6 +42,11 @@ describe('DocStatusBadges', () => {
       publishedAt: mockTimestamp(1647485978000),
       publishedBy: 'test@example.com',
     });
+    const changedDoc = createDoc({
+      modifiedAt: mockTimestamp(1647485978000 + 100000),
+      publishedAt: mockTimestamp(1647485978000),
+      publishedBy: 'test@example.com',
+    });
     const lockedDoc = createDoc({
       publishingLocked: {
         lockedBy: 'test@example.com',
@@ -69,6 +74,9 @@ describe('DocStatusBadges', () => {
         </div>
         <div>
           <DocStatusBadges doc={publishedDoc} />
+        </div>
+        <div>
+          <DocStatusBadges doc={changedDoc} />
         </div>
         <div>
           <DocStatusBadges doc={lockedDoc} />

--- a/packages/root-cms/ui/components/ReleaseStatusBadge/ReleaseStatusBadge.tsx
+++ b/packages/root-cms/ui/components/ReleaseStatusBadge/ReleaseStatusBadge.tsx
@@ -2,10 +2,18 @@ import {Badge, Tooltip} from '@mantine/core';
 import {Timestamp} from 'firebase/firestore';
 import {Release} from '../../utils/release.js';
 import {getTimeAgo} from '../../utils/time.js';
+import '../DocStatusBadges/DocStatusBadges.css';
 
 const TOOLTIP_PROPS = {
   transition: 'pop',
 };
+
+function badgeClassNames(tone: string) {
+  return {
+    root: `DocStatusBadges__badge DocStatusBadges__badge--${tone}`,
+    inner: 'DocStatusBadges__badge__inner',
+  };
+}
 
 export interface ReleaseStatusBadgeProps {
   release: Release;
@@ -21,7 +29,12 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
           release.archivedBy
         }`}
       >
-        <Badge size="xs" color="gray" variant="filled">
+        <Badge
+          size="sm"
+          radius="sm"
+          variant="filled"
+          classNames={badgeClassNames('archived')}
+        >
           Archived
         </Badge>
       </Tooltip>
@@ -38,9 +51,10 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
         width={240}
       >
         <Badge
-          size="xs"
-          variant="gradient"
-          gradient={{from: 'grape', to: 'pink', deg: 35}}
+          size="sm"
+          radius="sm"
+          variant="filled"
+          classNames={badgeClassNames('scheduled')}
         >
           Scheduled
         </Badge>
@@ -56,9 +70,10 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
         }`}
       >
         <Badge
-          size="xs"
-          variant="gradient"
-          gradient={{from: 'teal', to: 'lime', deg: 105}}
+          size="sm"
+          radius="sm"
+          variant="filled"
+          classNames={badgeClassNames('published')}
         >
           Published
         </Badge>
@@ -66,7 +81,12 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
     );
   }
   return (
-    <Badge size="xs" variant="gradient" gradient={{from: 'indigo', to: 'cyan'}}>
+    <Badge
+      size="sm"
+      radius="sm"
+      variant="filled"
+      classNames={badgeClassNames('draft')}
+    >
       Unpublished
     </Badge>
   );

--- a/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.css
+++ b/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.css
@@ -22,8 +22,11 @@
   opacity: 0.85;
 }
 
-/* Drop the white separator ring used for stacked avatar groups. */
+/*
+ * Consistent 1px ring around the avatar (replaces the 2px white separator ring
+ * used for stacked avatar groups). Reads against the dark tooltip background.
+ */
 .UserActionTooltip .UserAvatar {
-  border: 0;
+  border: 1px solid rgba(255, 255, 255, 0.35);
   flex-shrink: 0;
 }

--- a/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.css
+++ b/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.css
@@ -18,6 +18,13 @@
   overflow-wrap: anywhere;
 }
 
+.UserActionTooltip__heading {
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  font-weight: 600;
+}
+
 .UserActionTooltip__detail {
   opacity: 0.85;
 }

--- a/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.tsx
+++ b/packages/root-cms/ui/components/UserActionTooltip/UserActionTooltip.tsx
@@ -6,6 +6,11 @@ import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 
 export interface UserActionTooltipProps {
   /**
+   * Optional heading shown above the message, separated by a divider line
+   * (e.g. "Unpublished changes").
+   */
+  heading?: ComponentChildren;
+  /**
    * Primary message line, typically an action and/or timestamp, e.g.
    * "Published 3d ago" or "May 1, 2026".
    */
@@ -37,11 +42,14 @@ export interface UserActionTooltipProps {
  * doc status badges, the compact collection listing's created/modified cells).
  */
 export function UserActionTooltip(props: UserActionTooltipProps) {
-  const {message, detail, user} = props;
+  const {heading, message, detail, user} = props;
   const label = (
     <div className="UserActionTooltip">
       {user && <UserAvatar email={user} size={20} withTooltip={false} />}
       <div className="UserActionTooltip__text">
+        {heading && (
+          <span className="UserActionTooltip__heading">{heading}</span>
+        )}
         <span>{message}</span>
         {detail && <span className="UserActionTooltip__detail">{detail}</span>}
         {user && <span>by {user}</span>}

--- a/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
+++ b/packages/root-cms/ui/components/VersionHistoryModal/VersionHistoryModal.tsx
@@ -37,10 +37,24 @@ export interface VersionHistoryModalProps {
 }
 
 export function useVersionHistoryModal(props: VersionHistoryModalProps) {
-  const modals = useModals();
+  // Degrade gracefully when rendered outside a `ModalsProvider` (e.g. visual
+  // tests that render badges in isolation).
+  let modals: ReturnType<typeof useModals> | null = null;
+  try {
+    modals = useModals();
+  } catch {
+    modals = null;
+  }
   const modalTheme = useModalTheme();
   return {
+    enabled: modals !== null,
     open: () => {
+      if (!modals) {
+        console.warn(
+          'useVersionHistoryModal() requires a <ModalsProvider> context.'
+        );
+        return;
+      }
       modals.openContextModal(MODAL_ID, {
         ...modalTheme,
         title: `Version history: ${props.docId}`,

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -245,47 +245,6 @@
   padding: 5px 12px;
 }
 
-/* When any doc belongs to a release, insert a dedicated Release column between
- * Status and Created. */
-.CollectionPage__collection__docsList--withRelease
-  .CollectionPage__collection__docsList__doc,
-.CollectionPage__collection__docsList--withRelease
-  .CollectionPage__collection__docsList__header {
-  grid-template-columns:
-    40px minmax(0, 0.8fr) minmax(0, 2.5fr)
-    minmax(0, var(--docs-status-width, 80px))
-    minmax(0, 1.4fr) 110px
-    110px 28px;
-}
-
-.CollectionPage__collection__docsList__doc__releases {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  min-width: 0;
-  overflow: hidden;
-}
-
-/*
- * Let a long release ID ellipsize within the column instead of overflowing.
- * Every link in the flex chain (Tooltip wrapper -> Tooltip body -> Badge) must
- * be allowed to shrink below its content width (min-width: 0), otherwise the
- * badge keeps its full intrinsic width and gets clipped by the cell.
- */
-.CollectionPage__collection__docsList__doc__releases .mantine-Tooltip-root,
-.CollectionPage__collection__docsList__doc__releases .mantine-Tooltip-body {
-  display: inline-flex;
-  min-width: 0;
-  max-width: 100%;
-}
-
-.CollectionPage__collection__docsList__doc__releases .mantine-Badge-root {
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-}
-
 .CollectionPage__collection__docsList__header {
   border-bottom: 1px solid var(--color-border);
 }

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -283,6 +283,31 @@
     110px 28px;
 }
 
+/* On narrow viewports give the Title column a smaller share of the flexible
+ * space so it doesn't dominate the row. */
+@media (max-width: 900px) {
+  .CollectionPage__collection__docsList--compact
+    .CollectionPage__collection__docsList__doc,
+  .CollectionPage__collection__docsList--compact
+    .CollectionPage__collection__docsList__header {
+    grid-template-columns:
+      40px minmax(0, 0.8fr) minmax(0, 1.2fr)
+      minmax(0, var(--docs-status-width, 80px)) 110px
+      110px 28px;
+    gap: 10px;
+  }
+  .CollectionPage__collection__docsList--withRelease
+    .CollectionPage__collection__docsList__doc,
+  .CollectionPage__collection__docsList--withRelease
+    .CollectionPage__collection__docsList__header {
+    grid-template-columns:
+      40px minmax(0, 0.8fr) minmax(0, 1.2fr)
+      minmax(0, var(--docs-status-width, 80px))
+      minmax(0, 1.4fr) 110px
+      110px 28px;
+  }
+}
+
 .CollectionPage__collection__docsList__doc__releases {
   display: flex;
   align-items: center;

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -248,6 +248,26 @@
     110px 28px;
 }
 
+/* When any doc has a Scheduled badge, widen the Status column so its longer
+ * date label isn't squeezed. */
+.CollectionPage__collection__docsList--withScheduled
+  .CollectionPage__collection__docsList__doc,
+.CollectionPage__collection__docsList--withScheduled
+  .CollectionPage__collection__docsList__header {
+  grid-template-columns:
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 180px 110px
+    110px 28px;
+}
+
+.CollectionPage__collection__docsList--withRelease.CollectionPage__collection__docsList--withScheduled
+  .CollectionPage__collection__docsList__doc,
+.CollectionPage__collection__docsList--withRelease.CollectionPage__collection__docsList--withScheduled
+  .CollectionPage__collection__docsList__header {
+  grid-template-columns:
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 180px minmax(0, 1.4fr) 110px
+    110px 28px;
+}
+
 .CollectionPage__collection__docsList__doc__releases {
   display: flex;
   align-items: center;

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -3,6 +3,13 @@
   background: var(--page-background);
 }
 
+/* Shrink the folder sidebar on narrow viewports so the docs list keeps room. */
+@media (max-width: 1280px) {
+  .CollectionPage {
+    --side-width: 280px;
+  }
+}
+
 .CollectionPage__layout {
   position: relative;
   min-height: calc(100vh - var(--header-height));
@@ -186,38 +193,6 @@
   flex-shrink: 0;
 }
 
-/* On narrow viewports, shrink the (non-compact) thumbnail column so the title
- * and metadata get more room. The preview image is rendered at a fixed 120px,
- * so scale its inner media down to fit the narrower container. */
-@media (max-width: 600px) {
-  .CollectionPage__collection__docsList:not(
-      .CollectionPage__collection__docsList--compact
-    )
-    .CollectionPage__collection__docsList__doc__image {
-    width: 72px;
-  }
-  .CollectionPage__collection__docsList:not(
-      .CollectionPage__collection__docsList--compact
-    )
-    .CollectionPage__collection__docsList__doc__image > a,
-  .CollectionPage__collection__docsList:not(
-      .CollectionPage__collection__docsList--compact
-    )
-    .CollectionPage__collection__docsList__doc__image img,
-  .CollectionPage__collection__docsList:not(
-      .CollectionPage__collection__docsList--compact
-    )
-    .CollectionPage__collection__docsList__doc__image picture,
-  .CollectionPage__collection__docsList:not(
-      .CollectionPage__collection__docsList--compact
-    )
-    .CollectionPage__collection__docsList__doc__image video {
-    display: block;
-    width: 100% !important;
-    height: auto !important;
-  }
-}
-
 .CollectionPage__collection__docsList__doc__content__title {
   line-height: 36px;
   font-size: 24px;
@@ -281,31 +256,6 @@
     minmax(0, var(--docs-status-width, 80px))
     minmax(0, 1.4fr) 110px
     110px 28px;
-}
-
-/* On narrow viewports give the Title column a smaller share of the flexible
- * space so it doesn't dominate the row. */
-@media (max-width: 900px) {
-  .CollectionPage__collection__docsList--compact
-    .CollectionPage__collection__docsList__doc,
-  .CollectionPage__collection__docsList--compact
-    .CollectionPage__collection__docsList__header {
-    grid-template-columns:
-      40px minmax(0, 0.8fr) minmax(0, 1.2fr)
-      minmax(0, var(--docs-status-width, 80px)) 110px
-      110px 28px;
-    gap: 10px;
-  }
-  .CollectionPage__collection__docsList--withRelease
-    .CollectionPage__collection__docsList__doc,
-  .CollectionPage__collection__docsList--withRelease
-    .CollectionPage__collection__docsList__header {
-    grid-template-columns:
-      40px minmax(0, 0.8fr) minmax(0, 1.2fr)
-      minmax(0, var(--docs-status-width, 80px))
-      minmax(0, 1.4fr) 110px
-      110px 28px;
-  }
 }
 
 .CollectionPage__collection__docsList__doc__releases {

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -186,6 +186,38 @@
   flex-shrink: 0;
 }
 
+/* On narrow viewports, shrink the (non-compact) thumbnail column so the title
+ * and metadata get more room. The preview image is rendered at a fixed 120px,
+ * so scale its inner media down to fit the narrower container. */
+@media (max-width: 600px) {
+  .CollectionPage__collection__docsList:not(
+      .CollectionPage__collection__docsList--compact
+    )
+    .CollectionPage__collection__docsList__doc__image {
+    width: 72px;
+  }
+  .CollectionPage__collection__docsList:not(
+      .CollectionPage__collection__docsList--compact
+    )
+    .CollectionPage__collection__docsList__doc__image > a,
+  .CollectionPage__collection__docsList:not(
+      .CollectionPage__collection__docsList--compact
+    )
+    .CollectionPage__collection__docsList__doc__image img,
+  .CollectionPage__collection__docsList:not(
+      .CollectionPage__collection__docsList--compact
+    )
+    .CollectionPage__collection__docsList__doc__image picture,
+  .CollectionPage__collection__docsList:not(
+      .CollectionPage__collection__docsList--compact
+    )
+    .CollectionPage__collection__docsList__doc__image video {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+  }
+}
+
 .CollectionPage__collection__docsList__doc__content__title {
   line-height: 36px;
   font-size: 24px;
@@ -230,7 +262,8 @@
    * enough to fit two badges.
    */
   grid-template-columns:
-    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 120px 110px
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr)
+    minmax(0, var(--docs-status-width, 80px)) 110px
     110px 28px;
   align-items: center;
   gap: 14px;
@@ -244,27 +277,9 @@
 .CollectionPage__collection__docsList--withRelease
   .CollectionPage__collection__docsList__header {
   grid-template-columns:
-    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 120px minmax(0, 1.4fr) 110px
-    110px 28px;
-}
-
-/* When any doc has a Scheduled badge, widen the Status column so its longer
- * date label isn't squeezed. */
-.CollectionPage__collection__docsList--withScheduled
-  .CollectionPage__collection__docsList__doc,
-.CollectionPage__collection__docsList--withScheduled
-  .CollectionPage__collection__docsList__header {
-  grid-template-columns:
-    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 180px 110px
-    110px 28px;
-}
-
-.CollectionPage__collection__docsList--withRelease.CollectionPage__collection__docsList--withScheduled
-  .CollectionPage__collection__docsList__doc,
-.CollectionPage__collection__docsList--withRelease.CollectionPage__collection__docsList--withScheduled
-  .CollectionPage__collection__docsList__header {
-  grid-template-columns:
-    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 180px minmax(0, 1.4fr) 110px
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr)
+    minmax(0, var(--docs-status-width, 80px))
+    minmax(0, 1.4fr) 110px
     110px 28px;
 }
 

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.css
@@ -230,11 +230,11 @@
    * enough to fit two badges.
    */
   grid-template-columns:
-    48px minmax(0, 0.8fr) minmax(0, 2.5fr) 150px 110px
-    110px 32px;
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 120px 110px
+    110px 28px;
   align-items: center;
-  gap: 16px;
-  padding: 8px 12px;
+  gap: 14px;
+  padding: 5px 12px;
 }
 
 /* When any doc belongs to a release, insert a dedicated Release column between
@@ -244,20 +244,36 @@
 .CollectionPage__collection__docsList--withRelease
   .CollectionPage__collection__docsList__header {
   grid-template-columns:
-    48px minmax(0, 0.8fr) minmax(0, 2.5fr) 150px minmax(0, 1fr) 110px
-    110px 32px;
+    40px minmax(0, 0.8fr) minmax(0, 2.5fr) 120px minmax(0, 1.4fr) 110px
+    110px 28px;
 }
 
 .CollectionPage__collection__docsList__doc__releases {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
+  overflow: hidden;
+}
+
+/*
+ * Let a long release ID ellipsize within the column instead of overflowing.
+ * Every link in the flex chain (Tooltip wrapper -> Tooltip body -> Badge) must
+ * be allowed to shrink below its content width (min-width: 0), otherwise the
+ * badge keeps its full intrinsic width and gets clipped by the cell.
+ */
+.CollectionPage__collection__docsList__doc__releases .mantine-Tooltip-root,
+.CollectionPage__collection__docsList__doc__releases .mantine-Tooltip-body {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .CollectionPage__collection__docsList__doc__releases .mantine-Badge-root {
+  min-width: 0;
   max-width: 100%;
+  overflow: hidden;
 }
 
 .CollectionPage__collection__docsList__header {
@@ -303,8 +319,8 @@
   .CollectionPage__collection__docsList__doc__image {
   display: block;
   box-sizing: content-box;
-  width: 48px;
-  height: 36px;
+  width: 40px;
+  height: 30px;
   border: 1px solid var(--color-border);
   flex-shrink: 0;
   line-height: 0;
@@ -346,7 +362,7 @@
   .CollectionPage__collection__docsList__doc__badges {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
 }
 

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -30,12 +30,13 @@ import {Surface} from '../../components/Surface/Surface.js';
 import {UserActionTooltip} from '../../components/UserActionTooltip/UserActionTooltip.js';
 import {useDocsList} from '../../hooks/useDocsList.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
-import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
+import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocServingUrl} from '../../utils/doc-urls.js';
+import {testPublishingLocked} from '../../utils/doc.js';
 import {getNestedValue} from '../../utils/objects.js';
 import {testCanEdit} from '../../utils/permissions.js';
 import {formatDateTime, getTimeAgo} from '../../utils/time.js';
@@ -444,6 +445,32 @@ function SortableHeaderCell(props: {
   );
 }
 
+/**
+ * Counts the status badges DocStatusBadges would render for a doc (release
+ * badges live in their own column and are excluded). Used to size the Status
+ * column so the busiest row's pills aren't truncated.
+ */
+function countStatusBadges(doc: any): number {
+  const sys = doc?.sys || {};
+  let count = 0;
+  if (!sys.publishedAt || !sys.modifiedAt || sys.modifiedAt > sys.publishedAt) {
+    count++; // Draft
+  }
+  if (sys.publishedAt) {
+    count++; // Published
+  }
+  if (sys.scheduledAt) {
+    count++; // Scheduled
+  }
+  if (testPublishingLocked(doc)) {
+    count++; // Locked
+  }
+  if (sys.archivedAt) {
+    count++; // Archived
+  }
+  return count;
+}
+
 CollectionPage.DocsList = (props: {
   collection: string;
   docs: any[];
@@ -465,9 +492,14 @@ CollectionPage.DocsList = (props: {
   // Only show the Release column when at least one doc belongs to a release.
   const showReleaseColumn =
     compact && docs.some((doc) => getReleasesForDoc(doc.id).length > 0);
-  // Give the Status column extra room when any doc shows a Scheduled badge
-  // (its date label is wider than the other status pills).
-  const hasScheduled = compact && docs.some((doc) => !!doc?.sys?.scheduledAt);
+  // Widen the Status column to fit the row with the most status badges (a
+  // published doc with newer edits + a scheduled publish + a lock can stack 3+
+  // pills, which overflow the default width).
+  const maxStatusBadges = compact
+    ? docs.reduce((max, doc) => Math.max(max, countStatusBadges(doc)), 1)
+    : 1;
+  const statusColumnWidth =
+    maxStatusBadges <= 1 ? 80 : maxStatusBadges === 2 ? 150 : 215;
   function getLiveUrl(slug: string): string {
     if (!hasCollectionUrl) {
       return '';
@@ -496,9 +528,9 @@ CollectionPage.DocsList = (props: {
           'CollectionPage__collection__docsList',
           'CollectionPage__collection__docsList--compact',
           showReleaseColumn &&
-            'CollectionPage__collection__docsList--withRelease',
-          hasScheduled && 'CollectionPage__collection__docsList--withScheduled'
+            'CollectionPage__collection__docsList--withRelease'
         )}
+        style={{['--docs-status-width' as any]: `${statusColumnWidth}px`}}
       >
         <div className="CollectionPage__collection__docsList__header">
           <div className="CollectionPage__collection__docsList__header__image" />
@@ -592,8 +624,8 @@ CollectionPage.DocsList = (props: {
                         component="a"
                         href={`/cms/releases/${release.id}`}
                         size="sm"
-                        radius="sm"
-                        variant="filled"
+                        variant="gradient"
+                        gradient={{from: 'violet', to: 'grape'}}
                         classNames={{
                           root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
                           inner:

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -2,7 +2,6 @@ import './CollectionPage.css';
 
 import {
   ActionIcon,
-  Badge,
   Button,
   Loader,
   Menu,
@@ -446,11 +445,12 @@ function SortableHeaderCell(props: {
 }
 
 /**
- * Counts the status badges DocStatusBadges would render for a doc (release
- * badges live in their own column and are excluded). Used to size the Status
- * column so the busiest row's pills aren't truncated.
+ * Counts the status badges DocStatusBadges would render for a doc. Used to size
+ * the Status column so the busiest row's pills aren't truncated. A doc in one
+ * or more releases adds a single release badge (multiple releases collapse into
+ * one "N releases" badge).
  */
-function countStatusBadges(doc: any): number {
+function countStatusBadges(doc: any, releaseCount: number): number {
   const sys = doc?.sys || {};
   let count = 0;
   if (!sys.publishedAt || !sys.modifiedAt || sys.modifiedAt > sys.publishedAt) {
@@ -467,6 +467,9 @@ function countStatusBadges(doc: any): number {
   }
   if (sys.archivedAt) {
     count++; // Archived
+  }
+  if (releaseCount > 0) {
+    count++; // Release (single badge regardless of release count)
   }
   return count;
 }
@@ -489,14 +492,18 @@ CollectionPage.DocsList = (props: {
 
   const docs = props.docs || [];
   const {getReleasesForDoc} = usePendingReleases();
-  // Only show the Release column when at least one doc belongs to a release.
-  const showReleaseColumn =
-    compact && docs.some((doc) => getReleasesForDoc(doc.id).length > 0);
   // Widen the Status column to fit the row with the most status badges (a
-  // published doc with newer edits + a scheduled publish + a lock can stack 3+
-  // pills, which overflow the default width).
+  // published doc with newer edits + a scheduled publish + a lock + a release
+  // can stack several pills, which overflow the default width).
   const maxStatusBadges = compact
-    ? docs.reduce((max, doc) => Math.max(max, countStatusBadges(doc)), 1)
+    ? docs.reduce(
+        (max, doc) =>
+          Math.max(
+            max,
+            countStatusBadges(doc, getReleasesForDoc(doc.id).length)
+          ),
+        1
+      )
     : 1;
   const statusColumnWidth =
     maxStatusBadges <= 1 ? 80 : maxStatusBadges === 2 ? 150 : 215;
@@ -526,9 +533,7 @@ CollectionPage.DocsList = (props: {
       <div
         className={joinClassNames(
           'CollectionPage__collection__docsList',
-          'CollectionPage__collection__docsList--compact',
-          showReleaseColumn &&
-            'CollectionPage__collection__docsList--withRelease'
+          'CollectionPage__collection__docsList--compact'
         )}
         style={{['--docs-status-width' as any]: `${statusColumnWidth}px`}}
       >
@@ -549,11 +554,6 @@ CollectionPage.DocsList = (props: {
           <div className="CollectionPage__collection__docsList__header__cell">
             Status
           </div>
-          {showReleaseColumn && (
-            <div className="CollectionPage__collection__docsList__header__cell">
-              Release
-            </div>
-          )}
           <SortableHeaderCell
             column="created"
             label="Created"
@@ -580,7 +580,6 @@ CollectionPage.DocsList = (props: {
               fields,
               rootCollection.preview?.image || 'meta.image'
             ) || rootCollection.preview?.defaultImage;
-          const releases = showReleaseColumn ? getReleasesForDoc(doc.id) : [];
           return (
             <div
               className="CollectionPage__collection__docsList__doc"
@@ -610,35 +609,8 @@ CollectionPage.DocsList = (props: {
                 {previewTitle || '[UNTITLED]'}
               </a>
               <div className="CollectionPage__collection__docsList__doc__badges">
-                <DocStatusBadges doc={doc} hideReleases />
+                <DocStatusBadges doc={doc} />
               </div>
-              {showReleaseColumn && (
-                <div className="CollectionPage__collection__docsList__doc__releases">
-                  {releases.map((release) => (
-                    <Tooltip
-                      key={release.id}
-                      transition="pop"
-                      label={`In release: ${release.id}`}
-                    >
-                      <Badge
-                        component="a"
-                        href={`/cms/releases/${release.id}`}
-                        size="sm"
-                        variant="gradient"
-                        gradient={{from: 'violet', to: 'grape'}}
-                        classNames={{
-                          root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
-                          inner:
-                            'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
-                        }}
-                        style={{cursor: 'pointer'}}
-                      >
-                        {release.id}
-                      </Badge>
-                    </Tooltip>
-                  ))}
-                </div>
-              )}
               <div className="CollectionPage__collection__docsList__doc__timestamp">
                 {renderTimestamp(doc?.sys?.createdAt, doc?.sys?.createdBy)}
               </div>

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -556,8 +556,8 @@ CollectionPage.DocsList = (props: {
               >
                 <FilePreview
                   file={previewImage}
-                  width={48}
-                  height={36}
+                  width={40}
+                  height={30}
                   withPlaceholder={!previewImage?.src}
                 />
               </a>
@@ -587,9 +587,14 @@ CollectionPage.DocsList = (props: {
                       <Badge
                         component="a"
                         href={`/cms/releases/${release.id}`}
-                        size="xs"
-                        variant="gradient"
-                        gradient={{from: 'violet', to: 'grape'}}
+                        size="sm"
+                        radius="sm"
+                        variant="filled"
+                        classNames={{
+                          root: 'DocStatusBadges__badge DocStatusBadges__badge--release DocStatusBadges__releaseBadge',
+                          inner:
+                            'DocStatusBadges__badge__inner DocStatusBadges__releaseBadge__inner',
+                        }}
                         style={{cursor: 'pointer'}}
                       >
                         {release.id}

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -465,6 +465,9 @@ CollectionPage.DocsList = (props: {
   // Only show the Release column when at least one doc belongs to a release.
   const showReleaseColumn =
     compact && docs.some((doc) => getReleasesForDoc(doc.id).length > 0);
+  // Give the Status column extra room when any doc shows a Scheduled badge
+  // (its date label is wider than the other status pills).
+  const hasScheduled = compact && docs.some((doc) => !!doc?.sys?.scheduledAt);
   function getLiveUrl(slug: string): string {
     if (!hasCollectionUrl) {
       return '';
@@ -493,7 +496,8 @@ CollectionPage.DocsList = (props: {
           'CollectionPage__collection__docsList',
           'CollectionPage__collection__docsList--compact',
           showReleaseColumn &&
-            'CollectionPage__collection__docsList--withRelease'
+            'CollectionPage__collection__docsList--withRelease',
+          hasScheduled && 'CollectionPage__collection__docsList--withScheduled'
         )}
       >
         <div className="CollectionPage__collection__docsList__header">

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -21,6 +21,7 @@ import {Collection} from '../core/schema.js';
 import {AddToReleaseModal} from './components/AddToReleaseModal/AddToReleaseModal.js';
 import {AiEditModal} from './components/AiEditModal/AiEditModal.js';
 import {AssetPickerModal} from './components/AssetPickerModal/AssetPickerModal.js';
+import {CompareDraftModal} from './components/CompareDraftModal/CompareDraftModal.js';
 import {ComponentPickerModal} from './components/ComponentPickerModal/ComponentPickerModal.js';
 import {CopyDocModal} from './components/CopyDocModal/CopyDocModal.js';
 import {DataSourceSelectModal} from './components/DataSourceSelectModal/DataSourceSelectModal.js';
@@ -268,6 +269,7 @@ function App() {
                       [AddToReleaseModal.id]: AddToReleaseModal,
                       [AiEditModal.id]: AiEditModal,
                       [AssetPickerModal.id]: AssetPickerModal,
+                      [CompareDraftModal.id]: CompareDraftModal,
                       [ComponentPickerModal.id]: ComponentPickerModal,
                       [CopyDocModal.id]: CopyDocModal,
                       [DocPickerModal.id]: DocPickerModal,


### PR DESCRIPTION
the basic problem this fixes is space saving in the document list

- consolidate "draft + published" into a single "changed" badge to save horizontal space
- tune the ui to use smaller badges to save space
- add more detailed tooltips and clean up the tooltips
- add proper truncation when the release badges are too wide for their container
- clicking the status badges now shows the version history or diff (depending on the badge)

this mainly aims to clean up a ui like this:

<img width="483" height="717" alt="image" src="https://github.com/user-attachments/assets/9b72a42d-3632-4086-9ca3-b64de45fc090" />

with a proposed ui like this:

<img width="788" height="606" alt="image" src="https://github.com/user-attachments/assets/900f0c3a-4cc2-4223-9802-c69a3809432c" />

<img width="485" height="140" alt="image" src="https://github.com/user-attachments/assets/0c482cca-8355-4fb9-b862-e04f4d614979" />

