### PR TITLE
feat: add google drive asset sync provider to asset library

### DIFF
--- a/.changeset/tiny-masks-joke.md
+++ b/.changeset/tiny-masks-joke.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add google drive asset sync provider to asset library

--- a/packages/root-cms/docs/asset-sync-design.md
+++ b/packages/root-cms/docs/asset-sync-design.md
@@ -362,20 +362,35 @@ download concurrency (default 4) and the provider batches `/v1/images`
 ids (Figma accepts large id lists per call); on 429, back off using the
 `Retry-After` header and resume.
 
-### 5.2 Google Drive provider (future, validates the abstraction)
+### 5.2 Google Drive provider (`ui/utils/asset-sync/gdrive.ts`)
 
-- `parseSourceUrl`: `https://drive.google.com/drive/folders/<folderId>`.
-- Auth: the existing `useGapiClient` OAuth flow with
-  `drive.readonly` — the `SyncAuthContext` wraps `gapiClient.login()`,
-  so per-user access enforcement works identically (Drive's ACL decides).
-- `listRemoteAssets`: `drive.files.list({q: '<folderId>' in parents})`;
-  Drive supplies `md5Checksum` + `modifiedTime`, so `contentHash` is
-  known **before** download and unchanged files skip download entirely
-  (an optimization Figma can't offer).
-- `download`: existing `downloadFromDrive()` nearly verbatim.
+- `parseSourceUrl`: `https://drive.google.com/drive/folders/<folderId>`
+  (plus `/drive/u/<n>/folders/…` and `open?id=…` forms).
+- Auth: `authType: 'oauth'` — the provider interface grew a small OAuth
+  extension (`interactiveLogin()`, `loginLabel`, `createAuthContext()`)
+  and the UI shows a "Sign in with Google" button instead of a token
+  input. Sign-in uses the same GIS token flow and consent cache as
+  `useGapiClient` (one consent covers both features), with the read-only
+  Drive scope added; the access token is held in memory only. Per-user
+  access enforcement works identically to Figma: Drive's ACL decides.
+  Requires `gapi: {apiKey, clientId}` in the cmsPlugin options.
+- `listRemoteAssets`: Drive REST `files.list` (`'<folderId>' in parents`,
+  paginated, shared-drive aware) via plain `fetch` + Bearer token. Drive
+  supplies `md5Checksum`, so `contentHash` is known **before** download
+  and unchanged files skip the download entirely (an optimization Figma
+  can't offer). There is no cheap folder-level version, so
+  `RemoteAssetList.version` is unset and the whole-sync fast path doesn't
+  apply — a no-change re-sync costs one listing call, zero downloads.
+  v1 scope: direct children only (no subfolder recursion); native Google
+  editors files (Docs/Sheets/Slides) are skipped — no binary content.
+- `download`: `files/<id>?alt=media` with the Bearer token.
+- Rate limits (429 / 403 rate-limit reasons) reuse the Figma provider's
+  pattern: visible countdown, `Retry-After` honored, typed
+  `SyncRateLimitError` on exhaustion.
 
-Nothing in the engine, schema, or UI changes — which is the test the
-abstraction has to pass.
+The engine, schema, and folder UI needed no changes beyond the optional
+OAuth fields on the provider interface — the test the abstraction had to
+pass.
 
 ## 6. Sync engine (`ui/utils/asset-sync/engine.ts`)
 

--- a/packages/root-cms/ui/components/AssetBrowser/AssetSyncModals.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetSyncModals.tsx
@@ -3,6 +3,7 @@ import {showNotification} from '@mantine/notifications';
 import {
   IconAlertTriangle,
   IconBrandFigma,
+  IconBrandGoogleDrive,
   IconCloudDownload,
 } from '@tabler/icons-preact';
 import {ChangeEvent} from 'preact/compat';
@@ -36,6 +37,9 @@ export function SyncProviderIcon(props: {provider?: string; size?: number}) {
   if (props.provider === 'figma') {
     return <IconBrandFigma size={size} />;
   }
+  if (props.provider === 'gdrive') {
+    return <IconBrandGoogleDrive size={size} />;
+  }
   return <IconCloudDownload size={size} />;
 }
 
@@ -66,8 +70,11 @@ export function ConnectSyncModal(props: {
 
   const parsed = useMemo(() => parseSyncSourceUrl(url), [url]);
   const provider: AssetSyncProvider | null = parsed?.provider || null;
-  const hasStoredToken = provider ? !!getProviderToken(provider.id) : false;
-  const showTokenSection = !!provider && (!hasStoredToken || showTokenInput);
+  const isOAuth = provider?.authType === 'oauth';
+  const hasStoredToken =
+    provider && !isOAuth ? !!getProviderToken(provider.id) : false;
+  const showTokenSection =
+    !!provider && !isOAuth && (!hasStoredToken || showTokenInput);
   const folderPath = joinFolderPath(folder.parent, folder.name);
 
   async function onSubmit() {
@@ -84,24 +91,32 @@ export function ConnectSyncModal(props: {
     }
     setSubmitting(true);
     try {
-      const token = tokenInput.trim();
-      if (token) {
-        if (provider.validateToken) {
-          const check = await provider.validateToken(token, parsed.source);
-          if (!check.valid) {
-            setError(
-              check.error ||
-                `The ${provider.label} token appears to be invalid. Check the token and try again.`
-            );
-            setSubmitting(false);
-            return;
-          }
+      if (isOAuth) {
+        // Interactive sign-in must happen within the submit click gesture
+        // so the popup isn't blocked. With prior consent this is silent.
+        if (provider.interactiveLogin) {
+          await provider.interactiveLogin();
         }
-        setProviderToken(provider.id, token);
-      } else if (!hasStoredToken) {
-        setError(`Enter your ${provider.label} access token.`);
-        setSubmitting(false);
-        return;
+      } else {
+        const token = tokenInput.trim();
+        if (token) {
+          if (provider.validateToken) {
+            const check = await provider.validateToken(token, parsed.source);
+            if (!check.valid) {
+              setError(
+                check.error ||
+                  `The ${provider.label} token appears to be invalid. Check the token and try again.`
+              );
+              setSubmitting(false);
+              return;
+            }
+          }
+          setProviderToken(provider.id, token);
+        } else if (!hasStoredToken) {
+          setError(`Enter your ${provider.label} access token.`);
+          setSubmitting(false);
+          return;
+        }
       }
       const updated = await connectFolderSync(folder, parsed.source);
       showNotification({
@@ -149,24 +164,30 @@ export function ConnectSyncModal(props: {
         }}
       >
         <div className="AssetBrowser__syncModal__text">
-          Sync the exportable assets of a Figma file or node into this folder.
-          Assets marked for export in Figma are imported here and can be
-          re-synced when the designs change.
+          Sync assets from an external source into this folder — the exportable
+          assets of a Figma file or node, or the files of a Google Drive folder.
+          The connection is saved with this folder and can be re-synced when the
+          source changes.
         </div>
         <TextInput
           data-autofocus
           label="Source URL"
-          placeholder="https://www.figma.com/design/..."
+          placeholder="https://www.figma.com/design/… or https://drive.google.com/drive/folders/…"
           description={
             provider
               ? `Source: ${provider.label}`
-              : 'Link to a Figma file, or a specific node ("Copy link to selection" in Figma).'
+              : 'Link to a Figma file/node ("Copy link to selection" in Figma) or a Google Drive folder.'
           }
           value={url}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             setUrl(e.currentTarget.value)
           }
         />
+        {isOAuth && provider?.tokenHelp && (
+          <div className="AssetBrowser__syncModal__tokenHelp">
+            {provider.tokenHelp.text}
+          </div>
+        )}
         {showTokenSection && provider && (
           <div className="AssetBrowser__syncModal__token">
             <TextInput
@@ -328,6 +349,23 @@ export function SyncProgressModal(props: {
     }
   }
 
+  /** OAuth providers: interactive sign-in (within the click gesture). */
+  async function signInAndRetry() {
+    if (!provider?.interactiveLogin) {
+      return;
+    }
+    setSavingToken(true);
+    setError('');
+    try {
+      await provider.interactiveLogin();
+      setSavingToken(false);
+      run();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+      setSavingToken(false);
+    }
+  }
+
   const running = status === 'running';
 
   return (
@@ -370,7 +408,31 @@ export function SyncProgressModal(props: {
           </div>
         )}
 
-        {status === 'token' && provider && (
+        {status === 'token' && provider && provider.authType === 'oauth' && (
+          <div className="AssetBrowser__syncProgress__token">
+            <div className="AssetBrowser__syncModal__text">
+              {provider.tokenHelp?.text ||
+                `Sign in to ${provider.label} to sync. Only your account's access to the source is used.`}
+            </div>
+            {error && (
+              <div className="AssetBrowser__syncModal__error">{error}</div>
+            )}
+            <div className="AssetBrowser__syncModal__buttons">
+              <Button variant="default" onClick={props.onClose}>
+                Cancel
+              </Button>
+              <Button
+                color="dark"
+                loading={savingToken}
+                onClick={() => signInAndRetry()}
+              >
+                {provider.loginLabel || `Sign in to ${provider.label}`}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {status === 'token' && provider && provider.authType !== 'oauth' && (
           <div className="AssetBrowser__syncProgress__token">
             <div className="AssetBrowser__syncModal__text">
               A {provider.label} access token is needed to sync. Your token is

--- a/packages/root-cms/ui/hooks/useGapiClient.ts
+++ b/packages/root-cms/ui/hooks/useGapiClient.ts
@@ -161,7 +161,12 @@ async function loadGapiScript() {
 
 let loadGisScriptPromise: Promise<void> | null = null;
 
-async function loadGisScript() {
+/**
+ * Loads the Google Identity Services script (used for OAuth token flows).
+ * Exported for non-hook consumers (e.g. the Google Drive asset sync
+ * provider in `ui/utils/asset-sync/gdrive.ts`).
+ */
+export async function loadGisScript() {
   if (!loadGisScriptPromise) {
     loadGisScriptPromise = new Promise((resolve, reject) => {
       const script = document.createElement('script');

--- a/packages/root-cms/ui/utils/asset-sync/engine.ts
+++ b/packages/root-cms/ui/utils/asset-sync/engine.ts
@@ -154,7 +154,10 @@ export async function syncFolder(
   if (!provider) {
     throw new Error(`Unknown sync provider: ${sync.provider}`);
   }
-  const auth = options.auth ?? createBrowserAuthContext(provider.id);
+  const auth =
+    options.auth ??
+    provider.createAuthContext?.() ??
+    createBrowserAuthContext(provider.id);
   const concurrency = options.concurrency || DEFAULT_CONCURRENCY;
 
   // Progress reporting. Providers report transient status (e.g. rate-limit

--- a/packages/root-cms/ui/utils/asset-sync/gdrive.test.ts
+++ b/packages/root-cms/ui/utils/asset-sync/gdrive.test.ts
@@ -1,0 +1,229 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {GDRIVE_PROVIDER, parseDriveFolderUrl} from './gdrive.js';
+import {
+  SyncAccessError,
+  SyncAuthContext,
+  SyncTokenRequiredError,
+} from './types.js';
+
+const FOLDER_ID = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ012345';
+
+const SOURCE = {
+  provider: 'gdrive',
+  url: `https://drive.google.com/drive/folders/${FOLDER_ID}`,
+  gdrive: {folderId: FOLDER_ID},
+};
+
+const AUTH: SyncAuthContext = {
+  getToken: async () => 'tok',
+  invalidateToken: () => {},
+};
+
+const FOLDER_MIME = 'application/vnd.google-apps.folder';
+
+describe('parseDriveFolderUrl', () => {
+  it('parses folder URLs', () => {
+    expect(
+      parseDriveFolderUrl(`https://drive.google.com/drive/folders/${FOLDER_ID}`)
+    ).toEqual({folderId: FOLDER_ID});
+  });
+
+  it('parses account-scoped folder URLs with query params', () => {
+    expect(
+      parseDriveFolderUrl(
+        `https://drive.google.com/drive/u/0/folders/${FOLDER_ID}?usp=sharing`
+      )
+    ).toEqual({folderId: FOLDER_ID});
+  });
+
+  it('parses open?id= URLs', () => {
+    expect(
+      parseDriveFolderUrl(`https://drive.google.com/open?id=${FOLDER_ID}`)
+    ).toEqual({folderId: FOLDER_ID});
+  });
+
+  it('rejects non-drive URLs and file URLs', () => {
+    expect(parseDriveFolderUrl('https://example.com/drive/folders/x')).toBe(
+      null
+    );
+    expect(
+      parseDriveFolderUrl(`https://drive.google.com/file/d/${FOLDER_ID}/view`)
+    ).toBeNull();
+    expect(parseDriveFolderUrl('https://drive.google.com/')).toBeNull();
+    expect(parseDriveFolderUrl('not a url')).toBeNull();
+    // Ids must look like Drive ids.
+    expect(
+      parseDriveFolderUrl('https://drive.google.com/drive/folders/x')
+    ).toBeNull();
+  });
+});
+
+describe('GDRIVE_PROVIDER.parseSourceUrl', () => {
+  it('returns a source ref for drive folder URLs', () => {
+    expect(GDRIVE_PROVIDER.parseSourceUrl(SOURCE.url)).toEqual({
+      provider: 'gdrive',
+      url: SOURCE.url,
+      gdrive: {folderId: FOLDER_ID},
+    });
+  });
+
+  it('returns null for unrecognized URLs', () => {
+    expect(GDRIVE_PROVIDER.parseSourceUrl('https://example.com/x')).toBeNull();
+  });
+});
+
+describe('GDRIVE_PROVIDER.listRemoteAssets', () => {
+  /** Stubs global fetch, routing by URL substring (first match wins). */
+  function stubFetch(
+    routes: Array<[string, (url: string) => {status: number; body: any}]>
+  ) {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(String(url));
+        const match = routes.find(([key]) => String(url).includes(key));
+        const {status, body} = match
+          ? match[1](String(url))
+          : {status: 404, body: {}};
+        const res = {
+          ok: status >= 200 && status < 300,
+          status,
+          headers: {get: () => null},
+          json: async () => body,
+          clone: () => res,
+        };
+        return res as any;
+      })
+    );
+    return calls;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists files with md5 hashes, skipping folders and native docs', async () => {
+    stubFetch([
+      [
+        `/drive/v3/files/${FOLDER_ID}?`,
+        () => ({status: 200, body: {id: FOLDER_ID, mimeType: FOLDER_MIME}}),
+      ],
+      [
+        '/drive/v3/files?',
+        () => ({
+          status: 200,
+          body: {
+            files: [
+              {
+                id: 'file1',
+                name: 'hero.png',
+                mimeType: 'image/png',
+                md5Checksum: 'md5-1',
+              },
+              {id: 'sub', name: 'Subfolder', mimeType: FOLDER_MIME},
+              {
+                id: 'doc1',
+                name: 'Spec',
+                mimeType: 'application/vnd.google-apps.document',
+              },
+              {id: 'file2', name: 'movie.mp4', mimeType: 'video/mp4'},
+            ],
+          },
+        }),
+      ],
+    ]);
+    const result = await GDRIVE_PROVIDER.listRemoteAssets(SOURCE, AUTH);
+    // No cheap folder-level version on Drive.
+    expect(result.version).toBeUndefined();
+    expect(result.assets).toEqual([
+      {
+        remoteId: 'file1',
+        name: 'hero.png',
+        filename: 'hero.png',
+        contentHash: 'md5-1',
+        ref: {mimeType: 'image/png'},
+      },
+      {
+        remoteId: 'file2',
+        name: 'movie.mp4',
+        filename: 'movie.mp4',
+        ref: {mimeType: 'video/mp4'},
+      },
+    ]);
+  });
+
+  it('paginates through all pages', async () => {
+    stubFetch([
+      [
+        `/drive/v3/files/${FOLDER_ID}?`,
+        () => ({status: 200, body: {id: FOLDER_ID, mimeType: FOLDER_MIME}}),
+      ],
+      [
+        'pageToken=page2',
+        () => ({
+          status: 200,
+          body: {
+            files: [{id: 'b', name: 'b.png', mimeType: 'image/png'}],
+          },
+        }),
+      ],
+      [
+        '/drive/v3/files?',
+        () => ({
+          status: 200,
+          body: {
+            files: [{id: 'a', name: 'a.png', mimeType: 'image/png'}],
+            nextPageToken: 'page2',
+          },
+        }),
+      ],
+    ]);
+    const result = await GDRIVE_PROVIDER.listRemoteAssets(SOURCE, AUTH);
+    expect(result.assets.map((a) => a.remoteId)).toEqual(['a', 'b']);
+  });
+
+  it('rejects URLs that point at a file rather than a folder', async () => {
+    stubFetch([
+      [
+        `/drive/v3/files/${FOLDER_ID}?`,
+        () => ({status: 200, body: {id: FOLDER_ID, mimeType: 'image/png'}}),
+      ],
+    ]);
+    await expect(
+      GDRIVE_PROVIDER.listRemoteAssets(SOURCE, AUTH)
+    ).rejects.toThrow('not a folder');
+  });
+
+  it('maps 401 to SyncTokenRequiredError', async () => {
+    stubFetch([
+      [
+        '/drive/v3/files',
+        () => ({status: 401, body: {error: {message: 'Invalid credentials'}}}),
+      ],
+    ]);
+    await expect(
+      GDRIVE_PROVIDER.listRemoteAssets(SOURCE, AUTH)
+    ).rejects.toThrow(SyncTokenRequiredError);
+  });
+
+  it('maps non-rate-limit 403 to SyncAccessError', async () => {
+    stubFetch([
+      [
+        '/drive/v3/files',
+        () => ({
+          status: 403,
+          body: {
+            error: {
+              message: 'Insufficient permissions',
+              errors: [{reason: 'insufficientFilePermissions'}],
+            },
+          },
+        }),
+      ],
+    ]);
+    await expect(
+      GDRIVE_PROVIDER.listRemoteAssets(SOURCE, AUTH)
+    ).rejects.toThrow(SyncAccessError);
+  });
+});

--- a/packages/root-cms/ui/utils/asset-sync/gdrive.ts
+++ b/packages/root-cms/ui/utils/asset-sync/gdrive.ts
@@ -1,0 +1,425 @@
+/**
+ * @fileoverview Google Drive sync provider.
+ *
+ * Syncs the files of a Google Drive folder into an asset-library folder.
+ * Auth uses the same Google OAuth (GIS) flow as the rest of the CMS
+ * (`useGapiClient`), with the read-only Drive scope added -- the signed-in
+ * user's own access decides which folders they can sync. Requires the
+ * project to configure `gapi: {apiKey, clientId}` in the cmsPlugin options.
+ *
+ * Unlike Figma, Drive reports a per-file `md5Checksum` during enumeration,
+ * so unchanged files are skipped without downloading. Drive has no cheap
+ * folder-level version, so the engine's whole-sync fast path doesn't apply
+ * (`RemoteAssetList.version` is left unset); a no-change re-sync costs one
+ * listing call and zero downloads.
+ *
+ * Scope notes (v1): only the folder's direct children are synced (no
+ * subfolder recursion), and native Google Docs/Sheets/Slides files are
+ * skipped -- they have no binary content to import (exporting them to
+ * PDF/XLSX is a possible future option).
+ */
+
+import {loadGisScript} from '../../hooks/useGapiClient.js';
+import {sanitizeAssetName} from './names.js';
+import {
+  AssetSyncProvider,
+  RemoteAsset,
+  RemoteAssetList,
+  SyncAccessError,
+  SyncAuthContext,
+  SyncProviderContext,
+  SyncRateLimitError,
+  SyncSourceRef,
+  SyncTokenRequiredError,
+} from './types.js';
+
+const DRIVE_API_ORIGIN = 'https://www.googleapis.com';
+
+const DRIVE_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
+
+/**
+ * Scopes requested at sign-in. Includes the same base scopes as
+ * `useGapiClient` so a single consent covers both the asset sync and the
+ * existing Drive/Sheets features (the consent cache is shared).
+ */
+const LOGIN_SCOPES = [
+  'https://www.googleapis.com/auth/drive.file',
+  'https://www.googleapis.com/auth/spreadsheets',
+  DRIVE_READONLY_SCOPE,
+];
+
+const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+
+/** Native Google editors files (Docs/Sheets/...) have no binary content. */
+const GOOGLE_APPS_MIME_PREFIX = 'application/vnd.google-apps';
+
+/** Max retries for rate-limited API requests. */
+const MAX_RATE_LIMIT_RETRIES = 3;
+
+/** Max seconds to wait out a single Retry-After before retrying. */
+const MAX_RETRY_WAIT_SECONDS = 120;
+
+/** Files returned per files.list page. */
+const LIST_PAGE_SIZE = 1000;
+
+/** Download payload attached to each RemoteAsset. */
+interface DriveAssetRef {
+  mimeType?: string;
+}
+
+// The GIS access token is held in memory only (like the gapi client's own
+// token handling) and expires after ~1 hour; a new sync after expiry
+// re-runs the (usually promptless) sign-in.
+let cachedToken: {accessToken: string; expiresAt: number} | null = null;
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function getCachedAccessToken(): string | null {
+  if (cachedToken && nowSeconds() < cachedToken.expiresAt - 30) {
+    return cachedToken.accessToken;
+  }
+  return null;
+}
+
+/**
+ * The user's Google consent record, shared with `useGapiClient` (which
+ * writes the same localStorage key via Mantine's useLocalStorage) so that
+ * consenting once covers both features.
+ */
+interface GapiUserConsent {
+  clientId?: string;
+  scopes?: string[];
+  at?: number;
+}
+
+function getConsentStorageKey(): string {
+  const projectId = window.__ROOT_CTX.rootConfig.projectId;
+  return `root-cms::${projectId}::gapi-user-consent`;
+}
+
+function readUserConsent(): GapiUserConsent | null {
+  try {
+    const raw = localStorage.getItem(getConsentStorageKey());
+    return raw ? (JSON.parse(raw) as GapiUserConsent) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeUserConsent(consent: GapiUserConsent) {
+  try {
+    localStorage.setItem(getConsentStorageKey(), JSON.stringify(consent));
+  } catch {
+    // localStorage may be unavailable; consent is simply not remembered.
+  }
+}
+
+/**
+ * Interactively signs the user in with Google (GIS token flow) and caches
+ * the access token in memory. Skips the consent dialog when the user has
+ * previously consented to the requested scopes. Must be called from a user
+ * gesture so the popup isn't blocked.
+ */
+async function driveInteractiveLogin(): Promise<void> {
+  const clientId = window.__ROOT_CTX.gapi?.clientId;
+  if (!clientId) {
+    throw new Error(
+      'Google Drive sync requires the CMS Google API config. Add `gapi: {apiKey, clientId}` to the cmsPlugin options in root.config.ts.'
+    );
+  }
+  await loadGisScript();
+  await new Promise<void>((resolve, reject) => {
+    const tokenClient = google.accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: LOGIN_SCOPES.join(' '),
+      callback: (token: any) => {
+        if (!token || token.error) {
+          reject(
+            new Error(
+              `Google sign-in failed${token?.error ? `: ${token.error}` : '.'}`
+            )
+          );
+          return;
+        }
+        cachedToken = {
+          accessToken: token.access_token,
+          expiresAt: nowSeconds() + Number(token.expires_in || 3600),
+        };
+        writeUserConsent({
+          at: nowSeconds(),
+          clientId: clientId,
+          scopes: LOGIN_SCOPES,
+        });
+        resolve();
+      },
+      error_callback: (err: any) => {
+        reject(new Error(err?.message || 'Google sign-in was cancelled.'));
+      },
+    });
+    const consent = readUserConsent();
+    const promptless =
+      consent?.clientId === clientId &&
+      LOGIN_SCOPES.every((scope) => consent?.scopes?.includes(scope));
+    tokenClient.requestAccessToken({prompt: promptless ? '' : 'consent'});
+  });
+}
+
+function createAuthContext(): SyncAuthContext {
+  return {
+    async getToken() {
+      const token = getCachedAccessToken();
+      if (!token) {
+        throw new SyncTokenRequiredError(
+          'gdrive',
+          'Sign in with Google to sync from Drive.'
+        );
+      }
+      return token;
+    },
+    invalidateToken() {
+      cachedToken = null;
+    },
+  };
+}
+
+/**
+ * Parses a Google Drive folder URL into a folder id. Supported forms:
+ *
+ *   https://drive.google.com/drive/folders/<folderId>
+ *   https://drive.google.com/drive/u/0/folders/<folderId>?usp=sharing
+ *   https://drive.google.com/open?id=<folderId>
+ */
+export function parseDriveFolderUrl(url: string): {folderId: string} | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.hostname !== 'drive.google.com') {
+    return null;
+  }
+  let folderId: string;
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  const foldersIndex = parts.findIndex((p) => p === 'folders');
+  if (foldersIndex !== -1 && parts[foldersIndex + 1]) {
+    folderId = parts[foldersIndex + 1];
+  } else if (parts[0] === 'open' && parsed.searchParams.get('id')) {
+    folderId = parsed.searchParams.get('id')!;
+  } else {
+    return null;
+  }
+  if (!/^[A-Za-z0-9_-]{10,}$/.test(folderId)) {
+    return null;
+  }
+  return {folderId};
+}
+
+function isRateLimited(status: number, body: any): boolean {
+  if (status === 429) {
+    return true;
+  }
+  if (status !== 403) {
+    return false;
+  }
+  const reason = String(
+    body?.error?.errors?.[0]?.reason || body?.error?.status || ''
+  ).toLowerCase();
+  return reason.includes('ratelimit') || reason.includes('resource_exhausted');
+}
+
+/**
+ * Calls the Drive REST API, mapping auth failures to typed errors and
+ * retrying rate-limited requests with a user-visible countdown (mirrors the
+ * Figma provider's behavior). Returns the raw Response; callers parse.
+ */
+async function driveFetch(
+  path: string,
+  token: string,
+  onStatus?: (message: string) => void
+): Promise<Response> {
+  let attempt = 0;
+  for (;;) {
+    const res = await fetch(`${DRIVE_API_ORIGIN}${path}`, {
+      headers: {Authorization: `Bearer ${token}`},
+    });
+    if (res.ok) {
+      return res;
+    }
+    const body = await res
+      .clone()
+      .json()
+      .catch(() => ({}));
+    if (isRateLimited(res.status, body)) {
+      attempt += 1;
+      const retryAfter = Number(res.headers?.get?.('retry-after')) || 0;
+      if (attempt > MAX_RATE_LIMIT_RETRIES) {
+        throw new SyncRateLimitError(
+          'Google Drive is rate-limiting API requests for your account. Wait a minute or two, then sync again — the sync picks up where it left off.',
+          retryAfter || undefined
+        );
+      }
+      const delaySeconds = Math.min(
+        Math.max(retryAfter, 10 * attempt),
+        MAX_RETRY_WAIT_SECONDS
+      );
+      for (let remaining = delaySeconds; remaining > 0; remaining--) {
+        onStatus?.(
+          `Google Drive rate limit reached — retrying in ${remaining}s… (attempt ${attempt} of ${MAX_RATE_LIMIT_RETRIES})`
+        );
+        await sleep(1000);
+      }
+      onStatus?.('Retrying…');
+      continue;
+    }
+    if (res.status === 401) {
+      cachedToken = null;
+      throw new SyncTokenRequiredError(
+        'gdrive',
+        'Your Google session expired. Sign in again to continue.'
+      );
+    }
+    if (res.status === 403) {
+      throw new SyncAccessError(
+        "Your Google account doesn't have access to this Drive folder."
+      );
+    }
+    if (res.status === 404) {
+      throw new SyncAccessError(
+        'Drive folder not found. Check the URL, or ask for access to the folder.'
+      );
+    }
+    const errMessage = String(body?.error?.message || '');
+    throw new Error(
+      `Google Drive API request failed (${res.status})${
+        errMessage ? `: ${errMessage}` : ''
+      }`
+    );
+  }
+}
+
+function sleep(millis: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, millis));
+}
+
+interface DriveFile {
+  id: string;
+  name: string;
+  mimeType?: string;
+  md5Checksum?: string;
+}
+
+async function listRemoteAssets(
+  source: SyncSourceRef,
+  auth: SyncAuthContext,
+  ctx?: SyncProviderContext
+): Promise<RemoteAssetList> {
+  const folderId = source.gdrive?.folderId;
+  if (!folderId) {
+    throw new Error('Missing Google Drive folder id.');
+  }
+  const token = await auth.getToken();
+
+  // Verify the target is actually a folder (open?id= URLs can point at
+  // files) and that the user can read it, so errors surface clearly.
+  const metaRes = await driveFetch(
+    `/drive/v3/files/${encodeURIComponent(folderId)}?fields=id,mimeType&supportsAllDrives=true`,
+    token,
+    ctx?.onStatus
+  );
+  const meta = await metaRes.json().catch(() => ({}));
+  if (meta?.mimeType !== FOLDER_MIME_TYPE) {
+    throw new SyncAccessError(
+      'The URL points to a Drive file, not a folder. Paste a link to a Drive folder.'
+    );
+  }
+
+  const files: DriveFile[] = [];
+  let pageToken = '';
+  do {
+    const params = new URLSearchParams({
+      q: `'${folderId}' in parents and trashed = false`,
+      fields: 'nextPageToken,files(id,name,mimeType,md5Checksum)',
+      pageSize: String(LIST_PAGE_SIZE),
+      supportsAllDrives: 'true',
+      includeItemsFromAllDrives: 'true',
+    });
+    if (pageToken) {
+      params.set('pageToken', pageToken);
+    }
+    const res = await driveFetch(
+      `/drive/v3/files?${params.toString()}`,
+      token,
+      ctx?.onStatus
+    );
+    const data = await res.json();
+    files.push(...(data?.files || []));
+    pageToken = data?.nextPageToken || '';
+  } while (pageToken);
+
+  const assets: RemoteAsset[] = files
+    .filter((file) => {
+      const mimeType = String(file.mimeType || '');
+      // Subfolders are not recursed into (v1) and native Google editors
+      // files (Docs/Sheets/Slides/shortcuts) have no binary content.
+      return file.id && !mimeType.startsWith(GOOGLE_APPS_MIME_PREFIX);
+    })
+    .map((file) => {
+      const ref: DriveAssetRef = {mimeType: file.mimeType};
+      return {
+        remoteId: file.id,
+        name: file.name || file.id,
+        filename: sanitizeAssetName(file.name || file.id),
+        // Drive reports md5 up front, so unchanged files skip the download
+        // entirely (see `source.remoteHash` in the engine).
+        ...(file.md5Checksum ? {contentHash: file.md5Checksum} : {}),
+        ref: ref,
+      };
+    });
+  // Drive has no cheap folder-level version, so `version` is left unset
+  // (the engine's whole-sync fast path doesn't apply; the md5 skip above
+  // keeps unchanged re-syncs download-free).
+  return {assets};
+}
+
+async function download(
+  asset: RemoteAsset,
+  source: SyncSourceRef,
+  auth: SyncAuthContext,
+  ctx?: SyncProviderContext
+): Promise<File> {
+  const token = await auth.getToken();
+  const res = await driveFetch(
+    `/drive/v3/files/${encodeURIComponent(asset.remoteId)}?alt=media&supportsAllDrives=true`,
+    token,
+    ctx?.onStatus
+  );
+  const blob = await res.blob();
+  const ref = asset.ref as DriveAssetRef | undefined;
+  return new File([blob], asset.filename, {
+    type: ref?.mimeType || blob.type || 'application/octet-stream',
+  });
+}
+
+export const GDRIVE_PROVIDER: AssetSyncProvider = {
+  id: 'gdrive',
+  label: 'Google Drive',
+  authType: 'oauth',
+  loginLabel: 'Sign in with Google',
+  interactiveLogin: driveInteractiveLogin,
+  createAuthContext: createAuthContext,
+  tokenHelp: {
+    text: 'Sign in with a Google account that has access to the Drive folder. Only your account’s access is used — teammates sync with their own accounts.',
+  },
+  parseSourceUrl: (url: string) => {
+    const gdrive = parseDriveFolderUrl(url);
+    if (!gdrive) {
+      return null;
+    }
+    return {provider: 'gdrive', url, gdrive};
+  },
+  listRemoteAssets: listRemoteAssets,
+  download: download,
+};

--- a/packages/root-cms/ui/utils/asset-sync/registry.ts
+++ b/packages/root-cms/ui/utils/asset-sync/registry.ts
@@ -7,9 +7,13 @@
  */
 
 import {FIGMA_PROVIDER} from './figma.js';
+import {GDRIVE_PROVIDER} from './gdrive.js';
 import {AssetSyncProvider, SyncSourceRef} from './types.js';
 
-export const SYNC_PROVIDERS: AssetSyncProvider[] = [FIGMA_PROVIDER];
+export const SYNC_PROVIDERS: AssetSyncProvider[] = [
+  FIGMA_PROVIDER,
+  GDRIVE_PROVIDER,
+];
 
 /** Returns the sync provider with the given id, if registered. */
 export function getSyncProvider(id: string): AssetSyncProvider | null {

--- a/packages/root-cms/ui/utils/asset-sync/types.ts
+++ b/packages/root-cms/ui/utils/asset-sync/types.ts
@@ -137,7 +137,29 @@ export interface AssetSyncProvider {
   id: string;
   /** Display name, e.g. `Figma`. */
   label: string;
-  /** Help copy for the token prompt in the UI. */
+  /**
+   * How users authenticate with the provider. Defaults to `token` (the
+   * user pastes a personal access token, stored in the browser token
+   * store). `oauth` providers sign the user in interactively via
+   * {@link interactiveLogin} instead, and typically supply their own
+   * {@link createAuthContext}.
+   */
+  authType?: 'token' | 'oauth';
+  /**
+   * OAuth providers: interactively signs the user in (e.g. opens the
+   * Google sign-in popup). Must be called from a user gesture (click
+   * handler) so the popup isn't blocked.
+   */
+  interactiveLogin?(): Promise<void>;
+  /** OAuth providers: sign-in button label, e.g. `Sign in with Google`. */
+  loginLabel?: string;
+  /**
+   * Returns the auth context used by the sync engine. When absent, the
+   * engine falls back to the browser token store (`tokens.ts`), which
+   * suits `token`-type providers.
+   */
+  createAuthContext?(): SyncAuthContext;
+  /** Help copy for the token/sign-in prompt in the UI. */
   tokenHelp?: {
     /** Short instructions, e.g. where to create a token. */
     text: string;


### PR DESCRIPTION
Implements a new Google Drive asset sync provider for the asset library, allowing users to sync files from Google Drive folders alongside the existing Figma support.

## Summary
This adds a complete Google Drive sync provider (`gdrive.ts`) that integrates with the existing asset sync engine. The provider uses OAuth authentication (via the same GIS token flow as `useGapiClient`) rather than personal access tokens, establishing a new `oauth` auth type for sync providers.

## Key Changes

- **New Google Drive provider** (`ui/utils/asset-sync/gdrive.ts`):
  - Parses Drive folder URLs (supports multiple URL formats: `/drive/folders/`, `/drive/u/n/folders/`, and `open?id=`)
  - Lists files via Drive REST API with pagination and shared-drive support
  - Leverages Drive's `md5Checksum` to skip unchanged files without downloading
  - Handles rate limiting with user-visible countdown and retry logic
  - Maps API errors to typed sync errors (`SyncAccessError`, `SyncTokenRequiredError`, `SyncRateLimitError`)
  - Filters out folders and native Google editor files (Docs/Sheets/Slides) which have no binary content
  - Comprehensive test coverage for URL parsing, file listing, pagination, and error handling

- **OAuth authentication extension** (`types.ts`):
  - Added `authType` field to `AssetSyncProvider` (defaults to `'token'`, supports `'oauth'`)
  - New optional methods: `interactiveLogin()`, `loginLabel`, `createAuthContext()`
  - Allows providers to implement custom auth flows beyond the browser token store

- **UI updates** (`AssetSyncModals.tsx`):
  - Conditional rendering for OAuth vs token-based auth
  - "Sign in with Google" button for OAuth providers (instead of token input)
  - OAuth sign-in happens within the submit click gesture to avoid popup blocking
  - Added Google Drive icon support via `IconBrandGoogleDrive`
  - Updated help text to mention both Figma and Drive sources

- **Integration**:
  - Registered `GDRIVE_PROVIDER` in the sync provider registry
  - Updated engine to use provider's `createAuthContext()` when available
  - Exported `loadGisScript` from `useGapiClient` for non-hook consumers

## Implementation Details

- **Auth token handling**: Access tokens are cached in memory with expiry tracking; expired tokens trigger re-authentication on next sync
- **Consent caching**: Shares localStorage consent record with `useGapiClient` so users consent once for both features
- **No folder-level version**: Drive has no cheap folder-level version, so `RemoteAssetList.version` is left unset; unchanged re-syncs cost one listing call and zero downloads (vs Figma's whole-sync fast path)
- **Rate limit handling**: Mirrors Figma provider behavior with exponential backoff and user-visible countdown
- **Scope**: v1 implementation syncs direct children only (no subfolder recursion) and skips native Google editor files

https://claude.ai/code/session_01Kv5GTb2ddUqL46zSitS6Lf