### PR TITLE
chore: show "not found" indicator for stale doc references

### DIFF
--- a/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.css
+++ b/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.css
@@ -77,3 +77,29 @@ a.DocPreviewCard {
   zoom: 0.9;
   gap: 6px;
 }
+
+.DocPreviewCard--notfound {
+  color: var(--color-text-secondary, #868e96);
+}
+
+.DocPreviewCard__notfound__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 60px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary, #f1f3f5);
+  color: #868e96;
+}
+
+.DocPreviewCard__notfound__message {
+  font-size: 14px;
+  font-weight: 500;
+  font-style: italic;
+}
+
+.DocPreviewCard--compact .DocPreviewCard__notfound__message {
+  font-size: 13px;
+}

--- a/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
+++ b/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.tsx
@@ -1,6 +1,7 @@
 import './DocPreviewCard.css';
 
 import {Loader} from '@mantine/core';
+import {IconFileOff} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocFromCacheOrFetch} from '../../utils/doc-cache.js';
@@ -52,9 +53,31 @@ export function DocPreviewCard(props: DocPreviewCardProps) {
     );
   }
 
-  // Short circuit if there is no doc (i.e. a stale reference).
+  // If there is no doc (i.e. a stale reference to a doc that was deleted or
+  // archived), show a "not found" indicator instead of a blank card.
   if (!doc) {
-    return;
+    return (
+      <div
+        className={joinClassNames(
+          props.className,
+          'DocPreviewCard',
+          'DocPreviewCard--notfound',
+          props.variant && `DocPreviewCard--${props.variant}`
+        )}
+      >
+        <div className="DocPreviewCard__notfound__icon">
+          <IconFileOff size={24} stroke={1.5} />
+        </div>
+        <div className="DocPreviewCard__content">
+          <div className="DocPreviewCard__content__header">
+            <div className="DocPreviewCard__content__header__docId">{docId}</div>
+          </div>
+          <div className="DocPreviewCard__notfound__message">
+            Doc not found (was it deleted or archived?)
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const [collection] = docId.split('/');

--- a/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.visual.test.tsx
+++ b/packages/root-cms/ui/components/DocPreviewCard/DocPreviewCard.visual.test.tsx
@@ -118,6 +118,32 @@ describe('DocPreviewCard', () => {
       .toMatchScreenshot('DocPreviewCard-badges.png');
   });
 
+  it('renders not found indicator for a stale reference', async () => {
+    render(
+      <div data-testid="card-notfound" style={{width: '300px'}}>
+        <DocPreviewCard docId="products/deleted-doc" />
+      </div>
+    );
+    await expect.element(page.getByText('products/deleted-doc')).toBeVisible();
+    await expect.element(page.getByText(/Doc not found/)).toBeVisible();
+    await expect
+      .element(page.getByTestId('card-notfound'))
+      .toMatchScreenshot('DocPreviewCard-notfound.png');
+  });
+
+  it('renders compact not found indicator for a stale reference', async () => {
+    render(
+      <div data-testid="card-notfound-compact" style={{width: '300px'}}>
+        <DocPreviewCard docId="products/deleted-doc" variant="compact" />
+      </div>
+    );
+    await expect.element(page.getByText('products/deleted-doc')).toBeVisible();
+    await expect.element(page.getByText(/Doc not found/)).toBeVisible();
+    await expect
+      .element(page.getByTestId('card-notfound-compact'))
+      .toMatchScreenshot('DocPreviewCard-notfound-compact.png');
+  });
+
   it('renders compact with badges', async () => {
     const doc = createDoc('products/test-doc', {
       publishedAt: mockTimestamp(1647485978000),


### PR DESCRIPTION
## Summary
Instead of rendering nothing when a document reference is stale (deleted or archived), the DocPreviewCard now displays a "not found" indicator with the document ID and a helpful message.

## Key Changes
- **Component Logic**: Modified the null doc handling in `DocPreviewCard.tsx` to render a styled "not found" card instead of returning nothing
- **UI Elements**: Added an icon (IconFileOff from Tabler) and message to indicate the document was not found
- **Styling**: Added new CSS classes to style the not found state with secondary colors and a bordered icon container
- **Tests**: Added visual regression tests for both default and compact variants of the not found indicator

## Implementation Details
- The not found card maintains the same structure as a regular preview card (with className composition and variant support) for consistency
- Uses semantic styling with secondary colors and italicized message text to differentiate from valid documents
- The icon container has a fixed size (80x60px) with a border and secondary background color
- Compact variant has slightly smaller font size (13px vs 14px) for the message
- Tests verify visibility of the document ID and "Doc not found" message for both card variants

https://claude.ai/code/session_01CiAAHMi1GPwQiQ2gNim72n