### PR TITLE
chore: turn file field background purple on drag/drop 

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.css
@@ -9,7 +9,8 @@
 }
 
 .FileField:has(.dragging) .FileField__Dropzone,
-.FileField:has(.dragging) .FileField__Canvas {
+.FileField:has(.dragging) .FileField__Canvas,
+.FileField:has(.dragging) .FileField__Canvas__Info {
   background-color: #f3d9fa;
 }
 


### PR DESCRIPTION
## Summary
Updated the FileField drag-over styling to include the Canvas Info component, ensuring consistent visual feedback across all child elements during file drag operations.

## Key Changes
- Extended the `:has(.dragging)` selector to apply the drag-over background color (`#f3d9fa`) to `.FileField__Canvas__Info` in addition to the existing `.FileField__Dropzone` and `.FileField__Canvas` elements

## Implementation Details
This change ensures that when a user drags a file over the FileField component, all relevant child elements (Dropzone, Canvas, and Canvas Info) receive the same visual feedback with the light purple background color, providing a more cohesive and complete user experience.

https://claude.ai/code/session_01QxCmDVJsPgqaxLbU8KsyLr