### PR TITLE
feat: add middleware for requiring cms login

### DIFF
--- a/.changeset/major-rooms-care.md
+++ b/.changeset/major-rooms-care.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add middleware for requiring cms login

--- a/packages/root-cms/core/core.ts
+++ b/packages/root-cms/core/core.ts
@@ -1,4 +1,5 @@
 export * from './client.js';
+export * from './middleware.js';
 export * from './route.js';
 export * from './runtime.js';
 export * as schema from './schema.js';

--- a/packages/root-cms/core/middleware.ts
+++ b/packages/root-cms/core/middleware.ts
@@ -1,0 +1,102 @@
+import {NextFunction, Request, RequestMiddleware, Response} from '@blinkk/root';
+
+export interface RequireLoginOptions {
+  /**
+   * Restricts the guard to matching request paths. Accepts a path prefix (e.g.
+   * `/admin`), a list of prefixes, or a predicate `(req) => boolean`. When
+   * omitted, login is enforced for every request the middleware sees.
+   *
+   * This is useful when adding the middleware to `root.config.ts`'s
+   * `server.middlewares`, which are mounted app-wide with no path scope.
+   */
+  match?: string | string[] | ((req: Request) => boolean);
+
+  /**
+   * The login page to redirect unauthenticated users to. Defaults to
+   * `/cms/login`. The original URL is added as a `continue` query param so the
+   * user is returned to the requested page after signing in.
+   */
+  loginUrl?: string;
+}
+
+/**
+ * Express middleware that enforces Root CMS login on a custom route, without
+ * requiring the `?preview=true` query param.
+ *
+ * The Root CMS plugin's auth middleware runs before any user middleware and
+ * populates `req.user` on every request that carries a valid session cookie
+ * (see core/plugin.ts). This guard simply requires that `req.user` to exist:
+ * authenticated requests fall through to the next handler, while
+ * unauthenticated ones are redirected to the CMS login page (or answered with a
+ * `401` for API / XHR requests).
+ *
+ * It must be used in a project that installs the `root-cms` plugin, since that
+ * plugin is what resolves and attaches `req.user`.
+ *
+ * Usage in `root.config.ts` — protect everything under `/admin`:
+ *
+ *     import {requireCmsLogin} from '@blinkk/root-cms';
+ *
+ *     export default defineConfig({
+ *       server: {
+ *         middlewares: [requireCmsLogin({match: '/admin'})],
+ *       },
+ *     });
+ *
+ * Or, from a plugin with direct `server` access, scope it with express:
+ *
+ *     server.use('/admin', requireCmsLogin());
+ */
+export function requireCmsLogin(
+  options?: RequireLoginOptions
+): RequestMiddleware {
+  const loginUrl = options?.loginUrl || '/cms/login';
+  const match = options?.match;
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Skip requests that fall outside the configured path scope.
+    if (match && !matchesRequest(req, match)) {
+      next();
+      return;
+    }
+    // Authenticated: `req.user` is populated by the root-cms auth middleware.
+    if (req.user) {
+      next();
+      return;
+    }
+    // Not authenticated. Return a 401 for API / XHR requests (which can't act on
+    // a redirect), otherwise redirect to the login page with a `continue` param
+    // so the user lands back here after signing in.
+    const originalUrl = String(req.originalUrl);
+    if (
+      originalUrl.toLowerCase().startsWith('/cms/api') ||
+      req.xhr ||
+      expectsJson(req)
+    ) {
+      res.status(401).json({success: false, error: 'NOT_AUTHORIZED'});
+      return;
+    }
+    const params = new URLSearchParams({continue: originalUrl});
+    res.redirect(`${loginUrl}?${params.toString()}`);
+  };
+}
+
+/** Tests a request path against a `match` option. */
+function matchesRequest(
+  req: Request,
+  match: string | string[] | ((req: Request) => boolean)
+): boolean {
+  if (typeof match === 'function') {
+    return match(req);
+  }
+  const urlPath = String(req.originalUrl).split('?')[0];
+  const prefixes = Array.isArray(match) ? match : [match];
+  return prefixes.some(
+    (prefix) => urlPath === prefix || urlPath.startsWith(`${prefix}/`)
+  );
+}
+
+/** Returns true when the request prefers a JSON response. */
+function expectsJson(req: Request): boolean {
+  const accept = String(req.headers?.accept || '');
+  return accept.includes('application/json');
+}

--- a/packages/root-cms/ui/utils/iframe-url-sync.test.ts
+++ b/packages/root-cms/ui/utils/iframe-url-sync.test.ts
@@ -29,9 +29,38 @@ describe('iframeLocationToCmsUrl', () => {
       iframeLocationToCmsUrl(
         '/myroute/foo',
         'foo',
+        parts('/myroute/foo/bar/?q=1#section')
+      )
+    ).toBe('/cms/tools/foo/bar/?q=1#section');
+  });
+
+  // `?preview=true` is an auth-transport param; it should be hidden from the
+  // clean CMS URL while other params are preserved.
+  it('strips preview=true from the cms url', () => {
+    expect(
+      iframeLocationToCmsUrl(
+        '/myroute/foo',
+        'foo',
         parts('/myroute/foo/bar/?preview=true#section')
       )
-    ).toBe('/cms/tools/foo/bar/?preview=true#section');
+    ).toBe('/cms/tools/foo/bar/#section');
+  });
+
+  it('strips preview=true but keeps other params', () => {
+    expect(
+      iframeLocationToCmsUrl(
+        '/myroute/foo',
+        'foo',
+        parts('/myroute/foo/bar/?preview=true&q=1')
+      )
+    ).toBe('/cms/tools/foo/bar/?q=1');
+    expect(
+      iframeLocationToCmsUrl(
+        '/myroute/foo',
+        'foo',
+        parts('/myroute/foo/bar/?q=1&preview=true')
+      )
+    ).toBe('/cms/tools/foo/bar/?q=1');
   });
 
   it('returns the bare prefix at the tool home', () => {
@@ -128,6 +157,35 @@ describe('cmsUrlToIframeSrc', () => {
       )
     ).toBe('https://tool.example.com/bar/');
   });
+
+  // The CMS URL strips `preview=true`, so it must be re-added onto the iframe
+  // src when the configured iframe url uses it (otherwise a refresh would drop
+  // preview/auth mode).
+  it('restores preview=true from the configured iframe url', () => {
+    expect(
+      cmsUrlToIframeSrc(
+        '/myroute/foo/?preview=true',
+        'foo',
+        parts('/cms/tools/foo/bar/')
+      )
+    ).toBe('http://localhost:3000/myroute/foo/bar/?preview=true');
+  });
+
+  it('restores preview=true alongside the cms url params', () => {
+    expect(
+      cmsUrlToIframeSrc(
+        '/myroute/foo/?preview=true',
+        'foo',
+        parts('/cms/tools/foo/bar/?q=1')
+      )
+    ).toBe('http://localhost:3000/myroute/foo/bar/?q=1&preview=true');
+  });
+
+  it('does not add preview=true when the iframe url lacks it', () => {
+    expect(
+      cmsUrlToIframeSrc('/myroute/foo', 'foo', parts('/cms/tools/foo/bar/?q=1'))
+    ).toBe('http://localhost:3000/myroute/foo/bar/?q=1');
+  });
 });
 
 describe('round trip', () => {
@@ -143,5 +201,24 @@ describe('round trip', () => {
         hash: loc.hash,
       })
     ).toBe(cmsUrl);
+  });
+
+  // With a preview-authed iframe url, the CMS URL stays clean (no preview) but
+  // the iframe src keeps preview=true, and the round trip is stable.
+  it('keeps the cms url clean while preserving preview on the iframe', () => {
+    const iframeUrl = 'https://tool.example.com/app/?preview=true';
+    const cleanCmsUrl = '/cms/tools/app/reports/?tab=all#top';
+    const src = cmsUrlToIframeSrc(iframeUrl, 'app', parts(cleanCmsUrl));
+    expect(src).toBe(
+      'https://tool.example.com/app/reports/?tab=all&preview=true#top'
+    );
+    const loc = new URL(src);
+    expect(
+      iframeLocationToCmsUrl(iframeUrl, 'app', {
+        pathname: loc.pathname,
+        search: loc.search,
+        hash: loc.hash,
+      })
+    ).toBe(cleanCmsUrl);
   });
 });

--- a/packages/root-cms/ui/utils/iframe-url-sync.ts
+++ b/packages/root-cms/ui/utils/iframe-url-sync.ts
@@ -20,9 +20,54 @@ export interface UrlParts {
   hash: string;
 }
 
+/**
+ * Query param used to enforce Root CMS auth / draft-preview mode on a route
+ * (see `loginRequired()` in core/plugin.ts). It's an auth-transport param, not
+ * something the user navigates to, so it's stripped from the CMS URL to keep
+ * tool URLs clean and re-added onto the iframe src from the configured iframe
+ * URL. See {@link stripPreviewParam} and {@link restorePreviewParam}.
+ */
+const PREVIEW_PARAM = 'preview';
+
 /** Returns the CMS route prefix for a tool, e.g. `/cms/tools/foo`. */
 export function cmsToolPrefix(id: string): string {
   return `/cms/tools/${id}`;
+}
+
+/**
+ * Removes `preview=true` from a search string so it doesn't leak into the CMS
+ * URL. Any other params are preserved. The search is returned verbatim when it
+ * has no `preview=true`, so unrelated URLs aren't needlessly re-encoded.
+ */
+function stripPreviewParam(search: string): string {
+  if (!search.includes(`${PREVIEW_PARAM}=`)) {
+    return search;
+  }
+  const params = new URLSearchParams(search);
+  if (params.get(PREVIEW_PARAM) !== 'true') {
+    return search;
+  }
+  params.delete(PREVIEW_PARAM);
+  const result = params.toString();
+  return result ? `?${result}` : '';
+}
+
+/**
+ * Restores `preview=true` onto an iframe search string when the configured
+ * iframe `base` URL uses it. Because the CMS URL strips `preview=true`, it must
+ * be re-added when rebuilding the iframe src on refresh, or the tool would lose
+ * its auth / preview mode.
+ */
+function restorePreviewParam(search: string, base: URL): string {
+  if (base.searchParams.get(PREVIEW_PARAM) !== 'true') {
+    return search;
+  }
+  const params = new URLSearchParams(search);
+  if (params.get(PREVIEW_PARAM) === 'true') {
+    return search;
+  }
+  params.set(PREVIEW_PARAM, 'true');
+  return `?${params.toString()}`;
 }
 
 /** Strips trailing slashes from a path, preserving the root `/`. */
@@ -73,7 +118,8 @@ export function iframeLocationToCmsUrl(
   if (subpath === null) {
     return null;
   }
-  return `${cmsToolPrefix(id)}${subpath}${loc.search}${loc.hash}`;
+  const search = stripPreviewParam(loc.search);
+  return `${cmsToolPrefix(id)}${subpath}${search}${loc.hash}`;
 }
 
 /**
@@ -104,7 +150,8 @@ export function cmsUrlToIframeSrc(
       basePath === '/' ? subpath || '/' : `${basePath}${subpath}`;
     // The CMS URL mirrors the iframe's search/hash, so prefer it; fall back to
     // any search/hash on the configured iframe URL when the CMS URL has none.
-    target.search = loc.search || base.search;
+    // The CMS URL strips `preview=true`, so re-add it from the iframe base URL.
+    target.search = restorePreviewParam(loc.search || base.search, base);
     target.hash = loc.hash || base.hash;
     return target.toString();
   } catch {

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -68,10 +68,12 @@ export type RequestMiddleware =
 
 /** Root.js express app. */
 export type Server = Express & {
-  use(middlewares: RequestMiddleware | RequestMiddleware[]): any;
+  use(
+    ...middlewares: Array<RequestMiddleware | RequestMiddleware[]>
+  ): any;
   use(
     urlPath: string,
-    middlewares: RequestMiddleware | RequestMiddleware[]
+    ...middlewares: Array<RequestMiddleware | RequestMiddleware[]>
   ): any;
 };
 

--- a/packages/root/src/core/types.ts
+++ b/packages/root/src/core/types.ts
@@ -68,9 +68,7 @@ export type RequestMiddleware =
 
 /** Root.js express app. */
 export type Server = Express & {
-  use(
-    ...middlewares: Array<RequestMiddleware | RequestMiddleware[]>
-  ): any;
+  use(...middlewares: Array<RequestMiddleware | RequestMiddleware[]>): any;
   use(
     urlPath: string,
     ...middlewares: Array<RequestMiddleware | RequestMiddleware[]>


### PR DESCRIPTION
Adds a `requireCmsLogin()` express.js middleware that enforces login without the use of `?preview=true`. This PR also ignores the use of `?preview=true` query param in the `/cms/tools/` routes.