### PR TITLE
fix: prevent undefined values from reaching firestore

### DIFF
--- a/.changeset/tricky-tires-allow.md
+++ b/.changeset/tricky-tires-allow.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: prevent undefined values from reaching firestore

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -1123,6 +1123,13 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       const data = state ?? {};
       const order = [...(data._array || [])];
       const key = order[action.index];
+      if (!key) {
+        // The item no longer exists (e.g. removed by a concurrent update
+        // before the dispatch landed). Writing would target a bogus
+        // `undefined` key.
+        console.error('updateItem: no item at index', action.index);
+        return state;
+      }
       const newValue = action.newValue ?? {};
       action.draft.updateKey(`${action.deepKey}.${key}`, newValue);
       return {
@@ -1202,11 +1209,14 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       };
     }
     case 'moveUp': {
-      if (action.index === 0) {
-        return state;
-      }
       const data = state ?? {};
       const order = [...(data._array || [])];
+      // Bounds-check against the current state; a stale index (e.g. from a
+      // dispatch racing a concurrent update) would otherwise make arraySwap()
+      // write `undefined` entries into `_array`.
+      if (action.index <= 0 || action.index >= order.length) {
+        return state;
+      }
       arraySwap(order, action.index, action.index - 1);
       action.draft.updateKeys({
         [`${action.deepKey}._array`]: order,
@@ -1220,7 +1230,7 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
     case 'moveDown': {
       const data = state ?? {};
       const order = [...(data._array || [])];
-      if (action.index >= order.length - 1) {
+      if (action.index < 0 || action.index >= order.length - 1) {
         return state;
       }
       arraySwap(order, action.index, action.index + 1);
@@ -1261,6 +1271,10 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       const order = data._array || [];
       const newOrder = [...order];
       const oldKey = newOrder[action.index];
+      if (!oldKey) {
+        console.error('removeAt: no item at index', action.index);
+        return state;
+      }
       delete data[oldKey];
       newOrder.splice(action.index, 1);
       action.draft.updateKeys({

--- a/packages/root-cms/ui/hooks/useDraftDoc.controller.test.ts
+++ b/packages/root-cms/ui/hooks/useDraftDoc.controller.test.ts
@@ -1,0 +1,231 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {updateDocMock, onSnapshotMock} = vi.hoisted(() => ({
+  updateDocMock: vi.fn(async () => {}),
+  onSnapshotMock: vi.fn(() => () => {}),
+}));
+
+vi.mock('firebase/firestore', () => {
+  /** Stand-in for the Firestore FieldValue sentinel base class. */
+  class FieldValue {
+    constructor(readonly _methodName: string) {}
+  }
+  class Timestamp {}
+  const noop = vi.fn();
+  return {
+    FieldValue,
+    Timestamp,
+    doc: vi.fn(() => ({path: 'Projects/test/Collections/pages/Drafts/index'})),
+    onSnapshot: onSnapshotMock,
+    updateDoc: updateDocMock,
+    serverTimestamp: () => new FieldValue('serverTimestamp'),
+    deleteField: () => new FieldValue('deleteField'),
+    arrayUnion: () => new FieldValue('arrayUnion'),
+    collection: noop,
+    getDoc: noop,
+    getDocs: noop,
+    setDoc: noop,
+    deleteDoc: noop,
+    runTransaction: noop,
+    writeBatch: noop,
+    documentId: noop,
+    query: noop,
+    where: noop,
+    orderBy: noop,
+    limit: noop,
+    startAfter: noop,
+    Query: class {},
+    WriteBatch: class {},
+    DocumentReference: class {},
+    QueryDocumentSnapshot: class {},
+    Firestore: class {},
+  };
+});
+
+vi.mock('@mantine/notifications', () => ({
+  showNotification: vi.fn(),
+}));
+
+import {DraftDocController} from './useDraftDoc.js';
+
+/** Recursively collects paths whose value is literally `undefined`. */
+function findUndefinedPaths(value: any, path = ''): string[] {
+  const found: string[] = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => {
+      if (item === undefined) {
+        found.push(`${path}[${i}]`);
+      } else {
+        found.push(...findUndefinedPaths(item, `${path}[${i}]`));
+      }
+    });
+    return found;
+  }
+  if (value && typeof value === 'object') {
+    for (const key of Object.keys(value)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (value[key] === undefined) {
+        found.push(childPath);
+      } else {
+        found.push(...findUndefinedPaths(value[key], childPath));
+      }
+    }
+  }
+  return found;
+}
+
+describe('DraftDocController', () => {
+  beforeEach(() => {
+    updateDocMock.mockClear();
+    onSnapshotMock.mockClear();
+    (window as any).__ROOT_CTX = {
+      rootConfig: {projectId: 'test-project'},
+      collections: {},
+    };
+    (window as any).firebase = {
+      db: {},
+      user: {email: 'test@example.com'},
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({status: 200, text: async () => ''}))
+    );
+  });
+
+  /**
+   * Repro for the paste race: pasting an array item queues the full item
+   * object in pendingUpdates. The same object reference is inserted into the
+   * local JsonTrieStore, so a removeKey() on a nested key (e.g. removing an
+   * item from a nested array of the pasted block, or a child field clearing
+   * itself) used to set `undefined` *inside* the still-pending parent object.
+   * At flush time the child update is dropped in favor of the pending parent,
+   * and the parent was sent to Firestore containing a nested `undefined`,
+   * which updateDoc() rejects.
+   */
+  it('flushes no nested undefined when a child key is removed while its parent is pending (paste race)', async () => {
+    const controller = new DraftDocController('pages/index');
+
+    // Simulate pasting an array item (DocEditor arrayReducer "pasteAfter").
+    controller.updateKeys({
+      'fields.blocks._array': ['a', 'new1'],
+      'fields.blocks.new1': {
+        title: 'Pasted block',
+        items: {
+          _array: ['k1', 'k2'],
+          k1: {name: 'one'},
+          k2: {name: 'two'},
+        },
+      },
+    });
+
+    // Within the save-debounce window, remove an item from the nested array
+    // of the freshly-pasted block (arrayReducer "removeAt").
+    controller.updateKeys({
+      'fields.blocks.new1.items._array': ['k2'],
+    });
+    await controller.removeKey('fields.blocks.new1.items.k1');
+
+    await controller.flush();
+
+    expect(updateDocMock).toHaveBeenCalledTimes(1);
+    const payload = updateDocMock.mock.calls[0][1] as Record<string, any>;
+    expect(findUndefinedPaths(payload)).toEqual([]);
+
+    // The pasted block should be written with the nested removal applied.
+    const block = payload['fields.blocks.new1'];
+    expect(block.items._array).toEqual(['k2']);
+    expect('k1' in block.items).toBe(false);
+    expect(block.items.k2).toEqual({name: 'two'});
+  });
+
+  it('removeKey() deletes the key from the local store data', async () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKeys({
+      'fields.blocks._array': ['a'],
+      'fields.blocks.a': {title: 'Block A'},
+    });
+    await controller.removeKey('fields.blocks.a');
+
+    const blocks = controller.getValue('fields.blocks');
+    expect('a' in blocks).toBe(false);
+    expect(findUndefinedPaths(controller.getData())).toEqual([]);
+  });
+
+  it('keeps top-level deleteField sentinels in the flush payload', async () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKeys({
+      'fields.blocks._array': [],
+    });
+    await controller.removeKey('fields.blocks.a');
+    await controller.flush();
+
+    const payload = updateDocMock.mock.calls[0][1] as Record<string, any>;
+    expect(payload['fields.blocks.a']).toBeTruthy();
+    expect(payload['fields.blocks.a']._methodName).toEqual('deleteField');
+  });
+
+  /**
+   * Repro for the snapshot-echo race: when a remote snapshot arrives while a
+   * removal is pending, the pending deleteField() sentinel used to be copied
+   * into the local snapshot data verbatim (instead of deleting the key).
+   * Subscribers then observed the sentinel object as field data, and any
+   * flow that writes such an object back to Firestore would fail.
+   */
+  it('applies pending removals as deletions when merging a remote snapshot', async () => {
+    const controller = new DraftDocController('pages/index');
+    await controller.start();
+    expect(onSnapshotMock).toHaveBeenCalledTimes(1);
+    const snapshotCallback = onSnapshotMock.mock.calls[0][1] as (
+      snapshot: any
+    ) => void;
+
+    // Local unsaved edits: paste a block, then cut (remove) block "b".
+    controller.updateKeys({
+      'fields.blocks._array': ['a', 'new1'],
+      'fields.blocks.new1': {title: 'Pasted block'},
+    });
+    await controller.removeKey('fields.blocks.b');
+
+    // A remote snapshot arrives before the local changes are flushed. The
+    // server still has block "b".
+    snapshotCallback({
+      metadata: {hasPendingWrites: false},
+      data: () => ({
+        fields: {
+          blocks: {
+            _array: ['a', 'b'],
+            a: {title: 'Block A'},
+            b: {title: 'Block B'},
+          },
+        },
+      }),
+    });
+
+    const blocks = controller.getValue('fields.blocks');
+    // The local removal must be preserved as a deletion, not as a leaked
+    // sentinel object (or undefined).
+    expect('b' in blocks).toBe(false);
+    // The local paste must be preserved.
+    expect(blocks.new1).toEqual({title: 'Pasted block'});
+    expect(blocks._array).toEqual(['a', 'new1']);
+    expect(findUndefinedPaths(controller.getData())).toEqual([]);
+  });
+
+  it('prunes undefined values that callers pass inside objects', async () => {
+    const controller = new DraftDocController('pages/index');
+    // structuredClone() (used by the array "duplicate"/paste actions)
+    // preserves undefined-valued properties, so guard against callers passing
+    // such objects directly.
+    controller.updateKey('fields.blocks.a', {
+      title: 'Block A',
+      subtitle: undefined,
+      nested: {value: undefined, kept: 'yes'},
+    });
+    await controller.flush();
+
+    const payload = updateDocMock.mock.calls[0][1] as Record<string, any>;
+    expect(findUndefinedPaths(payload)).toEqual([]);
+    expect(payload['fields.blocks.a'].nested.kept).toEqual('yes');
+    expect('subtitle' in payload['fields.blocks.a']).toBe(false);
+  });
+});

--- a/packages/root-cms/ui/hooks/useDraftDoc.tsx
+++ b/packages/root-cms/ui/hooks/useDraftDoc.tsx
@@ -2,6 +2,7 @@ import {showNotification} from '@mantine/notifications';
 import {
   doc,
   DocumentReference,
+  FieldValue,
   Firestore,
   onSnapshot,
   updateDoc,
@@ -266,8 +267,8 @@ export class DraftDocController extends EventListener {
       const val = updates[key];
       if (val === null || val === undefined) {
         // Firestore doesn't support `undefined`, so use deleteField() instead.
-        // NOTE(stevenle): this doesn't currently handle nested `undefined`
-        // values.
+        // Nested `undefined` values are pruned at flush time by
+        // `removeUndefinedValuesDeep()`.
         this.setPendingUpdate(key, deleteField());
       } else {
         this.setPendingUpdate(key, val);
@@ -320,9 +321,19 @@ export class DraftDocController extends EventListener {
 
   /** Returns pending updates normalized for Firestore updateDoc(). */
   private getPendingUpdates() {
-    return removeOverlappingChildUpdates(
+    const updates = removeOverlappingChildUpdates(
       Object.fromEntries(this.pendingUpdates)
     );
+    // Firestore rejects `undefined` anywhere in the payload. Queued object
+    // values share references with the local store, so a child key that was
+    // removed after its parent was queued (e.g. pasting an array item and then
+    // deleting one of its sub-fields before the debounced save fires) could
+    // otherwise inject `undefined` into the parent object. Dropping the key
+    // from the parent write achieves the deletion.
+    for (const key in updates) {
+      updates[key] = removeUndefinedValuesDeep(updates[key]);
+    }
+    return updates;
   }
 
   /**
@@ -406,7 +417,9 @@ export class DraftDocController extends EventListener {
     // Immediately clear the pending updates so that there's no race condition
     // with any new updates the user makes while the changes are being saved to
     // the db. If the db save fails for any reason, re-apply the pending updates
-    // and re-queue the db save.
+    // and re-queue the db save. Keep the original (unpruned) entries around so
+    // a retry preserves the store-object aliasing that later edits rely on.
+    const prevPending = new Map(this.pendingUpdates);
     this.pendingUpdates.clear();
     try {
       this.setSaveState(SaveState.SAVING);
@@ -435,7 +448,7 @@ export class DraftDocController extends EventListener {
         color: 'red',
         autoClose: false,
       });
-      for (const key in updates) {
+      for (const [key, value] of prevPending) {
         // Ignore sys updates.
         if (key.startsWith('sys.')) {
           continue;
@@ -444,7 +457,7 @@ export class DraftDocController extends EventListener {
         if (this.pendingUpdates.has(key)) {
           continue;
         }
-        this.pendingUpdates.set(key, updates[key]);
+        this.pendingUpdates.set(key, value);
         this.queueChanges();
         console.log('re-queued updates');
         console.log(this.pendingUpdates);
@@ -481,13 +494,55 @@ function applyUpdates(data: any, updates: any) {
       data[head] ??= {};
       applyUpdates(data[head], {[tail]: val});
     } else {
-      if (typeof val === 'undefined') {
+      if (typeof val === 'undefined' || val instanceof FieldValue) {
+        // The only FieldValue sentinel stored in pendingUpdates is
+        // deleteField() (from removeKey()), which locally means "remove the
+        // key". Copying the sentinel into the data as a value would leak it to
+        // subscribers and eventually back into a Firestore write.
         delete data[key];
       } else {
         data[key] = val;
       }
     }
   }
+}
+
+/**
+ * Returns a copy of a value with `undefined` entries removed from plain
+ * objects and arrays. Non-plain objects (e.g. Timestamp or FieldValue
+ * sentinels) are returned as-is. Firestore rejects `undefined` anywhere in an
+ * updateDoc() payload.
+ */
+export function removeUndefinedValuesDeep(value: any): any {
+  if (Array.isArray(value)) {
+    const result: any[] = [];
+    for (const item of value) {
+      if (item !== undefined) {
+        result.push(removeUndefinedValuesDeep(item));
+      }
+    }
+    return result;
+  }
+  if (isPlainObject(value)) {
+    const result: Record<string, any> = {};
+    for (const key of Object.keys(value)) {
+      const val = value[key];
+      if (val !== undefined) {
+        result[key] = removeUndefinedValuesDeep(val);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
+/** Returns true for plain objects (object literals, JSON-parsed objects). */
+function isPlainObject(value: any): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 function splitKey(key: string) {

--- a/packages/root-cms/ui/utils/json-trie-store.ts
+++ b/packages/root-cms/ui/utils/json-trie-store.ts
@@ -101,7 +101,15 @@ export class JsonTrieStore extends EventListener {
         current = current[key];
       }
       const oldValue = current[lastKey];
-      current[lastKey] = newValue;
+      if (newValue === undefined) {
+        // Remove the key entirely rather than storing `undefined`. Objects in
+        // the store are shared by reference with pending Firestore updates
+        // (and with subscribers), and Firestore rejects `undefined` values, so
+        // a `key: undefined` entry must never linger in the data tree.
+        delete current[lastKey];
+      } else {
+        current[lastKey] = newValue;
+      }
       this.dispatch(JsonTrieStoreEventType.VALUE_CHANGE, path, newValue);
 
       // Collect notify subscribers on the current path and child paths.


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where `undefined` values could leak into Firestore `updateDoc()` payloads, causing write failures. The problem occurred when nested fields were modified after their parent object was queued for saving, or when remote snapshots arrived during pending removals.

## Key Changes

- **Added `removeUndefinedValuesDeep()` function** to recursively strip `undefined` values from update payloads before sending to Firestore. This handles the "paste race" scenario where a pasted array item's nested fields are modified before the parent is flushed.

- **Fixed snapshot merging** to properly apply pending `deleteField()` sentinels as actual deletions rather than copying the sentinel object into the data tree, preventing leakage to subscribers.

- **Updated `applyUpdates()` logic** to recognize `FieldValue` sentinels and delete keys instead of storing them as values.

- **Preserved store-object aliasing on retry** by keeping the original pending updates map around so failed flushes can re-queue updates without losing the shared references that later edits depend on.

- **Added bounds-checking in `arrayReducer`** to prevent stale indices from writing `undefined` entries into `_array` during concurrent updates (e.g., `moveUp`, `moveDown`, `removeAt`, `updateItem`).

- **Updated `JsonTrieStore.setValue()`** to delete keys when set to `undefined` rather than storing the undefined value, since objects are shared by reference with Firestore updates.

- **Added comprehensive test suite** (`useDraftDoc.controller.test.ts`) covering the paste race, snapshot-echo race, and undefined-pruning scenarios.

## Notable Implementation Details

- The fix maintains backward compatibility by only pruning `undefined` from plain objects and arrays, leaving non-plain objects (like Firestore `Timestamp` or `FieldValue` sentinels) untouched.
- The solution leverages the existing shared-reference pattern between the local store and pending updates, using it as a feature rather than fighting it.
- Bounds-checking in array operations prevents race conditions where concurrent updates could invalidate indices before a dispatch lands.

https://claude.ai/code/session_01ERLWyGLHtgxrSB18wfC9LD