### PR TITLE
feat: undo/redo field edits in the doc editor

### DIFF
--- a/.changeset/undo-redo-field-edits.md
+++ b/.changeset/undo-redo-field-edits.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: undo/redo field edits in the doc editor

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -31,6 +31,20 @@
   margin-right: 16px;
 }
 
+.DocEditor__statusBar__undoRedo {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 16px;
+}
+
+.DocEditor__undoNotification {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .DocEditor__statusBar__buttonGroup {
   display: flex;
 }

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -34,8 +34,15 @@
 .DocEditor__undoRedo {
   display: flex;
   align-items: center;
-  gap: 2px;
   margin-right: 4px;
+}
+
+.DocEditor__undoRedo__button {
+  border: none;
+}
+
+.DocEditor__undoRedo__button:disabled {
+  background: transparent;
 }
 
 .DocEditor__undoNotification {
@@ -56,13 +63,17 @@
   margin-left: -1px;
 }
 
-.DocEditor__statusBar__buttonGroup > *:first-child .DocEditor__statusBar__buttonGroup__button {
+.DocEditor__statusBar__buttonGroup
+  > *:first-child
+  .DocEditor__statusBar__buttonGroup__button {
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
   margin-left: 0;
 }
 
-.DocEditor__statusBar__buttonGroup > *:last-child .DocEditor__statusBar__buttonGroup__button {
+.DocEditor__statusBar__buttonGroup
+  > *:last-child
+  .DocEditor__statusBar__buttonGroup__button {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }
@@ -113,13 +124,14 @@
 }
 
 .DocEditor__FieldHeader__label__deeplink {
-  color: #CED4DA;
+  color: #ced4da;
   text-decoration: none;
   opacity: 0;
   transition: opacity 0.3s ease;
 }
 
-.DocEditor__FieldHeader__label:focus-within .DocEditor__FieldHeader__label__deeplink,
+.DocEditor__FieldHeader__label:focus-within
+  .DocEditor__FieldHeader__label__deeplink,
 .DocEditor__FieldHeader__label:hover .DocEditor__FieldHeader__label__deeplink {
   opacity: 1;
 }
@@ -162,7 +174,8 @@
   margin-bottom: 8px;
 }
 
-.DocEditor__field[data-type="object"][data-level="0"] > .DocEditor__FieldHeader {
+.DocEditor__field[data-type='object'][data-level='0']
+  > .DocEditor__FieldHeader {
   padding: 4px 12px;
   margin-top: 12px;
   margin-left: -12px;
@@ -171,12 +184,15 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-.DocEditor__field[data-type="object"]:not([data-level="0"]) .DocEditor__ObjectField__fields {
+.DocEditor__field[data-type='object']:not([data-level='0'])
+  .DocEditor__ObjectField__fields {
   padding-left: 12px;
   border-left: 2px solid lightblue;
 }
 
-.DocEditor__ObjectFieldDrawer .mantine-Accordion-label > .DocEditor__FieldHeader {
+.DocEditor__ObjectFieldDrawer
+  .mantine-Accordion-label
+  > .DocEditor__FieldHeader {
   margin-bottom: 0;
 }
 
@@ -198,7 +214,7 @@
 }
 
 .DocEditor__ObjectFieldDrawer__drawer__toggle:hover {
-  background: #F8F9FA;
+  background: #f8f9fa;
 }
 
 .DocEditor__ObjectFieldDrawer__drawer__toggle__header {
@@ -215,7 +231,9 @@
   transition: transform 0.3s ease;
 }
 
-.DocEditor__ObjectFieldDrawer__drawer[open] > summary > .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
+.DocEditor__ObjectFieldDrawer__drawer[open]
+  > summary
+  > .DocEditor__ObjectFieldDrawer__drawer__toggle__icon {
   transform: rotate(90deg);
 }
 
@@ -237,13 +255,15 @@
   text-wrap: pretty;
 }
 
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__toggle {
+.DocEditor__ObjectFieldDrawer--inline
+  .DocEditor__ObjectFieldDrawer__drawer__toggle {
   justify-content: flex-start;
   border-top: none;
   border-bottom: none;
 }
 
-.DocEditor__ObjectFieldDrawer--inline .DocEditor__ObjectFieldDrawer__drawer__content {
+.DocEditor__ObjectFieldDrawer--inline
+  .DocEditor__ObjectFieldDrawer__drawer__content {
   padding-left: 48px;
 }
 
@@ -254,10 +274,14 @@
   width: 100%;
   align-items: center;
   margin-bottom: 8px;
-  transition: box-shadow 0.36s ease, background-color 0.36s ease, border 0.36s ease;
+  transition:
+    box-shadow 0.36s ease,
+    background-color 0.36s ease,
+    border 0.36s ease;
 }
 
-.DocEditor__ArrayField__item__wrapper:has(> .DocEditor__ArrayField__item[open]) > .DocEditor__ArrayField__item__handle {
+.DocEditor__ArrayField__item__wrapper:has(> .DocEditor__ArrayField__item[open])
+  > .DocEditor__ArrayField__item__handle {
   /** Suppress the drag handle when the item is open. */
   visibility: hidden;
 }
@@ -273,10 +297,14 @@
   border: 1px solid #dedede;
   border-radius: 2px;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 0 10px 15px -5px, rgba(0, 0, 0, 0.04) 0 7px 7px -5px;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 0 10px 15px -5px,
+    rgba(0, 0, 0, 0.04) 0 7px 7px -5px;
 }
 
-.DocEditor__ArrayField__item__wrapper--dragging .DocEditor__ArrayField__item__header {
+.DocEditor__ArrayField__item__wrapper--dragging
+  .DocEditor__ArrayField__item__header {
   outline: none !important;
 }
 
@@ -316,25 +344,43 @@
   --array-field-header-offset: 60px;
 }
 
-.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField {
+.DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField {
   --array-field-header-offset: 90px;
 }
 
-.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+.DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField__item__header {
   top: calc(var(--top-bar-height) + var(--array-field-header-offset));
   z-index: 8;
 }
 
-.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+.DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField__item__header {
   z-index: 7;
 }
 
-.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+.DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField__item__header {
   z-index: 6;
 }
 
 /** Nested array fields more than three levels deep don't get the sticky behavior. */
-.DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField .DocEditor__ArrayField  .DocEditor__ArrayField  .DocEditor__ArrayField .DocEditor__ArrayField__item__header {
+.DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField
+  .DocEditor__ArrayField__item__header {
   border-bottom: unset;
   position: static;
 }
@@ -344,7 +390,9 @@
   border-radius: 0;
 }
 
-.DocEditor__ArrayField__item[open] > .DocEditor__ArrayField__item__header + .DocEditor__ArrayField__item__body {
+.DocEditor__ArrayField__item[open]
+  > .DocEditor__ArrayField__item__header
+  + .DocEditor__ArrayField__item__body {
   border-top: 0;
 }
 
@@ -354,7 +402,9 @@
   transform: rotate(90deg);
 }
 
-.DocEditor__ArrayField__item[open] > summary > .DocEditor__ArrayField__item__header__icon {
+.DocEditor__ArrayField__item[open]
+  > summary
+  > .DocEditor__ArrayField__item__header__icon {
   transform: rotate(180deg);
   margin-top: -2px;
 }
@@ -430,19 +480,19 @@
   font-family: var(--font-family-mono);
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"],
-.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"] {
+.DocEditor__ArrayField__item__header__controls__menu [role='menuitem'],
+.DocEditor__ObjectFieldDrawer__drawer__menu [role='menuitem'] {
   padding: 8px 12px;
   font-size: 14px;
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:hover,
-.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"]:hover {
+.DocEditor__ArrayField__item__header__controls__menu [role='menuitem']:hover,
+.DocEditor__ObjectFieldDrawer__drawer__menu [role='menuitem']:hover {
   background-color: var(--button-background-hover);
 }
 
-.DocEditor__ArrayField__item__header__controls__menu [role="menuitem"]:active,
-.DocEditor__ObjectFieldDrawer__drawer__menu [role="menuitem"]:active {
+.DocEditor__ArrayField__item__header__controls__menu [role='menuitem']:active,
+.DocEditor__ObjectFieldDrawer__drawer__menu [role='menuitem']:active {
   background-color: var(--button-background-active);
 }
 
@@ -470,11 +520,11 @@
   outline: none;
 }
 
-.DocEditor__ArrayField__item[open] .DocEditor__ArrayField__item__header:focus  {
+.DocEditor__ArrayField__item[open] .DocEditor__ArrayField__item__header:focus {
   padding-left: 10px;
 }
 
-.DocEditor__ArrayField__item__header:focus  {
+.DocEditor__ArrayField__item__header:focus {
   background-color: #f8f9fa;
   border-radius: 2px;
 }

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.css
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.css
@@ -31,11 +31,11 @@
   margin-right: 16px;
 }
 
-.DocEditor__statusBar__undoRedo {
+.DocEditor__undoRedo {
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin-right: 16px;
+  gap: 2px;
+  margin-right: 4px;
 }
 
 .DocEditor__undoNotification {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -44,7 +44,7 @@ import {
   IconTrash,
   IconTriangleFilled,
 } from '@tabler/icons-preact';
-import {createContext} from 'preact';
+import {createContext, RefObject} from 'preact';
 import {
   useContext,
   useEffect,
@@ -211,6 +211,7 @@ export function DocEditor(props: DocEditorProps) {
   const draft = useDraftDoc();
   const loading = collection.loading || draft.loading;
   const fields = collection.schema?.fields || [];
+  const rootRef = useRef<HTMLDivElement>(null);
 
   if (draft.error) {
     return (
@@ -225,11 +226,15 @@ export function DocEditor(props: DocEditorProps) {
       value={collection?.schema?.types || {}}
     >
       <DeeplinkProvider>
-        <div className={joinClassNames(props.className, 'DocEditor')}>
+        <div
+          className={joinClassNames(props.className, 'DocEditor')}
+          ref={rootRef}
+        >
           <LoadingOverlay
             visible={loading}
             loaderProps={{color: 'gray', size: 'xl'}}
           />
+          <DocEditor.HistoryDeeplink rootRef={rootRef} />
           {!loading && !props.hideStatusBar && (
             <DocEditor.StatusBar
               {...props}
@@ -406,7 +411,6 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
         <Viewers id={`doc/${props.docId}`} />
       </div>
       <DocEditor.SaveState />
-      {canEdit && <DocEditor.UndoRedoButtons />}
       {data?.sys && (
         <div className="DocEditor__statusBar__statusBadges">
           <DocStatusBadges
@@ -585,6 +589,11 @@ DocEditor.SaveState = () => {
   );
 };
 
+/**
+ * Undo/redo buttons for the doc editor, including the document-level
+ * keyboard shortcuts (⌘Z / ⌘⇧Z). Rendered in the DocumentPage side header
+ * next to the save button.
+ */
 DocEditor.UndoRedoButtons = () => {
   const history = useDraftDocHistory();
 
@@ -633,43 +642,89 @@ DocEditor.UndoRedoButtons = () => {
     : 'Redo (⌘ ⇧ Z)';
 
   return (
-    <div className="DocEditor__statusBar__undoRedo">
-      <Tooltip
-        label={undoLabel}
-        transition="pop"
-        withArrow
-        disabled={!history.canUndo}
-      >
+    <div className="DocEditor__undoRedo">
+      <Tooltip label={undoLabel} disabled={!history.canUndo}>
         <ActionIcon
-          className="DocEditor__statusBar__undoRedo__button"
-          variant="default"
-          size="sm"
+          className="DocEditor__undoRedo__button"
           disabled={!history.canUndo}
           onClick={() => history.undo()}
           aria-label="Undo"
         >
-          <IconArrowBackUp size={16} strokeWidth={1.75} />
+          <IconArrowBackUp size={16} />
         </ActionIcon>
       </Tooltip>
-      <Tooltip
-        label={redoLabel}
-        transition="pop"
-        withArrow
-        disabled={!history.canRedo}
-      >
+      <Tooltip label={redoLabel} disabled={!history.canRedo}>
         <ActionIcon
-          className="DocEditor__statusBar__undoRedo__button"
-          variant="default"
-          size="sm"
+          className="DocEditor__undoRedo__button"
           disabled={!history.canRedo}
           onClick={() => history.redo()}
           aria-label="Redo"
         >
-          <IconArrowForwardUp size={16} strokeWidth={1.75} />
+          <IconArrowForwardUp size={16} />
         </ActionIcon>
       </Tooltip>
     </div>
   );
+};
+
+/**
+ * Finds the closest rendered field element for an applied history deepkey.
+ * Applied keys often target values without their own field div (array order
+ * keys like `<deepKey>._array`, array item keys), so walk up the key path
+ * until a rendered `.DocEditor__field` is found. The search is scoped to the
+ * editor root so nested editors (e.g. the reference editor modal) never
+ * match each other's fields.
+ */
+function resolveHistoryFieldElement(
+  root: HTMLElement,
+  deepKey: string
+): HTMLElement | null {
+  let key = deepKey;
+  while (key && key !== 'fields') {
+    const el = root.querySelector<HTMLElement>(`[id="${key}"]`);
+    if (el && el.classList.contains('DocEditor__field')) {
+      return el;
+    }
+    const index = key.lastIndexOf('.');
+    if (index === -1) {
+      return null;
+    }
+    key = key.slice(0, index);
+  }
+  return null;
+}
+
+/**
+ * Headless component that gives the user a visual indicator of what an
+ * undo/redo changed by deeplinking to the affected field: the existing
+ * deeplink functionality highlights the field and scrolls it into view
+ * (opening collapsed drawers along the way).
+ */
+DocEditor.HistoryDeeplink = (props: {rootRef: RefObject<HTMLDivElement>}) => {
+  const deeplink = useDeeplink();
+  const deeplinkRef = useRef(deeplink);
+  deeplinkRef.current = deeplink;
+
+  useDraftDocHistoryApplied((keys: string[]) => {
+    // Wait a beat for the re-render triggered by the restore, so fields
+    // recreated by the undo (e.g. a restored array item) are in the DOM.
+    window.setTimeout(() => {
+      const root = props.rootRef.current;
+      if (!root) {
+        return;
+      }
+      for (const key of keys) {
+        const el = resolveHistoryFieldElement(root, key);
+        if (el) {
+          deeplinkRef.current.setValue(el.id);
+          scrollToDeeplink(el, {behavior: 'smooth', force: true});
+          return;
+        }
+      }
+    }, 50);
+  });
+
+  return null;
 };
 
 DocEditor.Field = (props: FieldProps) => {

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -16,8 +16,10 @@ import {
   Tooltip,
 } from '@mantine/core';
 import {useModals} from '@mantine/modals';
-import {showNotification} from '@mantine/notifications';
+import {hideNotification, showNotification} from '@mantine/notifications';
 import {
+  IconArrowBackUp,
+  IconArrowForwardUp,
   IconBraces,
   IconChevronDown,
   IconChevronRight,
@@ -67,6 +69,8 @@ import {
   SaveState,
   useDraftDoc,
   useDraftDocField,
+  useDraftDocHistory,
+  useDraftDocHistoryApplied,
   useDraftDocSaveState,
 } from '../../hooks/useDraftDoc.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
@@ -86,6 +90,11 @@ import {
 import {extractField} from '../../utils/extract.js';
 import {getDefaultFieldValue, normalizePresetData} from '../../utils/fields.js';
 import {requestHighlightNode} from '../../utils/iframe-preview.js';
+import {
+  isEditableTarget,
+  isRedoKeyEvent,
+  isUndoKeyEvent,
+} from '../../utils/keyboard.js';
 import {deepMerge} from '../../utils/objects.js';
 import {testCanEdit, testCanPublish} from '../../utils/permissions.js';
 import {autokey} from '../../utils/rand.js';
@@ -134,6 +143,54 @@ interface DocEditorProps {
   className?: string;
   docId: string;
   hideStatusBar?: boolean;
+}
+
+/**
+ * Shows a transient notification with an "Undo" button after a destructive
+ * one-click action (e.g. removing an array item, clearing a section). The
+ * undo is scoped to the history entry that was just created, so it no-ops
+ * (with an explanation) if newer edits have landed in the meantime.
+ */
+function showUndoNotification(draft: DraftDocController, message: string) {
+  const entry = draft.history.peekUndo();
+  if (!entry) {
+    showNotification({message, autoClose: 2000});
+    return;
+  }
+  const notificationId = `undo-${entry.id}`;
+  showNotification({
+    id: notificationId,
+    message: (
+      <div className="DocEditor__undoNotification">
+        <Text size="body-sm">{message}</Text>
+        <Button
+          variant="default"
+          size="xs"
+          compact
+          onClick={() => {
+            hideNotification(notificationId);
+            const result = draft.undo({onlyEntryId: entry.id});
+            if (result.status === 'empty') {
+              showNotification({
+                message: 'Newer edits were made. Use ⌘Z to undo step by step.',
+                autoClose: 4000,
+              });
+            } else if (result.status === 'conflict') {
+              showNotification({
+                title: 'Undo discarded',
+                message: 'This field was changed by another editor.',
+                color: 'yellow',
+                autoClose: 5000,
+              });
+            }
+          }}
+        >
+          Undo
+        </Button>
+      </div>
+    ),
+    autoClose: 4000,
+  });
 }
 
 const COLLECTION_SCHEMA_TYPES_CONTEXT = createContext<
@@ -349,6 +406,7 @@ DocEditor.StatusBar = (props: StatusBarProps) => {
         <Viewers id={`doc/${props.docId}`} />
       </div>
       <DocEditor.SaveState />
+      {canEdit && <DocEditor.UndoRedoButtons />}
       {data?.sys && (
         <div className="DocEditor__statusBar__statusBadges">
           <DocStatusBadges
@@ -523,6 +581,93 @@ DocEditor.SaveState = () => {
       {saveState === SaveState.SAVING && 'saving...'}
       {saveState === SaveState.UPDATES_PENDING && 'saving...'}
       {saveState === SaveState.ERROR && 'error saving'}
+    </div>
+  );
+};
+
+DocEditor.UndoRedoButtons = () => {
+  const history = useDraftDocHistory();
+
+  // The handler closes over the latest history state via a ref so the
+  // document-level listener only binds once.
+  const historyRef = useRef(history);
+  historyRef.current = history;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Text inputs and contenteditable (Lexical) keep their own undo/redo;
+      // the doc-level shortcut only fires outside of them.
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+      // Ignore events from open modals (e.g. the reference editor modal,
+      // which nests its own doc editor) so the main doc isn't undone while
+      // a modal has focus.
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest('[role="dialog"]')
+      ) {
+        return;
+      }
+      if (isUndoKeyEvent(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        historyRef.current.undo();
+      } else if (isRedoKeyEvent(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        historyRef.current.redo();
+      }
+    };
+    document.documentElement.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.documentElement.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const undoLabel = history.undoLabel
+    ? `Undo: ${history.undoLabel} (⌘ Z)`
+    : 'Undo (⌘ Z)';
+  const redoLabel = history.redoLabel
+    ? `Redo: ${history.redoLabel} (⌘ ⇧ Z)`
+    : 'Redo (⌘ ⇧ Z)';
+
+  return (
+    <div className="DocEditor__statusBar__undoRedo">
+      <Tooltip
+        label={undoLabel}
+        transition="pop"
+        withArrow
+        disabled={!history.canUndo}
+      >
+        <ActionIcon
+          className="DocEditor__statusBar__undoRedo__button"
+          variant="default"
+          size="sm"
+          disabled={!history.canUndo}
+          onClick={() => history.undo()}
+          aria-label="Undo"
+        >
+          <IconArrowBackUp size={16} strokeWidth={1.75} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip
+        label={redoLabel}
+        transition="pop"
+        withArrow
+        disabled={!history.canRedo}
+      >
+        <ActionIcon
+          className="DocEditor__statusBar__undoRedo__button"
+          variant="default"
+          size="sm"
+          disabled={!history.canRedo}
+          onClick={() => history.redo()}
+          aria-label="Redo"
+        >
+          <IconArrowForwardUp size={16} strokeWidth={1.75} />
+        </ActionIcon>
+      </Tooltip>
     </div>
   );
 };
@@ -869,13 +1014,13 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
   };
 
   const clearValue = async (modalId?: string) => {
-    await draft.removeKey(props.deepKey);
-    showNotification({
-      message: 'Cleared',
-      autoClose: 2000,
+    draft.history.group('Cleared section', () => {
+      draft.removeKey(props.deepKey);
     });
+    showUndoNotification(draft, 'Section cleared');
     // Clear is destructive, so persist immediately instead of waiting for
-    // autosave.
+    // autosave. Undoing afterwards re-queues the restored values through the
+    // normal save flow.
     await draft.flush();
     if (modalId) {
       modals.closeModal(modalId);
@@ -893,7 +1038,7 @@ DocEditor.ObjectFieldDrawer = (props: FieldProps) => {
           weight="semi-bold"
           className="DocEditor__ObjectFieldDrawer__confirmText"
         >
-          This will clear all values in this section. There is no undo.
+          This will clear all values in this section. You can undo this with ⌘Z.
         </Text>
       ),
       labels: {confirm: 'Clear', cancel: 'Cancel'},
@@ -1277,10 +1422,13 @@ function arrayReducer(state: ArrayFieldValue, action: ArrayAction) {
       }
       delete data[oldKey];
       newOrder.splice(action.index, 1);
+      // A single updateKeys() call so the removal (order + item data) is
+      // captured as one undoable history entry. `undefined` values map to
+      // deleteField() in the db and delete the key from the local store.
       action.draft.updateKeys({
         [`${action.deepKey}._array`]: newOrder,
+        [`${action.deepKey}.${oldKey}`]: undefined,
       });
-      action.draft.removeKey(`${action.deepKey}.${oldKey}`);
       return {
         ...data,
         _array: newOrder,
@@ -1367,6 +1515,17 @@ DocEditor.ArrayField = (props: FieldProps) => {
     dispatch({type: 'update', newValue});
   });
 
+  // Undo/redo restores write child keys (e.g. `<deepKey>._array`) directly,
+  // which does not notify this component's plain subscription on the parent
+  // key, so re-pull the array value whenever a history entry touches this
+  // field's subtree.
+  useDraftDocHistoryApplied((keys: string[]) => {
+    const prefix = `${props.deepKey}.`;
+    if (keys.some((key) => key === props.deepKey || key.startsWith(prefix))) {
+      dispatch({type: 'update', newValue: draft.getValue(props.deepKey)});
+    }
+  });
+
   // Focus the field that was just moved or pasted.
   useEffect(() => {
     if (value._moved) {
@@ -1451,12 +1610,22 @@ DocEditor.ArrayField = (props: FieldProps) => {
   };
 
   const removeAt = (index: number) => {
-    dispatch({
-      type: 'removeAt',
-      draft: draft,
-      deepKey: props.deepKey,
-      index: index,
+    // The label appears in the undo tooltip. When called from a cut+paste
+    // move, the nested group joins the outer "Moved item" group instead.
+    draft.history.group('Removed item', () => {
+      dispatch({
+        type: 'removeAt',
+        draft: draft,
+        deepKey: props.deepKey,
+        index: index,
+      });
     });
+  };
+
+  /** Removes an item and offers a transient "Undo" action. */
+  const removeItem = (index: number) => {
+    removeAt(index);
+    showUndoNotification(draft, 'Item removed');
   };
 
   /** Focus the field header (the clickable "summary" part). */
@@ -1518,15 +1687,18 @@ DocEditor.ArrayField = (props: FieldProps) => {
       return;
     }
 
-    pasteAfter(index, data);
-    if (cutIndex !== null) {
-      let indexToRemove = cutIndex;
-      if (index < cutIndex) {
-        indexToRemove += 1;
+    // Group so that a cut+paste (move) undoes as a single step.
+    draft.history.group('Moved item', () => {
+      pasteAfter(index, data);
+      if (cutIndex !== null) {
+        let indexToRemove = cutIndex;
+        if (index < cutIndex) {
+          indexToRemove += 1;
+        }
+        removeAt(indexToRemove);
+        setCutIndex(null);
       }
-      removeAt(indexToRemove);
-      setCutIndex(null);
-    }
+    });
     showNotification({
       message: 'Pasted item',
       autoClose: 2000,
@@ -1596,11 +1768,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
         pasteFromVirtualClipboard(index);
       } else if (e.metaKey && (e.key === 'Backspace' || e.key === 'Delete')) {
         e.preventDefault();
-        removeAt(index);
-        showNotification({
-          message: 'Deleted item',
-          autoClose: 2000,
-        });
+        removeItem(index);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         moveUp(index);
@@ -1709,7 +1877,7 @@ DocEditor.ArrayField = (props: FieldProps) => {
                     onPasteAfter={pasteAfterFromVirtualClipboard}
                     onEditJson={editJson}
                     onAiEdit={aiEdit}
-                    onRemove={removeAt}
+                    onRemove={removeItem}
                   />
                 );
               })}

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../hooks/useGlobalSearch.js';
 import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {DataSource, listDataSources} from '../../utils/data-source.js';
+import {isEditableTarget} from '../../utils/keyboard.js';
 import {
   RecentView,
   recentViewFromUrl,
@@ -237,25 +238,6 @@ function buildTipsRow(): SpotlightAction {
     onTrigger: () => {},
     meta,
   };
-}
-
-/**
- * Returns true when the event originates from a field where the user is
- * actively typing, e.g. a text input or a `contenteditable` rich text editor
- * (Lexical). Cmd+K should not open the global search in those contexts —
- * Lexical, for instance, binds Cmd+K to "insert link".
- */
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  const tag = target.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
-    return true;
-  }
-  // True for the contenteditable host and any element nested inside one
-  // (e.g. Lexical rich text fields).
-  return target.isContentEditable;
 }
 
 function GlobalSearchInner(props: {

--- a/packages/root-cms/ui/hooks/useDraftDoc.history.test.ts
+++ b/packages/root-cms/ui/hooks/useDraftDoc.history.test.ts
@@ -1,0 +1,258 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {updateDocMock, onSnapshotMock} = vi.hoisted(() => ({
+  updateDocMock: vi.fn(async () => {}),
+  onSnapshotMock: vi.fn(() => () => {}),
+}));
+
+vi.mock('firebase/firestore', () => {
+  /** Stand-in for the Firestore FieldValue sentinel base class. */
+  class FieldValue {
+    constructor(readonly _methodName: string) {}
+  }
+  class Timestamp {}
+  const noop = vi.fn();
+  return {
+    FieldValue,
+    Timestamp,
+    doc: vi.fn(() => ({path: 'Projects/test/Collections/pages/Drafts/index'})),
+    onSnapshot: onSnapshotMock,
+    updateDoc: updateDocMock,
+    serverTimestamp: () => new FieldValue('serverTimestamp'),
+    deleteField: () => new FieldValue('deleteField'),
+    arrayUnion: () => new FieldValue('arrayUnion'),
+    collection: noop,
+    getDoc: noop,
+    getDocs: noop,
+    setDoc: noop,
+    deleteDoc: noop,
+    runTransaction: noop,
+    writeBatch: noop,
+    documentId: noop,
+    query: noop,
+    where: noop,
+    orderBy: noop,
+    limit: noop,
+    startAfter: noop,
+    Query: class {},
+    WriteBatch: class {},
+    DocumentReference: class {},
+    QueryDocumentSnapshot: class {},
+    Firestore: class {},
+  };
+});
+
+vi.mock('@mantine/notifications', () => ({
+  showNotification: vi.fn(),
+}));
+
+import {DraftDocController, DraftDocEventType} from './useDraftDoc.js';
+
+describe('DraftDocController undo/redo history', () => {
+  beforeEach(() => {
+    updateDocMock.mockClear();
+    onSnapshotMock.mockClear();
+    (window as any).__ROOT_CTX = {
+      rootConfig: {projectId: 'test-project'},
+      collections: {},
+    };
+    (window as any).firebase = {
+      db: {},
+      user: {email: 'test@example.com'},
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({status: 200, text: async () => ''}))
+    );
+  });
+
+  it('captures field edits and restores the before-value on undo', async () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKey('fields.title', 'v1');
+    // Coalescing merges rapid same-key edits, so this still forms one entry
+    // with the original before-value (undefined).
+    controller.updateKey('fields.title', 'v2');
+    expect(controller.history.canUndo()).toBe(true);
+
+    const result = controller.undo();
+    expect(result.status).toEqual('applied');
+    expect(controller.getValue('fields.title')).toBeUndefined();
+    expect(controller.history.canUndo()).toBe(false);
+    expect(controller.history.canRedo()).toBe(true);
+
+    const redone = controller.redo();
+    expect(redone.status).toEqual('applied');
+    expect(controller.getValue('fields.title')).toEqual('v2');
+  });
+
+  it('does not capture sys.* writes', () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKey('sys.locales', ['en', 'fr']);
+    controller.updateKeys({'sys.publishingLocked': {reason: 'test'}});
+    expect(controller.history.canUndo()).toBe(false);
+  });
+
+  it('does not capture or apply history in readOnly mode', () => {
+    const controller = new DraftDocController('pages/index');
+    controller.readOnly = true;
+    controller.updateKey('fields.title', 'v1');
+    expect(controller.history.canUndo()).toBe(false);
+    expect(controller.undo().status).toEqual('empty');
+  });
+
+  it('flushes undo restores through the normal save path with deleteField sentinels', async () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKeys({
+      'fields.blocks._array': ['a'],
+      'fields.blocks.a': {title: 'Block A'},
+    });
+    await controller.flush();
+    updateDocMock.mockClear();
+
+    const result = controller.undo();
+    expect(result.status).toEqual('applied');
+    await controller.flush();
+
+    expect(updateDocMock).toHaveBeenCalledTimes(1);
+    const payload = updateDocMock.mock.calls[0][1] as Record<string, any>;
+    // Undoing the "add" removes both keys in Firestore.
+    expect(payload['fields.blocks._array']._methodName).toEqual('deleteField');
+    expect(payload['fields.blocks.a']._methodName).toEqual('deleteField');
+    // And the local store no longer contains the keys.
+    const blocks = controller.getValue('fields.blocks');
+    expect('a' in blocks).toBe(false);
+    expect('_array' in blocks).toBe(false);
+  });
+
+  it('round-trips an atomic array removal (order + item) as one entry', () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKeys({
+      'fields.blocks._array': ['a', 'b'],
+      'fields.blocks.a': {title: 'Block A'},
+      'fields.blocks.b': {title: 'Block B'},
+    });
+
+    // Atomic removal of item "a" (mirrors the arrayReducer removeAt shape).
+    controller.updateKeys({
+      'fields.blocks._array': ['b'],
+      'fields.blocks.a': undefined,
+    });
+    expect(controller.getValue('fields.blocks.a')).toBeUndefined();
+
+    const result = controller.undo();
+    expect(result.status).toEqual('applied');
+    expect(controller.getValue('fields.blocks._array')).toEqual(['a', 'b']);
+    expect(controller.getValue('fields.blocks.a')).toEqual({title: 'Block A'});
+
+    const redone = controller.redo();
+    expect(redone.status).toEqual('applied');
+    expect(controller.getValue('fields.blocks._array')).toEqual(['b']);
+    expect(controller.getValue('fields.blocks.a')).toBeUndefined();
+  });
+
+  it('dispatches HISTORY_APPLIED with the written keys', () => {
+    const controller = new DraftDocController('pages/index');
+    const applied: string[][] = [];
+    controller.on(DraftDocEventType.HISTORY_APPLIED, (keys: string[]) => {
+      applied.push(keys);
+    });
+    controller.updateKeys({
+      'fields.blocks._array': ['a'],
+      'fields.blocks.a': {title: 'A'},
+    });
+    controller.undo();
+    expect(applied.length).toEqual(1);
+    expect(applied[0].sort()).toEqual([
+      'fields.blocks._array',
+      'fields.blocks.a',
+    ]);
+  });
+
+  it('prunes stale entries when a remote snapshot changes captured fields', async () => {
+    const controller = new DraftDocController('pages/index');
+    await controller.start();
+    const snapshotCallback = onSnapshotMock.mock.calls[0][1] as (
+      snapshot: any
+    ) => void;
+
+    controller.updateKey('fields.title', 'local');
+    await controller.flush();
+    expect(controller.history.canUndo()).toBe(true);
+
+    // Another editor overwrites the field after our write committed.
+    snapshotCallback({
+      metadata: {hasPendingWrites: false},
+      data: () => ({fields: {title: 'remote'}}),
+    });
+    expect(controller.getValue('fields.title')).toEqual('remote');
+    expect(controller.history.canUndo()).toBe(false);
+  });
+
+  it('keeps entries when a snapshot merges with unflushed local edits', async () => {
+    const controller = new DraftDocController('pages/index');
+    await controller.start();
+    const snapshotCallback = onSnapshotMock.mock.calls[0][1] as (
+      snapshot: any
+    ) => void;
+
+    // Local edit is still pending (not flushed).
+    controller.updateKey('fields.title', 'local');
+    expect(controller.history.canUndo()).toBe(true);
+
+    // A snapshot arrives with the server's older value; the pending local
+    // update is re-applied on top, so the entry remains valid.
+    snapshotCallback({
+      metadata: {hasPendingWrites: false},
+      data: () => ({fields: {title: 'server'}}),
+    });
+    expect(controller.getValue('fields.title')).toEqual('local');
+    expect(controller.history.canUndo()).toBe(true);
+  });
+
+  it('undo with onlyEntryId is a no-op unless that entry is on top', () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKey('fields.a', 1);
+    const entryId = controller.history.peekUndo()!.id;
+
+    // A newer edit to a different key pushes a new entry on top.
+    controller.updateKey('fields.b', 2);
+    const result = controller.undo({onlyEntryId: entryId});
+    expect(result.status).toEqual('empty');
+    expect(controller.getValue('fields.a')).toEqual(1);
+    expect(controller.getValue('fields.b')).toEqual(2);
+
+    // With the matching top entry, the scoped undo applies.
+    const undoB = controller.undo({
+      onlyEntryId: controller.history.peekUndo()!.id,
+    });
+    expect(undoB.status).toEqual('applied');
+    expect(controller.getValue('fields.b')).toBeUndefined();
+  });
+
+  it('captures group() compound operations as a single entry', () => {
+    const controller = new DraftDocController('pages/index');
+    controller.updateKeys({
+      'fields.blocks._array': ['a', 'b'],
+      'fields.blocks.a': {title: 'A'},
+      'fields.blocks.b': {title: 'B'},
+    });
+
+    // Simulates a cut+paste (move) of item "a" to a new key.
+    controller.history.group('Move item', () => {
+      controller.updateKeys({
+        'fields.blocks._array': ['b', 'a2'],
+        'fields.blocks.a2': {title: 'A'},
+        'fields.blocks.a': undefined,
+      });
+    });
+
+    const result = controller.undo();
+    expect(result.status).toEqual('applied');
+    expect(result.status === 'applied' && result.entry.label).toEqual(
+      'Move item'
+    );
+    expect(controller.getValue('fields.blocks._array')).toEqual(['a', 'b']);
+    expect(controller.getValue('fields.blocks.a')).toEqual({title: 'A'});
+    expect(controller.getValue('fields.blocks.a2')).toBeUndefined();
+  });
+});

--- a/packages/root-cms/ui/hooks/useDraftDoc.tsx
+++ b/packages/root-cms/ui/hooks/useDraftDoc.tsx
@@ -17,6 +17,11 @@ import {containsAssetId, extractAssetIds} from '../utils/assets.js';
 import {debounce} from '../utils/debounce.js';
 import {setDocToCache} from '../utils/doc-cache.js';
 import {CMSDoc} from '../utils/doc.js';
+import {
+  EditHistory,
+  EditHistoryApplyResult,
+  EditHistoryChange,
+} from '../utils/edit-history.js';
 import {EventListener} from '../utils/events.js';
 import {
   JsonTrieStore,
@@ -44,6 +49,13 @@ export enum DraftDocEventType {
   FLUSH = 'FLUSH',
   /** The db snapshot listener failed, e.g. permission denied. */
   ERROR = 'ERROR',
+  /** The undo/redo history stacks changed. */
+  HISTORY_CHANGE = 'HISTORY_CHANGE',
+  /**
+   * An undo/redo was applied to the draft. Payload is the list of deepkeys
+   * that were written.
+   */
+  HISTORY_APPLIED = 'HISTORY_APPLIED',
 }
 
 /**
@@ -57,11 +69,15 @@ export class DraftDocController extends EventListener {
   readonly docId: string;
   readonly collectionId: string;
   readonly slug: string;
+  /** In-session undo/redo history of field edits. */
+  readonly history = new EditHistory();
   private db: Firestore;
   private docRef: DocumentReference;
   private store: JsonTrieStore;
 
   private pendingUpdates = new Map<string, any>();
+  /** Set while an undo/redo is being applied, to suppress history capture. */
+  private isApplyingHistory = false;
   private dbUnsubscribe?: () => void;
   private saveState = SaveState.NO_CHANGES;
   private autolock = false;
@@ -113,6 +129,9 @@ export class DraftDocController extends EventListener {
         this.dispatch(DraftDocEventType.VALUE_CHANGE, key, value);
       }
     );
+    this.history.onChange(() => {
+      this.dispatch(DraftDocEventType.HISTORY_CHANGE);
+    });
     const collection = window.__ROOT_CTX.collections[collectionId];
     if (collection) {
       this.autolock = !!collection.autolock;
@@ -145,6 +164,12 @@ export class DraftDocController extends EventListener {
           applyUpdates(data, Object.fromEntries(this.pendingUpdates));
         }
         this.store.setData(data);
+        // Remote replacements (another editor's write, version restore,
+        // revert draft, AI edits) invalidate history entries whose expected
+        // values no longer match. Our own committed writes are skipped above
+        // via `hasPendingWrites`, and merged local pending updates keep their
+        // entries valid, so this only drops genuinely stale entries.
+        this.history.handleRemoteData((key) => this.store.get(key));
         // Backfill `sys.assets` on the next flush if a legacy doc loaded without
         // the reverse index. Only checked on initial load to avoid retriggering
         // on every remote sync.
@@ -243,6 +268,7 @@ export class DraftDocController extends EventListener {
     if (this.readOnly) {
       return;
     }
+    this.captureHistory({[key]: value});
     if (value === undefined) {
       // Firestore doesn't support `undefined`, so use deleteField() instead.
       this.setPendingUpdate(key, deleteField());
@@ -263,6 +289,7 @@ export class DraftDocController extends EventListener {
     if (this.readOnly) {
       return;
     }
+    this.captureHistory(updates);
     for (const key in updates) {
       const val = updates[key];
       if (val === null || val === undefined) {
@@ -288,12 +315,91 @@ export class DraftDocController extends EventListener {
     if (this.readOnly) {
       return;
     }
+    this.captureHistory({[key]: undefined});
     this.setPendingUpdate(key, deleteField());
     this.store.set(key, undefined);
     this.setSaveState(SaveState.UPDATES_PENDING);
     if (this.autoSave) {
       this.queueChanges();
     }
+  }
+
+  /**
+   * Records the before/after transition of a pending write in the undo
+   * history. Only content keys (`fields` and below) are captured; `sys.*`
+   * bookkeeping writes are not undoable. Suppressed while an undo/redo is
+   * itself being applied.
+   */
+  private captureHistory(updates: Record<string, any>) {
+    if (this.isApplyingHistory) {
+      return;
+    }
+    const changes: Record<string, EditHistoryChange> = {};
+    // Read all before-values prior to any store mutation so multi-key
+    // updates with overlapping ancestor/descendant keys capture consistent
+    // transitions.
+    for (const key in updates) {
+      if (key === 'fields' || key.startsWith('fields.')) {
+        changes[key] = {before: this.store.get(key), after: updates[key]};
+      }
+    }
+    if (Object.keys(changes).length > 0) {
+      this.history.capture(changes);
+    }
+  }
+
+  /**
+   * Reverts the most recent field edit. The restore goes through
+   * `updateKeys()`, so autosave, save states, and `sys.assets` bookkeeping
+   * treat it exactly like a hand edit.
+   *
+   * When `onlyEntryId` is set, the undo is a no-op unless that entry is
+   * still on top of the stack (used by transient "Undo" toasts so they can
+   * never revert a newer edit).
+   */
+  undo(options?: {onlyEntryId?: string}): EditHistoryApplyResult {
+    return this.applyHistory('undo', options);
+  }
+
+  /** Re-applies the most recently undone field edit. */
+  redo(): EditHistoryApplyResult {
+    return this.applyHistory('redo');
+  }
+
+  private applyHistory(
+    direction: 'undo' | 'redo',
+    options?: {onlyEntryId?: string}
+  ): EditHistoryApplyResult {
+    if (this.readOnly) {
+      return {status: 'empty'};
+    }
+    if (options?.onlyEntryId) {
+      const top =
+        direction === 'undo'
+          ? this.history.peekUndo()
+          : this.history.peekRedo();
+      if (!top || top.id !== options.onlyEntryId) {
+        return {status: 'empty'};
+      }
+    }
+    const getValue = (key: string) => this.store.get(key);
+    const result =
+      direction === 'undo'
+        ? this.history.undo(getValue)
+        : this.history.redo(getValue);
+    if (result.status === 'applied') {
+      this.isApplyingHistory = true;
+      try {
+        this.updateKeys(result.updates);
+      } finally {
+        this.isApplyingHistory = false;
+      }
+      this.dispatch(
+        DraftDocEventType.HISTORY_APPLIED,
+        Object.keys(result.updates)
+      );
+    }
+    return result;
   }
 
   /**
@@ -482,6 +588,7 @@ export class DraftDocController extends EventListener {
    */
   async dispose() {
     super.dispose();
+    this.history.dispose();
     this.stop();
   }
 }
@@ -755,6 +862,78 @@ export function useDraftDocField<T>(deepKey: string, cb: (data: T) => void) {
   const {controller} = useDraftDoc();
   useEffect(() => {
     return controller.subscribe(deepKey, cb);
+  }, [controller]);
+}
+
+export interface DraftDocHistoryState {
+  canUndo: boolean;
+  canRedo: boolean;
+  /** Optional label of the entry that would be undone, e.g. "Removed item". */
+  undoLabel?: string;
+  redoLabel?: string;
+  undo: () => void;
+  redo: () => void;
+}
+
+/**
+ * Hook for the doc editor's undo/redo controls. Subscribes to history stack
+ * changes and surfaces a toast when an undo/redo is discarded because the
+ * targeted field was changed elsewhere (e.g. by another editor).
+ */
+export function useDraftDocHistory(): DraftDocHistoryState {
+  const {controller} = useDraftDoc();
+
+  const readState = () => ({
+    canUndo: controller.history.canUndo(),
+    canRedo: controller.history.canRedo(),
+    undoLabel: controller.history.peekUndo()?.label,
+    redoLabel: controller.history.peekRedo()?.label,
+  });
+  const [state, setState] = useState(readState);
+
+  useEffect(() => {
+    setState(readState());
+    return controller.on(DraftDocEventType.HISTORY_CHANGE, () => {
+      setState(readState());
+    });
+  }, [controller]);
+
+  const notifyConflict = (label: string) => {
+    showNotification({
+      title: `${label} discarded`,
+      message: 'This field was changed by another editor.',
+      color: 'yellow',
+      autoClose: 5000,
+    });
+  };
+
+  const undo = () => {
+    const result = controller.undo();
+    if (result.status === 'conflict') {
+      notifyConflict('Undo');
+    }
+  };
+
+  const redo = () => {
+    const result = controller.redo();
+    if (result.status === 'conflict') {
+      notifyConflict('Redo');
+    }
+  };
+
+  return {...state, undo, redo};
+}
+
+/**
+ * Hook that fires a callback whenever an undo/redo write is applied to the
+ * draft. The callback receives the list of deepkeys that were written. Used
+ * by components that mirror draft state locally (e.g. array fields) and are
+ * not subscribed to the exact keys an undo may touch.
+ */
+export function useDraftDocHistoryApplied(cb: (keys: string[]) => void) {
+  const {controller} = useDraftDoc();
+  useEffect(() => {
+    return controller.on(DraftDocEventType.HISTORY_APPLIED, cb);
   }, [controller]);
 }
 

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -348,6 +348,7 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
                 <div className="DocumentPage__side__header__docId">{docId}</div>
               </div>
               <div className="DocumentPage__side__header__buttons">
+                {canEdit && <DocEditor.UndoRedoButtons />}
                 <ConditionalTooltip
                   label="You don't have access to edit this document"
                   condition={!canEdit}

--- a/packages/root-cms/ui/utils/edit-history.test.ts
+++ b/packages/root-cms/ui/utils/edit-history.test.ts
@@ -1,0 +1,556 @@
+import {describe, expect, it} from 'vitest';
+import {
+  EditHistory,
+  bumpRichTextTimes,
+  clonePreservingNonPlain,
+} from './edit-history.js';
+
+/**
+ * Minimal stand-in for the draft doc store: a flat map of deepkey -> value
+ * that mirrors applied updates, the way DraftDocController.updateKeys()
+ * would.
+ */
+function createStore(initial?: Record<string, any>) {
+  const values = new Map<string, any>(Object.entries(initial || {}));
+  return {
+    get: (key: string) => values.get(key),
+    set: (key: string, value: any) => {
+      if (value === undefined) {
+        values.delete(key);
+      } else {
+        values.set(key, value);
+      }
+    },
+    applyUpdates: (updates: Record<string, any>) => {
+      for (const key of Object.keys(updates)) {
+        if (updates[key] === undefined) {
+          values.delete(key);
+        } else {
+          values.set(key, updates[key]);
+        }
+      }
+    },
+  };
+}
+
+function createHistory(options?: {maxEntries?: number}) {
+  let time = 1000;
+  const history = new EditHistory({
+    maxEntries: options?.maxEntries,
+    coalesceWindowMs: 1000,
+    now: () => time,
+  });
+  return {
+    history,
+    tick: (ms: number) => {
+      time += ms;
+    },
+    getTime: () => time,
+  };
+}
+
+describe('EditHistory', () => {
+  it('round-trips a single field edit through undo and redo', () => {
+    const {history} = createHistory();
+    const store = createStore({'fields.title': 'v1'});
+
+    store.set('fields.title', 'v2');
+    history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+    expect(history.canUndo()).toBe(true);
+    expect(history.canRedo()).toBe(false);
+
+    const undone = history.undo(store.get);
+    expect(undone.status).toEqual('applied');
+    if (undone.status === 'applied') {
+      expect(undone.updates).toEqual({'fields.title': 'v1'});
+      store.applyUpdates(undone.updates);
+    }
+    expect(history.canUndo()).toBe(false);
+    expect(history.canRedo()).toBe(true);
+
+    const redone = history.redo(store.get);
+    expect(redone.status).toEqual('applied');
+    if (redone.status === 'applied') {
+      expect(redone.updates).toEqual({'fields.title': 'v2'});
+      store.applyUpdates(redone.updates);
+    }
+    expect(store.get('fields.title')).toEqual('v2');
+    expect(history.canUndo()).toBe(true);
+    expect(history.canRedo()).toBe(false);
+  });
+
+  it('undoing an added key restores it to undefined (removed)', () => {
+    const {history} = createHistory();
+    const store = createStore();
+
+    store.set('fields.image', {src: 'a.png'});
+    history.capture({
+      'fields.image': {before: undefined, after: {src: 'a.png'}},
+    });
+
+    const undone = history.undo(store.get);
+    expect(undone.status).toEqual('applied');
+    if (undone.status === 'applied') {
+      expect('fields.image' in undone.updates).toBe(true);
+      expect(undone.updates['fields.image']).toBeUndefined();
+      store.applyUpdates(undone.updates);
+    }
+    expect(store.get('fields.image')).toBeUndefined();
+  });
+
+  it('clears the redo stack when a new capture arrives', () => {
+    const {history, tick} = createHistory();
+    const store = createStore({'fields.title': 'v1'});
+
+    store.set('fields.title', 'v2');
+    history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+    const undone = history.undo(store.get);
+    if (undone.status === 'applied') {
+      store.applyUpdates(undone.updates);
+    }
+    expect(history.canRedo()).toBe(true);
+
+    tick(5000);
+    store.set('fields.desc', 'hello');
+    history.capture({'fields.desc': {before: undefined, after: 'hello'}});
+    expect(history.canRedo()).toBe(false);
+  });
+
+  it('skips captures where before and after are deep-equal', () => {
+    const {history} = createHistory();
+    history.capture({
+      'fields.obj': {before: {a: 1, b: [2]}, after: {a: 1, b: [2]}},
+    });
+    expect(history.canUndo()).toBe(false);
+  });
+
+  describe('coalescing', () => {
+    it('merges rapid same-key captures into one entry', () => {
+      const {history, tick} = createHistory();
+      const store = createStore({'fields.title': 'abc'});
+
+      history.capture({'fields.title': {before: '', after: 'a'}});
+      tick(100);
+      history.capture({'fields.title': {before: 'a', after: 'ab'}});
+      tick(100);
+      history.capture({'fields.title': {before: 'ab', after: 'abc'}});
+
+      const undone = history.undo(store.get);
+      expect(undone.status).toEqual('applied');
+      if (undone.status === 'applied') {
+        expect(undone.updates).toEqual({'fields.title': ''});
+      }
+      expect(history.canUndo()).toBe(false);
+    });
+
+    it('does not merge captures for different keys', () => {
+      const {history, tick} = createHistory();
+      history.capture({'fields.title': {before: '', after: 'a'}});
+      tick(100);
+      history.capture({'fields.desc': {before: '', after: 'b'}});
+
+      const store = createStore({'fields.title': 'a', 'fields.desc': 'b'});
+      const first = history.undo(store.get);
+      expect(first.status).toEqual('applied');
+      if (first.status === 'applied') {
+        expect(first.updates).toEqual({'fields.desc': ''});
+        store.applyUpdates(first.updates);
+      }
+      expect(history.canUndo()).toBe(true);
+    });
+
+    it('does not merge captures outside the coalesce window', () => {
+      const {history, tick} = createHistory();
+      history.capture({'fields.title': {before: '', after: 'a'}});
+      tick(2000);
+      history.capture({'fields.title': {before: 'a', after: 'ab'}});
+
+      const store = createStore({'fields.title': 'ab'});
+      const first = history.undo(store.get);
+      if (first.status === 'applied') {
+        expect(first.updates).toEqual({'fields.title': 'a'});
+        store.applyUpdates(first.updates);
+      }
+      expect(history.canUndo()).toBe(true);
+    });
+
+    it('never merges multi-key captures', () => {
+      const {history, tick} = createHistory();
+      history.capture({'fields.a': {before: 1, after: 2}});
+      tick(100);
+      history.capture({
+        'fields.a': {before: 2, after: 3},
+        'fields.b': {before: 1, after: 2},
+      });
+      const store = createStore({'fields.a': 3, 'fields.b': 2});
+      const first = history.undo(store.get);
+      if (first.status === 'applied') {
+        expect(first.updates).toEqual({'fields.a': 2, 'fields.b': 1});
+        store.applyUpdates(first.updates);
+      }
+      expect(history.canUndo()).toBe(true);
+    });
+
+    it('drops the entry when coalescing cancels out to a no-op', () => {
+      const {history, tick} = createHistory();
+      history.capture({'fields.title': {before: 'a', after: 'ab'}});
+      tick(100);
+      history.capture({'fields.title': {before: 'ab', after: 'a'}});
+      expect(history.canUndo()).toBe(false);
+    });
+
+    it('never merges into a group() entry', () => {
+      const {history, tick} = createHistory();
+      history.group('Move item', () => {
+        history.capture({'fields.a': {before: 1, after: 2}});
+      });
+      tick(100);
+      history.capture({'fields.a': {before: 2, after: 3}});
+
+      const store = createStore({'fields.a': 3});
+      const first = history.undo(store.get);
+      if (first.status === 'applied') {
+        expect(first.updates).toEqual({'fields.a': 2});
+        store.applyUpdates(first.updates);
+      }
+      expect(history.canUndo()).toBe(true);
+    });
+  });
+
+  describe('group()', () => {
+    it('merges all captures during the callback into one entry', () => {
+      const {history} = createHistory();
+      const store = createStore({
+        'fields.blocks._array': ['b'],
+        'fields.blocks.b': {title: 'B'},
+      });
+
+      history.group('Move item', () => {
+        history.capture({
+          'fields.blocks._array': {before: ['a', 'b'], after: ['b']},
+          'fields.blocks.a': {before: {title: 'A'}, after: undefined},
+        });
+        history.capture({
+          'fields.blocks._array': {before: ['b'], after: ['b', 'a2']},
+          'fields.blocks.a2': {before: undefined, after: {title: 'A'}},
+        });
+      });
+
+      store.applyUpdates({
+        'fields.blocks._array': ['b', 'a2'],
+        'fields.blocks.a2': {title: 'A'},
+      });
+      const undone = history.undo(store.get);
+      expect(undone.status).toEqual('applied');
+      if (undone.status === 'applied') {
+        // The group undoes to the pre-group state in one step, including the
+        // first-seen `before` for the twice-captured `_array` key.
+        expect(undone.updates['fields.blocks._array']).toEqual(['a', 'b']);
+        expect(undone.updates['fields.blocks.a']).toEqual({title: 'A'});
+        expect(undone.updates['fields.blocks.a2']).toBeUndefined();
+        expect(undone.entry.label).toEqual('Move item');
+      }
+      expect(history.canUndo()).toBe(false);
+    });
+
+    it('does not push an entry when the group cancels out', () => {
+      const {history} = createHistory();
+      history.group('noop', () => {
+        history.capture({'fields.a': {before: 1, after: 2}});
+        history.capture({'fields.a': {before: 2, after: 1}});
+      });
+      expect(history.canUndo()).toBe(false);
+    });
+
+    it('joins nested groups into the outermost group', () => {
+      const {history} = createHistory();
+      history.group('outer', () => {
+        history.capture({'fields.a': {before: 1, after: 2}});
+        history.group('inner', () => {
+          history.capture({'fields.b': {before: 1, after: 2}});
+        });
+      });
+      const store = createStore({'fields.a': 2, 'fields.b': 2});
+      const undone = history.undo(store.get);
+      expect(undone.status).toEqual('applied');
+      if (undone.status === 'applied') {
+        expect(undone.updates).toEqual({'fields.a': 1, 'fields.b': 1});
+        expect(undone.entry.label).toEqual('outer');
+      }
+      expect(history.canUndo()).toBe(false);
+    });
+  });
+
+  it('caps the number of entries, dropping the oldest', () => {
+    const {history, tick} = createHistory({maxEntries: 3});
+    const store = createStore();
+    for (let i = 1; i <= 5; i++) {
+      store.set('fields.n', i);
+      history.capture({'fields.n': {before: i - 1, after: i}});
+      tick(5000);
+    }
+    // Only the newest 3 entries survive: 5->4, 4->3, 3->2.
+    for (const expected of [4, 3, 2]) {
+      const result = history.undo(store.get);
+      expect(result.status).toEqual('applied');
+      if (result.status === 'applied') {
+        store.applyUpdates(result.updates);
+        expect(store.get('fields.n')).toEqual(expected);
+      }
+    }
+    expect(history.canUndo()).toBe(false);
+  });
+
+  describe('conflict handling', () => {
+    it('drops the entry and applies nothing when the current value no longer matches', () => {
+      const {history} = createHistory();
+      const store = createStore({'fields.title': 'v1'});
+
+      store.set('fields.title', 'v2');
+      history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+
+      // A remote edit lands on the same key (without a local capture).
+      store.set('fields.title', 'remote');
+
+      const result = history.undo(store.get);
+      expect(result.status).toEqual('conflict');
+      expect(store.get('fields.title')).toEqual('remote');
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
+    });
+
+    it('conflicts on redo when a newer value landed after the undo', () => {
+      const {history} = createHistory();
+      const store = createStore({'fields.title': 'v1'});
+
+      store.set('fields.title', 'v2');
+      history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+      const undone = history.undo(store.get);
+      if (undone.status === 'applied') {
+        store.applyUpdates(undone.updates);
+      }
+
+      store.set('fields.title', 'remote');
+      const result = history.redo(store.get);
+      expect(result.status).toEqual('conflict');
+      expect(store.get('fields.title')).toEqual('remote');
+      expect(history.canRedo()).toBe(false);
+    });
+  });
+
+  describe('handleRemoteData()', () => {
+    it('drains conflicting entries from the top of the undo stack', () => {
+      const {history, tick} = createHistory();
+      const store = createStore();
+      store.set('fields.a', 1);
+      history.capture({'fields.a': {before: undefined, after: 1}});
+      tick(5000);
+      store.set('fields.b', 2);
+      history.capture({'fields.b': {before: undefined, after: 2}});
+      tick(5000);
+
+      // Remote replacement wipes both fields.
+      store.applyUpdates({'fields.a': undefined, 'fields.b': undefined});
+      history.handleRemoteData(store.get);
+      expect(history.canUndo()).toBe(false);
+    });
+
+    it('stops draining at the first non-conflicting entry', () => {
+      const {history, tick} = createHistory();
+      const store = createStore();
+      store.set('fields.a', 1);
+      history.capture({'fields.a': {before: undefined, after: 1}});
+      tick(5000);
+      store.set('fields.b', 2);
+      history.capture({'fields.b': {before: undefined, after: 2}});
+      tick(5000);
+
+      // Remote edit only touches the newest entry's key.
+      store.set('fields.b', 99);
+      history.handleRemoteData(store.get);
+      expect(history.canUndo()).toBe(true);
+
+      const result = history.undo(store.get);
+      expect(result.status).toEqual('applied');
+      if (result.status === 'applied') {
+        expect(result.updates).toEqual({'fields.a': undefined});
+      }
+    });
+
+    it('keeps entries when our own committed write echoes back unchanged', () => {
+      const {history} = createHistory();
+      const store = createStore({'fields.title': 'v1'});
+      store.set('fields.title', 'v2');
+      history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+
+      // Same data arrives via a snapshot (values unchanged).
+      history.handleRemoteData(store.get);
+      expect(history.canUndo()).toBe(true);
+    });
+
+    it('drains conflicting redo entries against their before values', () => {
+      const {history} = createHistory();
+      const store = createStore({'fields.title': 'v1'});
+      store.set('fields.title', 'v2');
+      history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+      const undone = history.undo(store.get);
+      if (undone.status === 'applied') {
+        store.applyUpdates(undone.updates);
+      }
+      expect(history.canRedo()).toBe(true);
+
+      store.set('fields.title', 'remote');
+      history.handleRemoteData(store.get);
+      expect(history.canRedo()).toBe(false);
+    });
+  });
+
+  describe('cloning and aliasing', () => {
+    it('isolates captured values from later in-place mutations', () => {
+      const {history, tick} = createHistory();
+      const item = {title: 'original'};
+      const store = createStore();
+      store.set('fields.item', item);
+      history.capture({'fields.item': {before: undefined, after: item}});
+      tick(5000);
+
+      // The store mutates the same object in place (as JsonTrieStore does)
+      // and a separate capture records the child edit.
+      item.title = 'edited';
+      history.capture({
+        'fields.item.title': {before: 'original', after: 'edited'},
+      });
+      tick(5000);
+
+      // Undo the child edit first.
+      const first = history.undo((key) => {
+        if (key === 'fields.item.title') {
+          return item.title;
+        }
+        return store.get(key);
+      });
+      expect(first.status).toEqual('applied');
+      if (first.status === 'applied') {
+        item.title = first.updates['fields.item.title'];
+      }
+
+      // The add-entry's captured `after` must still hold the ORIGINAL item
+      // (title: 'original'), not the mutated one, so validation passes.
+      const second = history.undo(store.get);
+      expect(second.status).toEqual('applied');
+    });
+
+    it('returns cloned updates so store mutations cannot corrupt redo', () => {
+      const {history} = createHistory();
+      const store = createStore({'fields.obj': {n: 1}});
+      store.set('fields.obj', {n: 2});
+      history.capture({'fields.obj': {before: {n: 1}, after: {n: 2}}});
+
+      const undone = history.undo(store.get);
+      expect(undone.status).toEqual('applied');
+      if (undone.status !== 'applied') {
+        return;
+      }
+      store.applyUpdates(undone.updates);
+      // Simulate an in-place store mutation of the applied object.
+      store.get('fields.obj').n = 99;
+
+      // Redo must detect the conflict (current {n:99} != before {n:1})
+      // instead of silently re-applying over the newer edit.
+      const redone = history.redo(store.get);
+      expect(redone.status).toEqual('conflict');
+    });
+
+    it('passes non-plain objects through by reference when cloning', () => {
+      class FakeTimestamp {
+        constructor(readonly seconds: number) {}
+      }
+      const ts = new FakeTimestamp(123);
+      const cloned = clonePreservingNonPlain({a: {b: ts}, c: [ts]});
+      expect(cloned.a.b).toBe(ts);
+      expect(cloned.c[0]).toBe(ts);
+      expect(cloned.a).not.toBe(undefined);
+    });
+  });
+
+  describe('rich text time bump', () => {
+    const richText = () => ({
+      time: 500,
+      version: '1.0.0',
+      blocks: [{type: 'paragraph', data: {text: 'hello'}}],
+    });
+
+    it('stamps restored rich text values with a fresh time', () => {
+      const {history, getTime} = createHistory();
+      const before = richText();
+      const after = {...richText(), time: 600, blocks: []};
+      const store = createStore({'fields.body': after});
+      history.capture({'fields.body': {before, after}});
+
+      const undone = history.undo(store.get);
+      expect(undone.status).toEqual('applied');
+      if (undone.status === 'applied') {
+        expect(undone.updates['fields.body'].time).toEqual(getTime());
+        expect(undone.updates['fields.body'].time).not.toEqual(500);
+      }
+    });
+
+    it('keeps redo validation passing after the time bump', () => {
+      const {history} = createHistory();
+      const before = richText();
+      const after = {...richText(), time: 600};
+      const store = createStore({'fields.body': after});
+      history.capture({'fields.body': {before, after}});
+
+      const undone = history.undo(store.get);
+      if (undone.status === 'applied') {
+        store.applyUpdates(undone.updates);
+      }
+      // The bump was written back into the stored entry, so the redo
+      // validation (current value vs entry.before) still matches exactly.
+      const redone = history.redo(store.get);
+      expect(redone.status).toEqual('applied');
+      if (redone.status === 'applied') {
+        store.applyUpdates(redone.updates);
+      }
+      // And undo again still validates against the re-bumped `after`.
+      const undoneAgain = history.undo(store.get);
+      expect(undoneAgain.status).toEqual('applied');
+    });
+
+    it('bumps rich text nested inside restored objects', () => {
+      const now = () => 9999;
+      const value = {section: {body: richText()}, other: 'x'};
+      bumpRichTextTimes(value, now);
+      expect(value.section.body.time).toEqual(9999);
+      expect(value.other).toEqual('x');
+    });
+  });
+
+  it('clear() empties both stacks', () => {
+    const {history} = createHistory();
+    const store = createStore({'fields.title': 'v1'});
+    store.set('fields.title', 'v2');
+    history.capture({'fields.title': {before: 'v1', after: 'v2'}});
+    const undone = history.undo(store.get);
+    if (undone.status === 'applied') {
+      store.applyUpdates(undone.updates);
+    }
+    store.set('fields.other', 1);
+    history.capture({'fields.other': {before: undefined, after: 1}});
+    history.clear();
+    expect(history.canUndo()).toBe(false);
+    expect(history.canRedo()).toBe(false);
+  });
+
+  it('emits change events when stacks change', () => {
+    const {history} = createHistory();
+    const events: number[] = [];
+    history.onChange(() => events.push(1));
+    history.capture({'fields.a': {before: 1, after: 2}});
+    expect(events.length).toEqual(1);
+    const store = createStore({'fields.a': 2});
+    history.undo(store.get);
+    expect(events.length).toEqual(2);
+  });
+});

--- a/packages/root-cms/ui/utils/edit-history.ts
+++ b/packages/root-cms/ui/utils/edit-history.ts
@@ -1,0 +1,395 @@
+import {isRichTextData} from '../../shared/marshal.js';
+import {EventListener} from './events.js';
+import {deepEqual} from './objects.js';
+import {autokey} from './rand.js';
+
+/**
+ * In-session undo/redo history for the doc editor.
+ *
+ * The history stores value transitions per deepkey and applies them with
+ * compare-and-swap semantics: an entry is only applied when the current value
+ * still matches what the entry expects, so undo/redo can never clobber a
+ * newer edit (e.g. from another user via the realtime snapshot listener).
+ */
+
+const MAX_ENTRIES = 100;
+
+/**
+ * Rapid successive single-key captures (e.g. typing) within this window are
+ * merged into one history entry.
+ */
+const COALESCE_WINDOW_MS = 1000;
+
+export enum EditHistoryEventType {
+  /** The undo/redo stacks changed (entries pushed, popped, or dropped). */
+  CHANGE = 'CHANGE',
+}
+
+/** One key's captured transition. `undefined` means the key does not exist. */
+export interface EditHistoryChange {
+  before: any;
+  after: any;
+}
+
+export interface EditHistoryEntry {
+  id: string;
+  /** Map of deepkey -> transition. Multi-key entries undo as one step. */
+  changes: Record<string, EditHistoryChange>;
+  createdAt: number;
+  updatedAt: number;
+  /** Optional human label, e.g. "Removed item" (shown in tooltips/toasts). */
+  label?: string;
+  /** Entries created via `group()` never coalesce with later captures. */
+  sealed?: boolean;
+}
+
+export type EditHistoryApplyResult =
+  | {status: 'applied'; updates: Record<string, any>; entry: EditHistoryEntry}
+  | {status: 'conflict'; entry: EditHistoryEntry}
+  | {status: 'empty'};
+
+export interface EditHistoryOptions {
+  maxEntries?: number;
+  coalesceWindowMs?: number;
+  /** Clock function, injectable for tests. */
+  now?: () => number;
+}
+
+export class EditHistory extends EventListener {
+  private undoStack: EditHistoryEntry[] = [];
+  private redoStack: EditHistoryEntry[] = [];
+  /** Non-null while inside a `group()` callback. */
+  private groupEntry: EditHistoryEntry | null = null;
+  private maxEntries: number;
+  private coalesceWindowMs: number;
+  private now: () => number;
+
+  constructor(options?: EditHistoryOptions) {
+    super();
+    this.maxEntries = options?.maxEntries ?? MAX_ENTRIES;
+    this.coalesceWindowMs = options?.coalesceWindowMs ?? COALESCE_WINDOW_MS;
+    this.now = options?.now ?? Date.now;
+  }
+
+  /**
+   * Records a set of value transitions as a single history entry. Values are
+   * cloned at capture time: the store mutates its objects in place and shares
+   * references with pending Firestore updates, so an uncloned `after` would
+   * silently absorb later child edits and break the compare-and-swap
+   * validation in `undo()`/`redo()`.
+   */
+  capture(
+    changes: Record<string, EditHistoryChange>,
+    options?: {label?: string}
+  ) {
+    const cloned: Record<string, EditHistoryChange> = {};
+    for (const key of Object.keys(changes)) {
+      const change = changes[key];
+      if (deepEqual(change.before, change.after)) {
+        continue;
+      }
+      cloned[key] = {
+        before: clonePreservingNonPlain(change.before),
+        after: clonePreservingNonPlain(change.after),
+      };
+    }
+    const keys = Object.keys(cloned);
+    if (keys.length === 0) {
+      return;
+    }
+
+    if (this.groupEntry) {
+      // Merge into the open group, preserving the first-seen `before` so the
+      // whole group undoes to the pre-group state in one step.
+      for (const key of keys) {
+        const existing = this.groupEntry.changes[key];
+        if (existing) {
+          existing.after = cloned[key].after;
+        } else {
+          this.groupEntry.changes[key] = cloned[key];
+        }
+      }
+      this.groupEntry.updatedAt = this.now();
+      return;
+    }
+
+    const timestamp = this.now();
+    const top = this.undoStack[this.undoStack.length - 1];
+    if (
+      top &&
+      !top.sealed &&
+      keys.length === 1 &&
+      hasSingleKey(top.changes, keys[0]) &&
+      timestamp - top.updatedAt < this.coalesceWindowMs
+    ) {
+      const key = keys[0];
+      top.changes[key].after = cloned[key].after;
+      top.updatedAt = timestamp;
+      // Typing forward and back within the window can leave the coalesced
+      // entry a no-op; drop it rather than surfacing an undo that does
+      // nothing.
+      if (deepEqual(top.changes[key].before, top.changes[key].after)) {
+        this.undoStack.pop();
+      }
+      this.clearRedo();
+      this.dispatchChange();
+      return;
+    }
+
+    this.pushEntry({
+      id: autokey(),
+      changes: cloned,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      label: options?.label,
+    });
+  }
+
+  /**
+   * Runs `fn`, merging every capture that happens during it into a single
+   * history entry (e.g. cut+paste of an array item). Nested groups join the
+   * outermost group.
+   */
+  group<T>(label: string, fn: () => T): T {
+    if (this.groupEntry) {
+      return fn();
+    }
+    const timestamp = this.now();
+    const entry: EditHistoryEntry = {
+      id: autokey(),
+      changes: {},
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      label: label,
+      sealed: true,
+    };
+    this.groupEntry = entry;
+    try {
+      return fn();
+    } finally {
+      this.groupEntry = null;
+      // Prune keys whose transitions cancelled out within the group.
+      for (const key of Object.keys(entry.changes)) {
+        const change = entry.changes[key];
+        if (deepEqual(change.before, change.after)) {
+          delete entry.changes[key];
+        }
+      }
+      if (Object.keys(entry.changes).length > 0) {
+        this.pushEntry(entry);
+      }
+    }
+  }
+
+  /**
+   * Pops the top undo entry and returns the updates map that restores its
+   * `before` values. The entry is only applied when every key's current value
+   * (via `getValue`) still deep-equals the entry's `after` value; otherwise
+   * the entry is stale (e.g. a remote edit landed) and is dropped.
+   */
+  undo(getValue: (key: string) => any): EditHistoryApplyResult {
+    return this.apply(this.undoStack, this.redoStack, 'before', getValue);
+  }
+
+  /** Reverse of `undo()`: re-applies the top redo entry's `after` values. */
+  redo(getValue: (key: string) => any): EditHistoryApplyResult {
+    return this.apply(this.redoStack, this.undoStack, 'after', getValue);
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  peekUndo(): EditHistoryEntry | undefined {
+    return this.undoStack[this.undoStack.length - 1];
+  }
+
+  peekRedo(): EditHistoryEntry | undefined {
+    return this.redoStack[this.redoStack.length - 1];
+  }
+
+  /**
+   * Drops entries invalidated by a remote data replacement (another editor's
+   * write, version restore, revert draft, AI edits). Only the top of each
+   * stack is checked, draining while stale: deeper entries cannot be
+   * validated eagerly since their expected values legitimately differ
+   * whenever a later entry touched the same key; those are validated lazily
+   * at apply time instead.
+   */
+  handleRemoteData(getValue: (key: string) => any) {
+    let changed = false;
+    while (this.undoStack.length > 0) {
+      const top = this.undoStack[this.undoStack.length - 1];
+      if (entryMatchesCurrent(top, 'after', getValue)) {
+        break;
+      }
+      this.undoStack.pop();
+      changed = true;
+    }
+    while (this.redoStack.length > 0) {
+      const top = this.redoStack[this.redoStack.length - 1];
+      if (entryMatchesCurrent(top, 'before', getValue)) {
+        break;
+      }
+      this.redoStack.pop();
+      changed = true;
+    }
+    if (changed) {
+      this.dispatchChange();
+    }
+  }
+
+  clear() {
+    if (this.undoStack.length === 0 && this.redoStack.length === 0) {
+      return;
+    }
+    this.undoStack = [];
+    this.redoStack = [];
+    this.dispatchChange();
+  }
+
+  onChange(callback: () => void): () => void {
+    return this.on(EditHistoryEventType.CHANGE, callback);
+  }
+
+  private apply(
+    fromStack: EditHistoryEntry[],
+    toStack: EditHistoryEntry[],
+    restoreSide: 'before' | 'after',
+    getValue: (key: string) => any
+  ): EditHistoryApplyResult {
+    const entry = fromStack[fromStack.length - 1];
+    if (!entry) {
+      return {status: 'empty'};
+    }
+    const expectSide = restoreSide === 'before' ? 'after' : 'before';
+    if (!entryMatchesCurrent(entry, expectSide, getValue)) {
+      fromStack.pop();
+      this.dispatchChange();
+      return {status: 'conflict', entry};
+    }
+    fromStack.pop();
+    const updates: Record<string, any> = {};
+    for (const key of Object.keys(entry.changes)) {
+      const change = entry.changes[key];
+      // Lexical's OnChangePlugin only accepts an external value whose `time`
+      // is newer than its last serialization, so restored rich text blobs get
+      // a fresh stamp. The bump is written into the stored change (not just
+      // the outgoing clone) to keep the entry's values exactly in sync with
+      // the store for future compare-and-swap validation.
+      bumpRichTextTimes(change[restoreSide], this.now);
+      // Clone on the way out: the store absorbs applied values by reference
+      // and mutates them in place, which would otherwise alias the entry's
+      // stored values and corrupt validation.
+      updates[key] = clonePreservingNonPlain(change[restoreSide]);
+    }
+    toStack.push(entry);
+    this.dispatchChange();
+    return {status: 'applied', updates, entry};
+  }
+
+  private pushEntry(entry: EditHistoryEntry) {
+    this.undoStack.push(entry);
+    if (this.undoStack.length > this.maxEntries) {
+      this.undoStack.shift();
+    }
+    this.clearRedo();
+    this.dispatchChange();
+  }
+
+  private clearRedo() {
+    if (this.redoStack.length > 0) {
+      this.redoStack = [];
+    }
+  }
+
+  private dispatchChange() {
+    this.dispatch(EditHistoryEventType.CHANGE);
+  }
+}
+
+/** Returns true when `changes` has exactly one key equal to `key`. */
+function hasSingleKey(changes: Record<string, EditHistoryChange>, key: string) {
+  const keys = Object.keys(changes);
+  return keys.length === 1 && keys[0] === key;
+}
+
+/**
+ * Returns true when every key in the entry currently holds the value the
+ * entry expects on the given side.
+ */
+function entryMatchesCurrent(
+  entry: EditHistoryEntry,
+  side: 'before' | 'after',
+  getValue: (key: string) => any
+): boolean {
+  for (const key of Object.keys(entry.changes)) {
+    if (!valuesEqual(getValue(key), entry.changes[key][side])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** deepEqual() with support for scalar `undefined`/primitive comparisons. */
+function valuesEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+  return deepEqual(a, b);
+}
+
+/**
+ * Deep-clones arrays and plain objects while passing non-plain objects (e.g.
+ * Firestore Timestamp) through by reference. `structuredClone()` is not used
+ * because it strips class prototypes, which would break `Timestamp` values.
+ */
+export function clonePreservingNonPlain(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map((item) => clonePreservingNonPlain(item));
+  }
+  if (isPlainObject(value)) {
+    const result: Record<string, any> = {};
+    for (const key of Object.keys(value)) {
+      result[key] = clonePreservingNonPlain(value[key]);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Recursively refreshes the `time` stamp on any rich text data within a
+ * value (mutating in place). Returns the value for convenience.
+ */
+export function bumpRichTextTimes(value: any, now: () => number): any {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      bumpRichTextTimes(item, now);
+    }
+    return value;
+  }
+  if (isPlainObject(value)) {
+    if (isRichTextData(value)) {
+      value.time = now();
+      return value;
+    }
+    for (const key of Object.keys(value)) {
+      bumpRichTextTimes(value[key], now);
+    }
+  }
+  return value;
+}
+
+/** Returns true for plain objects (object literals, JSON-parsed objects). */
+function isPlainObject(value: any): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/packages/root-cms/ui/utils/keyboard.ts
+++ b/packages/root-cms/ui/utils/keyboard.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared keyboard helpers for document-level shortcut handlers that must not
+ * interfere with text editing (native input undo, Lexical shortcuts, etc.).
+ */
+
+const IS_APPLE =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+/**
+ * Returns true when the event originates from a field where the user is
+ * actively typing, e.g. a text input or a `contenteditable` rich text editor
+ * (Lexical). Document-level shortcuts should not fire in those contexts —
+ * Lexical, for instance, binds its own Cmd+K ("insert link") and Cmd+Z
+ * (undo), and native inputs have built-in text undo.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true;
+  }
+  // True for the contenteditable host and any element nested inside one
+  // (e.g. Lexical rich text fields).
+  return target.isContentEditable;
+}
+
+/** Returns true for the platform "undo" shortcut (⌘Z / Ctrl+Z). */
+export function isUndoKeyEvent(event: KeyboardEvent): boolean {
+  return (
+    isKey(event, 'z', 'KeyZ') &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+/**
+ * Returns true for the platform "redo" shortcut (⌘⇧Z / Ctrl+Shift+Z, plus
+ * Ctrl+Y on non-Apple platforms, mirroring Lexical's shortcut map).
+ */
+export function isRedoKeyEvent(event: KeyboardEvent): boolean {
+  if (
+    isKey(event, 'z', 'KeyZ') &&
+    (event.metaKey || event.ctrlKey) &&
+    event.shiftKey &&
+    !event.altKey
+  ) {
+    return true;
+  }
+  return (
+    !IS_APPLE &&
+    isKey(event, 'y', 'KeyY') &&
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+function isKey(event: KeyboardEvent, key: string, code: string): boolean {
+  return event.key.toLowerCase() === key || event.code === code;
+}


### PR DESCRIPTION
## Summary
Implements a complete undo/redo system for field edits in the document editor, allowing users to revert and replay changes with keyboard shortcuts (⌘Z / Ctrl+Z for undo, ⌘⇧Z / Ctrl+⇧Z for redo).

## Key Changes

- **New `EditHistory` class** (`edit-history.ts`): Core undo/redo engine with:
  - Compare-and-swap validation to prevent clobbering remote edits
  - Automatic coalescing of rapid same-key edits (e.g., typing) within a 1-second window
  - `group()` API for atomic multi-key operations (e.g., array item removal)
  - Conflict detection and handling for remote data replacements
  - Deep cloning of captured values while preserving non-plain objects (e.g., Firestore Timestamps)
  - Configurable entry limits with FIFO eviction

- **Integration with `DraftDocController`** (`useDraftDoc.tsx`):
  - Captures field edit transitions (before/after values) via `captureHistory()`
  - Applies undo/redo through the normal save path with proper Firestore `deleteField()` sentinels
  - Invalidates stale history entries when remote snapshots arrive
  - Dispatches `HISTORY_CHANGE` and `HISTORY_APPLIED` events for UI updates

- **UI Components** (`DocEditor.tsx`):
  - Added undo/redo buttons in the status bar with keyboard shortcut hints
  - Document-level keyboard listener for ⌘Z/⌘⇧Z (respects text input and modal focus)
  - Transient "Undo" notifications for destructive one-click actions (e.g., clearing sections)
  - Scoped undo toasts that no-op if newer edits have landed

- **Keyboard utilities** (`keyboard.ts`):
  - `isEditableTarget()`: Detects active text editing contexts (inputs, textareas, contenteditable)
  - `isUndoKeyEvent()` / `isRedoKeyEvent()`: Platform-aware shortcut detection (⌘Z, Ctrl+Z, Ctrl+Y)

- **Comprehensive test coverage**:
  - 556-line test suite for `EditHistory` covering coalescing, grouping, conflicts, and remote data handling
  - 258-line integration tests for `DraftDocController` history capture and apply

## Notable Implementation Details

- Values are cloned at capture time to isolate them from in-place mutations by the store
- Rich text (Lexical) timestamps are bumped on restore to satisfy Lexical's validation
- Multi-key captures never coalesce; only single-key rapid edits merge
- Grouped operations are sealed and never merge with later captures
- Undo/redo only applies when current values match expected values (prevents clobbering concurrent edits)
- History is suppressed during undo/redo application to avoid recursive captures

https://claude.ai/code/session_01N2LVW7rTke88CCfr4aDJrH