### PR TITLE
fix: prevent the CMS loading screen from hanging indefinitely

### DIFF
--- a/.changeset/proud-hoops-tap.md
+++ b/.changeset/proud-hoops-tap.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: prevent the CMS loading screen from hanging indefinitely

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -1749,11 +1749,16 @@ export class RootCMSClient {
   }
 
   /**
-   * Gets the user's role from the project's ACL.
+   * Looks up the user's entry in the project's ACL with a single Firestore
+   * read. `exists` is `true` if the user (or their domain's wildcard entry,
+   * e.g. `*@example.com`) is in the ACL; `role` may be `null` for entries
+   * without an assigned role.
    */
-  async getUserRole(email: string): Promise<UserRole | null> {
+  async getUserAcl(
+    email: string
+  ): Promise<{exists: boolean; role: UserRole | null}> {
     if (!email) {
-      return null;
+      return {exists: false, role: null};
     }
     const docRef = this.db.doc(`Projects/${this.projectId}`);
     const snapshot = await docRef.get();
@@ -1761,46 +1766,36 @@ export class RootCMSClient {
     const acl = data.roles || {};
 
     if (email in acl) {
-      return acl[email];
+      return {exists: true, role: acl[email] ?? null};
     }
 
     // Check wildcard domains, e.g. `*@example.com`.
     if (!email.includes('@')) {
       console.warn(`invalid email: ${email}`);
-      return null;
+      return {exists: false, role: null};
     }
     const domain = email.split('@').at(-1);
-    if (domain && `*@${domain}` in acl) {
-      return acl[`*@${domain}`];
+    const wildcard = `*@${domain}`;
+    if (domain && wildcard in acl) {
+      return {exists: true, role: acl[wildcard] ?? null};
     }
-    return null;
+    return {exists: false, role: null};
+  }
+
+  /**
+   * Gets the user's role from the project's ACL.
+   */
+  async getUserRole(email: string): Promise<UserRole | null> {
+    const acl = await this.getUserAcl(email);
+    return acl.role;
   }
 
   /**
    * Verifies user exists in the ACL list.
    */
   async userExistsInAcl(email: string): Promise<boolean> {
-    if (!email) {
-      return false;
-    }
-    const docRef = this.db.doc(`Projects/${this.projectId}`);
-    const snapshot = await docRef.get();
-    const data = snapshot.data() || {};
-    const acl = data.roles || {};
-    if (email in acl) {
-      return true;
-    }
-
-    // Check wildcard domains, e.g. `*@example.com`.
-    if (!email.includes('@')) {
-      console.warn(`invalid email: ${email}`);
-      return false;
-    }
-    const domain = email.split('@').at(-1);
-    if (domain && `*@${domain}` in acl) {
-      return true;
-    }
-    return false;
+    const acl = await this.getUserAcl(email);
+    return acl.exists;
   }
 
   /**

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -112,6 +112,72 @@ const NONCONF_STATIC_PATHS = [
   '/cms/static/ui.js',
 ];
 
+/**
+ * Max time to wait for the Firebase Auth / Firestore calls that verify the
+ * current user's session. The Firestore gRPC channel can get into a stuck
+ * state where requests never settle (e.g. after credentials expire or a
+ * long-lived connection drops); without a deadline every request awaiting
+ * `getCurrentUser()` would hang and the CMS would sit on its loading screen
+ * until the server is restarted.
+ */
+const GET_CURRENT_USER_TIMEOUT_MS = 15 * 1000;
+
+class TimeoutError extends Error {}
+
+/**
+ * Rejects with a `TimeoutError` if the promise doesn't settle within
+ * `timeoutMs`. The underlying promise's eventual rejection (if any) is still
+ * consumed so it doesn't surface as an unhandled rejection.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TimeoutError(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
+/**
+ * Returns true if the error indicates the server's Google Cloud credentials
+ * have expired and require reauthentication.
+ * See: https://github.com/googleapis/nodejs-firestore/issues/1023
+ */
+function isGcloudReauthError(err: unknown): boolean {
+  const message = (err as Error)?.message || '';
+  return (
+    message.includes('reauth related error') ||
+    message.includes('invalid_grant')
+  );
+}
+
+function logGcloudReauthHint() {
+  console.log('\n');
+  console.log('==================================================');
+  console.log('Google Cloud Reauthentication Required');
+  console.log('==================================================');
+  console.log(
+    'Your Google Cloud credentials have expired or require reauthentication.'
+  );
+  console.log('Please run the following command to reauthenticate:');
+  console.log('\n    gcloud auth application-default login\n');
+  console.log('==================================================');
+  console.log('\n');
+}
+
 export interface CMSUser {
   email: string;
   /**
@@ -683,52 +749,55 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       }
       // Verify the user exists in the DB's ACL list.
       const cmsClient = new RootCMSClient(req.rootConfig!);
-      const userHasAccess = await cmsClient.userExistsInAcl(jwt.email);
-      if (!userHasAccess) {
+      const acl = await cmsClient.getUserAcl(jwt.email);
+      if (!acl.exists) {
         console.log('session failed: user is not in the firestore acl list');
         return null;
       }
-      const role = await cmsClient.getUserRole(jwt.email).catch(() => null);
-      return {email: jwt.email, role};
+      return {email: jwt.email, role: acl.role};
     }
 
+    let jwt: DecodedIdToken;
     try {
       // Verify the idToken using firebase auth, checking for token revocations.
-      const jwt = await auth.verifySessionCookie(sessionCookie, true);
-      if (isExpired(jwt)) {
-        console.log('session failed: token is expired');
-        return null;
-      }
-      // Verify user's email is verified.
-      if (!jwt.email || !jwt.email_verified) {
-        console.log('session failed: email not verified');
-        return null;
-      }
-      // Check whether user is authorized.
-      if (options.isUserAuthorized) {
-        const authorized = await options.isUserAuthorized(req, {
-          email: jwt.email!,
-        });
-        if (!authorized) {
-          console.log('session failed: not authorized');
-          return null;
-        }
-      }
-      // Verify the user exists in the DB's ACL list.
-      const cmsClient = new RootCMSClient(req.rootConfig!);
-      const userHasAccess = await cmsClient.userExistsInAcl(jwt.email);
-      if (!userHasAccess) {
-        console.log('session failed: user is not in the firestore acl list');
-        return null;
-      }
-      // JWT verified.
-      const role = await cmsClient.getUserRole(jwt.email!).catch(() => null);
-      return {email: jwt.email!, role};
+      // An invalid, expired, or revoked cookie throws here and is treated as
+      // "signed out". Errors from the checks below are backend failures and
+      // are left to propagate so callers can respond with an explicit error
+      // instead of bouncing an authenticated user to the login page.
+      jwt = await auth.verifySessionCookie(sessionCookie, true);
     } catch (err) {
       console.error('failed to verify jwt token');
       console.error(err);
       return null;
     }
+    if (isExpired(jwt)) {
+      console.log('session failed: token is expired');
+      return null;
+    }
+    // Verify user's email is verified.
+    if (!jwt.email || !jwt.email_verified) {
+      console.log('session failed: email not verified');
+      return null;
+    }
+    // Check whether user is authorized.
+    if (options.isUserAuthorized) {
+      const authorized = await options.isUserAuthorized(req, {
+        email: jwt.email,
+      });
+      if (!authorized) {
+        console.log('session failed: not authorized');
+        return null;
+      }
+    }
+    // Verify the user exists in the DB's ACL list.
+    const cmsClient = new RootCMSClient(req.rootConfig!);
+    const acl = await cmsClient.getUserAcl(jwt.email);
+    if (!acl.exists) {
+      console.log('session failed: user is not in the firestore acl list');
+      return null;
+    }
+    // JWT verified.
+    return {email: jwt.email, role: acl.role};
   }
 
   function redirectToLogin(req: Request, res: Response) {
@@ -911,10 +980,71 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         res.redirect('/cms/login');
       });
 
+      // Serve the CMS UI's static assets before any auth middleware runs.
+      // These files ship with the root-cms package and contain no project
+      // data, and serving them without blocking on auth guarantees the CMS
+      // shell can always boot — even when the Firestore/Auth backend is slow
+      // or stuck, or when the login session expires while the app is open
+      // (requests for lazy route chunks would otherwise get redirected to the
+      // login page and the dynamic import would fail).
+      const staticDir = path.resolve(__dirname, 'ui');
+      if (process.env.NODE_ENV === 'development') {
+        // In dev, the `?c=` cachebust param is fixed for the lifetime of the
+        // server process while the UI may be rebuilt underneath it, so
+        // disable browser caching to avoid serving a stale ui.js that
+        // references hashed chunk files that no longer exist.
+        server.use(
+          '/cms/static',
+          (req: Request, res: Response, next: NextFunction) => {
+            res.setHeader('cache-control', 'no-store');
+            next();
+          }
+        );
+      }
+      server.use(
+        '/cms/static',
+        sirv(staticDir, {dev: process.env.NODE_ENV === 'development'})
+      );
+
       // Inject the current user into the req object and check if login is
       // required, sending unauthenticated users to the login page.
       server.use(async (req: Request, res: Response, next: NextFunction) => {
-        const user = await getCurrentUser(req);
+        let user: CMSUser | null;
+        try {
+          user = await withTimeout(
+            getCurrentUser(req),
+            GET_CURRENT_USER_TIMEOUT_MS,
+            'getCurrentUser()'
+          );
+        } catch (err) {
+          // A failure here is an infra error (e.g. a stuck Firestore channel
+          // or expired server credentials), not an invalid session. Respond
+          // with an explicit 503 on paths that require login so the request
+          // fails fast and visibly. Without this, the rejected middleware
+          // promise would leave the request hanging forever and the CMS stuck
+          // on its loading screen until the server restarts.
+          console.error('failed to fetch the current user:');
+          console.error(err);
+          if (isGcloudReauthError(err)) {
+            logGcloudReauthHint();
+          }
+          if (loginRequired(req)) {
+            res.setHeader('cache-control', 'no-store');
+            if (String(req.originalUrl).toLowerCase().startsWith('/cms/api')) {
+              res.status(503).json({success: false, error: 'AUTH_UNAVAILABLE'});
+            } else {
+              res
+                .status(503)
+                .send(
+                  'Root CMS was unable to verify your login session (the auth backend did not respond). Reload the page to try again, and check the server logs if the problem persists.'
+                );
+            }
+            return;
+          }
+          // Public paths that don't require login proceed without a user.
+          next();
+          return;
+        }
         if (user) {
           req.user = user;
         }
@@ -928,12 +1058,6 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
 
         next();
       });
-
-      const staticDir = path.resolve(__dirname, 'ui');
-      server.use(
-        '/cms/static',
-        sirv(staticDir, {dev: process.env.NODE_ENV === 'development'})
-      );
 
       // Register server-sent events (SSE) endpoints.
       const sseData = sse(server);
@@ -973,22 +1097,8 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       // Handle Firestore reauth errors.
       // See: https://github.com/googleapis/nodejs-firestore/issues/1023
       process.on('unhandledRejection', (reason) => {
-        const err = reason as any;
-        if (
-          err?.message?.includes('reauth related error') ||
-          err?.message?.includes('invalid_grant')
-        ) {
-          console.log('\n');
-          console.log('==================================================');
-          console.log('Google Cloud Reauthentication Required');
-          console.log('==================================================');
-          console.log(
-            'Your Google Cloud credentials have expired or require reauthentication.'
-          );
-          console.log('Please run the following command to reauthenticate:');
-          console.log('\n    gcloud auth application-default login\n');
-          console.log('==================================================');
-          console.log('\n');
+        if (isGcloudReauthError(reason)) {
+          logGcloudReauthHint();
         }
       });
     },

--- a/packages/root-cms/ui/styles/global.css
+++ b/packages/root-cms/ui/styles/global.css
@@ -139,6 +139,24 @@ body.menu\:open {
   max-width: 640px;
 }
 
+.bootstrap__error-button {
+  appearance: none;
+  background: #1a1b1e;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  margin-top: 8px;
+  padding: 10px 20px;
+}
+
+.bootstrap__error-button:hover {
+  background: #333;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -424,6 +424,13 @@ installNavigationGuards();
 
 const root = document.getElementById('root')!;
 
+/**
+ * Max time to wait for Firebase Auth to report the auth state before showing
+ * an error screen. Without a deadline, a stalled auth request would leave the
+ * "Loading..." screen up indefinitely with no way to tell what went wrong.
+ */
+const AUTH_STATE_TIMEOUT_MS = 15 * 1000;
+
 function getStartupErrorMessage(err: any): string {
   const code = err?.code || '';
   if (code === 'auth/invalid-api-key') {
@@ -446,7 +453,13 @@ function showStartupError(err: any) {
   message.className = 'bootstrap__error-message';
   message.textContent = getStartupErrorMessage(err);
 
-  container.append(title, message);
+  const reloadButton = document.createElement('button');
+  reloadButton.type = 'button';
+  reloadButton.className = 'bootstrap__error-button';
+  reloadButton.textContent = 'Reload page';
+  reloadButton.addEventListener('click', () => window.location.reload());
+
+  container.append(title, message, reloadButton);
   root.append(container);
 }
 
@@ -473,18 +486,38 @@ try {
   );
   const auth = getAuth(app);
   const storage = getStorage(app);
-  auth.onAuthStateChanged((user) => {
-    if (!user) {
-      loginRedirect();
-      return;
-    }
-    window.firebase = {app, auth, db, storage, user};
-    root.innerHTML = '';
-    render(<App />, root);
+  // Watchdog: if the auth state never arrives (e.g. a stalled network
+  // request), replace the loading screen with an error screen instead of
+  // spinning forever. If the auth state eventually arrives after the deadline,
+  // the app still renders over the error screen and recovers.
+  const authWatchdog = window.setTimeout(() => {
+    showStartupError(
+      new Error(
+        'Timed out waiting for Firebase Authentication to respond. Check your network connection and reload the page.'
+      )
+    );
+  }, AUTH_STATE_TIMEOUT_MS);
+  auth.onAuthStateChanged(
+    (user) => {
+      window.clearTimeout(authWatchdog);
+      if (!user) {
+        loginRedirect();
+        return;
+      }
+      window.firebase = {app, auth, db, storage, user};
+      root.innerHTML = '';
+      render(<App />, root);
 
-    updateSession(user);
-    saveUserProfile(user, db);
-  });
+      updateSession(user).catch((err) => {
+        console.error('failed to update login session:', err);
+      });
+      saveUserProfile(user, db);
+    },
+    (err) => {
+      window.clearTimeout(authWatchdog);
+      showStartupError(err);
+    }
+  );
 } catch (err) {
   showStartupError(err);
 }

--- a/packages/root-cms/ui/utils/lazy-route.test.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.test.tsx
@@ -1,6 +1,6 @@
-import {render} from '@testing-library/preact';
+import {cleanup, render} from '@testing-library/preact';
 import {FunctionComponent} from 'preact';
-import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   ROUTE_IMPORT_RELOAD_KEY,
   importRouteComponent,
@@ -29,6 +29,12 @@ vi.mock('../layout/Layout.js', () => {
 function TestComponent() {
   return <div>test page</div>;
 }
+
+// The testing library's auto-cleanup requires vitest globals, which aren't
+// enabled, so clean up rendered components explicitly to keep tests isolated.
+afterEach(() => {
+  cleanup();
+});
 
 describe('importRouteComponent', () => {
   beforeEach(() => {
@@ -67,12 +73,35 @@ describe('importRouteComponent', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const factory = vi.fn().mockRejectedValue(new Error('fetch failed'));
     const reload = vi.fn();
-    // The returned promise intentionally never settles when reloading, so
-    // wait on the reload spy instead of awaiting the result.
+    // The returned promise doesn't settle until a grace period after the
+    // reload is triggered, so wait on the reload spy instead of awaiting the
+    // result.
     void importRouteComponent(factory, {retryDelayMs: 0, reload});
     await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
     expect(factory).toHaveBeenCalledTimes(3);
     expect(window.sessionStorage.getItem(ROUTE_IMPORT_RELOAD_KEY)).toBeTruthy();
+  });
+
+  test('falls back to an error screen if the triggered reload never happens', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const factory = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const reload = vi.fn();
+    vi.useFakeTimers();
+    let ErrorComponent: FunctionComponent;
+    try {
+      const promise = importRouteComponent(factory, {retryDelayMs: 0, reload});
+      // Run through the retry delays and the post-reload grace period.
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      expect(reload).toHaveBeenCalledTimes(1);
+      ErrorComponent = await promise;
+    } finally {
+      // Restore real timers before rendering so the testing library's
+      // auto-cleanup works as usual.
+      vi.useRealTimers();
+    }
+    const result = render(<ErrorComponent />);
+    expect(result.getByText('Page failed to load')).toBeTruthy();
+    expect(result.getByText('fetch failed')).toBeTruthy();
   });
 
   test('falls back to an error screen if a reload was recently attempted', async () => {

--- a/packages/root-cms/ui/utils/lazy-route.tsx
+++ b/packages/root-cms/ui/utils/lazy-route.tsx
@@ -18,6 +18,14 @@ export const ROUTE_IMPORT_RELOAD_KEY = 'root::lazyRoute::reloadedAt';
 /** Minimum time between automatic reloads triggered by route import failures. */
 const ROUTE_IMPORT_RELOAD_INTERVAL_MS = 60 * 1000;
 
+/**
+ * Time to wait after triggering an automatic reload before falling back to
+ * the error screen. The reload may never happen (e.g. it can be blocked by an
+ * unsaved-changes prompt), in which case the route would otherwise be stuck
+ * on the loading screen forever.
+ */
+const ROUTE_IMPORT_RELOAD_GRACE_MS = 10 * 1000;
+
 export interface ImportRouteComponentOptions {
   /** Number of times to attempt the import before giving up. */
   attempts?: number;
@@ -72,7 +80,8 @@ function reloadOnRouteImportError(reload: () => void): boolean {
  * change), when the login session expires, or due to flaky network requests.
  * If the import still fails after all attempts, the page is automatically
  * reloaded to fetch the latest version of the CMS. If a reload was already
- * attempted recently, resolves to a `RouteLoadError` screen instead.
+ * attempted recently (or the triggered reload never happens), resolves to a
+ * `RouteLoadError` screen instead.
  *
  * NOTE: The returned promise never rejects; failures resolve to a component
  * that renders the error screen, so callers can render the result directly.
@@ -97,9 +106,15 @@ export async function importRouteComponent<P>(
   }
   console.error('failed to import route component:', lastError);
   if (reloadOnRouteImportError(reload)) {
-    // The page is about to reload; return a promise that never settles so the
-    // router stays in its current state until the reload occurs.
-    return new Promise(() => {});
+    // The page is about to reload; keep the loading screen up while the
+    // reload happens, but fall back to the error screen if the page is still
+    // alive after a grace period (e.g. the reload was blocked by an
+    // unsaved-changes prompt).
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(() => <RouteLoadError error={lastError} />);
+      }, ROUTE_IMPORT_RELOAD_GRACE_MS);
+    });
   }
   return () => <RouteLoadError error={lastError} />;
 }


### PR DESCRIPTION
## Summary
This PR adds timeout protection and error handling to prevent the CMS loading screen from hanging indefinitely when Firebase Auth or Firestore backends are slow, stuck, or require reauthentication.

## Key Changes

**Backend (plugin.ts)**
- Added `GET_CURRENT_USER_TIMEOUT_MS` (15s) timeout for `getCurrentUser()` calls to prevent requests from hanging when Firestore gRPC channels get stuck
- Implemented `withTimeout()` utility to wrap promises with deadline enforcement
- Added `isGcloudReauthError()` and `logGcloudReauthHint()` helpers to detect and handle Google Cloud credential expiration
- Moved static asset serving before auth middleware so the CMS shell can boot even when auth backend is unavailable
- Enhanced auth middleware to catch timeout errors and respond with explicit 503 status instead of hanging requests
- Consolidated duplicate ACL lookup logic by refactoring `getUserRole()` and `userExistsInAcl()` to use new `getUserAcl()` method

**Frontend (ui.tsx)**
- Added `AUTH_STATE_TIMEOUT_MS` (15s) watchdog timer to detect stalled Firebase Auth initialization
- Enhanced error screen with "Reload page" button for better UX when auth fails
- Added error callback to `onAuthStateChanged()` to handle auth state errors explicitly
- Wrapped `updateSession()` in error handler to prevent unhandled rejections

**Route Loading (lazy-route.tsx)**
- Added `ROUTE_IMPORT_RELOAD_GRACE_MS` (10s) grace period after triggering automatic reload
- Changed reload behavior to fall back to error screen if reload doesn't complete within grace period, preventing indefinite loading state

**Styling (global.css)**
- Added `.bootstrap__error-button` styles for the new reload button on error screens

**Testing (lazy-route.test.tsx)**
- Added explicit cleanup between tests to prevent test isolation issues
- Added test case for reload grace period timeout scenario

## Implementation Details
- Timeouts are applied at multiple layers: server auth verification (15s), client auth state (15s), and route reload grace period (10s)
- Static assets are now served without auth to ensure the CMS UI shell always loads
- Errors are logged with helpful hints for Google Cloud reauthentication issues
- The solution gracefully degrades: if auth eventually succeeds after timeout, the app still renders and recovers

https://claude.ai/code/session_01FUuTL9vvYTVcjfJRGWjSw2