### PR TITLE
feat: add support for tel: and sms: URL schemes in sanitizer

### DIFF
--- a/.changeset/silent-cobras-drop.md
+++ b/.changeset/silent-cobras-drop.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add support for tel: and sms: URL schemes in sanitizer

--- a/packages/root-cms/shared/sanitize.test.ts
+++ b/packages/root-cms/shared/sanitize.test.ts
@@ -38,6 +38,16 @@ describe('sanitizeInlineHtml', () => {
     expect(out).not.toContain('data:');
   });
 
+  it('preserves mailto: hrefs', () => {
+    const out = sanitizeInlineHtml('<a href="mailto:hi@x.test">x</a>');
+    expect(out).toContain('href="mailto:hi@x.test"');
+  });
+
+  it('preserves tel: hrefs', () => {
+    const out = sanitizeInlineHtml('<a href="tel:+1234567890">x</a>');
+    expect(out).toContain('href="tel:+1234567890"');
+  });
+
   it('drops block-level tags in inline context', () => {
     const out = sanitizeInlineHtml('<p>hi</p><div>x</div>');
     expect(out).not.toContain('<p>');
@@ -94,5 +104,10 @@ describe('sanitizeBlockHtml', () => {
   it('blocks protocol-relative URLs', () => {
     const out = sanitizeBlockHtml('<a href="//evil.test">x</a>');
     expect(out).not.toContain('//evil.test');
+  });
+
+  it('preserves tel: hrefs', () => {
+    const out = sanitizeBlockHtml('<a href="tel:+1234567890">x</a>');
+    expect(out).toContain('href="tel:+1234567890"');
   });
 });

--- a/packages/root-cms/shared/sanitize.test.ts
+++ b/packages/root-cms/shared/sanitize.test.ts
@@ -48,6 +48,11 @@ describe('sanitizeInlineHtml', () => {
     expect(out).toContain('href="tel:+1234567890"');
   });
 
+  it('preserves sms: hrefs', () => {
+    const out = sanitizeInlineHtml('<a href="sms:+1234567890">x</a>');
+    expect(out).toContain('href="sms:+1234567890"');
+  });
+
   it('drops block-level tags in inline context', () => {
     const out = sanitizeInlineHtml('<p>hi</p><div>x</div>');
     expect(out).not.toContain('<p>');
@@ -109,5 +114,10 @@ describe('sanitizeBlockHtml', () => {
   it('preserves tel: hrefs', () => {
     const out = sanitizeBlockHtml('<a href="tel:+1234567890">x</a>');
     expect(out).toContain('href="tel:+1234567890"');
+  });
+
+  it('preserves sms: hrefs', () => {
+    const out = sanitizeBlockHtml('<a href="sms:+1234567890">x</a>');
+    expect(out).toContain('href="sms:+1234567890"');
   });
 });

--- a/packages/root-cms/shared/sanitize.ts
+++ b/packages/root-cms/shared/sanitize.ts
@@ -58,7 +58,7 @@ const ALLOWED_ATTRIBUTES: Record<string, string[]> = {
 };
 
 const COMMON_OPTIONS: IOptions = {
-  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+  allowedSchemes: ['http', 'https', 'mailto', 'tel', 'sms'],
   allowedSchemesByTag: {
     img: ['http', 'https', 'data'],
   },

--- a/packages/root-cms/shared/sanitize.ts
+++ b/packages/root-cms/shared/sanitize.ts
@@ -58,7 +58,7 @@ const ALLOWED_ATTRIBUTES: Record<string, string[]> = {
 };
 
 const COMMON_OPTIONS: IOptions = {
-  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
   allowedSchemesByTag: {
     img: ['http', 'https', 'data'],
   },


### PR DESCRIPTION
## Summary
Extended the HTML sanitizer to allow `tel:` and `sms:` URL schemes in addition to the existing `http`, `https`, and `mailto` schemes. This enables support for phone and SMS links in sanitized HTML content.

## Changes
- Updated `COMMON_OPTIONS.allowedSchemes` in `sanitize.ts` to include `'tel'` and `'sms'` schemes
- Added test coverage for `mailto:`, `tel:`, and `sms:` href preservation in `sanitizeInlineHtml()`
- Added test coverage for `tel:` and `sms:` href preservation in `sanitizeBlockHtml()`

## Details
The sanitizer now permits anchor tags with `tel:` and `sms:` protocols, allowing users to create clickable phone number and SMS links in both inline and block-level HTML contexts. This is a common UX pattern for mobile-friendly content.

https://claude.ai/code/session_01VAKu74nPjo8G7kX4uu8Pnz