### PR TITLE
feat: sync sidebar tool location with cms url

### DIFF
--- a/.changeset/social-bottles-talk.md
+++ b/.changeset/social-bottles-talk.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: sync sidebar tool location with cms url

--- a/packages/root-cms/shared/embed-protocol.test.ts
+++ b/packages/root-cms/shared/embed-protocol.test.ts
@@ -2,6 +2,7 @@ import {describe, it, expect} from 'vitest';
 import {
   isHighlightNodeMessage,
   isRootEmbedMessage,
+  isRootToolLocationMessage,
   isScrollToDeeplinkMessage,
 } from './embed-protocol.js';
 
@@ -47,6 +48,32 @@ describe('isScrollToDeeplinkMessage', () => {
       false
     );
     expect(isScrollToDeeplinkMessage({root: {type: 'ready'}})).toBe(false);
+  });
+});
+
+describe('isRootToolLocationMessage', () => {
+  it('accepts locationchange messages', () => {
+    expect(
+      isRootToolLocationMessage({
+        rootTool: {type: 'locationchange', url: '/foo?a=1#h'},
+      })
+    ).toBe(true);
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(isRootToolLocationMessage(null)).toBe(false);
+    expect(isRootToolLocationMessage({})).toBe(false);
+    expect(isRootToolLocationMessage({rootTool: null})).toBe(false);
+    expect(isRootToolLocationMessage({rootTool: {}})).toBe(false);
+    expect(
+      isRootToolLocationMessage({rootTool: {type: 'locationchange'}})
+    ).toBe(false);
+    expect(
+      isRootToolLocationMessage({rootTool: {type: 'other', url: '/foo'}})
+    ).toBe(false);
+    expect(
+      isRootToolLocationMessage({rootTool: {type: 'locationchange', url: 1}})
+    ).toBe(false);
   });
 });
 

--- a/packages/root-cms/shared/embed-protocol.ts
+++ b/packages/root-cms/shared/embed-protocol.ts
@@ -47,6 +47,24 @@ export interface RootEmbedMessage {
   };
 }
 
+/**
+ * Posted from an iframed sidebar tool to the parent CMS window to report the
+ * tool's current location. The CMS mirrors this into its own address bar so
+ * the tool's sub-path, query params, and hash survive a refresh and can be
+ * deep-linked/shared.
+ *
+ * Same-origin tools are synced automatically (the CMS reads
+ * `contentWindow.location` directly), so this message only needs to be posted
+ * by cross-origin tools, which the browser prevents the CMS from reading.
+ */
+export interface RootToolLocationMessage {
+  rootTool: {
+    type: 'locationchange';
+    /** The tool's current URL, absolute or relative to the tool's origin. */
+    url: string;
+  };
+}
+
 /** Requests that the doc editor scroll to (focus) a specific field. */
 export interface ScrollToDeeplinkMessage {
   scrollToDeeplink: {
@@ -78,6 +96,19 @@ export function isRootEmbedMessage(data: unknown): data is RootEmbedMessage {
     typeof root === 'object' &&
     root !== null &&
     EMBED_MESSAGE_TYPES.includes(root.type)
+  );
+}
+
+/** Returns whether a postMessage payload is a {@link RootToolLocationMessage}. */
+export function isRootToolLocationMessage(
+  data: unknown
+): data is RootToolLocationMessage {
+  const req = (data as RootToolLocationMessage)?.rootTool;
+  return (
+    typeof req === 'object' &&
+    req !== null &&
+    req.type === 'locationchange' &&
+    typeof req.url === 'string'
   );
 }
 

--- a/packages/root-cms/ui/pages/SidebarToolsPage/SidebarToolsPage.tsx
+++ b/packages/root-cms/ui/pages/SidebarToolsPage/SidebarToolsPage.tsx
@@ -1,10 +1,33 @@
-import {useEffect} from 'preact/hooks';
+import {useEffect, useRef, useState} from 'preact/hooks';
+import {isRootToolLocationMessage} from '../../../shared/embed-protocol.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
 import './SidebarToolsPage.css';
 
 interface SidebarToolsPageProps {
   id: string;
+}
+
+/**
+ * Query param on the CMS tool URL (`/cms/tools/:id`) that stores the iframe's
+ * current location (its origin-relative `pathname + search + hash`). Mirroring
+ * the iframe's location here keeps the address bar in sync with where the user
+ * is inside the tool, so the path survives a refresh and can be shared.
+ */
+const IFRAME_PATH_PARAM = 'path';
+
+/** Polling interval (ms) used to detect SPA navigations in same-origin tools. */
+const POLL_INTERVAL_MS = 400;
+
+/** Returns the origin-relative `pathname + search + hash` of a URL. */
+function getRelativePath(url: URL): string {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+/** Reads the stored iframe sub-path from the current CMS URL. */
+function getStoredIframePath(): string {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(IFRAME_PATH_PARAM) || '';
 }
 
 export function SidebarToolsPage(props: SidebarToolsPageProps) {
@@ -75,8 +98,151 @@ export function SidebarToolsPage(props: SidebarToolsPageProps) {
   return (
     <Layout>
       <div className="SidebarToolsPage">
-        <iframe src={tool.iframeUrl} />
+        <ToolIframe iframeUrl={tool.iframeUrl} />
       </div>
     </Layout>
   );
+}
+
+interface ToolIframeProps {
+  iframeUrl: string;
+}
+
+/**
+ * Renders a sidebar tool inside an iframe and keeps the iframe's location in
+ * sync with the CMS URL, both ways:
+ *
+ * - On mount, the iframe is opened at the sub-path stored on the CMS URL (the
+ *   `path` query param), so refreshing or sharing the page lands the user back
+ *   where they were inside the tool.
+ * - As the user navigates within the tool, the CMS URL's `path` param is
+ *   updated to mirror the iframe's location (path, query params, and hash).
+ *
+ * Same-origin tools are synced automatically by reading `contentWindow`. The
+ * browser blocks reading the location of a cross-origin tool, so those tools
+ * can opt in by posting a {@link RootToolLocationMessage} on navigation; until
+ * they do, the initial restore on refresh still works (the iframe is simply
+ * opened at the stored URL).
+ */
+function ToolIframe(props: ToolIframeProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Resolve the iframe's base URL once. `iframeUrl` may be absolute or relative
+  // to the CMS origin.
+  const [base] = useState(() => new URL(props.iframeUrl, window.location.href));
+
+  // Compute the initial src once, restoring any stored sub-path. Resolving the
+  // stored origin-relative path against the tool's origin reconstructs the full
+  // URL the user was last on.
+  const [initialSrc] = useState(() => {
+    const stored = getStoredIframePath();
+    if (!stored) {
+      return props.iframeUrl;
+    }
+    try {
+      return new URL(stored, base.origin).toString();
+    } catch {
+      return props.iframeUrl;
+    }
+  });
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) {
+      return;
+    }
+
+    const homePath = getRelativePath(base);
+    let lastSynced: string | null = null;
+    // Set true once we detect the tool has navigated to a cross-origin page,
+    // whose location the browser won't let us read. We then rely on the tool
+    // posting location updates instead of polling.
+    let crossOrigin = false;
+
+    /** Mirrors the tool's relative location into the CMS URL `path` param. */
+    const syncCmsUrl = (relativePath: string) => {
+      if (relativePath === lastSynced) {
+        return;
+      }
+      lastSynced = relativePath;
+      const url = new URL(window.location.href);
+      if (relativePath && relativePath !== homePath) {
+        url.searchParams.set(IFRAME_PATH_PARAM, relativePath);
+      } else {
+        // At the tool's home location: drop the param to keep the URL clean.
+        url.searchParams.delete(IFRAME_PATH_PARAM);
+      }
+      // Use replaceState (not pushState) so each in-tool navigation doesn't add
+      // a redundant CMS history entry on top of the iframe's own history entry.
+      // Preserve the existing history state so the router isn't disrupted.
+      window.history.replaceState(window.history.state, '', url.toString());
+    };
+
+    /** Reads the same-origin tool's relative location, or null if unreadable. */
+    const readRelativePath = (): string | null => {
+      try {
+        const loc = iframe.contentWindow?.location;
+        if (!loc || loc.href === 'about:blank') {
+          return null;
+        }
+        return `${loc.pathname}${loc.search}${loc.hash}`;
+      } catch {
+        // Cross-origin: the browser blocks reading the location.
+        crossOrigin = true;
+        return null;
+      }
+    };
+
+    const handleLoad = () => {
+      const relativePath = readRelativePath();
+      if (relativePath !== null) {
+        syncCmsUrl(relativePath);
+      }
+    };
+    iframe.addEventListener('load', handleLoad);
+
+    // SPA navigations and hash changes inside a same-origin tool don't fire the
+    // iframe's load event, so poll the location to pick them up.
+    let pollTimer = 0;
+    const poll = () => {
+      if (!crossOrigin) {
+        const relativePath = readRelativePath();
+        if (relativePath !== null) {
+          syncCmsUrl(relativePath);
+        }
+      }
+      if (!crossOrigin) {
+        pollTimer = window.setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+    pollTimer = window.setTimeout(poll, POLL_INTERVAL_MS);
+
+    // Cross-origin tools can opt in to syncing by posting their location.
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow) {
+        return;
+      }
+      if (event.origin !== base.origin) {
+        return;
+      }
+      if (!isRootToolLocationMessage(event.data)) {
+        return;
+      }
+      try {
+        const toolUrl = new URL(event.data.rootTool.url, base.origin);
+        syncCmsUrl(getRelativePath(toolUrl));
+      } catch {
+        // Ignore malformed URLs.
+      }
+    };
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      iframe.removeEventListener('load', handleLoad);
+      window.clearTimeout(pollTimer);
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [base]);
+
+  return <iframe ref={iframeRef} src={initialSrc} />;
 }


### PR DESCRIPTION
## Summary
This PR adds location synchronization between iframed sidebar tools and the CMS address bar, enabling users to refresh or share deep links to specific pages within tools.

## Key Changes
- **ToolIframe component**: New component that wraps the sidebar tool iframe and manages bidirectional location syncing
  - Restores the iframe to a previously stored sub-path on mount (from the `path` query parameter)
  - Polls same-origin tools every 400ms to detect SPA navigations and hash changes
  - Listens for `RootToolLocationMessage` postMessages from cross-origin tools
  - Updates the CMS URL's `path` query parameter to mirror the tool's current location
  
- **Location sync protocol**: Added `RootToolLocationMessage` interface to the embed protocol
  - Allows cross-origin tools to opt-in to location tracking by posting their current URL
  - Includes type guard `isRootToolLocationMessage()` for validation
  
- **Helper utilities**:
  - `getRelativePath()`: Extracts origin-relative path from a URL
  - `getStoredIframePath()`: Reads the stored iframe sub-path from CMS query params
  - Constants for the query parameter name (`IFRAME_PATH_PARAM`) and polling interval (`POLL_INTERVAL_MS`)

## Implementation Details
- Uses `replaceState` instead of `pushState` to avoid creating redundant history entries for in-tool navigations
- Gracefully handles cross-origin restrictions by detecting when location reads fail and switching to message-based syncing
- Cleans up the `path` query parameter when the tool is at its home location to keep URLs clean
- Includes comprehensive test coverage for the new message type validation

Fixes #1277

https://claude.ai/code/session_01YR2YcPG6f9prt6VaSLgJb4