### PR TITLE
fix: remove limit on the number of docs in a release

### DIFF
--- a/.changeset/big-releases-publish.md
+++ b/.changeset/big-releases-publish.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: remove limit on the number of docs in a release

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -730,10 +730,11 @@ export class RootCMSClient {
       }
     }
 
-    // // Each transaction or batch can write a max of 500 ops.
-    // // https://firebase.google.com/docs/firestore/manage-data/transactions
+    // Each transaction or batch can write a max of 500 ops, so commit the
+    // batch in chunks, starting a new batch after each commit.
+    // https://firebase.google.com/docs/firestore/manage-data/transactions
     let batchCount = 0;
-    const batch = options?.batch || this.db.batch();
+    let batch = options?.batch || this.db.batch();
     const versionTags = ['published'];
     if (options?.releaseId) {
       versionTags.push(`release:${options.releaseId}`);
@@ -815,6 +816,7 @@ export class RootCMSClient {
 
       if (batchCount >= 400) {
         await batch.commit();
+        batch = this.db.batch();
         batchCount = 0;
       }
     }
@@ -860,7 +862,7 @@ export class RootCMSClient {
     }
 
     let batchCount = 0;
-    const batch = options?.batch || this.db.batch();
+    let batch = options?.batch || this.db.batch();
     const unpublishedDocs: any[] = [];
 
     for (const doc of docs) {
@@ -898,6 +900,7 @@ export class RootCMSClient {
 
       if (batchCount >= 400) {
         await batch.commit();
+        batch = this.db.batch();
         batchCount = 0;
       }
     }
@@ -951,10 +954,11 @@ export class RootCMSClient {
       return [];
     }
 
-    // Each transaction or batch can write a max of 500 ops.
+    // Each transaction or batch can write a max of 500 ops, so commit the
+    // batch in chunks, starting a new batch after each commit.
     // https://firebase.google.com/docs/firestore/manage-data/transactions
     let batchCount = 0;
-    const batch = this.db.batch();
+    let batch = this.db.batch();
     const versionTags = ['published'];
     const publishedDocs: any[] = [];
     for (const doc of docs) {
@@ -1035,8 +1039,8 @@ export class RootCMSClient {
 
       if (batchCount >= 400) {
         await batch.commit();
+        batch = this.db.batch();
         batchCount = 0;
-        continue;
       }
     }
 
@@ -1070,26 +1074,27 @@ export class RootCMSClient {
 
     for (const snapshot of querySnapshot.docs) {
       const release = snapshot.data() as Release;
-      const batch = this.db.batch();
       const publishedBy = release.scheduledBy || 'root-cms-client';
-      batch.update(snapshot.ref, {
+      const dataSourceIds = release.dataSourceIds || [];
+      if (dataSourceIds.length > 0) {
+        await this.publishDataSources(dataSourceIds, {publishedBy});
+      }
+      const docIds = release.docIds || [];
+      if (docIds.length > 0) {
+        await this.publishDocs(docIds, {
+          publishedBy,
+          releaseId: release.id,
+        });
+      }
+
+      // Mark the release as published only after the doc and data source
+      // writes above have been committed. If any of those writes fails, the
+      // release remains scheduled and publishing is retried on the next run.
+      await snapshot.ref.update({
         publishedAt: Timestamp.now(),
         publishedBy: publishedBy,
         scheduledAt: FieldValue.delete(),
         scheduledBy: FieldValue.delete(),
-      });
-      const dataSourceIds = release.dataSourceIds || [];
-      if (dataSourceIds.length > 0) {
-        await this.publishDataSources(dataSourceIds, {
-          publishedBy,
-          batch,
-          commitBatch: false,
-        });
-      }
-      await this.publishDocs(release.docIds || [], {
-        publishedBy,
-        batch,
-        releaseId: release.id,
       });
 
       // Log an action for the published release.

--- a/packages/root-cms/core/release-publish.integration.test.ts
+++ b/packages/root-cms/core/release-publish.integration.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+/**
+ * Integration test for release publishing limits (issue #457).
+ *
+ * Publishing a release used to fail when it contained more than ~30 docs
+ * (firestore `in` query limit) or more than 100 docs (write batch reuse after
+ * commit). These tests run the real `RootCMSClient` publishing flow against
+ * the firestore emulator with 120 docs to verify releases are not limited in
+ * the number of docs they contain.
+ *
+ * Requires the firestore emulator (run via `firebase emulators:exec`).
+ */
+
+import {App, deleteApp, initializeApp} from 'firebase-admin/app';
+import {Firestore, Timestamp, getFirestore} from 'firebase-admin/firestore';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import {RootCMSClient} from './client.js';
+
+const NUM_DOCS = 120;
+
+/**
+ * Creates a `RootCMSClient` bound to the emulator db without requiring a full
+ * root config / CMS plugin setup. The publishing methods under test only use
+ * `db`, `projectId` and the cms plugin config (via `logAction()`).
+ */
+function createTestClient(db: Firestore, projectId: string): RootCMSClient {
+  const client = Object.create(RootCMSClient.prototype);
+  Object.assign(client, {
+    projectId,
+    db,
+    cmsPlugin: {getConfig: () => ({})},
+  });
+  return client as RootCMSClient;
+}
+
+async function seedDraftDocs(
+  db: Firestore,
+  projectId: string,
+  collectionId: string,
+  slugs: string[]
+) {
+  const draftsPath = `Projects/${projectId}/Collections/${collectionId}/Drafts`;
+  let batch = db.batch();
+  let count = 0;
+  for (const slug of slugs) {
+    batch.set(db.doc(`${draftsPath}/${slug}`), {
+      id: `${collectionId}/${slug}`,
+      collection: collectionId,
+      slug: slug,
+      sys: {
+        createdAt: Timestamp.now(),
+        createdBy: 'seed@example.com',
+        modifiedAt: Timestamp.now(),
+        modifiedBy: 'seed@example.com',
+      },
+      fields: {title: `title for ${slug}`},
+    });
+    count += 1;
+    if (count >= 400) {
+      await batch.commit();
+      batch = db.batch();
+      count = 0;
+    }
+  }
+  if (count > 0) {
+    await batch.commit();
+  }
+}
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
+  'release publishing (issue #457)',
+  () => {
+    let app: App;
+    let db: Firestore;
+
+    beforeAll(() => {
+      app = initializeApp({projectId: 'demo-issue-457'}, 'issue-457');
+      db = getFirestore(app);
+    });
+
+    afterAll(async () => {
+      await deleteApp(app);
+    });
+
+    it(
+      `publishDocs() publishes ${NUM_DOCS} docs at once`,
+      {timeout: 60000},
+      async () => {
+        const projectId = 'publish-docs-test';
+        const client = createTestClient(db, projectId);
+        const slugs = Array.from({length: NUM_DOCS}, (_, i) => `page-${i}`);
+        const docIds = slugs.map((slug) => `pages/${slug}`);
+        await seedDraftDocs(db, projectId, 'pages', slugs);
+
+        const publishedDocs = await client.publishDocs(docIds, {
+          publishedBy: 'publisher@example.com',
+        });
+        expect(publishedDocs).toHaveLength(NUM_DOCS);
+
+        // Verify all docs were copied to the "Published" collection.
+        const publishedSnapshot = await db
+          .collection(`Projects/${projectId}/Collections/pages/Published`)
+          .get();
+        expect(publishedSnapshot.size).toBe(NUM_DOCS);
+        const published = await db
+          .doc(`Projects/${projectId}/Collections/pages/Published/page-119`)
+          .get();
+        expect(published.exists).toBe(true);
+        expect(published.data()?.fields?.title).toBe('title for page-119');
+        expect(published.data()?.sys?.publishedBy).toBe(
+          'publisher@example.com'
+        );
+      }
+    );
+
+    it(
+      `publishScheduledReleases() publishes a release with ${NUM_DOCS} docs`,
+      {timeout: 60000},
+      async () => {
+        const projectId = 'scheduled-release-test';
+        const client = createTestClient(db, projectId);
+        const releaseId = 'big-release';
+        const slugs = Array.from({length: NUM_DOCS}, (_, i) => `page-${i}`);
+        const docIds = slugs.map((slug) => `pages/${slug}`);
+        await seedDraftDocs(db, projectId, 'pages', slugs);
+
+        // Schedule a release containing all of the docs.
+        const releaseRef = db.doc(
+          `Projects/${projectId}/Releases/${releaseId}`
+        );
+        await releaseRef.set({
+          id: releaseId,
+          docIds: docIds,
+          createdAt: Timestamp.now(),
+          createdBy: 'scheduler@example.com',
+          scheduledAt: Timestamp.fromMillis(Date.now() - 1000),
+          scheduledBy: 'scheduler@example.com',
+        });
+
+        await client.publishScheduledReleases();
+
+        // Verify all docs in the release were published.
+        const publishedSnapshot = await db
+          .collection(`Projects/${projectId}/Collections/pages/Published`)
+          .get();
+        expect(publishedSnapshot.size).toBe(NUM_DOCS);
+
+        // Verify the version snapshot is tagged with the release id.
+        const versionsSnapshot = await db
+          .collection(
+            `Projects/${projectId}/Collections/pages/Drafts/page-0/Versions`
+          )
+          .get();
+        expect(versionsSnapshot.size).toBe(1);
+        expect(versionsSnapshot.docs[0].data().tags).toContain(
+          `release:${releaseId}`
+        );
+
+        // Verify the release was marked as published.
+        const release = (await releaseRef.get()).data()!;
+        expect(release.publishedAt).toBeDefined();
+        expect(release.publishedBy).toBe('scheduler@example.com');
+        expect(release.scheduledAt).toBeUndefined();
+        expect(release.scheduledBy).toBeUndefined();
+      }
+    );
+  }
+);

--- a/packages/root-cms/ui/utils/batch.test.ts
+++ b/packages/root-cms/ui/utils/batch.test.ts
@@ -1,0 +1,133 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {MultiBatch} from './batch.js';
+
+const mockDb = {type: 'mock-db'};
+
+// Mock firebase/firestore. Each call to `writeBatch()` returns a new mock
+// batch that records its writes so tests can verify how writes are
+// distributed across the underlying batches.
+interface MockBatch {
+  set: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  commit: ReturnType<typeof vi.fn>;
+  numWrites: () => number;
+}
+
+const mockBatches: MockBatch[] = [];
+const commitOrder: number[] = [];
+
+vi.mock('firebase/firestore', () => ({
+  writeBatch: () => {
+    const index = mockBatches.length;
+    const batch: MockBatch = {
+      set: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn(async () => {
+        commitOrder.push(index);
+      }),
+      numWrites: () =>
+        batch.set.mock.calls.length +
+        batch.update.mock.calls.length +
+        batch.delete.mock.calls.length,
+    };
+    mockBatches.push(batch);
+    return batch;
+  },
+}));
+
+describe('MultiBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBatches.length = 0;
+    commitOrder.length = 0;
+  });
+
+  it('uses a single underlying batch for a small number of writes', async () => {
+    const batch = new MultiBatch(mockDb as any);
+    batch.update('ref-1' as any, {foo: 1});
+    batch.set('ref-2' as any, {bar: 2});
+    batch.delete('ref-3' as any);
+    await batch.commit();
+
+    expect(mockBatches).toHaveLength(1);
+    expect(mockBatches[0].update).toHaveBeenCalledWith('ref-1', {foo: 1});
+    expect(mockBatches[0].set).toHaveBeenCalledWith('ref-2', {bar: 2});
+    expect(mockBatches[0].delete).toHaveBeenCalledWith('ref-3');
+    expect(mockBatches[0].commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits writes across multiple batches when exceeding the limit', async () => {
+    const batch = new MultiBatch(mockDb as any, {maxWritesPerBatch: 10});
+    for (let i = 0; i < 25; i++) {
+      batch.set(`ref-${i}` as any, {i});
+    }
+    await batch.commit();
+
+    // 25 writes with a limit of 10 => batches of 10 + 10 + 5.
+    expect(mockBatches).toHaveLength(3);
+    expect(mockBatches[0].numWrites()).toBe(10);
+    expect(mockBatches[1].numWrites()).toBe(10);
+    expect(mockBatches[2].numWrites()).toBe(5);
+    mockBatches.forEach((b) => expect(b.commit).toHaveBeenCalledTimes(1));
+  });
+
+  it('commits underlying batches sequentially in insertion order', async () => {
+    const batch = new MultiBatch(mockDb as any, {maxWritesPerBatch: 2});
+    for (let i = 0; i < 6; i++) {
+      batch.set(`ref-${i}` as any, {i});
+    }
+    await batch.commit();
+
+    expect(commitOrder).toEqual([0, 1, 2]);
+  });
+
+  it('keeps grouped writes in the same batch with ensureCapacity()', async () => {
+    const batch = new MultiBatch(mockDb as any, {maxWritesPerBatch: 10});
+    // Add 3 groups of 4 writes each. Without ensureCapacity, the 3rd group
+    // would straddle batches (8 + 2 in the first batch, 2 in the second).
+    for (let group = 0; group < 3; group++) {
+      batch.ensureCapacity(4);
+      for (let i = 0; i < 4; i++) {
+        batch.set(`ref-${group}-${i}` as any, {group, i});
+      }
+    }
+    await batch.commit();
+
+    expect(mockBatches).toHaveLength(2);
+    // Groups 1-2 fit in the first batch, group 3 rolls to a new batch.
+    expect(mockBatches[0].numWrites()).toBe(8);
+    expect(mockBatches[1].numWrites()).toBe(4);
+  });
+
+  it('does not create an empty leading batch when ensureCapacity() is called first', async () => {
+    const batch = new MultiBatch(mockDb as any, {maxWritesPerBatch: 10});
+    batch.ensureCapacity(4);
+    batch.set('ref-1' as any, {foo: 1});
+    await batch.commit();
+
+    expect(mockBatches).toHaveLength(1);
+    expect(mockBatches[0].numWrites()).toBe(1);
+  });
+
+  it('commits nothing when no writes were added', async () => {
+    const batch = new MultiBatch(mockDb as any);
+    await batch.commit();
+    expect(mockBatches).toHaveLength(0);
+  });
+
+  it('stops committing subsequent batches when a commit fails', async () => {
+    const batch = new MultiBatch(mockDb as any, {maxWritesPerBatch: 2});
+    for (let i = 0; i < 6; i++) {
+      batch.set(`ref-${i}` as any, {i});
+    }
+    mockBatches[1].commit.mockRejectedValueOnce(new Error('commit failed'));
+
+    await expect(batch.commit()).rejects.toThrow('commit failed');
+    expect(mockBatches[0].commit).toHaveBeenCalledTimes(1);
+    expect(mockBatches[1].commit).toHaveBeenCalledTimes(1);
+    // The batch after the failed one is never committed.
+    expect(mockBatches[2].commit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/ui/utils/batch.ts
+++ b/packages/root-cms/ui/utils/batch.ts
@@ -1,0 +1,107 @@
+import {
+  DocumentData,
+  DocumentReference,
+  Firestore,
+  PartialWithFieldValue,
+  SetOptions,
+  UpdateData,
+  WriteBatch,
+  writeBatch,
+} from 'firebase/firestore';
+
+/**
+ * Firestore write batches support a maximum of 500 writes per batch. Use a
+ * conservative limit to leave headroom for callers that add a few extra
+ * writes of their own (e.g. releases add data source writes and a release
+ * status update).
+ */
+const MAX_WRITES_PER_BATCH = 400;
+
+/**
+ * A wrapper around firestore's `WriteBatch` that automatically splits writes
+ * across multiple underlying batches whenever the number of writes exceeds
+ * firestore's per-batch limit. This allows callers (e.g. release publishing)
+ * to batch an arbitrary number of writes without hitting the limit.
+ *
+ * Note that while each underlying batch is committed atomically, atomicity is
+ * NOT guaranteed across batches. Batches are committed sequentially in the
+ * order writes were added, so callers should add writes in an order where a
+ * partial failure leaves the system in a retryable state (e.g. add a "status"
+ * write last so it only commits after everything else succeeded).
+ */
+export class MultiBatch {
+  private readonly db: Firestore;
+  private readonly maxWritesPerBatch: number;
+  private batches: WriteBatch[] = [];
+  private currentBatchSize = 0;
+
+  constructor(db: Firestore, options?: {maxWritesPerBatch?: number}) {
+    this.db = db;
+    this.maxWritesPerBatch = options?.maxWritesPerBatch ?? MAX_WRITES_PER_BATCH;
+  }
+
+  /**
+   * Starts a new underlying batch if the current one doesn't have capacity
+   * for `numWrites` more writes. Call this before adding a group of related
+   * writes to guarantee the whole group is committed atomically within a
+   * single underlying batch.
+   */
+  ensureCapacity(numWrites: number): this {
+    if (
+      this.batches.length > 0 &&
+      this.currentBatchSize + numWrites > this.maxWritesPerBatch
+    ) {
+      this.batches.push(writeBatch(this.db));
+      this.currentBatchSize = 0;
+    }
+    return this;
+  }
+
+  set(
+    ref: DocumentReference,
+    data: PartialWithFieldValue<DocumentData>,
+    options?: SetOptions
+  ): this {
+    if (options) {
+      this.nextBatch().set(ref, data, options);
+    } else {
+      this.nextBatch().set(ref, data);
+    }
+    return this;
+  }
+
+  update(ref: DocumentReference, data: UpdateData<DocumentData>): this {
+    this.nextBatch().update(ref, data);
+    return this;
+  }
+
+  delete(ref: DocumentReference): this {
+    this.nextBatch().delete(ref);
+    return this;
+  }
+
+  /**
+   * Commits the underlying batches sequentially, in the order writes were
+   * added. If a batch fails to commit, subsequent batches are not committed.
+   */
+  async commit(): Promise<void> {
+    const batches = this.batches;
+    this.batches = [];
+    this.currentBatchSize = 0;
+    for (const batch of batches) {
+      await batch.commit();
+    }
+  }
+
+  private nextBatch(): WriteBatch {
+    if (
+      this.batches.length === 0 ||
+      this.currentBatchSize >= this.maxWritesPerBatch
+    ) {
+      this.batches.push(writeBatch(this.db));
+      this.currentBatchSize = 0;
+    }
+    this.currentBatchSize += 1;
+    return this.batches[this.batches.length - 1];
+  }
+}

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -1,6 +1,5 @@
 import {
   Timestamp,
-  WriteBatch,
   collection,
   deleteField,
   doc,
@@ -13,6 +12,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import {logAction} from './actions.js';
+import {MultiBatch} from './batch.js';
 import {GSpreadsheet, parseSpreadsheetUrl} from './gsheets.js';
 
 export type DataSourceType = 'http' | 'gsheet';
@@ -375,14 +375,14 @@ export async function unpublishDataSource(id: string) {
 
 export async function cmsPublishDataSources(
   ids: string[],
-  options?: {batch?: WriteBatch; commitBatch?: boolean}
+  options?: {batch?: MultiBatch; commitBatch?: boolean}
 ) {
   if (ids.length === 0) {
     return;
   }
   const db = window.firebase.db;
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
-  const batch = options?.batch || writeBatch(db);
+  const batch = options?.batch || new MultiBatch(db);
   for (const id of ids) {
     const dataSource = await getDataSource(id);
     if (!dataSource) {
@@ -392,6 +392,10 @@ export async function cmsPublishDataSources(
       throw new Error(`data source is archived: ${id}`);
     }
     const dataRes = await getFromDataSource(id, {mode: 'draft'});
+    // Each published data source adds 3 writes to the batch. Reserve capacity
+    // for all of them so the writes for a single data source are committed
+    // atomically.
+    batch.ensureCapacity(3);
     const dataSourceDocRef = doc(db, 'Projects', projectId, 'DataSources', id);
     const dataDocRefDraft = doc(
       db,

--- a/packages/root-cms/ui/utils/doc.test.ts
+++ b/packages/root-cms/ui/utils/doc.test.ts
@@ -3,7 +3,9 @@ import {
   cmsAssignSortKeys,
   cmsCopyDoc,
   cmsCreateDoc,
+  cmsPublishDocs,
   cmsSetDocSortKey,
+  getDraftDocs,
 } from './doc.js';
 
 const mocks = vi.hoisted(() => ({
@@ -11,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   collection: vi.fn(),
   deleteField: vi.fn(),
   doc: vi.fn(),
+  documentId: vi.fn(),
   getDoc: vi.fn(),
   getDocs: vi.fn(),
   limit: vi.fn(),
@@ -33,6 +36,7 @@ vi.mock('firebase/firestore', () => ({
   collection: mocks.collection,
   deleteField: mocks.deleteField,
   doc: mocks.doc,
+  documentId: mocks.documentId,
   getDoc: mocks.getDoc,
   getDocs: mocks.getDocs,
   limit: mocks.limit,
@@ -341,5 +345,163 @@ describe('cmsCreateDoc custom sorting', () => {
     expect(mocks.setDoc).toHaveBeenCalled();
     const savedData = mocks.setDoc.mock.calls[0][1];
     expect(savedData.sys.sortKey).toBeUndefined();
+  });
+});
+
+/**
+ * Fake db of draft docs, keyed by the "Drafts" collection path, then by slug,
+ * e.g. `fakeDrafts['Projects/test-project/Collections/pages/Drafts']['foo']`.
+ */
+let fakeDrafts: Record<string, Record<string, any>>;
+
+function addFakeDrafts(collectionId: string, slugs: string[]) {
+  const path = `Projects/test-project/Collections/${collectionId}/Drafts`;
+  const collectionDrafts = (fakeDrafts[path] ??= {});
+  slugs.forEach((slug) => {
+    collectionDrafts[slug] = {
+      id: `${collectionId}/${slug}`,
+      collection: collectionId,
+      slug: slug,
+      sys: {},
+      fields: {title: `title for ${slug}`},
+    };
+  });
+}
+
+function setupDraftQueryMocks() {
+  fakeDrafts = {};
+  mocks.collection.mockImplementation((_db: unknown, ...path: string[]) => ({
+    path: path.join('/'),
+  }));
+  // documentId() is just a sentinel field path. query()/where() pass the
+  // requested chunk straight through so the fake db (getDocs) can resolve it.
+  mocks.documentId.mockReturnValue('__name__');
+  mocks.where.mockImplementation((_field: any, _op: any, chunk: string[]) => ({
+    chunk,
+  }));
+  mocks.query.mockImplementation((colRef: any, whereClause: any) => ({
+    colRef,
+    chunk: whereClause.chunk,
+  }));
+  // Resolve a query by returning only the docs whose slug is in the chunk,
+  // mirroring firestore's `where(documentId(), 'in', chunk)` semantics.
+  mocks.getDocs.mockImplementation(
+    (q: {colRef: {path: string}; chunk: string[]}) => {
+      const collectionDrafts = fakeDrafts[q.colRef.path] || {};
+      const matched = q.chunk
+        .filter((slug) => collectionDrafts[slug] !== undefined)
+        .map((slug) => ({id: slug, data: () => collectionDrafts[slug]}));
+      return {
+        forEach: (cb: (doc: {id: string; data: () => any}) => void) =>
+          matched.forEach(cb),
+      };
+    }
+  );
+}
+
+describe('getDraftDocs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWindowMocks();
+    setupDraftQueryMocks();
+  });
+
+  it('fetches draft docs across collections', async () => {
+    addFakeDrafts('pages', ['foo', 'bar']);
+    addFakeDrafts('blog', ['baz']);
+
+    const drafts = await getDraftDocs(['pages/foo', 'pages/bar', 'blog/baz']);
+
+    expect(Object.keys(drafts).sort()).toEqual([
+      'blog/baz',
+      'pages/bar',
+      'pages/foo',
+    ]);
+    expect((drafts['pages/foo'] as any).fields).toEqual({
+      title: 'title for foo',
+    });
+    // One query per collection (both under the 30-slug chunk limit).
+    expect(mocks.getDocs).toHaveBeenCalledTimes(2);
+  });
+
+  it('chunks `in` queries into batches of 30 per collection', async () => {
+    const pageSlugs = Array.from({length: 65}, (_, i) => `page-${i}`);
+    const blogSlugs = Array.from({length: 5}, (_, i) => `post-${i}`);
+    addFakeDrafts('pages', pageSlugs);
+    addFakeDrafts('blog', blogSlugs);
+    const docIds = [
+      ...pageSlugs.map((slug) => `pages/${slug}`),
+      ...blogSlugs.map((slug) => `blog/${slug}`),
+    ];
+
+    const drafts = await getDraftDocs(docIds);
+
+    // 65 page slugs chunked by 30 => 3 queries (30 + 30 + 5), plus 1 query
+    // for the 5 blog slugs.
+    expect(mocks.getDocs).toHaveBeenCalledTimes(4);
+    mocks.getDocs.mock.calls.forEach(([q]) => {
+      expect(q.chunk.length).toBeLessThanOrEqual(30);
+    });
+    expect(Object.keys(drafts)).toHaveLength(70);
+  });
+});
+
+describe('cmsPublishDocs', () => {
+  let batches: Array<{
+    set: any;
+    update: any;
+    delete: any;
+    commit: any;
+    numWrites: () => number;
+  }>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWindowMocks();
+    setupDraftQueryMocks();
+    batches = [];
+    mocks.writeBatch.mockImplementation(() => {
+      const batch = {
+        set: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        commit: vi.fn().mockResolvedValue(undefined),
+        numWrites: () =>
+          batch.set.mock.calls.length +
+          batch.update.mock.calls.length +
+          batch.delete.mock.calls.length,
+      };
+      batches.push(batch);
+      return batch;
+    });
+  });
+
+  it('publishes more than 100 docs (issue #457)', async () => {
+    const slugs = Array.from({length: 120}, (_, i) => `page-${i}`);
+    addFakeDrafts('pages', slugs);
+    const docIds = slugs.map((slug) => `pages/${slug}`);
+
+    await cmsPublishDocs(docIds);
+
+    // Draft docs are fetched with `in` queries chunked at 30 slugs.
+    expect(mocks.getDocs).toHaveBeenCalledTimes(4);
+    // Each published doc adds 4 writes (draft sys update, published copy,
+    // scheduled delete, version snapshot), and writes are split across
+    // batches of at most 400 => 120 docs = 480 writes = 2 batches (400 + 80).
+    expect(batches.length).toBe(2);
+    expect(batches[0].numWrites()).toBe(400);
+    expect(batches[1].numWrites()).toBe(80);
+    batches.forEach((batch) => {
+      expect(batch.commit).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.removeDocsFromCache).toHaveBeenCalledWith(docIds);
+  });
+
+  it('throws if a doc does not exist', async () => {
+    addFakeDrafts('pages', ['exists']);
+
+    await expect(
+      cmsPublishDocs(['pages/exists', 'pages/missing'])
+    ).rejects.toThrow('doc does not exist: pages/missing');
   });
 });

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -16,7 +16,6 @@ import {
   documentId,
   where,
   Query,
-  WriteBatch,
   DocumentReference,
   limit,
   startAfter,
@@ -26,6 +25,7 @@ import {testValidRichTextData} from '../../shared/richtext.js';
 import {generateKeyAfter} from '../../shared/sort-key.js';
 import {logAction} from './actions.js';
 import {extractAssetIds} from './assets.js';
+import {MultiBatch} from './batch.js';
 import {removeDocFromCache, removeDocsFromCache} from './doc-cache.js';
 import {GoogleSheetId} from './gsheets.js';
 import {
@@ -142,10 +142,21 @@ export async function cmsPublishDoc(
 
 /**
  * Batch publishes a group of docs.
+ *
+ * There is no limit on the number of docs that can be published at once. The
+ * writes are automatically split across multiple batch requests to stay
+ * within firestore's per-batch write limits. When a shared `batch` is
+ * provided, the caller is responsible for committing it (unless
+ * `commitBatch: true` is passed).
  */
 export async function cmsPublishDocs(
   docIds: string[],
-  options?: {batch?: WriteBatch; releaseId?: string; publishMessage?: string}
+  options?: {
+    batch?: MultiBatch;
+    commitBatch?: boolean;
+    releaseId?: string;
+    publishMessage?: string;
+  }
 ) {
   if (docIds.length === 0) {
     console.log('no docs to publish');
@@ -154,14 +165,8 @@ export async function cmsPublishDocs(
 
   const db = window.firebase.db;
 
-  if (docIds.length > 100) {
-    throw new Error(
-      'publish docs exceeds limit of 100 docs. break up your request into multiple calls.'
-    );
-  }
-
   const draftDocs = await getDraftDocs(docIds);
-  const batch = options?.batch || writeBatch(db);
+  const batch = options?.batch || new MultiBatch(db);
   const versionTags = ['published'];
   if (options?.releaseId) {
     versionTags.push(`release:${options.releaseId}`);
@@ -179,7 +184,9 @@ export async function cmsPublishDocs(
       options?.publishMessage
     );
   });
-  await batch.commit();
+  if (!options?.batch || options?.commitBatch) {
+    await batch.commit();
+  }
 
   if (docIds.length === 1) {
     console.log(`published ${docIds[0]}`);
@@ -206,7 +213,7 @@ export async function cmsPublishDocs(
  * - Copies the "draft" data to "published" data
  */
 function updatePublishedDocDataInBatch(
-  batch: WriteBatch,
+  batch: MultiBatch,
   docId: string,
   draftData: CMSDoc,
   versionTags: string[],
@@ -219,6 +226,10 @@ function updatePublishedDocDataInBatch(
   if (testIsArchived(draftData)) {
     throw new Error(`cannot publish archived doc: ${draftData.id}`);
   }
+
+  // Each published doc adds 4 writes to the batch. Reserve capacity for all
+  // of them so the writes for a single doc are committed atomically.
+  batch.ensureCapacity(4);
 
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   const db = window.firebase.db;
@@ -900,9 +911,18 @@ export async function getDraftDocs(
       collectionSlugs[collectionId] = [slug];
     }
   });
+  // Firestore allows a maximum of 30 values per `in` query, so fetch the docs
+  // in parallel chunks of 30 slugs per collection.
+  const CHUNK_SIZE = 30;
+  const chunks: Array<{collectionId: string; slugs: string[]}> = [];
+  Object.entries(collectionSlugs).forEach(([collectionId, slugs]) => {
+    for (let i = 0; i < slugs.length; i += CHUNK_SIZE) {
+      chunks.push({collectionId, slugs: slugs.slice(i, i + CHUNK_SIZE)});
+    }
+  });
   const drafts: Record<string, CMSDoc> = {};
   await Promise.all(
-    Object.entries(collectionSlugs).map(async ([collectionId, slugs]) => {
+    chunks.map(async ({collectionId, slugs}) => {
       const dbCollection = collection(
         db,
         'Projects',

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -11,10 +11,10 @@ import {
   runTransaction,
   serverTimestamp,
   updateDoc,
-  writeBatch,
 } from 'firebase/firestore';
 import {renderAutoSlug} from '../../shared/auto-slug.js';
 import {logAction} from './actions.js';
+import {MultiBatch} from './batch.js';
 import {cmsPublishDataSources} from './data-source.js';
 import {cmsPublishDocs} from './doc.js';
 
@@ -138,16 +138,12 @@ export async function publishRelease(id: string) {
   const db = window.firebase.db;
   const docRef = doc(db, 'Projects', projectId, COLLECTION_ID, id);
 
-  // Create a batch request and publish docs and update the release in an
-  // atomic write to firestore.
-  const batch = writeBatch(db);
-  // Update the release's publishedAt.
-  batch.update(docRef, {
-    publishedAt: serverTimestamp(),
-    publishedBy: window.firebase.user.email,
-    scheduledAt: deleteField(),
-    scheduledBy: deleteField(),
-  });
+  // Create a batch request that publishes the release's docs and data sources
+  // and updates the release. `MultiBatch` automatically splits the writes
+  // across multiple batch requests as needed to stay within firestore's
+  // per-batch write limits, so there is no limit on the number of docs in a
+  // release.
+  const batch = new MultiBatch(db);
   if (dataSourceIds.length > 0) {
     await cmsPublishDataSources(dataSourceIds, {batch, commitBatch: false});
   }
@@ -156,6 +152,16 @@ export async function publishRelease(id: string) {
     releaseId: id,
     publishMessage: release.description,
   });
+  // Update the release's publishedAt. This write is intentionally added last
+  // so that if any of the previous batches fails to commit, the release is
+  // not marked as published and publishing can be retried.
+  batch.update(docRef, {
+    publishedAt: serverTimestamp(),
+    publishedBy: window.firebase.user.email,
+    scheduledAt: deleteField(),
+    scheduledBy: deleteField(),
+  });
+  await batch.commit();
   console.log(`published release: ${id}`);
   const metadata: Record<string, unknown> = {
     releaseId: id,


### PR DESCRIPTION
## Summary
Fixes issue #457 by removing the artificial limit on the number of documents that can be published in a release. Previously, releases were limited to ~30 docs (due to Firestore's `in` query limit) or 100 docs (due to write batch reuse). This change introduces a `MultiBatch` utility that automatically splits writes across multiple Firestore batches while maintaining sequential commit ordering.

## Key Changes

- **New `MultiBatch` class** (`packages/root-cms/ui/utils/batch.ts`): A wrapper around Firestore's `WriteBatch` that automatically splits writes across multiple underlying batches when exceeding the 400-write limit per batch (conservative limit below Firestore's 500-write max). Batches are committed sequentially to maintain a retryable state on partial failures.

- **Updated `cmsPublishDocs()`** (`packages/root-cms/ui/utils/doc.ts`):
  - Removed the 100-doc limit check
  - Changed to use `MultiBatch` instead of raw `WriteBatch`
  - Added `ensureCapacity(4)` calls to keep writes for a single doc atomic within a batch
  - Updated `getDraftDocs()` to chunk `in` queries at 30 docs per Firestore's limit

- **Updated `publishRelease()`** (`packages/root-cms/ui/utils/release.ts`):
  - Changed to use `MultiBatch` for coordinating doc and data source publishing
  - Moved release status update to the end of the batch to ensure it only commits after all doc/data source writes succeed

- **Updated `cmsPublishDataSources()`** (`packages/root-cms/ui/utils/data-source.ts`):
  - Changed to accept `MultiBatch` instead of `WriteBatch`

- **Updated `RootCMSClient.publishDocs()` and related methods** (`packages/root-cms/core/client.ts`):
  - Fixed batch reuse after commit by creating a new batch after each commit
  - Removed unnecessary `continue` statement

- **Integration tests** (`packages/root-cms/core/release-publish.integration.test.ts`):
  - Added comprehensive tests verifying 120 docs can be published at once
  - Tests both direct `publishDocs()` and scheduled release publishing flows

- **Unit tests** (`packages/root-cms/ui/utils/batch.test.ts`, `packages/root-cms/ui/utils/doc.test.ts`):
  - Added full test coverage for `MultiBatch` including capacity management and sequential commits
  - Added tests for `getDraftDocs()` chunking and `cmsPublishDocs()` with 120+ docs

## Implementation Details

- `MultiBatch` uses a conservative 400-write limit per batch (vs Firestore's 500 max) to leave headroom for callers that add extra writes
- Batches are committed sequentially in insertion order, ensuring partial failures leave the system in a retryable state
- `ensureCapacity()` method allows grouping related writes to guarantee they're committed atomically within a single batch
- Draft doc fetching is chunked at 30 docs per `in` query to respect Firestore's query limit

https://claude.ai/code/session_016TXu3sikP7q9k6Li147nKj