### PR TITLE
feat: add user role to auth object

### DIFF
--- a/.changeset/early-meals-invent.md
+++ b/.changeset/early-meals-invent.md
@@ -1,0 +1,6 @@
+---
+'@blinkk/root-cms': patch
+'@blinkk/root': patch
+---
+
+feat: add user role to auth object

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -27,7 +27,7 @@ import {SSEEvent, SSESchemaChangedEvent} from '../shared/sse.js';
 import {type AiConfig} from './ai.js';
 import {api} from './api.js';
 import {type CMSCheck} from './checks.js';
-import {Action, RootCMSClient} from './client.js';
+import {Action, RootCMSClient, UserRole} from './client.js';
 import {type CMSNotificationService} from './services-notifications.js';
 import {sse, SSEBroadcastFn} from './sse.js';
 import {type CMSTranslationService} from './translations.js';
@@ -114,6 +114,11 @@ const NONCONF_STATIC_PATHS = [
 
 export interface CMSUser {
   email: string;
+  /**
+   * The user's role within the project's ACL, or `null` if unassigned. This is
+   * populated on `req.user` for every authenticated request.
+   */
+  role?: UserRole | null;
 }
 
 /**
@@ -683,7 +688,8 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         console.log('session failed: user is not in the firestore acl list');
         return null;
       }
-      return {email: jwt.email};
+      const role = await cmsClient.getUserRole(jwt.email).catch(() => null);
+      return {email: jwt.email, role};
     }
 
     try {
@@ -716,7 +722,8 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         return null;
       }
       // JWT verified.
-      return {email: jwt.email!};
+      const role = await cmsClient.getUserRole(jwt.email!).catch(() => null);
+      return {email: jwt.email!, role};
     } catch (err) {
       console.error('failed to verify jwt token');
       console.error(err);

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -84,7 +84,15 @@ export type Request = ExpressRequest & {
   /** The root.js renderer, to render routes within middleware. */
   renderer?: Renderer;
   /** Logged in user for the request. */
-  user?: {email: string};
+  user?: {
+    email: string;
+    /**
+     * The user's role, when provided by an auth plugin (e.g. Root CMS sets
+     * this to `'ADMIN' | 'EDITOR' | 'CONTRIBUTOR' | 'VIEWER'`, or `null` when
+     * the user has no assigned role).
+     */
+    role?: string | null;
+  };
 
   /**
    * Handler context, provided to route files that export a custom `handler()`


### PR DESCRIPTION
## Summary
This PR adds support for populating and exposing user roles during authentication in the Root CMS plugin. User roles are now fetched from the CMS client and included in the authenticated request context.

## Key Changes
- **CMS Plugin (`plugin.ts`)**:
  - Import `UserRole` type from the client module
  - Add optional `role` field to `CMSUser` interface with documentation
  - Fetch user role via `cmsClient.getUserRole()` in both authentication flows (Firestore ACL and JWT verification)
  - Include the resolved role in the returned user object, defaulting to `null` if the fetch fails

- **Root Types (`types.ts`)**:
  - Extend `Request.user` object to include an optional `role` field
  - Add documentation clarifying that the role is provided by auth plugins (e.g., Root CMS) and can be `null` when unassigned
  - Specify that Root CMS uses role values: `'ADMIN' | 'EDITOR' | 'CONTRIBUTOR' | 'VIEWER'`

## Implementation Details
- Role fetching is wrapped in `.catch(() => null)` to gracefully handle failures without breaking authentication
- The role field is optional and nullable, allowing for backward compatibility and cases where roles are not assigned
- Both authentication paths (Firestore ACL and JWT) now consistently populate the user role

https://claude.ai/code/session_01EDb6uja3iw4pWwjWFcsDoF