### PR TITLE
ci: retry firebase deploy on transient auth failures

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -330,26 +330,10 @@ jobs:
         run: |
           # Deploy only the PR-specific SSR function generated above. This does
           # not deploy or overwrite the public www-server or any other function.
-          #
-          # firebase-tools resolves credentials from GOOGLE_APPLICATION_CREDENTIALS
-          # via GoogleAuth.getAccessToken(), which performs a network token
-          # exchange that intermittently fails with "Failed to authenticate, have
-          # you run firebase login?" (the same commit succeeds on a re-run).
-          # Retry the deploy a few times to ride out those transient failures.
-          attempt=1
-          max_attempts=3
-          until pnpm exec firebase deploy \
+          scripts/deploy_firebase.sh deploy \
             --only "functions:${{ steps.preview-config.outputs.server_function }}" \
             --project rootjs-dev \
-            --force; do
-            if [[ "$attempt" -ge "$max_attempts" ]]; then
-              echo "firebase deploy failed after ${max_attempts} attempts." >&2
-              exit 1
-            fi
-            echo "firebase deploy attempt ${attempt} failed; retrying in 15s..." >&2
-            attempt=$((attempt + 1))
-            sleep 15
-          done
+            --force
 
       - name: Deploy preview to Firebase Hosting
         id: deploy
@@ -357,24 +341,10 @@ jobs:
         run: |
           CHANNEL="pr-${{ steps.preview-context.outputs.pr_number }}"
           OUTPUT_FILE="$(mktemp)"
-          # Retry to ride out the intermittent "Failed to authenticate" error
-          # from firebase-tools' credential token exchange (see the function
-          # deploy step above).
-          attempt=1
-          max_attempts=3
-          until pnpm exec firebase hosting:channel:deploy "$CHANNEL" \
+          scripts/deploy_firebase.sh hosting:channel:deploy "$CHANNEL" \
             --project rootjs-dev \
             --expires 2d \
-            --json > "$OUTPUT_FILE"; do
-            if [[ "$attempt" -ge "$max_attempts" ]]; then
-              echo "firebase hosting:channel:deploy failed after ${max_attempts} attempts." >&2
-              cat "$OUTPUT_FILE" >&2 || true
-              exit 1
-            fi
-            echo "hosting deploy attempt ${attempt} failed; retrying in 15s..." >&2
-            attempt=$((attempt + 1))
-            sleep 15
-          done
+            --json > "$OUTPUT_FILE"
 
           cat "$OUTPUT_FILE"
           URL="$(node -e "

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -330,10 +330,26 @@ jobs:
         run: |
           # Deploy only the PR-specific SSR function generated above. This does
           # not deploy or overwrite the public www-server or any other function.
-          pnpm exec firebase deploy \
+          #
+          # firebase-tools resolves credentials from GOOGLE_APPLICATION_CREDENTIALS
+          # via GoogleAuth.getAccessToken(), which performs a network token
+          # exchange that intermittently fails with "Failed to authenticate, have
+          # you run firebase login?" (the same commit succeeds on a re-run).
+          # Retry the deploy a few times to ride out those transient failures.
+          attempt=1
+          max_attempts=3
+          until pnpm exec firebase deploy \
             --only "functions:${{ steps.preview-config.outputs.server_function }}" \
             --project rootjs-dev \
-            --force
+            --force; do
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "firebase deploy failed after ${max_attempts} attempts." >&2
+              exit 1
+            fi
+            echo "firebase deploy attempt ${attempt} failed; retrying in 15s..." >&2
+            attempt=$((attempt + 1))
+            sleep 15
+          done
 
       - name: Deploy preview to Firebase Hosting
         id: deploy
@@ -341,10 +357,24 @@ jobs:
         run: |
           CHANNEL="pr-${{ steps.preview-context.outputs.pr_number }}"
           OUTPUT_FILE="$(mktemp)"
-          pnpm exec firebase hosting:channel:deploy "$CHANNEL" \
+          # Retry to ride out the intermittent "Failed to authenticate" error
+          # from firebase-tools' credential token exchange (see the function
+          # deploy step above).
+          attempt=1
+          max_attempts=3
+          until pnpm exec firebase hosting:channel:deploy "$CHANNEL" \
             --project rootjs-dev \
             --expires 2d \
-            --json > "$OUTPUT_FILE"
+            --json > "$OUTPUT_FILE"; do
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "firebase hosting:channel:deploy failed after ${max_attempts} attempts." >&2
+              cat "$OUTPUT_FILE" >&2 || true
+              exit 1
+            fi
+            echo "hosting deploy attempt ${attempt} failed; retrying in 15s..." >&2
+            attempt=$((attempt + 1))
+            sleep 15
+          done
 
           cat "$OUTPUT_FILE"
           URL="$(node -e "

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -182,7 +182,22 @@ jobs:
       - name: Deploy rootjs.dev to Firebase
         working-directory: docs
         run: |
-          pnpm exec firebase deploy \
+          # firebase-tools resolves credentials from GOOGLE_APPLICATION_CREDENTIALS
+          # via GoogleAuth.getAccessToken(), which performs a network token
+          # exchange that intermittently fails with "Failed to authenticate, have
+          # you run firebase login?" (the same commit succeeds on a re-run).
+          # Retry the deploy a few times to ride out those transient failures.
+          attempt=1
+          max_attempts=3
+          until pnpm exec firebase deploy \
             --only hosting,functions:www-server,functions:www-cron \
             --project rootjs-dev \
-            --force
+            --force; do
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "firebase deploy failed after ${max_attempts} attempts." >&2
+              exit 1
+            fi
+            echo "firebase deploy attempt ${attempt} failed; retrying in 15s..." >&2
+            attempt=$((attempt + 1))
+            sleep 15
+          done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -182,22 +182,7 @@ jobs:
       - name: Deploy rootjs.dev to Firebase
         working-directory: docs
         run: |
-          # firebase-tools resolves credentials from GOOGLE_APPLICATION_CREDENTIALS
-          # via GoogleAuth.getAccessToken(), which performs a network token
-          # exchange that intermittently fails with "Failed to authenticate, have
-          # you run firebase login?" (the same commit succeeds on a re-run).
-          # Retry the deploy a few times to ride out those transient failures.
-          attempt=1
-          max_attempts=3
-          until pnpm exec firebase deploy \
+          scripts/deploy_firebase.sh deploy \
             --only hosting,functions:www-server,functions:www-cron \
             --project rootjs-dev \
-            --force; do
-            if [[ "$attempt" -ge "$max_attempts" ]]; then
-              echo "firebase deploy failed after ${max_attempts} attempts." >&2
-              exit 1
-            fi
-            echo "firebase deploy attempt ${attempt} failed; retrying in 15s..." >&2
-            attempt=$((attempt + 1))
-            sleep 15
-          done
+            --force

--- a/docs/scripts/deploy_firebase.sh
+++ b/docs/scripts/deploy_firebase.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Runs `firebase <args>` with a few retries.
+#
+# firebase-tools resolves credentials from GOOGLE_APPLICATION_CREDENTIALS via
+# GoogleAuth.getAccessToken(), which performs a network token exchange that
+# intermittently fails with "Failed to authenticate, have you run firebase
+# login?" (the same commit succeeds on a re-run). Retry a few times to ride out
+# those transient failures.
+#
+# All diagnostics are written to stderr so callers can safely capture the
+# command's stdout (e.g. `firebase ... --json`).
+#
+# Usage:
+#   docs/scripts/deploy_firebase.sh deploy --only hosting --project rootjs-dev --force
+set -euo pipefail
+
+max_attempts="${FIREBASE_DEPLOY_MAX_ATTEMPTS:-3}"
+retry_delay="${FIREBASE_DEPLOY_RETRY_DELAY:-15}"
+
+attempt=1
+until pnpm exec firebase "$@"; do
+  if [[ "$attempt" -ge "$max_attempts" ]]; then
+    echo "firebase $1 failed after ${max_attempts} attempts." >&2
+    exit 1
+  fi
+  echo "firebase $1 attempt ${attempt} failed; retrying in ${retry_delay}s..." >&2
+  attempt=$((attempt + 1))
+  sleep "$retry_delay"
+done


### PR DESCRIPTION
## Problem

Both deploy workflows intermittently fail at the `firebase deploy` step with:

```
Error: Failed to authenticate, have you run firebase login?
```

This is **not** a code/build regression — it's a flaky auth failure. The same commit both succeeds and fails depending on when it runs:

- `bef3c53`: succeeded at 19:47 & 19:58, failed at 20:42
- `45480ad`: failed at 18:50, succeeded at 19:10

`google-github-actions/auth@v2` reports "Successfully authenticated" and writes the credentials file, but firebase-tools (`lib/requireAuth.js` → `autoAuth()` → google-auth-library `GoogleAuth.getAccessToken()`) performs a network token exchange that occasionally fails transiently (it throws ~2s in, well under its own 15s timeout), surfacing the generic "Failed to authenticate" message.

## Fix

Wrap the Firebase deploy commands in a 3-attempt retry loop (15s backoff) in both deploy workflows:

- `.github/workflows/docs.yml` — "Deploy rootjs.dev to Firebase"
- `.github/workflows/docs-preview.yml` — "Deploy preview function to Firebase" and "Deploy preview to Firebase Hosting" (retry preserves the `--json` capture)

Note: `docs-preview.yml` is triggered by `issue_comment`, so the retry only takes effect for `/preview` runs once merged to `main`.
