### PR TITLE
chore: increase ai chat title length limit 80 chars

### DIFF
--- a/packages/root-cms/core/ai.test.ts
+++ b/packages/root-cms/core/ai.test.ts
@@ -97,7 +97,7 @@ describe('ai', () => {
       const title = deriveChatTitle([
         {id: '1', role: 'user', parts: [{type: 'text', text: longText}]} as any,
       ]);
-      expect(title.length).toBeLessThanOrEqual(60);
+      expect(title.length).toBeLessThanOrEqual(80);
       expect(title.endsWith('…')).toBe(true);
     });
   });
@@ -246,7 +246,7 @@ describe('ai', () => {
 
     it('truncates overly long titles with an ellipsis', () => {
       const title = sanitizeGeneratedTitle('a'.repeat(120));
-      expect(title.length).toBeLessThanOrEqual(60);
+      expect(title.length).toBeLessThanOrEqual(80);
       expect(title.endsWith('…')).toBe(true);
     });
   });

--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -277,7 +277,7 @@ export async function generateChatTitle(
       model,
       system: TITLE_GENERATION_SYSTEM_PROMPT,
       prompt: buildTitlePrompt(context),
-      maxOutputTokens: 64,
+      maxOutputTokens: 96,
       temperature: 0.3,
     });
     const title = sanitizeGeneratedTitle(result.text);

--- a/packages/root-cms/shared/ai/prompt-utils.ts
+++ b/packages/root-cms/shared/ai/prompt-utils.ts
@@ -11,6 +11,20 @@
  */
 import type {UIMessage} from 'ai';
 
+/**
+ * Hard cap on the length of a generated/derived chat title. Titles double as
+ * the session summary in the Root AI sidebar, so this leaves room for a
+ * slightly fuller summary while still fitting on one line.
+ */
+export const MAX_TITLE_LENGTH = 80;
+
+/** Truncates a title to `MAX_TITLE_LENGTH`, appending an ellipsis if cut. */
+function truncateTitle(text: string): string {
+  return text.length > MAX_TITLE_LENGTH
+    ? `${text.slice(0, MAX_TITLE_LENGTH - 3)}…`
+    : text;
+}
+
 /** Derives a short title from the first user message (used as fallback). */
 export function deriveChatTitle(messages: UIMessage[]): string {
   const first = messages.find((m) => m.role === 'user');
@@ -25,7 +39,7 @@ export function deriveChatTitle(messages: UIMessage[]): string {
   if (!text) {
     return 'New chat';
   }
-  return text.length > 60 ? `${text.slice(0, 57)}…` : text;
+  return truncateTitle(text);
 }
 
 /**
@@ -102,7 +116,7 @@ export function sanitizeGeneratedTitle(raw: string): string {
   if (!title) {
     return '';
   }
-  return title.length > 60 ? `${title.slice(0, 57)}…` : title;
+  return truncateTitle(title);
 }
 
 /** System prompt used to generate a short summary title for a chat. */
@@ -115,7 +129,7 @@ export const TITLE_GENERATION_SYSTEM_PROMPT = [
   'Rules:',
   '- Output ONLY the title text. No quotes, no trailing punctuation,',
   '  no "Title:" prefix, no markdown.',
-  '- 5 to 10 words. Hard cap of 60 characters.',
+  '- 7 to 12 words. Hard cap of 80 characters.',
   '- Use a noun phrase in Sentence case (e.g. "Translate homepage',
   '  hero copy", "Debug image upload error", "Draft blog post about',
   '  pricing").',

--- a/packages/root-cms/ui/utils/ai-chats.ts
+++ b/packages/root-cms/ui/utils/ai-chats.ts
@@ -198,7 +198,7 @@ export async function generateChatTitle(
       model: languageModel,
       system: TITLE_GENERATION_SYSTEM_PROMPT,
       prompt: buildTitlePrompt(context),
-      maxOutputTokens: 64,
+      maxOutputTokens: 96,
       temperature: 0.3,
     });
     const title = sanitizeGeneratedTitle(result.text);


### PR DESCRIPTION
## Summary
Increased the maximum length for AI-generated chat titles from 60 to 80 characters to allow for more descriptive session summaries while maintaining single-line display in the Root AI sidebar.

## Key Changes
- Added `MAX_TITLE_LENGTH` constant (80 characters) to centralize the title length limit
- Extracted title truncation logic into a reusable `truncateTitle()` function to eliminate code duplication
- Updated `deriveChatTitle()` and `sanitizeGeneratedTitle()` to use the new `truncateTitle()` function
- Increased `maxOutputTokens` from 64 to 96 in both `generateChatTitle()` implementations (core and UI) to accommodate longer titles
- Updated title generation system prompt guidelines:
  - Word count: 5-10 words → 7-12 words
  - Character limit: 60 → 80 characters
- Updated corresponding tests to expect the new 80-character limit

## Implementation Details
- The `truncateTitle()` function maintains the existing ellipsis behavior (appending "…" when text exceeds the limit)
- All title truncation now uses a single source of truth via the `MAX_TITLE_LENGTH` constant
- The increased token budget ensures the LLM has sufficient capacity to generate titles within the new length constraints

https://claude.ai/code/session_01MTAAscjPQ5kx4kugRKZH3U