### PR TITLE
chore: lighten file field drag/drop background color

### DIFF
--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.css
@@ -11,7 +11,7 @@
 .FileField:has(.dragging) .FileField__Dropzone,
 .FileField:has(.dragging) .FileField__Canvas,
 .FileField:has(.dragging) .FileField__Canvas__Info {
-  background-color: #f3d9fa;
+  background-color: rgb(249, 238, 252);
 }
 
 .FileField:has(.FileField__Canvas) {
@@ -194,7 +194,7 @@ a.FileField__Preview__AssetLibraryBadge:active {
 }
 
 .FileField__Canvas.dragging {
-  background-color: #f3d9fa;
+  background-color: rgb(249, 238, 252);
 }
 
 .FileField__Preview__Image {
@@ -231,7 +231,7 @@ a.FileField__Preview__AssetLibraryBadge:active {
 }
 
 .FileField__Dropzone.dragging {
-  background-color: #f3d9fa;
+  background-color: rgb(249, 238, 252);
 }
 
 .FileField__Empty {

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.css
@@ -1,4 +1,5 @@
 .FileField {
+  --file-field-dragging-bg-color: rgb(249, 238, 252);
   border: 1px solid #ced4da;
   padding: 10px;
   position: relative;
@@ -11,7 +12,7 @@
 .FileField:has(.dragging) .FileField__Dropzone,
 .FileField:has(.dragging) .FileField__Canvas,
 .FileField:has(.dragging) .FileField__Canvas__Info {
-  background-color: rgb(249, 238, 252);
+  background-color: var(--file-field-dragging-bg-color);
 }
 
 .FileField:has(.FileField__Canvas) {
@@ -194,7 +195,7 @@ a.FileField__Preview__AssetLibraryBadge:active {
 }
 
 .FileField__Canvas.dragging {
-  background-color: rgb(249, 238, 252);
+  background-color: var(--file-field-dragging-bg-color);
 }
 
 .FileField__Preview__Image {
@@ -231,7 +232,7 @@ a.FileField__Preview__AssetLibraryBadge:active {
 }
 
 .FileField__Dropzone.dragging {
-  background-color: rgb(249, 238, 252);
+  background-color: var(--file-field-dragging-bg-color);
 }
 
 .FileField__Empty {


### PR DESCRIPTION
## Summary

Follow-up to the file field drag/drop background change (#1281). The purple drag/drop active background felt a little dark, so this softens it from `#f3d9fa` to a lighter `rgb(249, 238, 252)` across all three drag/drop rules (empty dropzone, canvas, and the info panel).

## Changes

- `packages/root-cms/ui/components/DocEditor/fields/FileField.css`: update the drag/drop active background color to `rgb(249, 238, 252)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxCmDVJsPgqaxLbU8KsyLr)_