### PR TITLE
chore: refactor ReleaseStatusBadge to use shared StatusBadge component

### DIFF
--- a/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
+++ b/packages/root-cms/ui/components/DocStatusBadges/DocStatusBadges.tsx
@@ -13,7 +13,7 @@ import {UserActionTooltip} from '../UserActionTooltip/UserActionTooltip.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 import {useVersionHistoryModal} from '../VersionHistoryModal/VersionHistoryModal.js';
 
-type StatusTone =
+export type StatusTone =
   | 'draft'
   | 'published'
   | 'scheduled'
@@ -24,7 +24,7 @@ type StatusTone =
 /**
  * Per-tone Mantine gradient (matches the original badge colors exactly).
  */
-const TONE_GRADIENTS: Record<
+export const TONE_GRADIENTS: Record<
   StatusTone,
   {from: string; to: string; deg?: number}
 > = {
@@ -40,7 +40,7 @@ const TONE_GRADIENTS: Record<
  * Renders a compact status pill using the original Mantine gradient colors,
  * with the updated font styling/sizing applied via CSS.
  */
-function StatusBadge(props: {
+export function StatusBadge(props: {
   tone: StatusTone;
   children: ComponentChildren;
   leftSection?: ComponentChildren;

--- a/packages/root-cms/ui/components/ReleaseStatusBadge/ReleaseStatusBadge.tsx
+++ b/packages/root-cms/ui/components/ReleaseStatusBadge/ReleaseStatusBadge.tsx
@@ -1,19 +1,13 @@
-import {Badge, Tooltip} from '@mantine/core';
+import {Tooltip} from '@mantine/core';
 import {Timestamp} from 'firebase/firestore';
 import {Release} from '../../utils/release.js';
 import {getTimeAgo} from '../../utils/time.js';
+import {StatusBadge} from '../DocStatusBadges/DocStatusBadges.js';
 import '../DocStatusBadges/DocStatusBadges.css';
 
 const TOOLTIP_PROPS = {
   transition: 'pop',
 };
-
-function badgeClassNames(tone: string) {
-  return {
-    root: `DocStatusBadges__badge DocStatusBadges__badge--${tone}`,
-    inner: 'DocStatusBadges__badge__inner',
-  };
-}
 
 export interface ReleaseStatusBadgeProps {
   release: Release;
@@ -29,14 +23,7 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
           release.archivedBy
         }`}
       >
-        <Badge
-          size="sm"
-          radius="sm"
-          variant="filled"
-          classNames={badgeClassNames('archived')}
-        >
-          Archived
-        </Badge>
+        <StatusBadge tone="archived">Archived</StatusBadge>
       </Tooltip>
     );
   }
@@ -50,14 +37,7 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
         wrapLines
         width={240}
       >
-        <Badge
-          size="sm"
-          radius="sm"
-          variant="filled"
-          classNames={badgeClassNames('scheduled')}
-        >
-          Scheduled
-        </Badge>
+        <StatusBadge tone="scheduled">Scheduled</StatusBadge>
       </Tooltip>
     );
   }
@@ -69,27 +49,11 @@ export function ReleaseStatusBadge(props: ReleaseStatusBadgeProps) {
           release.publishedBy
         }`}
       >
-        <Badge
-          size="sm"
-          radius="sm"
-          variant="filled"
-          classNames={badgeClassNames('published')}
-        >
-          Published
-        </Badge>
+        <StatusBadge tone="published">Published</StatusBadge>
       </Tooltip>
     );
   }
-  return (
-    <Badge
-      size="sm"
-      radius="sm"
-      variant="filled"
-      classNames={badgeClassNames('draft')}
-    >
-      Unpublished
-    </Badge>
-  );
+  return <StatusBadge tone="draft">Unpublished</StatusBadge>;
 }
 
 function testIsValidTimestamp(ts: any): ts is Timestamp {


### PR DESCRIPTION
## Summary
Refactored `ReleaseStatusBadge` to use the reusable `StatusBadge` component from `DocStatusBadges`, eliminating duplicate badge styling logic and improving code maintainability.

## Key Changes
- Replaced direct `Badge` component usage in `ReleaseStatusBadge` with the `StatusBadge` component
- Removed the local `badgeClassNames()` helper function from `ReleaseStatusBadge` (now handled by `StatusBadge`)
- Removed direct import of `Badge` from `@mantine/core` in `ReleaseStatusBadge`
- Added import of `StatusBadge` component from `DocStatusBadges`
- Exported `StatusTone` type and `TONE_GRADIENTS` constant from `DocStatusBadges` to make them available for reuse
- Exported `StatusBadge` component from `DocStatusBadges` for use in other components

## Implementation Details
All four badge states (archived, scheduled, published, and unpublished/draft) now use the centralized `StatusBadge` component with the appropriate `tone` prop, ensuring consistent styling across the application and reducing code duplication.

https://claude.ai/code/session_01Xy1sLBKxeMPBo3DwrGeTPf