### PR TITLE
fix: bound mail api send with a timeout

### DIFF
--- a/apps/root-services/main.go
+++ b/apps/root-services/main.go
@@ -237,7 +237,14 @@ func processPendingEmails(ctx context.Context, fsClient *firestore.Client, proje
 			msg.HTMLBody = htmlBody
 		}
 
-		if err := mail.Send(ctx, msg); err != nil {
+		// Bound the Mail API RPC so a stalled backend fails fast instead of
+		// hanging until the App Engine request deadline (~60s). A wedged mail RPC
+		// would otherwise tie up the instance's request slot for a full minute,
+		// and one stuck message would block the rest of the batch.
+		sendCtx, cancel := context.WithTimeout(ctx, mailSendTimeout)
+		err := mail.Send(sendCtx, msg)
+		cancel()
+		if err != nil {
 			log.Printf("failed to send email %s: %v", doc.Ref.ID, err)
 			result.Failed++
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", doc.Ref.ID, err))
@@ -266,3 +273,7 @@ func processPendingEmails(ctx context.Context, fsClient *firestore.Client, proje
 	log.Printf("processed %d emails for project %s: %d sent, %d failed", len(docs), projectId, result.Sent, result.Failed)
 	return result, nil
 }
+
+// mailSendTimeout bounds each Mail API send so a stalled backend can't hang the
+// request (and the instance's request slot) up to the App Engine deadline.
+const mailSendTimeout = 25 * time.Second


### PR DESCRIPTION
## Problem

The App Engine legacy Mail API can intermittently wedge. In `processPendingEmails`, `mail.Send` was called with the raw request context (no deadline), so a stalled send would block until the App Engine request deadline (~60s). That ties up the instance's request slot for a full minute, and one stuck message blocks the rest of the pending-email batch.

## Fix

Wrap each `mail.Send` in a bounded context (`mailSendTimeout = 25s`) via `context.WithTimeout`, so a wedged backend fails fast, the message is marked `failed`, and the batch continues. Keeps the instance healthy instead of exhausting request slots.

## Notes

- No API/contract change — same request/response shape.
- `go build` and `go vet` pass.
- The App Engine legacy Mail API is deprecated and is the underlying source of these wedges; a follow-up could migrate off it (e.g. a supported SMTP relay / Gmail API). This PR is the low-risk mitigation.
