### PR TITLE
chore: unify ai chat ui between root ai page and edit modal

### DIFF
--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
@@ -139,14 +139,12 @@
   margin: 0 0 8px;
 }
 
-.AiEditModal__ChatPanel__streamingIndicator {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  font-size: 0.75rem;
-  color: rgb(134, 142, 150);
-}
+/*
+ * Tool-call, reasoning ("Thinking" toggle), and streaming-indicator styles are
+ * shared with the Root AI page via `RootAIChat.css` (imported by ChatPanel.tsx)
+ * to keep the two surfaces consistent. The corresponding `AiEditModal__ChatPanel__tool*`,
+ * `__reasoning*`, and `__streamingIndicator` rules intentionally live there.
+ */
 
 .AiEditModal__ChatPanel__error {
   margin: 8px 0;
@@ -214,29 +212,6 @@
   margin-bottom: 0;
 }
 
-.AiEditModal__ChatPanel__reasoning {
-  font-size: 0.8125rem;
-  border-left: 2px solid rgb(222, 226, 230);
-  padding-left: 8px;
-  color: rgb(73, 80, 87);
-}
-
-.AiEditModal__ChatPanel__reasoning__toggle {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: rgb(134, 142, 150);
-  font-weight: 500;
-}
-
-.AiEditModal__ChatPanel__reasoning__body {
-  margin-top: 4px;
-}
-
 .AiEditModal__ChatPanel__filePart img {
   max-width: 200px;
   border-radius: 4px;
@@ -248,52 +223,6 @@
   gap: 4px;
   font-size: 0.8125rem;
   color: rgb(34, 139, 230);
-}
-
-.AiEditModal__ChatPanel__tool {
-  border: 1px solid rgb(222, 226, 230);
-  border-radius: 4px;
-  font-size: 0.8125rem;
-  background: rgb(248, 249, 250);
-}
-
-.AiEditModal__ChatPanel__tool__header {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  text-align: left;
-}
-
-.AiEditModal__ChatPanel__tool__state {
-  color: rgb(134, 142, 150);
-  font-size: 0.75rem;
-}
-
-.AiEditModal__ChatPanel__tool__body {
-  padding: 6px 8px;
-  border-top: 1px solid rgb(222, 226, 230);
-}
-
-.AiEditModal__ChatPanel__tool__body pre {
-  font-size: 0.75rem;
-  background: white;
-  padding: 6px;
-  border-radius: 4px;
-  white-space: pre-wrap;
-  word-break: break-word;
-  max-height: 200px;
-  overflow: auto;
-  margin: 4px 0 0;
-}
-
-.AiEditModal__ChatPanel__tool__error {
-  color: rgb(201, 42, 42);
-  margin-top: 4px;
 }
 
 .AiEditModal__ChatPanel__composer {

--- a/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
@@ -13,13 +13,13 @@
  * user to approve and save.
  */
 import {useChat} from '@ai-sdk/react';
-import {ActionIcon, Loader, Tooltip} from '@mantine/core';
+import {ActionIcon, Badge, Loader, Tooltip} from '@mantine/core';
 import {
   IconChevronDown,
+  IconChevronRight,
   IconPaperclip,
   IconRobot,
   IconSend2,
-  IconTool,
   IconX,
 } from '@tabler/icons-preact';
 import type {UIMessage} from 'ai';
@@ -27,11 +27,18 @@ import {lastAssistantMessageIsCompleteWithToolCalls} from 'ai';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
+import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
 import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {Markdown} from '../Markdown/Markdown.js';
+// Tool-call, reasoning, and streaming-indicator UI is shared with the Root AI
+// page (`RootAIChat`) so the two surfaces stay visually consistent. Reuse its
+// stylesheet and the `RootAIChat__*` class names below rather than duplicating
+// the styles here.
+import '../RootAIChat/RootAIChat.css';
 import {createClientChatTransport} from '../RootAIChat/clientChatTransport.js';
 import {createReadOnlyClientCmsTools} from '../RootAIChat/clientCmsTools.js';
 import {executeCmsTool} from '../RootAIChat/cmsToolHandlers.js';
+import {prettyToolName, prettyToolState} from '../RootAIChat/toolLabels.js';
 
 /** Result emitted by the "Edit with AI" chat to the parent modal. */
 export interface AiResponse {
@@ -332,9 +339,8 @@ function ChatTranscript(props: {
           <MessageView key={m.id} message={m} />
         ))}
         {props.isStreaming && (
-          <div className="AiEditModal__ChatPanel__streamingIndicator">
-            <Loader size="xs" color="gray" />
-            <span>Thinking…</span>
+          <div className="RootAIChat__streamingIndicator">
+            <BouncingLoader size={6} />
           </div>
         )}
       </div>
@@ -419,13 +425,13 @@ function ReasoningPartView(props: {text: string}) {
   return (
     <div
       className={joinClassNames(
-        'AiEditModal__ChatPanel__reasoning',
-        open && 'AiEditModal__ChatPanel__reasoning--open'
+        'RootAIChat__reasoning',
+        open && 'RootAIChat__reasoning--open'
       )}
     >
       <button
         type="button"
-        className="AiEditModal__ChatPanel__reasoning__toggle"
+        className="RootAIChat__reasoning__toggle"
         onClick={() => setOpen(!open)}
       >
         <IconChevronDown
@@ -435,7 +441,7 @@ function ReasoningPartView(props: {text: string}) {
         <span>Thinking</span>
       </button>
       {open && (
-        <div className="AiEditModal__ChatPanel__reasoning__body">
+        <div className="RootAIChat__reasoning__body">
           <Markdown code={props.text} />
         </div>
       )}
@@ -473,63 +479,60 @@ function ToolPartView(props: {part: any}) {
   const state: string = part.state || '';
   const [open, setOpen] = useState(false);
   return (
-    <div className="AiEditModal__ChatPanel__tool">
+    <div className="RootAIChat__tool">
       <button
         type="button"
-        className="AiEditModal__ChatPanel__tool__header"
+        className="RootAIChat__tool__header"
         onClick={() => setOpen(!open)}
       >
-        <IconTool size={14} />
-        <code>{toolName}</code>
-        <span className="AiEditModal__ChatPanel__tool__state">
-          {prettyToolState(state)}
-        </span>
         <IconChevronDown
+          className={joinClassNames(
+            'RootAIChat__tool__header__icon',
+            open && 'RootAIChat__tool__header__icon--open'
+          )}
           size={14}
-          style={{
-            marginLeft: 'auto',
-            transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
-          }}
         />
+        <Badge color="dark" variant="filled" size="xs">
+          {toolName}
+        </Badge>
+        <span className="RootAIChat__tool__title">
+          {prettyToolName(toolName, part.input)}
+        </span>
+        <span className="RootAIChat__tool__state">{prettyToolState(state)}</span>
       </button>
       {open && (
-        <div className="AiEditModal__ChatPanel__tool__body">
+        <div className="RootAIChat__tool__body">
           {part.input && (
-            <details open>
-              <summary>Input</summary>
+            <details>
+              <summary>
+                <IconChevronRight
+                  size={14}
+                  className="RootAIChat__tool__json__icon"
+                />
+                <span>Input</span>
+              </summary>
               <pre>{JSON.stringify(part.input, null, 2)}</pre>
             </details>
           )}
           {part.output && (
-            <details open>
-              <summary>Output</summary>
+            <details>
+              <summary>
+                <IconChevronRight
+                  size={14}
+                  className="RootAIChat__tool__json__icon"
+                />
+                <span>Output</span>
+              </summary>
               <pre>{JSON.stringify(part.output, null, 2)}</pre>
             </details>
           )}
           {part.errorText && (
-            <div className="AiEditModal__ChatPanel__tool__error">
-              {part.errorText}
-            </div>
+            <div className="RootAIChat__tool__error">{part.errorText}</div>
           )}
         </div>
       )}
     </div>
   );
-}
-
-function prettyToolState(state: string): string {
-  switch (state) {
-    case 'input-streaming':
-      return 'preparing…';
-    case 'input-available':
-      return 'running…';
-    case 'output-available':
-      return 'done';
-    case 'output-error':
-      return 'error';
-    default:
-      return state;
-  }
 }
 
 function ChatComposer(props: {

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -284,6 +284,7 @@
 }
 
 .RootAIChat__streamingIndicator {
+  margin-top: 8px;
   padding-left: 44px;
 }
 

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -66,6 +66,7 @@ import {
   isCmsWriteTool,
   previewCmsWriteTool,
 } from './cmsToolHandlers.js';
+import {prettyToolName, prettyToolState} from './toolLabels.js';
 
 export type RootAIChatVariant = 'page' | 'panel';
 
@@ -1296,39 +1297,6 @@ function getToolCallId(part: any): string {
   return part.toolCallId || part.id || '';
 }
 
-function prettyToolName(toolName: string, input: any): string {
-  switch (toolName) {
-    case 'collections_list':
-      return 'List collections';
-    case 'docs_list':
-      return `List ${input?.collectionId || 'documents'}`;
-    case 'docs_search':
-      return `Search docs${input?.query ? ` for "${input.query}"` : ''}`;
-    case 'doc_get':
-      return `Read ${input?.docId || 'document'}`;
-    case 'doc_getVersion':
-      return `Read ${input?.docId || 'document'} version`;
-    case 'doc_set':
-      return `Replace ${input?.docId || 'draft fields'}`;
-    case 'doc_create':
-      return `Create ${input?.docId || 'draft document'}`;
-    case 'doc_updateField':
-      return `Update ${input?.path || 'field'}`;
-    case 'doc_edit':
-      return `Edit ${input?.docId || 'document'}`;
-    case 'doc_duplicate':
-      return `Duplicate ${input?.fromDocId || 'document'}`;
-    case 'doc_listVersions':
-      return `List versions for ${input?.docId || 'document'}`;
-    case 'doc_translateField':
-      return 'Translate field text';
-    case 'schema_get':
-      return `Read ${input?.collectionId || 'collection'} schema`;
-    default:
-      return toolName;
-  }
-}
-
 function ToolApprovalCard(props: {
   approval: PendingToolApproval;
   onApprove: () => void;
@@ -1433,21 +1401,6 @@ function ToolReceipt(props: {output: any}) {
 
 function prettyApprovalState(status: PendingToolApproval['status']): string {
   return status === 'executing' ? 'applying…' : 'waiting for approval';
-}
-
-function prettyToolState(state: string): string {
-  switch (state) {
-    case 'input-streaming':
-      return 'preparing…';
-    case 'input-available':
-      return 'running…';
-    case 'output-available':
-      return 'done';
-    case 'output-error':
-      return 'error';
-    default:
-      return state;
-  }
 }
 
 function ChatComposer(props: {

--- a/packages/root-cms/ui/components/RootAIChat/toolLabels.ts
+++ b/packages/root-cms/ui/components/RootAIChat/toolLabels.ts
@@ -1,0 +1,55 @@
+/**
+ * Human-readable labels for CMS tool calls, shared between the Root AI page
+ * (`RootAIChat`) and the "Edit with AI" modal (`AiEditModal/ChatPanel`) so both
+ * surfaces render tool calls identically.
+ */
+
+/** Returns a friendly title for a tool call given its name and input. */
+export function prettyToolName(toolName: string, input: any): string {
+  switch (toolName) {
+    case 'collections_list':
+      return 'List collections';
+    case 'docs_list':
+      return `List ${input?.collectionId || 'documents'}`;
+    case 'docs_search':
+      return `Search docs${input?.query ? ` for "${input.query}"` : ''}`;
+    case 'doc_get':
+      return `Read ${input?.docId || 'document'}`;
+    case 'doc_getVersion':
+      return `Read ${input?.docId || 'document'} version`;
+    case 'doc_set':
+      return `Replace ${input?.docId || 'draft fields'}`;
+    case 'doc_create':
+      return `Create ${input?.docId || 'draft document'}`;
+    case 'doc_updateField':
+      return `Update ${input?.path || 'field'}`;
+    case 'doc_edit':
+      return `Edit ${input?.docId || 'document'}`;
+    case 'doc_duplicate':
+      return `Duplicate ${input?.fromDocId || 'document'}`;
+    case 'doc_listVersions':
+      return `List versions for ${input?.docId || 'document'}`;
+    case 'doc_translateField':
+      return 'Translate field text';
+    case 'schema_get':
+      return `Read ${input?.collectionId || 'collection'} schema`;
+    default:
+      return toolName;
+  }
+}
+
+/** Returns a friendly label for a tool call's execution state. */
+export function prettyToolState(state: string): string {
+  switch (state) {
+    case 'input-streaming':
+      return 'preparing…';
+    case 'input-available':
+      return 'running…';
+    case 'output-available':
+      return 'done';
+    case 'output-error':
+      return 'error';
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
Refactored the "Edit with AI" modal's chat panel to reuse styling and components from the Root AI chat page, eliminating duplication and ensuring visual consistency across both surfaces.

## Key Changes
- **Extracted shared utilities**: Moved `prettyToolName()` and `prettyToolState()` functions from `RootAIChat.tsx` to a new shared module `toolLabels.ts` for use by both components
- **Unified styling**: Imported `RootAIChat.css` into `ChatPanel.tsx` and replaced all `AiEditModal__ChatPanel__*` class names with their `RootAIChat__*` equivalents for tool calls, reasoning sections, and streaming indicators
- **Removed duplicate styles**: Deleted tool, reasoning, and streaming indicator CSS rules from `AiEditModal.css` that are now provided by the shared stylesheet
- **Updated UI components**: 
  - Replaced custom `Loader` + text with `BouncingLoader` component for streaming indicator
  - Refactored tool call header to use `Badge` component and improved layout with icon rotation animations
  - Updated details sections to use `IconChevronRight` with consistent styling
- **Updated imports**: Added `Badge` and `IconChevronRight` imports, removed unused `IconTool` import, and added `BouncingLoader` import

## Implementation Details
- The shared stylesheet is imported via a comment explaining the rationale for code reuse
- Tool call rendering now uses the same visual hierarchy and interactive patterns as the Root AI page
- All styling is now centralized in `RootAIChat.css`, reducing maintenance burden and ensuring consistency

https://claude.ai/code/session_012suGWMQFuoB5oxwpRe1yQa