### PR TITLE
feat: add support for enumerated attrs and CSSProperties type

### DIFF
--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -46,6 +46,12 @@ test('renders disableRemotePlayback as a boolean attribute', () => {
   expect(output).toBe('<video disableremoteplayback></video>');
 });
 
+test('renders disablePictureInPicture as a boolean attribute', () => {
+  const vnode = <video disablePictureInPicture />;
+  const output = renderJsxToString(vnode, {mode: 'minimal'});
+  expect(output).toBe('<video disablepictureinpicture></video>');
+});
+
 test('renders popover as a boolean attribute', () => {
   // `<div popover />` should minimize to `popover` (treated as "auto" by the
   // browser) rather than rendering an invalid `popover="true"` value.
@@ -60,6 +66,23 @@ test('renders popover as a boolean attribute', () => {
   expect(
     renderJsxToString(<div popover="manual" />, {mode: 'minimal'})
   ).toBe('<div popover="manual"></div>');
+});
+
+test('renders crossorigin with a valid default value', () => {
+  // `<link crossorigin />` should render `crossorigin="anonymous"` (the
+  // spec-defined missing/invalid-value default) rather than the invalid
+  // `crossorigin="true"`.
+  expect(
+    renderJsxToString(<link rel="preload" href="/x.js" crossOrigin />, {
+      mode: 'minimal',
+    })
+  ).toBe('<link rel="preload" href="/x.js" crossorigin="anonymous">');
+  // Explicit string values are preserved.
+  expect(
+    renderJsxToString(<link href="/x.js" crossOrigin="use-credentials" />, {
+      mode: 'minimal',
+    })
+  ).toBe('<link href="/x.js" crossorigin="use-credentials">');
 });
 
 test('handles falsy attribute values', () => {

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -147,6 +147,7 @@ const BOOLEAN_ATTRS = new Set([
   'default',
   'defer',
   'disabled',
+  'disablepictureinpicture',
   'disableremoteplayback',
   'download',
   'draggable',
@@ -170,6 +171,24 @@ const BOOLEAN_ATTRS = new Set([
 ]);
 
 /**
+ * Enumerated attributes that have no boolean form. When written as a bare JSX
+ * prop (e.g. `<link crossorigin />`, which Preact passes as `true`), rendering
+ * `="true"` would be an invalid value, so emit the attribute's spec-defined
+ * default instead. For `crossorigin` the missing/invalid-value default is
+ * `anonymous`.
+ *
+ * Keyed by HTML attribute name (post-`PROP_TO_ATTR` remapping). A
+ * null-prototype object so the common "not enumerated" lookup misses without
+ * walking `Object.prototype`.
+ */
+const ENUMERATED_ATTR_TRUE_DEFAULTS: Record<string, string> = Object.assign(
+  Object.create(null),
+  {
+    crossorigin: 'anonymous',
+  }
+);
+
+/**
  * JSX prop name -> HTML attribute name.
  *
  * A null-prototype object so that the very common "no remapping needed" lookup
@@ -191,6 +210,7 @@ const PROP_TO_ATTR: Record<string, string> = Object.assign(
     contentEditable: 'contenteditable',
     crossOrigin: 'crossorigin',
     dateTime: 'datetime',
+    disablePictureInPicture: 'disablepictureinpicture',
     disableRemotePlayback: 'disableremoteplayback',
     encType: 'enctype',
     formAction: 'formaction',
@@ -730,11 +750,19 @@ export function renderJsxToString(
         // escaping, so skip `escapeAttr` entirely.
         result += ' ' + attrName + '="' + value + '"';
       } else if (value === true) {
-        // Boolean HTML attributes minimize to a bare attribute when `true`;
-        // other attributes are stringified (e.g. id="true").
-        result += BOOLEAN_ATTRS.has(attrName)
-          ? ' ' + attrName
-          : ' ' + attrName + '="true"';
+        // Boolean HTML attributes minimize to a bare attribute when `true`.
+        // Enumerated attributes with no boolean form (e.g. crossorigin) render
+        // their spec default rather than the invalid `="true"`. Everything else
+        // is stringified (e.g. id="true").
+        if (BOOLEAN_ATTRS.has(attrName)) {
+          result += ' ' + attrName;
+        } else {
+          const enumDefault = ENUMERATED_ATTR_TRUE_DEFAULTS[attrName];
+          result +=
+            enumDefault !== undefined
+              ? ' ' + attrName + '="' + enumDefault + '"'
+              : ' ' + attrName + '="true"';
+        }
       } else if (value === false) {
         // Boolean HTML attributes are removed when `false`; other attributes
         // are stringified (e.g. data-foo="false").

--- a/packages/root/src/jsx/jsx.ts
+++ b/packages/root/src/jsx/jsx.ts
@@ -64,5 +64,6 @@ export type {
   ScriptHTMLAttributes,
   DOMAttributes,
   AriaAttributes,
+  CSSProperties,
 } from './types.js';
 export type {JSX} from './types.js';

--- a/packages/root/src/jsx/types.ts
+++ b/packages/root/src/jsx/types.ts
@@ -83,6 +83,35 @@ export interface DOMAttributes {
 
 type EventHandler = string | ((...args: any[]) => void);
 
+// =============================================================================
+// CSS Types
+// =============================================================================
+
+/**
+ * The camelCase CSS property names recognized by the DOM, derived from the
+ * string-valued members of lib.dom's `CSSStyleDeclaration` (e.g.
+ * `backgroundColor`, `alignItems`, `cssFloat`). The numeric index signature,
+ * `length`, `parentRule`, and method members are filtered out.
+ */
+type CSSPropertyName = {
+  [K in keyof CSSStyleDeclaration]: K extends string
+    ? CSSStyleDeclaration[K] extends string
+      ? K
+      : never
+    : never;
+}[keyof CSSStyleDeclaration];
+
+/**
+ * Typed CSS style object accepted by the `style` prop. Each known CSS property
+ * maps to a `string` or `number` (a number is emitted verbatim, matching the
+ * renderer's `styleToString`), and CSS custom properties (`--my-var`) are also
+ * permitted.
+ */
+export interface CSSProperties
+  extends Partial<Record<CSSPropertyName, string | number>> {
+  [key: `--${string}`]: string | number | undefined;
+}
+
 export interface AriaAttributes {
   role?: string;
   'aria-activedescendant'?: string;
@@ -285,7 +314,7 @@ export interface HTMLAttributes<T = HTMLElement>
   srcSet?: string;
   start?: number;
   step?: number | string;
-  style?: string | Record<string, string | number>;
+  style?: string | CSSProperties;
   summary?: string;
   tabIndex?: number;
   target?: string;

--- a/packages/root/src/jsx/types.ts
+++ b/packages/root/src/jsx/types.ts
@@ -192,7 +192,7 @@ export interface HTMLAttributes<T = HTMLElement>
   controls?: boolean;
   controlsList?: string;
   coords?: string;
-  crossOrigin?: string;
+  crossOrigin?: boolean | 'anonymous' | 'use-credentials' | (string & {});
   data?: string;
   dateTime?: string;
   default?: boolean;
@@ -428,7 +428,7 @@ export interface ScriptHTMLAttributes<
   T = HTMLScriptElement,
 > extends HTMLAttributes<T> {
   async?: boolean;
-  crossOrigin?: string;
+  crossOrigin?: boolean | 'anonymous' | 'use-credentials' | (string & {});
   defer?: boolean;
   integrity?: string;
   noModule?: boolean;


### PR DESCRIPTION
## Summary
This PR enhances JSX attribute handling by adding proper support for enumerated HTML attributes (like `crossorigin`) and improves type safety for CSS properties.

## Key Changes

- **Enumerated Attribute Support**: Added `ENUMERATED_ATTR_TRUE_DEFAULTS` map to handle enumerated attributes that have no boolean form. When passed as `true` in JSX, these attributes now render their spec-defined default values instead of the invalid `="true"` string. For example, `<link crossOrigin />` now renders as `crossorigin="anonymous"` rather than `crossorigin="true"`.

- **Boolean Attribute Addition**: Added `disablepictureinpicture` to the `BOOLEAN_ATTRS` set and mapped the camelCase prop `disablePictureInPicture` in `PROP_TO_ATTR`.

- **CSS Properties Type**: Introduced a new `CSSProperties` interface that provides proper typing for the `style` prop. It derives valid CSS property names from the DOM's `CSSStyleDeclaration` type and supports both string and number values, plus CSS custom properties (`--my-var`).

- **Improved crossOrigin Typing**: Updated the `crossOrigin` attribute type in `HTMLAttributes` and `ScriptHTMLAttributes` to accept `boolean | 'anonymous' | 'use-credentials' | (string & {})`, providing better type safety and IDE autocomplete for valid values.

- **Updated style Prop Type**: Changed the `style` prop type from `string | Record<string, string | number>` to `string | CSSProperties` for more precise typing.

- **Test Coverage**: Added tests for `disablePictureInPicture` boolean attribute rendering and `crossOrigin` enumerated attribute handling with both bare and explicit values.

## Implementation Details

The enumerated attribute handling uses a null-prototype object (`Object.create(null)`) to avoid prototype chain lookups when checking for enumerated attribute defaults, ensuring efficient property access.

https://claude.ai/code/session_015Qd7Qijofxrg8mmLPRVGcE