### PR TITLE
feat: allow routes to override site-wide i18n.locales

### DIFF
--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -179,12 +179,27 @@ export type GetStaticContent = (
   props: any
 ) => Promise<StaticContentResult | string> | StaticContentResult | string;
 
+/**
+ * Route-level config that a route module can export to override the site-wide
+ * serving behavior on a per-route basis.
+ */
+export interface RouteConfig {
+  /**
+   * Overrides the site-wide `i18n.locales` for this route. When set, the SSG
+   * build only generates localized paths for the locales listed here instead of
+   * the locales defined in `root.config.ts`. The default-locale path is always
+   * generated. Defaults to the site-wide `i18n.locales`.
+   */
+  locales?: string[];
+}
+
 export interface RouteModule {
   default?: ComponentType<unknown>;
   getStaticPaths?: GetStaticPaths;
   getStaticProps?: GetStaticProps;
   handle?: Handler;
   getStaticContent?: GetStaticContent;
+  config?: RouteConfig;
 }
 
 export interface Route {

--- a/packages/root/src/render/router.ts
+++ b/packages/root/src/render/router.ts
@@ -71,26 +71,28 @@ export class Router {
 
       const routePath = formatUrl(urlFormat);
       const localeRoutePath = formatUrl(i18nUrlFormat);
+      const routeModule = ROUTES_FILES[modulePath];
 
       trie.add(routePath, {
         src,
-        module: ROUTES_FILES[modulePath],
+        module: routeModule,
         locale: defaultLocale,
         isDefaultLocale: true,
         routePath: routePath,
         localeRoutePath: localeRoutePath,
       });
 
-      // At the moment, all routes are assumed to use the site-wide i18n config.
-      // TODO(stevenle): provide routes with a way to override the default
-      // i18n serving behavior.
+      // A route can override the site-wide `i18n.locales` by exporting a
+      // `config` object with its own `locales` list. The default-locale path
+      // (added above) is always generated.
+      const routeLocales = routeModule.config?.locales || locales;
       if (i18nUrlFormat.includes('[locale]')) {
-        locales.forEach((locale) => {
+        routeLocales.forEach((locale) => {
           const localePath = localeRoutePath.replace('[locale]', locale);
           if (localePath !== relativeRoutePath) {
             trie.add(localePath, {
               src,
-              module: ROUTES_FILES[modulePath],
+              module: routeModule,
               locale: locale,
               isDefaultLocale: false,
               routePath,
@@ -126,8 +128,9 @@ export class Router {
         podName: entry.podName,
       });
 
+      const podRouteLocales = entry.module.config?.locales || locales;
       if (i18nUrlFormat.includes('[locale]')) {
-        locales.forEach((locale) => {
+        podRouteLocales.forEach((locale) => {
           const localePath = normalizedLocaleRoutePath.replace(
             '[locale]',
             locale

--- a/packages/root/test/fixtures/i18n-route-locales/root.config.ts
+++ b/packages/root/test/fixtures/i18n-route-locales/root.config.ts
@@ -1,0 +1,9 @@
+export default {
+  i18n: {
+    urlFormat: '/intl/[locale]/[path]',
+    locales: ['en', 'fr', 'de'],
+  },
+  jsxRenderer: {
+    mode: 'pretty',
+  },
+};

--- a/packages/root/test/fixtures/i18n-route-locales/routes/index.tsx
+++ b/packages/root/test/fixtures/i18n-route-locales/routes/index.tsx
@@ -1,0 +1,11 @@
+import {useRequestContext} from '../../../../dist/core';
+
+export default function Page() {
+  const ctx = useRequestContext();
+  return (
+    <>
+      <p>Current locale: {ctx.route.locale}</p>
+      <p>Current path: {ctx.currentPath}</p>
+    </>
+  );
+}

--- a/packages/root/test/fixtures/i18n-route-locales/routes/limited.tsx
+++ b/packages/root/test/fixtures/i18n-route-locales/routes/limited.tsx
@@ -1,0 +1,17 @@
+import {RouteConfig, useRequestContext} from '../../../../dist/core';
+
+export default function Page() {
+  const ctx = useRequestContext();
+  return (
+    <>
+      <p>Current locale: {ctx.route.locale}</p>
+      <p>Current path: {ctx.currentPath}</p>
+    </>
+  );
+}
+
+// This route overrides the site-wide `i18n.locales` (en, fr, de) and only
+// generates localized paths for `fr`.
+export const config: RouteConfig = {
+  locales: ['fr'],
+};

--- a/packages/root/test/i18n-route-locales.test.ts
+++ b/packages/root/test/i18n-route-locales.test.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import {assert, beforeEach, test, afterEach} from 'vitest';
+import {fileExists} from '../src/utils/fsutils.js';
+import {Fixture, loadFixture} from './testutils.js';
+
+let fixture: Fixture;
+
+beforeEach(async () => {
+  fixture = await loadFixture('./fixtures/i18n-route-locales');
+});
+
+afterEach(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+test('routes can override the site-wide i18n.locales', async () => {
+  await fixture.build();
+
+  const html = (...parts: string[]) =>
+    path.join(fixture.distDir, 'html', ...parts);
+
+  // The default index route uses the site-wide locales (en, fr, de).
+  assert.isTrue(await fileExists(html('index.html')));
+  assert.isTrue(await fileExists(html('intl/en/index.html')));
+  assert.isTrue(await fileExists(html('intl/fr/index.html')));
+  assert.isTrue(await fileExists(html('intl/de/index.html')));
+
+  // The default-locale path is always generated, even for routes that override
+  // their locales.
+  assert.isTrue(await fileExists(html('limited/index.html')));
+
+  // The /limited route overrides locales to ['fr'], so only the fr localized
+  // path is generated.
+  assert.isTrue(await fileExists(html('intl/fr/limited/index.html')));
+
+  // The en and de localized paths should NOT be generated for /limited.
+  assert.isFalse(await fileExists(html('intl/en/limited/index.html')));
+  assert.isFalse(await fileExists(html('intl/de/limited/index.html')));
+});


### PR DESCRIPTION
## Summary
This PR adds support for individual routes to override the site-wide `i18n.locales` configuration, enabling more granular control over which locales are generated for specific routes during the SSG build process.

## Key Changes
- **Added `RouteConfig` interface** (`src/core/types.ts`): New interface that allows routes to export a `config` object with a `locales` property to override the site-wide i18n configuration
- **Updated `RouteModule` type** (`src/core/types.ts`): Added optional `config?: RouteConfig` property to allow routes to export configuration
- **Modified router logic** (`src/render/router.ts`): Updated route registration to check for route-level `locales` configuration and use it instead of the site-wide locales when building localized paths. The default-locale path is always generated regardless of route-level overrides
- **Added comprehensive test** (`test/i18n-route-locales.test.ts`): New test suite verifying that routes can successfully override locales and that only the specified locales generate localized paths
- **Added test fixture** (`test/fixtures/i18n-route-locales/`): Complete fixture with root config (en, fr, de locales) and two routes:
  - `index.tsx`: Uses site-wide locales (default behavior)
  - `limited.tsx`: Overrides to only generate French locale paths

## Implementation Details
- Route-level locale overrides are read from `routeModule.config?.locales` during route registration
- Falls back to site-wide `locales` if no route-level override is specified
- The default-locale path (without `[locale]` placeholder) is always generated for all routes, even those with locale overrides
- Changes apply to both regular routes and pod-based routes

https://claude.ai/code/session_01TgrTTgu1XuVQbhFqpwwjun