### PR TITLE
feat: ai-friendly root-cms client CLI commands and agent skill

### DIFF
--- a/.changeset/new-fans-carry.md
+++ b/.changeset/new-fans-carry.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: ai-friendly root-cms client CLI commands and agent skill

--- a/packages/root-cms/README.md
+++ b/packages/root-cms/README.md
@@ -137,15 +137,17 @@ as `{"_seconds","_nanoseconds"}`, `{"_latitude","_longitude"}`, and
 ## Downloadable agent skill
 
 A ready-to-use skill that teaches AI coding agents how to use these commands
-ships with the package. Install it into your project's `.claude/skills/`
-directory with:
+ships with the package. Install it with:
 
 ```bash
 root-cms skill.install
 ```
 
-This creates `.claude/skills/root-cms-cli/`. Pass a different directory to
-install elsewhere (e.g. `root-cms skill.install ./my-agent/skills`), or
+Root stays agnostic of any particular AI provider: the command auto-detects
+existing agent skills directories (e.g. `.claude/skills`, `.agent/skills`, or
+any `.*/skills` directory already in your project) and installs into them. If
+none is found, it installs to `.agent/skills`. Pass an explicit directory to
+override detection (e.g. `root-cms skill.install ./my-agent/skills`), or
 `--force` to overwrite an existing copy.
 
 # Embedding the CMS (`@blinkk/root-cms/browser-client`)

--- a/packages/root-cms/README.md
+++ b/packages/root-cms/README.md
@@ -93,6 +93,61 @@ This is convenient for granting access to a whole workspace, but be aware:
 - Prefer explicit per-email grants for `ADMIN` and `EDITOR`; reserve the
   wildcard for `CONTRIBUTOR` or `VIEWER` if you use it at all.
 
+# CLI for AI agents (`root-cms client.*`)
+
+The `root-cms` CLI exposes two commands that let an AI coding agent (or any
+script) drive the `RootCMSClient` programmatically. Run them from the root of a
+Root.js project (a directory containing `root.config.ts`).
+
+Discover the available API:
+
+```bash
+# Human-readable list of methods + descriptions
+root-cms client.methods
+
+# Machine-readable JSON, including referenced type/interface definitions
+root-cms client.methods --json --types
+```
+
+Call any method with a JSON array of positional arguments:
+
+```bash
+# getDoc(collectionId, slug, options)
+root-cms client.call getDoc '["Pages", "home", {"mode": "draft"}]'
+
+# A no-arg method (omit the JSON array)
+root-cms client.call publishScheduledDocs
+
+# Read large args from stdin by passing `-`
+echo '["Pages/home", {"title": "Hello"}]' | root-cms client.call saveDraftData -
+```
+
+`client.call` prints a single-line JSON envelope to stdout and exits non-zero
+on failure:
+
+```json
+{"ok": true, "result": <value>}
+{"ok": false, "error": "<message>"}
+```
+
+Firestore `Timestamp`, `GeoPoint`, and `DocumentReference` values are encoded
+as `{"_seconds","_nanoseconds"}`, `{"_latitude","_longitude"}`, and
+`{"_referencePath"}` respectively in both arguments and results.
+
+## Downloadable agent skill
+
+A ready-to-use skill that teaches AI coding agents how to use these commands
+ships with the package. Install it into your project's `.claude/skills/`
+directory with:
+
+```bash
+root-cms skill.install
+```
+
+This creates `.claude/skills/root-cms-cli/`. Pass a different directory to
+install elsewhere (e.g. `root-cms skill.install ./my-agent/skills`), or
+`--force` to overwrite an existing copy.
+
 # Embedding the CMS (`@blinkk/root-cms/browser-client`)
 
 `@blinkk/root-cms/browser-client` is a dependency-free, framework-agnostic

--- a/packages/root-cms/cli/cli.ts
+++ b/packages/root-cms/cli/cli.ts
@@ -194,8 +194,12 @@ class CliRunner {
       .description(
         'installs the bundled "root-cms-cli" agent skill\n\n' +
           'Copies the skill (which teaches AI coding agents how to use the\n' +
-          '`root-cms client.*` commands) into a local skills directory.\n' +
-          'Defaults to `.claude/skills`, creating `.claude/skills/root-cms-cli`.\n\n' +
+          '`root-cms client.*` commands) into a local skills directory.\n\n' +
+          'When no directory is given, existing agent skills directories are\n' +
+          'auto-detected (e.g. `.claude/skills`, `.agent/skills`, or any\n' +
+          '`.*/skills` dir already in the project) so Root does not assume a\n' +
+          'specific AI provider. If none is found, it installs to\n' +
+          '`.agent/skills`.\n\n' +
           'Usage examples:\n' +
           '  $ root-cms skill.install\n' +
           '  $ root-cms skill.install ./my-agent/skills\n' +

--- a/packages/root-cms/cli/cli.ts
+++ b/packages/root-cms/cli/cli.ts
@@ -1,10 +1,12 @@
 import {Command} from 'commander';
 import {bgGreen, black} from 'kleur/colors';
+import {clientCall, clientMethods} from './client-cli.js';
 import {docsGet, docsSet, docsDownload, docsUpload} from './docs.js';
 import {exportData} from './export.js';
 import {generateTypes} from './generate-types.js';
 import {importData} from './import.js';
 import {initFirebase} from './init-firebase.js';
+import {installSkill} from './skill.js';
 
 class CliRunner {
   private name: string;
@@ -19,7 +21,12 @@ class CliRunner {
     const program = new Command(this.name);
     program.version(this.version);
     program.option('-q, --quiet', 'quiet');
-    program.hook('preAction', (cmd) => {
+    program.hook('preAction', (cmd, actionCommand) => {
+      // The `client.*` commands emit machine-readable JSON on stdout, so skip
+      // the decorative banner to keep their output clean for AI agents.
+      if (actionCommand.name().startsWith('client.')) {
+        return;
+      }
       if (!cmd.opts().quiet) {
         console.log(
           `🥕 ${bgGreen(black(` ${this.name} `))} v${this.version}\n`
@@ -149,12 +156,61 @@ class CliRunner {
         'doc mode: "draft" or "published" (default: "draft")'
       )
       .action(docsUpload);
+    program
+      .command('client.call <method> [jsonArgs]')
+      .description(
+        'calls a method on the RootCMSClient with JSON-encoded arguments\n\n' +
+          'Designed for AI agents. Arguments are a JSON array of positional\n' +
+          'args passed on the command line. When jsonArgs is omitted the\n' +
+          'method is called with no arguments; pass `-` to read the JSON args\n' +
+          'from stdin. The result is printed to stdout as a JSON envelope:\n' +
+          '  {"ok": true, "result": <value>}\n' +
+          '  {"ok": false, "error": "<message>"}\n\n' +
+          'Run `root-cms client.methods` to discover available methods and\n' +
+          'their argument signatures.\n\n' +
+          'Usage examples:\n' +
+          '  $ root-cms client.call getDoc \'["Pages", "home", {"mode": "draft"}]\'\n' +
+          '  $ root-cms client.call listDocs \'["Pages", {"mode": "published"}]\'\n' +
+          '  $ root-cms client.call publishScheduledDocs\n' +
+          '  $ echo \'["Pages", "home", {"mode": "draft"}]\' | root-cms client.call getDoc -'
+      )
+      .action(clientCall);
+    program
+      .command('client.methods')
+      .description(
+        'lists the methods available on the RootCMSClient\n\n' +
+          'Designed for AI discovery of available functionality. Prints each\n' +
+          "method's signature and description.\n\n" +
+          'Usage examples:\n' +
+          '  $ root-cms client.methods\n' +
+          '  $ root-cms client.methods --json\n' +
+          '  $ root-cms client.methods --json --types'
+      )
+      .option('--json', 'output machine-readable JSON')
+      .option('--types', 'include referenced type/interface definitions')
+      .action(clientMethods);
+    program
+      .command('skill.install [dir]')
+      .description(
+        'installs the bundled "root-cms-cli" agent skill\n\n' +
+          'Copies the skill (which teaches AI coding agents how to use the\n' +
+          '`root-cms client.*` commands) into a local skills directory.\n' +
+          'Defaults to `.claude/skills`, creating `.claude/skills/root-cms-cli`.\n\n' +
+          'Usage examples:\n' +
+          '  $ root-cms skill.install\n' +
+          '  $ root-cms skill.install ./my-agent/skills\n' +
+          '  $ root-cms skill.install --force'
+      )
+      .option('--force', 'overwrite the skill if it is already installed')
+      .action(installSkill);
     await program.parseAsync(argv);
   }
 }
 
 export {
   CliRunner,
+  clientCall,
+  clientMethods,
   docsGet,
   docsSet,
   docsDownload,
@@ -163,4 +219,5 @@ export {
   generateTypes,
   importData,
   initFirebase,
+  installSkill,
 };

--- a/packages/root-cms/cli/client-cli.ts
+++ b/packages/root-cms/cli/client-cli.ts
@@ -1,0 +1,171 @@
+import {loadRootConfig} from '@blinkk/root/node';
+import {RootCMSClient} from '../core/client.js';
+import {ClientApiInfo, getClientApiInfo} from './client-reflect.js';
+import {convertForExport, convertFirestoreTypes} from './utils.js';
+
+export interface ClientMethodsOptions {
+  /** Output machine-readable JSON instead of formatted help text. */
+  json?: boolean;
+  /** Include referenced type/interface definitions in the output. */
+  types?: boolean;
+}
+
+/**
+ * Runs a single method on the RootCMSClient with JSON-encoded arguments and
+ * prints the result as a JSON envelope to stdout.
+ *
+ * The result envelope is one of:
+ *   {"ok": true, "result": <json value>}
+ *   {"ok": false, "error": "<message>"}
+ *
+ * Usage:
+ *   root-cms client.call <method> [jsonArgs]
+ *   root-cms client.call getDoc '["Pages", "home", {"mode": "draft"}]'
+ *   root-cms client.call publishScheduledDocs
+ *   echo '["Pages", "home", {"mode": "draft"}]' | root-cms client.call getDoc -
+ */
+export async function clientCall(method: string, jsonArgs: string | undefined) {
+  try {
+    const args = await parseJsonArgs(jsonArgs);
+
+    const methods = getClientApiInfo().methods;
+    const methodInfo = methods.find((m) => m.name === method);
+    if (!methodInfo) {
+      const available = methods.map((m) => m.name).join(', ');
+      throw new Error(
+        `unknown method: "${method}". Run \`root-cms client.methods\` to ` +
+          `list available methods. Available: ${available}`
+      );
+    }
+
+    const rootDir = process.cwd();
+    const rootConfig = await loadRootConfig(rootDir, {command: 'root-cms'});
+    const client = new RootCMSClient(rootConfig);
+
+    const fn = (client as any)[method];
+    if (typeof fn !== 'function') {
+      throw new Error(`"${method}" is not a callable method on RootCMSClient`);
+    }
+
+    // Convert any serialized firestore types (Timestamp/GeoPoint/DocumentRef)
+    // in the input args back into real firestore objects.
+    const callArgs = convertFirestoreTypes(args, client.db);
+    const rawResult = await fn.apply(client, callArgs);
+
+    // Convert firestore types in the result into JSON-serializable values.
+    const result = convertForExport(rawResult);
+    process.stdout.write(
+      JSON.stringify({ok: true, result: result ?? null}) + '\n'
+    );
+  } catch (err: any) {
+    const message = err?.message || String(err);
+    process.stdout.write(JSON.stringify({ok: false, error: message}) + '\n');
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * Prints help text describing every public method available on the
+ * RootCMSClient so that an AI agent (or human) can discover functionality.
+ *
+ * Usage:
+ *   root-cms client.methods
+ *   root-cms client.methods --json
+ *   root-cms client.methods --types
+ */
+export async function clientMethods(options?: ClientMethodsOptions) {
+  const info = getClientApiInfo();
+
+  if (options?.json) {
+    const payload: ClientApiInfo = {
+      methods: info.methods,
+      types: options.types ? info.types : [],
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return;
+  }
+
+  const lines: string[] = [];
+  lines.push('RootCMSClient methods');
+  lines.push('=====================');
+  lines.push('');
+  lines.push('Call any method via:');
+  lines.push('  root-cms client.call <method> <jsonArgs>');
+  lines.push('');
+  lines.push('Where <jsonArgs> is a JSON array of positional arguments, e.g.:');
+  lines.push(
+    '  root-cms client.call getDoc \'["Pages", "home", {"mode": "draft"}]\''
+  );
+  lines.push('');
+  for (const method of info.methods) {
+    lines.push(method.signature);
+    if (method.description) {
+      for (const line of method.description.split('\n')) {
+        lines.push(`    ${line}`);
+      }
+    }
+    lines.push('');
+  }
+
+  if (options?.types && info.types.length > 0) {
+    lines.push('Referenced types');
+    lines.push('================');
+    lines.push('');
+    for (const type of info.types) {
+      if (type.description) {
+        for (const line of type.description.split('\n')) {
+          lines.push(`// ${line}`);
+        }
+      }
+      lines.push(type.declaration);
+      lines.push('');
+    }
+  }
+
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+/**
+ * Parses the JSON args string into an array of positional args.
+ *
+ * If `jsonArgs` is omitted, the method is called with no arguments. Pass `-`
+ * to read the JSON args from stdin (e.g. `echo '[...]' | client.call m -`).
+ */
+async function parseJsonArgs(jsonArgs: string | undefined): Promise<any[]> {
+  let raw = jsonArgs;
+  if (raw === '-') {
+    raw = await readStdin();
+  }
+  if (raw === undefined || raw.trim() === '') {
+    return [];
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw new Error(
+      `invalid JSON args: ${err?.message || String(err)}. Expected a JSON ` +
+        'array of positional arguments, e.g. \'["Pages", "home"]\'',
+      {cause: err}
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      'JSON args must be an array of positional arguments, e.g. ' +
+        '\'["Pages", "home", {"mode": "draft"}]\''
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Reads all data from stdin as a string.
+ */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}

--- a/packages/root-cms/cli/client-reflect.test.ts
+++ b/packages/root-cms/cli/client-reflect.test.ts
@@ -1,0 +1,86 @@
+import {describe, it, expect} from 'vitest';
+import {parseClientDts} from './client-reflect.js';
+
+const SAMPLE_DTS = `
+import { type RootConfig } from '@blinkk/root';
+export interface Doc<Fields = any> {
+    id: string;
+    fields: Fields;
+}
+export type DocMode = 'draft' | 'published';
+/**
+ * Options for getting a doc.
+ */
+export interface GetDocOptions {
+    mode: DocMode;
+}
+export declare class RootCMSClient {
+    readonly projectId: string;
+    constructor(rootConfig: RootConfig);
+    /**
+     * Converts a doc mode to the Firestore collection name.
+     */
+    private getModeCollection;
+    /**
+     * Retrieves doc data from Root.js CMS.
+     */
+    getDoc<Fields = any>(collectionId: string, slug: string, options: GetDocOptions): Promise<Doc<Fields> | null>;
+    /**
+     * Fetches data from a data source.
+     */
+    getFromDataSource<T = any>(dataSourceId: string, options?: {
+        mode?: 'draft' | 'published';
+    }): Promise<T | null>;
+    private fetchData;
+    publishScheduledDocs(): Promise<any[]>;
+}
+export declare function isRichTextData(data: any): boolean;
+`;
+
+describe('parseClientDts', () => {
+  const info = parseClientDts(SAMPLE_DTS);
+
+  it('extracts public methods only (skips private and constructor)', () => {
+    const names = info.methods.map((m) => m.name);
+    expect(names).toEqual([
+      'getDoc',
+      'getFromDataSource',
+      'publishScheduledDocs',
+    ]);
+  });
+
+  it('captures method signatures and descriptions', () => {
+    const getDoc = info.methods.find((m) => m.name === 'getDoc')!;
+    expect(getDoc.description).toBe('Retrieves doc data from Root.js CMS.');
+    expect(getDoc.signature).toBe(
+      'getDoc<Fields = any>(collectionId: string, slug: string, options: GetDocOptions): Promise<Doc<Fields> | null>'
+    );
+  });
+
+  it('handles multi-line signatures with inline object types', () => {
+    const method = info.methods.find((m) => m.name === 'getFromDataSource')!;
+    expect(method.signature).toBe(
+      "getFromDataSource<T = any>(dataSourceId: string, options?: { mode?: 'draft' | 'published'; }): Promise<T | null>"
+    );
+  });
+
+  it('handles zero-arg methods', () => {
+    const method = info.methods.find((m) => m.name === 'publishScheduledDocs')!;
+    expect(method.signature).toBe('publishScheduledDocs(): Promise<any[]>');
+  });
+
+  it('extracts top-level interfaces and type aliases', () => {
+    const typeNames = info.types.map((t) => t.name);
+    expect(typeNames).toContain('Doc');
+    expect(typeNames).toContain('DocMode');
+    expect(typeNames).toContain('GetDocOptions');
+    // The client class itself is not a "type".
+    expect(typeNames).not.toContain('RootCMSClient');
+  });
+
+  it('captures interface descriptions', () => {
+    const getDocOptions = info.types.find((t) => t.name === 'GetDocOptions')!;
+    expect(getDocOptions.description).toBe('Options for getting a doc.');
+    expect(getDocOptions.declaration).toContain('mode: DocMode;');
+  });
+});

--- a/packages/root-cms/cli/client-reflect.ts
+++ b/packages/root-cms/cli/client-reflect.ts
@@ -1,0 +1,287 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Metadata about a single public method on `RootCMSClient`. */
+export interface ClientMethodInfo {
+  /** Method name, e.g. "getDoc". */
+  name: string;
+  /**
+   * Full TypeScript signature (without the trailing semicolon), e.g.
+   * `getDoc(collectionId: string, slug: string, options: GetDocOptions): Promise<Doc<Fields> | null>`.
+   */
+  signature: string;
+  /** JSDoc description, if any. */
+  description: string;
+}
+
+/** A top-level type/interface declaration referenced by the client API. */
+export interface ClientTypeInfo {
+  /** Type name, e.g. "GetDocOptions". */
+  name: string;
+  /** Full declaration text (interface/type/enum body). */
+  declaration: string;
+  /** JSDoc description, if any. */
+  description: string;
+}
+
+export interface ClientApiInfo {
+  methods: ClientMethodInfo[];
+  types: ClientTypeInfo[];
+}
+
+let cachedApiInfo: ClientApiInfo | null = null;
+
+/**
+ * Reads and parses the shipped `client.d.ts` type declarations to build a
+ * catalog of the public RootCMSClient methods and referenced types.
+ */
+export function getClientApiInfo(): ClientApiInfo {
+  if (cachedApiInfo) {
+    return cachedApiInfo;
+  }
+  const src = readClientDts();
+  cachedApiInfo = parseClientDts(src);
+  return cachedApiInfo;
+}
+
+/**
+ * Locates and reads the generated `client.d.ts` file. The file is shipped as
+ * part of the package's `dist/` output. The CLI may run from `dist/cli.js` or
+ * from a bundled chunk in `dist/`, so a few candidate locations are checked.
+ */
+function readClientDts(): string {
+  const candidates = [
+    path.resolve(__dirname, 'core/client.d.ts'),
+    path.resolve(__dirname, '../core/client.d.ts'),
+    path.resolve(__dirname, '../dist/core/client.d.ts'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return fs.readFileSync(candidate, 'utf-8');
+    }
+  }
+  throw new Error(
+    `could not locate client.d.ts (looked in: ${candidates.join(', ')})`
+  );
+}
+
+/**
+ * Parses a `client.d.ts` source string into method and type metadata.
+ */
+export function parseClientDts(src: string): ClientApiInfo {
+  const lines = src.split('\n');
+  const methods = parseClassMethods(lines);
+  const types = parseTopLevelTypes(lines);
+  return {methods, types};
+}
+
+/**
+ * Extracts public method metadata from the `RootCMSClient` class body.
+ */
+function parseClassMethods(lines: string[]): ClientMethodInfo[] {
+  const classStart = lines.findIndex((line) =>
+    /^export declare class RootCMSClient\b/.test(line.trim())
+  );
+  if (classStart === -1) {
+    return [];
+  }
+  // Find the matching closing brace at column 0.
+  let classEnd = lines.length;
+  for (let i = classStart + 1; i < lines.length; i++) {
+    if (/^}/.test(lines[i])) {
+      classEnd = i;
+      break;
+    }
+  }
+
+  const methods: ClientMethodInfo[] = [];
+  let pendingDoc = '';
+  let i = classStart + 1;
+  while (i < classEnd) {
+    const trimmed = lines[i].trim();
+
+    // Collect JSDoc comment blocks.
+    if (trimmed.startsWith('/**')) {
+      const {doc, next} = collectJsDoc(lines, i, classEnd);
+      pendingDoc = doc;
+      i = next;
+      continue;
+    }
+    if (trimmed === '' || trimmed.startsWith('//')) {
+      i++;
+      continue;
+    }
+
+    // Collect a full member declaration (may span multiple lines).
+    const {text, next} = collectDeclaration(lines, i, classEnd);
+    i = next;
+
+    const doc = pendingDoc;
+    pendingDoc = '';
+
+    // Skip private members and non-method members (properties, constructor).
+    if (
+      text.startsWith('private ') ||
+      text.startsWith('constructor') ||
+      text.startsWith('readonly ') ||
+      text.startsWith('static ')
+    ) {
+      continue;
+    }
+    // A method has a parameter list; properties do not.
+    const nameMatch = text.match(/^([A-Za-z_$][\w$]*)\s*(?:<[^>]*>)?\s*\(/);
+    if (!nameMatch) {
+      continue;
+    }
+    const name = nameMatch[1];
+    const signature = text.replace(/;\s*$/, '');
+    methods.push({name, signature, description: doc});
+  }
+
+  return methods;
+}
+
+/**
+ * Extracts top-level exported interface/type/enum declarations.
+ */
+function parseTopLevelTypes(lines: string[]): ClientTypeInfo[] {
+  const types: ClientTypeInfo[] = [];
+  let pendingDoc = '';
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+
+    if (trimmed.startsWith('/**')) {
+      const {doc, next} = collectJsDoc(lines, i, lines.length);
+      pendingDoc = doc;
+      i = next;
+      continue;
+    }
+    if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('*')) {
+      i++;
+      continue;
+    }
+
+    const interfaceMatch = trimmed.match(
+      /^export (?:declare )?interface ([A-Za-z_$][\w$]*)/
+    );
+    const typeMatch = trimmed.match(
+      /^export (?:declare )?type ([A-Za-z_$][\w$]*)/
+    );
+    const enumMatch = trimmed.match(
+      /^export (?:declare )?enum ([A-Za-z_$][\w$]*)/
+    );
+
+    if (interfaceMatch || enumMatch) {
+      // Block declaration terminated by a closing brace at column 0.
+      const start = i;
+      let end = i;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (/^}/.test(lines[j])) {
+          end = j;
+          break;
+        }
+      }
+      const declaration = lines.slice(start, end + 1).join('\n');
+      types.push({
+        name: (interfaceMatch || enumMatch)![1],
+        declaration,
+        description: pendingDoc,
+      });
+      pendingDoc = '';
+      i = end + 1;
+      continue;
+    }
+
+    if (typeMatch) {
+      // Type alias terminated by a line ending in ';'.
+      const start = i;
+      let end = i;
+      for (let j = i; j < lines.length; j++) {
+        if (/;\s*$/.test(lines[j])) {
+          end = j;
+          break;
+        }
+      }
+      const declaration = lines.slice(start, end + 1).join('\n');
+      types.push({
+        name: typeMatch[1],
+        declaration,
+        description: pendingDoc,
+      });
+      pendingDoc = '';
+      i = end + 1;
+      continue;
+    }
+
+    pendingDoc = '';
+    i++;
+  }
+
+  return types;
+}
+
+/**
+ * Collects a JSDoc comment block starting at `start`, returning the cleaned
+ * description text and the index of the line after the block.
+ */
+function collectJsDoc(
+  lines: string[],
+  start: number,
+  end: number
+): {doc: string; next: number} {
+  const docLines: string[] = [];
+  let i = start;
+  while (i < end) {
+    const raw = lines[i];
+    const closed = raw.includes('*/');
+    let content = raw.trim();
+    content = content.replace(/^\/\*\*/, '').replace(/\*\/\s*$/, '');
+    content = content.replace(/^\*\s?/, '');
+    docLines.push(content);
+    i++;
+    if (closed) {
+      break;
+    }
+  }
+  const doc = docLines
+    .join('\n')
+    .replace(/^\n+/, '')
+    .replace(/\n+$/, '')
+    .trim();
+  return {doc, next: i};
+}
+
+/**
+ * Collects a full member declaration starting at `start`. Handles declarations
+ * that span multiple lines (e.g. inline object types) by balancing brackets
+ * until the terminating semicolon is reached.
+ */
+function collectDeclaration(
+  lines: string[],
+  start: number,
+  end: number
+): {text: string; next: number} {
+  let depth = 0;
+  const parts: string[] = [];
+  let i = start;
+  while (i < end) {
+    const line = lines[i];
+    parts.push(line.trim());
+    for (const ch of line) {
+      if (ch === '(' || ch === '{' || ch === '[') {
+        depth++;
+      } else if (ch === ')' || ch === '}' || ch === ']') {
+        depth--;
+      }
+    }
+    i++;
+    if (depth <= 0 && /;\s*$/.test(line)) {
+      break;
+    }
+  }
+  return {text: parts.join(' ').replace(/\s+/g, ' ').trim(), next: i};
+}

--- a/packages/root-cms/cli/docs.ts
+++ b/packages/root-cms/cli/docs.ts
@@ -2,9 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import * as readline from 'node:readline';
 import {loadRootConfig} from '@blinkk/root/node';
-import {Timestamp, GeoPoint} from 'firebase-admin/firestore';
 import {RootCMSClient, unmarshalData, getCmsPlugin} from '../core/client.js';
-import {convertForExport} from './utils.js';
+import {convertForExport, convertFirestoreTypes} from './utils.js';
 
 export interface DocsGetOptions {
   /** Doc mode: "draft" or "published". */
@@ -272,56 +271,4 @@ function parseDocId(docId: string): {collection: string; slug: string} {
     );
   }
   return {collection, slug};
-}
-
-/**
- * Recursively converts exported JSON back to Firestore types.
- */
-function convertFirestoreTypes(obj: any, db: any): any {
-  if (obj === null || obj === undefined) {
-    return obj;
-  }
-
-  // Timestamp objects ({_seconds, _nanoseconds}).
-  if (
-    typeof obj === 'object' &&
-    '_seconds' in obj &&
-    '_nanoseconds' in obj &&
-    Object.keys(obj).length === 2
-  ) {
-    return new Timestamp(obj._seconds, obj._nanoseconds);
-  }
-
-  // GeoPoint objects ({_latitude, _longitude}).
-  if (
-    typeof obj === 'object' &&
-    '_latitude' in obj &&
-    '_longitude' in obj &&
-    Object.keys(obj).length === 2
-  ) {
-    return new GeoPoint(obj._latitude, obj._longitude);
-  }
-
-  // DocumentReference objects ({_referencePath}).
-  if (
-    typeof obj === 'object' &&
-    '_referencePath' in obj &&
-    Object.keys(obj).length === 1
-  ) {
-    return db.doc(obj._referencePath);
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map((item) => convertFirestoreTypes(item, db));
-  }
-
-  if (typeof obj === 'object') {
-    const converted: any = {};
-    for (const [key, value] of Object.entries(obj)) {
-      converted[key] = convertFirestoreTypes(value, db);
-    }
-    return converted;
-  }
-
-  return obj;
 }

--- a/packages/root-cms/cli/skill.test.ts
+++ b/packages/root-cms/cli/skill.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {detectSkillsDirs} from './skill.js';
+
+describe('detectSkillsDirs', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'root-skill-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, {recursive: true, force: true});
+  });
+
+  it('detects an existing */skills directory', () => {
+    fs.mkdirSync(path.join(root, '.agent/skills'), {recursive: true});
+    expect(detectSkillsDirs(root)).toEqual([path.join(root, '.agent/skills')]);
+  });
+
+  it('detects a non-Claude provider skills directory', () => {
+    fs.mkdirSync(path.join(root, '.cursor/skills'), {recursive: true});
+    expect(detectSkillsDirs(root)).toEqual([path.join(root, '.cursor/skills')]);
+  });
+
+  it('detects multiple existing skills directories (sorted)', () => {
+    fs.mkdirSync(path.join(root, '.claude/skills'), {recursive: true});
+    fs.mkdirSync(path.join(root, '.agent/skills'), {recursive: true});
+    expect(detectSkillsDirs(root)).toEqual([
+      path.join(root, '.agent/skills'),
+      path.join(root, '.claude/skills'),
+    ]);
+  });
+
+  it('seeds skills/ for a known agent dir that exists without one', () => {
+    fs.mkdirSync(path.join(root, '.claude'), {recursive: true});
+    expect(detectSkillsDirs(root)).toEqual([path.join(root, '.claude/skills')]);
+  });
+
+  it('ignores non-agent dot dirs like .git', () => {
+    fs.mkdirSync(path.join(root, '.git'), {recursive: true});
+    expect(detectSkillsDirs(root)).toEqual([path.join(root, '.agent/skills')]);
+  });
+
+  it('falls back to .agent/skills when nothing is detected', () => {
+    expect(detectSkillsDirs(root)).toEqual([path.join(root, '.agent/skills')]);
+  });
+});

--- a/packages/root-cms/cli/skill.ts
+++ b/packages/root-cms/cli/skill.ts
@@ -7,15 +7,31 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** The name of the bundled skill directory. */
 const SKILL_NAME = 'root-cms-cli';
 
+/**
+ * Known AI-agent config directories that use the `SKILL.md` "skills"
+ * convention. Root stays agnostic of any particular AI provider: existing
+ * skills directories are auto-detected regardless of provider, and this list
+ * is only used to seed a sensible location when a provider's config dir exists
+ * but doesn't have a `skills/` subdir yet.
+ */
+const KNOWN_AGENT_DIRS = ['.claude', '.agent'];
+
+/** Neutral, provider-agnostic fallback when nothing else is detected. */
+const DEFAULT_SKILLS_DIR = '.agent/skills';
+
 export interface InstallSkillOptions {
   /** Overwrite the destination if it already exists. */
   force?: boolean;
 }
 
 /**
- * Installs the bundled `root-cms-cli` agent skill into a local skills
- * directory (default: `.claude/skills`). The skill is copied to
- * `<dir>/root-cms-cli/`.
+ * Installs the bundled `root-cms-cli` agent skill into the project's skills
+ * directory (or directories).
+ *
+ * When no directory is given, existing agent skills directories are
+ * auto-detected (e.g. `.claude/skills`, `.agent/skills`, or any other
+ * `<dir>/skills` directory already present) so Root does not assume a specific
+ * AI provider. If none is found, the skill is installed to `.agent/skills`.
  *
  * Usage:
  *   root-cms skill.install
@@ -27,21 +43,86 @@ export async function installSkill(
   options?: InstallSkillOptions
 ) {
   const src = findSkillDir();
-  const skillsDir = path.resolve(dirArg || '.claude/skills');
-  const dest = path.join(skillsDir, SKILL_NAME);
+  const rootDir = process.cwd();
+  const targets = dirArg ? [path.resolve(dirArg)] : detectSkillsDirs(rootDir);
 
-  if (fs.existsSync(dest)) {
-    if (!options?.force) {
-      throw new Error(
-        `skill already installed at ${dest}. Re-run with --force to overwrite.`
-      );
+  let installed = 0;
+  for (const skillsDir of targets) {
+    const dest = path.join(skillsDir, SKILL_NAME);
+    if (fs.existsSync(dest)) {
+      if (!options?.force) {
+        console.log(
+          `Skipped ${dest} (already installed; re-run with --force to overwrite)`
+        );
+        continue;
+      }
+      fs.rmSync(dest, {recursive: true, force: true});
     }
-    fs.rmSync(dest, {recursive: true, force: true});
+    fs.mkdirSync(skillsDir, {recursive: true});
+    fs.cpSync(src, dest, {recursive: true});
+    console.log(`Installed "${SKILL_NAME}" skill to ${dest}`);
+    installed++;
   }
 
-  fs.mkdirSync(skillsDir, {recursive: true});
-  fs.cpSync(src, dest, {recursive: true});
-  console.log(`Installed "${SKILL_NAME}" skill to ${dest}`);
+  if (installed === 0) {
+    console.log('No skills installed.');
+  }
+}
+
+/**
+ * Detects where the skill should be installed, provider-agnostically:
+ *
+ * 1. Any existing `.<agent>/skills` directory at the project root (whatever
+ *    provider it belongs to).
+ * 2. Otherwise, a `skills/` subdir under any known agent config dir that
+ *    already exists (e.g. `.claude`, `.agent`).
+ * 3. Otherwise, the neutral `.agent/skills` fallback.
+ *
+ * Exposed for testing.
+ */
+export function detectSkillsDirs(rootDir: string): string[] {
+  // 1. Existing "<dotdir>/skills" directories.
+  const existing: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(rootDir, {withFileTypes: true});
+  } catch {
+    entries = [];
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name.startsWith('.')) {
+      const skillsPath = path.join(rootDir, entry.name, 'skills');
+      if (isDirectory(skillsPath)) {
+        existing.push(skillsPath);
+      }
+    }
+  }
+  if (existing.length > 0) {
+    return existing.sort();
+  }
+
+  // 2. Known agent config dirs present but without a skills subdir yet.
+  const seeded: string[] = [];
+  for (const agentDir of KNOWN_AGENT_DIRS) {
+    if (isDirectory(path.join(rootDir, agentDir))) {
+      seeded.push(path.join(rootDir, agentDir, 'skills'));
+    }
+  }
+  if (seeded.length > 0) {
+    return seeded;
+  }
+
+  // 3. Neutral fallback.
+  return [path.join(rootDir, DEFAULT_SKILLS_DIR)];
+}
+
+/** Returns true if `p` exists and is a directory. */
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/root-cms/cli/skill.ts
+++ b/packages/root-cms/cli/skill.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** The name of the bundled skill directory. */
+const SKILL_NAME = 'root-cms-cli';
+
+export interface InstallSkillOptions {
+  /** Overwrite the destination if it already exists. */
+  force?: boolean;
+}
+
+/**
+ * Installs the bundled `root-cms-cli` agent skill into a local skills
+ * directory (default: `.claude/skills`). The skill is copied to
+ * `<dir>/root-cms-cli/`.
+ *
+ * Usage:
+ *   root-cms skill.install
+ *   root-cms skill.install ./my-agent/skills
+ *   root-cms skill.install --force
+ */
+export async function installSkill(
+  dirArg: string | undefined,
+  options?: InstallSkillOptions
+) {
+  const src = findSkillDir();
+  const skillsDir = path.resolve(dirArg || '.claude/skills');
+  const dest = path.join(skillsDir, SKILL_NAME);
+
+  if (fs.existsSync(dest)) {
+    if (!options?.force) {
+      throw new Error(
+        `skill already installed at ${dest}. Re-run with --force to overwrite.`
+      );
+    }
+    fs.rmSync(dest, {recursive: true, force: true});
+  }
+
+  fs.mkdirSync(skillsDir, {recursive: true});
+  fs.cpSync(src, dest, {recursive: true});
+  console.log(`Installed "${SKILL_NAME}" skill to ${dest}`);
+}
+
+/**
+ * Locates the bundled skill directory. The skill ships at `<package>/skills/`,
+ * while the CLI runs from `dist/`, so a few candidate locations are checked.
+ */
+function findSkillDir(): string {
+  const candidates = [
+    path.resolve(__dirname, `../skills/${SKILL_NAME}`),
+    path.resolve(__dirname, `../../skills/${SKILL_NAME}`),
+    path.resolve(__dirname, `skills/${SKILL_NAME}`),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, 'SKILL.md'))) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `could not locate the "${SKILL_NAME}" skill (looked in: ${candidates.join(
+      ', '
+    )})`
+  );
+}

--- a/packages/root-cms/cli/utils.ts
+++ b/packages/root-cms/cli/utils.ts
@@ -1,3 +1,5 @@
+import {Timestamp, GeoPoint} from 'firebase-admin/firestore';
+
 /**
  * Parses a comma-separated filter string into include and exclude patterns.
  * Exclude patterns are prefixed with "!".
@@ -164,6 +166,65 @@ export function convertForExport(obj: any): any {
     const converted: any = {};
     for (const [key, value] of Object.entries(obj)) {
       converted[key] = convertForExport(value);
+    }
+    return converted;
+  }
+
+  return obj;
+}
+
+/**
+ * Recursively converts exported/JSON data back into Firestore types.
+ *
+ * Recognizes the serialized forms produced by {@link convertForExport}:
+ * - `{_seconds, _nanoseconds}` -> `Timestamp`
+ * - `{_latitude, _longitude}` -> `GeoPoint`
+ * - `{_referencePath}` -> `DocumentReference`
+ *
+ * `db` is a Firestore instance used to construct DocumentReferences.
+ */
+export function convertFirestoreTypes(obj: any, db: any): any {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  // Timestamp objects ({_seconds, _nanoseconds}).
+  if (
+    typeof obj === 'object' &&
+    '_seconds' in obj &&
+    '_nanoseconds' in obj &&
+    Object.keys(obj).length === 2
+  ) {
+    return new Timestamp(obj._seconds, obj._nanoseconds);
+  }
+
+  // GeoPoint objects ({_latitude, _longitude}).
+  if (
+    typeof obj === 'object' &&
+    '_latitude' in obj &&
+    '_longitude' in obj &&
+    Object.keys(obj).length === 2
+  ) {
+    return new GeoPoint(obj._latitude, obj._longitude);
+  }
+
+  // DocumentReference objects ({_referencePath}).
+  if (
+    typeof obj === 'object' &&
+    '_referencePath' in obj &&
+    Object.keys(obj).length === 1
+  ) {
+    return db.doc(obj._referencePath);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => convertFirestoreTypes(item, db));
+  }
+
+  if (typeof obj === 'object') {
+    const converted: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      converted[key] = convertFirestoreTypes(value, db);
     }
     return converted;
   }

--- a/packages/root-cms/package.json
+++ b/packages/root-cms/package.json
@@ -12,7 +12,8 @@
     "directory": "packages/root-cms"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "skills/**/*"
   ],
   "bin": {
     "root-cms": "./bin/root-cms.js"

--- a/packages/root-cms/skills/root-cms-cli/SKILL.md
+++ b/packages/root-cms/skills/root-cms-cli/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: root-cms-cli
+description: >-
+  Interact with a Root.js CMS (@blinkk/root-cms) project from the command line.
+  Use this when you need to read, write, publish, translate, or otherwise
+  manipulate CMS content programmatically — fetching docs, saving drafts,
+  publishing/unpublishing, listing collections, managing data sources,
+  translations, releases, or user ACLs. Triggers on requests mentioning
+  "root-cms", "Root.js CMS", CMS docs/collections/drafts, or the `root-cms` CLI.
+---
+
+# Root.js CMS CLI
+
+`root-cms` is the CLI for [`@blinkk/root-cms`](https://www.npmjs.com/package/@blinkk/root-cms).
+It exposes two commands designed for programmatic/AI use that let you call any
+method on the `RootCMSClient` and discover what functionality is available:
+
+- `root-cms client.methods` — list every callable method with its TypeScript
+  signature and description (discovery).
+- `root-cms client.call <method> [jsonArgs]` — invoke a method with
+  JSON-encoded positional arguments and get a JSON result envelope.
+
+Together these give you full programmatic access to the CMS backend
+(Firestore) without needing to know the internals in advance.
+
+## Prerequisites
+
+- The command must be run **from the root of a Root.js project** (a directory
+  containing `root.config.ts`). The CLI loads that config to connect to the
+  correct Firebase project and Firestore database.
+- Authentication uses Application Default Credentials (the same as other
+  Firebase Admin tooling). If calls fail with auth errors, the environment
+  needs `gcloud auth application-default login` or a
+  `GOOGLE_APPLICATION_CREDENTIALS` service-account key.
+- Invoke via the package binary. If `@blinkk/root-cms` is installed locally,
+  use `npx root-cms ...` (or `pnpm exec root-cms ...`); otherwise the global
+  `root-cms` binary.
+
+## Step 1 — Discover available methods
+
+Always start by discovering the API surface. Prefer the JSON form with
+`--types` so you also get the exact shapes of the option/argument types:
+
+```bash
+npx root-cms client.methods --json --types
+```
+
+This prints:
+
+```json
+{
+  "methods": [
+    {
+      "name": "getDoc",
+      "signature": "getDoc<Fields = any>(collectionId: string, slug: string, options: GetDocOptions): Promise<Doc<Fields> | null>",
+      "description": "Retrieves doc data from Root.js CMS."
+    }
+  ],
+  "types": [
+    {
+      "name": "GetDocOptions",
+      "declaration": "export interface GetDocOptions {\n    mode: DocMode;\n}",
+      "description": ""
+    }
+  ]
+}
+```
+
+For a quick human-readable overview instead, run `npx root-cms client.methods`
+(optionally with `--types`).
+
+Use the `signature` of each method to construct the correct positional
+arguments, and the `types` block to fill in option objects (e.g. what fields
+`GetDocOptions` expects).
+
+## Step 2 — Call a method
+
+The argument to `client.call` after the method name is a **JSON array of the
+method's positional arguments**, in order. It is not human-friendly by design —
+it maps 1:1 to the TypeScript signature.
+
+```bash
+# getDoc(collectionId, slug, options)
+npx root-cms client.call getDoc '["Pages", "home", {"mode": "draft"}]'
+
+# listDocs(collectionId, options)
+npx root-cms client.call listDocs '["Pages", {"mode": "published", "limit": 10}]'
+
+# saveDraftData(docId, fieldsData, options?)
+npx root-cms client.call saveDraftData '["Pages/home", {"title": "Hello"}]'
+
+# A method that takes no arguments — omit the JSON array entirely:
+npx root-cms client.call publishScheduledDocs
+```
+
+### Passing large or complex args via stdin
+
+Pass `-` as the args value to read the JSON array from stdin. Useful for large
+payloads:
+
+```bash
+echo '["Pages/home", {"title": "Hello"}]' | npx root-cms client.call saveDraftData -
+cat args.json | npx root-cms client.call setRawDoc -
+```
+
+## Step 3 — Read the result envelope
+
+`client.call` always prints a single-line JSON envelope to **stdout** and
+exits `0` on success / `1` on failure:
+
+```json
+{"ok": true, "result": <the method's return value, or null for void methods>}
+{"ok": false, "error": "<error message>"}
+```
+
+Always parse stdout as JSON and branch on `ok`. On `ok: false`, read `error`
+for the reason (unknown method, invalid args, auth failure, not-found, etc.).
+
+## Firestore value encoding
+
+Special Firestore types are encoded as plain JSON objects in **both** the
+arguments you send and the results you receive, so they round-trip cleanly:
+
+| Firestore type      | JSON encoding                              |
+| ------------------- | ------------------------------------------ |
+| `Timestamp`         | `{"_seconds": 1700000000, "_nanoseconds": 0}` |
+| `GeoPoint`          | `{"_latitude": 37.77, "_longitude": -122.41}` |
+| `DocumentReference` | `{"_referencePath": "Projects/foo/..."}`   |
+
+When constructing args that need a timestamp or reference, use these shapes and
+they will be converted to real Firestore objects before the method is called.
+
+## Common recipes
+
+```bash
+# Fetch a published doc's fields
+npx root-cms client.call getDoc '["Pages", "home", {"mode": "published"}]'
+
+# Update a single nested field in a draft (partial update)
+npx root-cms client.call updateDraftData '["Pages/home", "hero.title", "New title"]'
+
+# Publish specific docs
+npx root-cms client.call publishDocs '[["Pages/home", "Pages/about"]]'
+
+# Count docs in a collection
+npx root-cms client.call getDocsCount '["Pages", {"mode": "draft"}]'
+
+# Look up a user's role
+npx root-cms client.call getUserRole '["someone@example.com"]'
+```
+
+Note: for a method like `publishDocs(docIds: string[], options?)`, the first
+positional argument is itself an array, so the JSON args array is
+`[["Pages/home", "Pages/about"]]` — an array containing the `docIds` array.
+
+## Guidance for agents
+
+- Run `client.methods --json --types` first; do not guess method names or
+  argument order — read them from the signatures.
+- The JSON args array is **positional and ordered** — match the signature
+  exactly. Optional trailing arguments (`options?`) may be omitted.
+- Treat writes (`saveDraftData`, `setRawDoc`, `publishDocs`, `unpublishDocs`,
+  `archiveDataSource`, etc.) as side-effecting. Confirm intent before running
+  them, and prefer `mode: "draft"` when reading to avoid touching published
+  content unintentionally.
+- Parse the stdout JSON envelope; never assume success from exit code alone.
+- These commands print only the JSON envelope/help to stdout (the decorative
+  CLI banner is suppressed), so stdout is safe to pipe into `jq` or a parser.


### PR DESCRIPTION
## Summary

Exposes the `RootCMSClient` to AI coding agents (and scripts) through the `root-cms` CLI, plus a downloadable skill that teaches agents how to use it.

### New commands

- **`root-cms client.call <method> [jsonArgs]`** — invokes any public method on `RootCMSClient`. Args are a JSON array of positional arguments matching the method's TypeScript signature. Output is a single-line JSON envelope on stdout:
  ```
  {"ok": true, "result": <value>}      # exit 0
  {"ok": false, "error": "<message>"}  # exit 1
  ```
  - Omit `jsonArgs` for zero-arg methods; pass `-` to read args from stdin (stdin is only read when explicitly requested, so no hangs).
  - Firestore `Timestamp` / `GeoPoint` / `DocumentReference` round-trip as `{_seconds,_nanoseconds}` / `{_latitude,_longitude}` / `{_referencePath}` in both args and results.

- **`root-cms client.methods [--json] [--types]`** — lists all public methods with their TS signatures and JSDoc descriptions for discovery; `--types` also emits the referenced interface/type definitions.

- **`root-cms skill.install [dir]`** — installs the bundled `root-cms-cli` agent skill into a local skills directory (default `.claude/skills`). Supports a custom dir and `--force`.

### How it works

The method/type catalog is parsed from the generated `dist/core/client.d.ts`, so it always matches the real API. Private methods are excluded. The decorative CLI banner is suppressed for `client.*` commands to keep stdout as clean JSON.

Also refactors the duplicated `convertFirestoreTypes` helper into `cli/utils.ts`.

### Downloadable skill

`skills/root-cms-cli/SKILL.md` teaches the discover-then-call workflow, arg encoding, the result envelope, and write-safety guidance. It ships with the npm package (`skills/**/*` added to `files`) and installs via `root-cms skill.install`.

## Testing

- `pnpm build:core` succeeds; `.d.ts` generation passes.
- 23 tests pass, including 6 new parser tests in `cli/client-reflect.test.ts` (private exclusion, multi-line signatures, zero-arg methods, type extraction).
- Lint clean.
- Manually verified `client.methods` (text + `--json --types`), `client.call` error/exit-code paths, and all `skill.install` scenarios (default, custom dir, duplicate error, `--force`).

Not exercised: a *successful* `client.call` requires a real Root.js project (`root.config.ts`) + Firebase credentials, which the repo root lacks — plumbing was verified up to config load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)