### PR TITLE
feat: add tools to root ai for creating and editing releases

### DIFF
--- a/.changeset/root-ai-release-tools.md
+++ b/.changeset/root-ai-release-tools.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: add release tools to Root AI for creating and editing releases

--- a/.changeset/root-ai-release-tools.md
+++ b/.changeset/root-ai-release-tools.md
@@ -1,5 +1,5 @@
 ---
-'@blinkk/root-cms': minor
+'@blinkk/root-cms': patch
 ---
 
-feat: add release tools to Root AI for creating and editing releases
+feat: add tools to root ai for creating and editing releases

--- a/packages/root-cms/core/ai-tools.test.ts
+++ b/packages/root-cms/core/ai-tools.test.ts
@@ -1,5 +1,13 @@
 import {describe, expect, it} from 'vitest';
-import {applyDocEdits, validateValueAtPath} from './ai-tools.js';
+import {
+  applyDocEdits,
+  computeReleaseDocIds,
+  createCmsTools,
+  createReadOnlyCmsTools,
+  getReleaseStatus,
+  validateValueAtPath,
+  type CmsToolReadBackend,
+} from './ai-tools.js';
 import {Collection} from './schema.js';
 
 describe('validateValueAtPath', () => {
@@ -505,5 +513,159 @@ describe('applyDocEdits', () => {
     if (!result.ok) {
       expect(result.error.message).toMatch(/unknown operation/i);
     }
+  });
+});
+
+describe('getReleaseStatus', () => {
+  it('returns "unpublished" when no stamps are set', () => {
+    expect(getReleaseStatus({})).toBe('unpublished');
+  });
+
+  it('returns "scheduled" when only scheduledAt is set', () => {
+    expect(getReleaseStatus({scheduledAt: 1234})).toBe('scheduled');
+  });
+
+  it('returns "published" when publishedAt is set', () => {
+    expect(getReleaseStatus({publishedAt: 1234})).toBe('published');
+  });
+
+  it('prefers "published" over "scheduled"', () => {
+    expect(getReleaseStatus({publishedAt: 1234, scheduledAt: 5678})).toBe(
+      'published'
+    );
+  });
+
+  it('prefers "archived" over everything else', () => {
+    expect(
+      getReleaseStatus({archivedAt: 1, publishedAt: 2, scheduledAt: 3})
+    ).toBe('archived');
+  });
+
+  it('treats truthy Timestamp-like objects as set', () => {
+    expect(getReleaseStatus({scheduledAt: {toMillis: () => 1}})).toBe(
+      'scheduled'
+    );
+  });
+});
+
+describe('computeReleaseDocIds', () => {
+  it('adds docs, deduped and sorted', () => {
+    expect(
+      computeReleaseDocIds(['Pages/home'], ['BlogPosts/a', 'Pages/home'])
+    ).toEqual(['BlogPosts/a', 'Pages/home']);
+  });
+
+  it('removes docs', () => {
+    expect(
+      computeReleaseDocIds(['Pages/a', 'Pages/b'], undefined, ['Pages/a'])
+    ).toEqual(['Pages/b']);
+  });
+
+  it('applies adds and removes together, removal winning on overlap', () => {
+    expect(
+      computeReleaseDocIds(['Pages/a'], ['Pages/b', 'Pages/c'], ['Pages/b'])
+    ).toEqual(['Pages/a', 'Pages/c']);
+  });
+
+  it('ignores removals of docs not in the release', () => {
+    expect(computeReleaseDocIds(['Pages/a'], [], ['Pages/zzz'])).toEqual([
+      'Pages/a',
+    ]);
+  });
+
+  it('dedupes an existing list with duplicates', () => {
+    expect(computeReleaseDocIds(['Pages/a', 'Pages/a'], [], [])).toEqual([
+      'Pages/a',
+    ]);
+  });
+
+  it('returns an empty list when everything is removed', () => {
+    expect(computeReleaseDocIds(['Pages/a'], undefined, ['Pages/a'])).toEqual(
+      []
+    );
+  });
+
+  it('does not mutate the inputs', () => {
+    const existing = ['Pages/b', 'Pages/a'];
+    computeReleaseDocIds(existing, ['Pages/c'], ['Pages/a']);
+    expect(existing).toEqual(['Pages/b', 'Pages/a']);
+  });
+});
+
+describe('release tools wiring', () => {
+  function stubBackend(): CmsToolReadBackend {
+    return {
+      listCollections: async () => [],
+      listDocs: async () => [],
+      getDoc: async () => null,
+      getDocVersion: async () => null,
+      listVersions: async () => [],
+      getSchemaFields: async () => null,
+      listReleases: async ({limit}) => {
+        return [
+          {
+            id: 'spring-launch',
+            docIds: ['Pages/home'],
+            dataSourceIds: [],
+            status: 'unpublished' as const,
+          },
+        ].slice(0, limit);
+      },
+      getRelease: async (releaseId) => {
+        if (releaseId !== 'spring-launch') {
+          return null;
+        }
+        return {
+          id: 'spring-launch',
+          docIds: ['Pages/home'],
+          dataSourceIds: [],
+          status: 'unpublished' as const,
+        };
+      },
+    };
+  }
+
+  it('exposes read tools with execute and write tools schema-only', () => {
+    const tools = createCmsTools(stubBackend());
+    expect(tools.releases_list.execute).toBeTypeOf('function');
+    expect(tools.release_get.execute).toBeTypeOf('function');
+    // Write tools are executed in the browser via `onToolCall` so the user
+    // can approve them first — they must NOT carry an execute here.
+    expect(tools.release_create.execute).toBeUndefined();
+    expect(tools.release_update.execute).toBeUndefined();
+  });
+
+  it('releases_list returns releases from the backend', async () => {
+    const tools = createCmsTools(stubBackend());
+    const result: any = await (tools.releases_list.execute as any)(
+      {limit: 10},
+      {} as any
+    );
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].id).toBe('spring-launch');
+  });
+
+  it('release_get reports found/not-found', async () => {
+    const tools = createCmsTools(stubBackend());
+    const found: any = await (tools.release_get.execute as any)(
+      {releaseId: 'spring-launch'},
+      {} as any
+    );
+    expect(found).toMatchObject({found: true});
+    expect(found.release.status).toBe('unpublished');
+    const missing: any = await (tools.release_get.execute as any)(
+      {releaseId: 'nope'},
+      {} as any
+    );
+    expect(missing).toEqual({found: false});
+  });
+
+  it('includes release read tools (but not write tools) in the read-only set', () => {
+    const tools = createReadOnlyCmsTools(stubBackend());
+    expect(tools.releases_list).toBeDefined();
+    expect(tools.release_get).toBeDefined();
+    expect(tools.release_create).toBeUndefined();
+    expect(tools.release_update).toBeUndefined();
+    expect(tools.doc_set).toBeUndefined();
   });
 });

--- a/packages/root-cms/core/ai-tools.ts
+++ b/packages/root-cms/core/ai-tools.ts
@@ -7,10 +7,10 @@
  * `ui/components/RootAIChat/clientCmsTools.ts`). The factory itself is
  * data-source agnostic.
  *
- * Write tools (`doc_set`, `doc_create`, `doc_updateField`, `doc_duplicate`)
- * stay schema-only here — the browser executes them via `onToolCall` so the
- * user can approve diffs in the UI and so Firestore listeners on other tabs
- * see the change immediately.
+ * Write tools (`doc_set`, `doc_create`, `doc_updateField`, `doc_duplicate`,
+ * `release_create`, `release_update`) stay schema-only here — the browser
+ * executes them via `onToolCall` so the user can approve diffs in the UI and
+ * so Firestore listeners on other tabs see the change immediately.
  *
  * Validation helpers (`validateFields`, `validateValueAtPath`) live here
  * too so both browser and server can share the same checks.
@@ -48,6 +48,10 @@ export const CMS_TOOL_NAMES = [
   'doc_listVersions',
   'doc_translateField',
   'schema_get',
+  'releases_list',
+  'release_get',
+  'release_create',
+  'release_update',
 ] as const;
 export type CmsToolName = (typeof CMS_TOOL_NAMES)[number];
 
@@ -65,6 +69,8 @@ export const READ_ONLY_CMS_TOOL_NAMES: readonly CmsToolName[] = [
   'doc_getVersion',
   'doc_listVersions',
   'schema_get',
+  'releases_list',
+  'release_get',
 ] as const;
 
 /** A CMS document shaped for the model (fields/sys already unmarshalled). */
@@ -96,6 +102,74 @@ export interface CmsToolCollectionSummary {
   id: string;
   name?: string;
   description?: string;
+}
+
+/** Lifecycle status of a release, derived via `getReleaseStatus()`. */
+export type CmsToolReleaseStatus =
+  | 'unpublished'
+  | 'scheduled'
+  | 'published'
+  | 'archived';
+
+/** A CMS release shaped for the model (timestamps in epoch millis). */
+export interface CmsToolRelease {
+  id: string;
+  description?: string;
+  /** Full doc ids (e.g. "Pages/home") published together by this release. */
+  docIds: string[];
+  /** Data source ids published with the release. Managed via the CMS UI. */
+  dataSourceIds: string[];
+  status: CmsToolReleaseStatus;
+  createdAt?: number;
+  createdBy?: string;
+  scheduledAt?: number;
+  scheduledBy?: string;
+  publishedAt?: number;
+  publishedBy?: string;
+  archivedAt?: number;
+  archivedBy?: string;
+}
+
+/**
+ * Derives the lifecycle status of a release from its stamp fields. Archived
+ * wins over everything (an archived release can never be published), then
+ * published (publishing clears `scheduledAt`), then scheduled.
+ */
+export function getReleaseStatus(release: {
+  archivedAt?: unknown;
+  publishedAt?: unknown;
+  scheduledAt?: unknown;
+}): CmsToolReleaseStatus {
+  if (release.archivedAt) {
+    return 'archived';
+  }
+  if (release.publishedAt) {
+    return 'published';
+  }
+  if (release.scheduledAt) {
+    return 'scheduled';
+  }
+  return 'unpublished';
+}
+
+/**
+ * Computes the new `docIds` list for a `release_update` call: the existing
+ * ids plus `addDocIds` minus `removeDocIds`, deduped and sorted (matching how
+ * the CMS UI maintains the list). Removal wins when an id appears in both.
+ */
+export function computeReleaseDocIds(
+  existingDocIds: string[],
+  addDocIds?: string[],
+  removeDocIds?: string[]
+): string[] {
+  const ids = new Set(existingDocIds);
+  for (const docId of addDocIds || []) {
+    ids.add(docId);
+  }
+  for (const docId of removeDocIds || []) {
+    ids.delete(docId);
+  }
+  return Array.from(ids).sort();
 }
 
 /**
@@ -134,6 +208,10 @@ export interface CmsToolReadBackend {
    * `simplifyFields`), or `null` if the collection is unknown.
    */
   getSchemaFields(collectionId: string): Promise<unknown[] | null>;
+  /** Lists releases, most recently created first. */
+  listReleases(options: {limit: number}): Promise<CmsToolRelease[]>;
+  /** Reads a single release, or `null` if it does not exist. */
+  getRelease(releaseId: string): Promise<CmsToolRelease | null>;
 }
 
 /**
@@ -156,11 +234,13 @@ export function createReadOnlyCmsTools(backend: CmsToolReadBackend): ToolSet {
  * Builds the full tool set advertised to the model.
  *
  * Read tools (`collections_list`, `docs_list`, `docs_search`, `doc_get`,
- * `doc_getVersion`, `doc_listVersions`, `schema_get`) carry an `execute` that
- * delegates to the supplied `CmsToolReadBackend`. Write tools (`doc_set`,
- * `doc_create`, `doc_updateField`, `doc_duplicate`, `doc_translateField`)
- * remain schema-only — the browser executes them via `onToolCall` so the user
- * can approve diffs before persistence.
+ * `doc_getVersion`, `doc_listVersions`, `schema_get`, `releases_list`,
+ * `release_get`) carry an `execute` that delegates to the supplied
+ * `CmsToolReadBackend`. Write tools (`doc_set`, `doc_create`,
+ * `doc_updateField`, `doc_duplicate`, `doc_translateField`,
+ * `release_create`, `release_update`) remain schema-only — the browser
+ * executes them via `onToolCall` so the user can approve diffs before
+ * persistence.
  *
  * Safety policy: this tool set is intentionally read + draft-write only.
  * The following operations are deliberately NOT exposed to the model
@@ -176,10 +256,21 @@ export function createReadOnlyCmsTools(backend: CmsToolReadBackend): ToolSet {
  *   - `doc_schedule` / `doc_unschedule` — affects future production state.
  *   - `doc_lockPublishing` / `doc_unlockPublishing` — affects governance state.
  *   - `doc_restoreVersion` — overwrites the current draft with old data.
+ *   - `release_publish` / `release_schedule` / `release_unschedule` —
+ *     pushes the release's docs to production (now or at a future time).
+ *   - `release_delete` / `release_archive` / `release_unarchive` —
+ *     destructive/governance state on releases.
  *   - Bulk variants (e.g. `docs_publish`) of any of the above.
  *
+ * `release_create` and `release_update` are exposed because grouping docs
+ * into a release publishes nothing by itself — but the client handlers
+ * restrict `release_update` to UNPUBLISHED releases, since editing the doc
+ * list of a scheduled release would change what auto-publishes at the
+ * scheduled time (equivalent to `doc_schedule`, which is excluded above).
+ *
  * If you add new write tools here, keep them limited to draft-mode edits
- * the user can easily review before publishing.
+ * (or similarly non-publishing changes) the user can easily review before
+ * publishing.
  */
 export function createCmsTools(backend: CmsToolReadBackend): ToolSet {
   return {
@@ -494,6 +585,89 @@ export function createCmsTools(backend: CmsToolReadBackend): ToolSet {
         }
         return {found: true, collectionId, fields};
       },
+    }),
+
+    releases_list: tool({
+      description:
+        'List CMS releases, most recently created first. A release is a ' +
+        'named group of docs (and data sources) that the user can publish ' +
+        'together, immediately or at a scheduled time. Each result ' +
+        'includes the release status ("unpublished", "scheduled", ' +
+        '"published" or "archived") and its doc ids.',
+      inputSchema: z.object({
+        limit: z.number().int().min(1).max(100).default(50),
+      }),
+      execute: async ({limit = 50}) => {
+        const max = clampInt(limit, 1, 100, 50);
+        return {releases: await backend.listReleases({limit: max})};
+      },
+    }),
+
+    release_get: tool({
+      description:
+        'Read a single CMS release, including its status, description, ' +
+        'doc ids, and schedule/publish metadata.',
+      inputSchema: z.object({
+        releaseId: z
+          .string()
+          .describe('Release id, e.g. "20260318-golden-meadow".'),
+      }),
+      execute: async ({releaseId}) => {
+        const release = await backend.getRelease(releaseId);
+        return release ? {found: true, release} : {found: false};
+      },
+    }),
+
+    release_create: tool({
+      description:
+        'Create a new CMS release with an optional description and ' +
+        'initial list of doc ids. Doc ids use the full "Collection/slug" ' +
+        'form and every doc must already exist as a draft. Fails if the ' +
+        'release id is already taken. Creating a release does NOT publish ' +
+        'anything — the user publishes or schedules the release from the ' +
+        'CMS UI. Requires publish permissions (ADMIN or EDITOR role).',
+      inputSchema: z.object({
+        releaseId: z
+          .string()
+          .describe(
+            'Release id using lowercase letters, numbers and dashes, ' +
+              'e.g. "spring-launch" or "20260318-golden-meadow".'
+          ),
+        description: z
+          .string()
+          .optional()
+          .describe('Optional description shown in the releases UI.'),
+        docIds: z
+          .array(z.string())
+          .optional()
+          .describe('Doc ids to include in the release, e.g. ["Pages/home"].'),
+      }),
+    }),
+
+    release_update: tool({
+      description:
+        'Update an UNPUBLISHED CMS release: add docs, remove docs, and/or ' +
+        'change the description. Pass full doc ids (e.g. "Pages/home"); ' +
+        'added docs must already exist as drafts. Scheduled, published and ' +
+        'archived releases cannot be edited with this tool — the user must ' +
+        'manage those from the CMS UI (e.g. unschedule first). Updating a ' +
+        'release does NOT publish anything — publishing remains manual. ' +
+        'Requires publish permissions (ADMIN or EDITOR role).',
+      inputSchema: z.object({
+        releaseId: z.string().describe('Release id to update.'),
+        description: z
+          .string()
+          .optional()
+          .describe('New description for the release.'),
+        addDocIds: z
+          .array(z.string())
+          .optional()
+          .describe('Doc ids to add to the release.'),
+        removeDocIds: z
+          .array(z.string())
+          .optional()
+          .describe('Doc ids to remove from the release.'),
+      }),
     }),
   };
 }

--- a/packages/root-cms/core/ai.test.ts
+++ b/packages/root-cms/core/ai.test.ts
@@ -337,6 +337,15 @@ describe('ai', () => {
         'Auto-apply draft edits'
       );
     });
+
+    it('explains the release policy only when writes are possible', () => {
+      for (const mode of ['approve', 'auto'] as const) {
+        const prompt = buildExecutionModePrompt(mode);
+        expect(prompt).toContain('Release tools');
+        expect(prompt).toContain('user-only actions');
+      }
+      expect(buildExecutionModePrompt('read')).not.toContain('Release tools');
+    });
   });
 
   describe('mergeIncomingMessage', () => {

--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -79,10 +79,10 @@ export const ROOT_MD_FILENAME = 'ROOT.md';
 export const DEFAULT_CHAT_SYSTEM_PROMPT = [
   'You are an assistant embedded in the Root CMS admin UI.',
   'Help the user explore and edit content, answer questions about the',
-  'project, and use the provided tools to read and write CMS docs.',
-  'Be concise and use markdown for rich responses. When you lack the',
-  'context to act safely, read the relevant docs first or ask the user',
-  'instead of guessing.',
+  'project, and use the provided tools to read and write CMS docs and',
+  'organize releases. Be concise and use markdown for rich responses.',
+  'When you lack the context to act safely, read the relevant docs first',
+  'or ask the user instead of guessing.',
 ].join(' ');
 
 /**
@@ -357,7 +357,8 @@ export function buildExecutionModePrompt(mode: AiExecutionMode): string {
     common.push(
       '- Before the first write, briefly state a plan that names the target docs, fields, intended changes, assumptions, and validation checks.',
       '- Never claim a draft change was applied until the matching tool output reports success.',
-      '- After write tools finish, provide a short receipt with changed docs, changed fields, validation result, and a reminder that publishing remains manual.'
+      '- After write tools finish, provide a short receipt with changed docs, changed fields, validation result, and a reminder that publishing remains manual.',
+      '- Release tools can create releases and add/remove docs on unpublished releases. Publishing, scheduling, unscheduling, archiving, and deleting releases are user-only actions in the CMS UI — never claim to do them.'
     );
   }
   if (mode === 'read') {

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -1357,7 +1357,7 @@ function ToolApprovalCard(props: {
           disabled={props.approval.status === 'executing'}
           onClick={props.onApprove}
         >
-          Approve draft edit
+          {preview.approveLabel || 'Approve draft edit'}
         </Button>
       </div>
     </div>
@@ -1392,7 +1392,7 @@ function ToolReceipt(props: {output: any}) {
           compact
           href={receipt.adminUrl}
         >
-          Open document
+          {receipt.linkLabel || 'Open document'}
         </Button>
       )}
     </div>

--- a/packages/root-cms/ui/components/RootAIChat/clientCmsTools.ts
+++ b/packages/root-cms/ui/components/RootAIChat/clientCmsTools.ts
@@ -21,9 +21,11 @@ import {
 import {
   createCmsTools,
   createReadOnlyCmsTools,
+  getReleaseStatus,
   simplifyFields,
   type CmsToolDoc,
   type CmsToolReadBackend,
+  type CmsToolRelease,
 } from '../../../core/ai-tools.js';
 import {fetchCollectionSchema} from '../../utils/collection.js';
 import {
@@ -33,6 +35,11 @@ import {
   parseDocId,
   unmarshalData,
 } from '../../utils/doc.js';
+import {
+  Release,
+  getRelease as cmsGetRelease,
+  listReleases as cmsListReleases,
+} from '../../utils/release.js';
 
 /** Shapes a raw Firestore CMS doc into the model-ready tool doc. */
 function shapeDoc(docId: string, raw: CMSDoc): CmsToolDoc {
@@ -43,6 +50,33 @@ function shapeDoc(docId: string, raw: CMSDoc): CmsToolDoc {
     slug: (raw as any).slug || slug,
     sys: unmarshalData((raw as any).sys || {}),
     fields: unmarshalData((raw as any).fields || {}),
+  };
+}
+
+/** Converts a Firestore Timestamp-ish value to epoch millis, if present. */
+function toMillis(value: any): number | undefined {
+  if (value && typeof value.toMillis === 'function') {
+    return value.toMillis();
+  }
+  return undefined;
+}
+
+/** Shapes a raw Firestore release into the model-ready tool release. */
+export function shapeRelease(release: Release): CmsToolRelease {
+  return {
+    id: release.id,
+    description: release.description || undefined,
+    docIds: release.docIds || [],
+    dataSourceIds: release.dataSourceIds || [],
+    status: getReleaseStatus(release),
+    createdAt: toMillis(release.createdAt),
+    createdBy: release.createdBy || undefined,
+    scheduledAt: toMillis(release.scheduledAt),
+    scheduledBy: release.scheduledBy || undefined,
+    publishedAt: toMillis(release.publishedAt),
+    publishedBy: release.publishedBy || undefined,
+    archivedAt: toMillis(release.archivedAt),
+    archivedBy: release.archivedBy || undefined,
   };
 }
 
@@ -112,6 +146,16 @@ export function createClientCmsToolBackend(): CmsToolReadBackend {
         console.error(`failed to load schema for ${collectionId}:`, err);
         return null;
       }
+    },
+
+    async listReleases({limit}) {
+      const releases = await cmsListReleases();
+      return releases.slice(0, limit).map(shapeRelease);
+    },
+
+    async getRelease(releaseId) {
+      const release = await cmsGetRelease(releaseId);
+      return release ? shapeRelease(release) : null;
     },
   };
 }

--- a/packages/root-cms/ui/components/RootAIChat/cmsToolHandlers.release.test.ts
+++ b/packages/root-cms/ui/components/RootAIChat/cmsToolHandlers.release.test.ts
@@ -1,0 +1,397 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  executeCmsTool,
+  isCmsWriteTool,
+  previewCmsWriteTool,
+} from './cmsToolHandlers.js';
+
+const mocks = vi.hoisted(() => ({
+  // firebase/firestore
+  deleteField: vi.fn(() => '__DELETE_FIELD__'),
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+  serverTimestamp: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  // utils/release.js
+  addRelease: vi.fn(),
+  getRelease: vi.fn(),
+  updateRelease: vi.fn(),
+  // hooks/useProjectRoles.js
+  fetchProjectRoles: vi.fn(),
+  // utils/collection.js
+  fetchCollectionSchema: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  deleteField: mocks.deleteField,
+  doc: mocks.doc,
+  getDoc: mocks.getDoc,
+  serverTimestamp: mocks.serverTimestamp,
+  setDoc: mocks.setDoc,
+  updateDoc: mocks.updateDoc,
+  Timestamp: class MockTimestamp {},
+}));
+
+vi.mock('../../utils/release.js', () => ({
+  addRelease: mocks.addRelease,
+  getRelease: mocks.getRelease,
+  updateRelease: mocks.updateRelease,
+}));
+
+vi.mock('../../hooks/useProjectRoles.js', () => ({
+  fetchProjectRoles: mocks.fetchProjectRoles,
+}));
+
+vi.mock('../../utils/collection.js', () => ({
+  fetchCollectionSchema: mocks.fetchCollectionSchema,
+}));
+
+const mockDb = {type: 'mock-db'};
+
+/** Draft doc paths that "exist" in the mocked Firestore. */
+let existingDrafts: Set<string>;
+
+function draftPath(collectionId: string, slug: string): string {
+  return `Projects/test-project/Collections/${collectionId}/Drafts/${slug}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.deleteField.mockReturnValue('__DELETE_FIELD__');
+  existingDrafts = new Set([
+    draftPath('Pages', 'home'),
+    draftPath('Pages', 'about'),
+    draftPath('BlogPosts', 'launch'),
+    draftPath('Pages', 'foo--bar'),
+  ]);
+  mocks.doc.mockImplementation((_db: unknown, ...segments: string[]) => ({
+    path: segments.join('/'),
+  }));
+  mocks.getDoc.mockImplementation(async (ref: {path: string}) => ({
+    exists: () => existingDrafts.has(ref.path),
+    data: () => ({}),
+  }));
+  mocks.fetchProjectRoles.mockResolvedValue({
+    'admin@example.com': 'ADMIN',
+    'viewer@example.com': 'VIEWER',
+  });
+  mocks.getRelease.mockResolvedValue(null);
+  (window as any).__ROOT_CTX = {
+    rootConfig: {projectId: 'test-project'},
+  };
+  (window as any).firebase = {
+    db: mockDb,
+    user: {email: 'admin@example.com'},
+  };
+});
+
+describe('release write tool registration', () => {
+  it('treats release_create and release_update as write tools', () => {
+    expect(isCmsWriteTool('release_create')).toBe(true);
+    expect(isCmsWriteTool('release_update')).toBe(true);
+    expect(isCmsWriteTool('releases_list')).toBe(false);
+    expect(isCmsWriteTool('release_get')).toBe(false);
+  });
+});
+
+describe('release_create', () => {
+  it('creates a release with deduped, sorted, canonicalized doc ids', async () => {
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'spring-launch',
+      description: 'Spring launch docs',
+      docIds: ['Pages/home', 'BlogPosts/launch', 'Pages/home', 'Pages/foo/bar'],
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.addRelease).toHaveBeenCalledWith('spring-launch', {
+      description: 'Spring launch docs',
+      docIds: ['BlogPosts/launch', 'Pages/foo--bar', 'Pages/home'],
+    });
+    expect(result.receipt.adminUrl).toBe('/cms/releases/spring-launch');
+    expect(result.receipt.linkLabel).toBe('Open release');
+  });
+
+  it('allows creating an empty release without docIds', async () => {
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'empty-release',
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.addRelease).toHaveBeenCalledWith('empty-release', {
+      docIds: [],
+    });
+  });
+
+  it('rejects an invalid release id', async () => {
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'Bad Release!',
+    });
+    expect(result).toMatchObject({success: false, error: 'INVALID_RELEASE_ID'});
+    expect(mocks.addRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects users without publish permission', async () => {
+    (window as any).firebase.user.email = 'viewer@example.com';
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'spring-launch',
+    });
+    expect(result).toMatchObject({success: false, error: 'PERMISSION_DENIED'});
+    expect(mocks.addRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the release already exists', async () => {
+    mocks.getRelease.mockResolvedValue({id: 'spring-launch'});
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'spring-launch',
+    });
+    expect(result).toMatchObject({success: false, error: 'ALREADY_EXISTS'});
+    expect(mocks.addRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects docs that do not exist or are malformed', async () => {
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'spring-launch',
+      docIds: ['Pages/home', 'Pages/missing', 'no-slash'],
+    });
+    expect(result).toMatchObject({success: false, error: 'INVALID_DOC_IDS'});
+    expect(result.errors).toEqual([
+      {docId: 'Pages/missing', message: 'Doc does not exist as a draft.'},
+      {
+        docId: 'no-slash',
+        message: 'Doc id must use the form "Collection/slug".',
+      },
+    ]);
+    expect(mocks.addRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed docIds payload', async () => {
+    const result: any = await executeCmsTool('release_create', {
+      releaseId: 'spring-launch',
+      docIds: 'Pages/home',
+    });
+    expect(result).toMatchObject({success: false, error: 'INVALID_INPUT'});
+  });
+
+  it('returns a preview with a release approve label', async () => {
+    const preview = await previewCmsWriteTool('release_create', {
+      releaseId: 'spring-launch',
+      docIds: ['Pages/home'],
+    });
+    expect(preview.error).toBeUndefined();
+    expect(preview.approveLabel).toBe('Approve release change');
+    expect(preview.before).toEqual({});
+    expect(preview.after).toEqual({
+      id: 'spring-launch',
+      docIds: ['Pages/home'],
+    });
+  });
+});
+
+describe('release_update', () => {
+  function unpublishedRelease(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'spring-launch',
+      description: 'Spring launch',
+      docIds: ['Pages/about', 'Pages/home'],
+      ...overrides,
+    };
+  }
+
+  it('adds and removes docs in a single update', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+      removeDocIds: ['Pages/about'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.addedDocIds).toEqual(['BlogPosts/launch']);
+    expect(result.removedDocIds).toEqual(['Pages/about']);
+    expect(mocks.updateRelease).toHaveBeenCalledWith('spring-launch', {
+      docIds: ['BlogPosts/launch', 'Pages/home'],
+    });
+    expect(result.receipt.adminUrl).toBe('/cms/releases/spring-launch');
+  });
+
+  it('removes docs referenced by their nested (slash) form', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({docIds: ['Pages/foo--bar', 'Pages/home']})
+    );
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      removeDocIds: ['Pages/foo/bar'],
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.updateRelease).toHaveBeenCalledWith('spring-launch', {
+      docIds: ['Pages/home'],
+    });
+  });
+
+  it('allows removing docs that no longer exist as drafts', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({docIds: ['Pages/deleted-doc', 'Pages/home']})
+    );
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      removeDocIds: ['Pages/deleted-doc'],
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.updateRelease).toHaveBeenCalledWith('spring-launch', {
+      docIds: ['Pages/home'],
+    });
+  });
+
+  it('updates only the description when no doc changes are given', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      description: 'New description',
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.updateRelease).toHaveBeenCalledWith('spring-launch', {
+      docIds: ['Pages/about', 'Pages/home'],
+      description: 'New description',
+    });
+  });
+
+  it('clears the description when an empty string is passed', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      description: '',
+    });
+    expect(result.success).toBe(true);
+    expect(mocks.updateRelease).toHaveBeenCalledWith('spring-launch', {
+      docIds: ['Pages/about', 'Pages/home'],
+      description: '__DELETE_FIELD__',
+    });
+  });
+
+  it('rejects updates to a scheduled release', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({scheduledAt: {toMillis: () => 1234}})
+    );
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: 'RELEASE_NOT_EDITABLE',
+    });
+    expect(result.message).toContain('scheduled');
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates to a published release', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({publishedAt: {toMillis: () => 1234}})
+    );
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: 'RELEASE_NOT_EDITABLE',
+    });
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates to an archived release', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({archivedAt: {toMillis: () => 1234}})
+    );
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: 'RELEASE_NOT_EDITABLE',
+    });
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates to a missing release', async () => {
+    mocks.getRelease.mockResolvedValue(null);
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'nope',
+      addDocIds: ['Pages/home'],
+    });
+    expect(result).toMatchObject({success: false, error: 'NOT_FOUND'});
+  });
+
+  it('rejects a call with no requested changes', async () => {
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+    });
+    expect(result).toMatchObject({success: false, error: 'NO_CHANGES'});
+    expect(mocks.getRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects a no-op update (add existing doc, remove absent doc)', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['Pages/home'],
+      removeDocIds: ['Pages/not-in-release'],
+    });
+    expect(result).toMatchObject({success: false, error: 'NO_CHANGES'});
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects users without publish permission', async () => {
+    (window as any).firebase.user.email = 'viewer@example.com';
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['Pages/home'],
+    });
+    expect(result).toMatchObject({success: false, error: 'PERMISSION_DENIED'});
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('rejects adds of docs that do not exist', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const result: any = await executeCmsTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['Pages/missing'],
+    });
+    expect(result).toMatchObject({success: false, error: 'INVALID_DOC_IDS'});
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('previews the before/after doc lists', async () => {
+    mocks.getRelease.mockResolvedValue(unpublishedRelease());
+    const preview = await previewCmsWriteTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+      removeDocIds: ['Pages/about'],
+      description: 'Updated description',
+    });
+    expect(preview.error).toBeUndefined();
+    expect(preview.approveLabel).toBe('Approve release change');
+    expect(preview.before).toEqual({
+      id: 'spring-launch',
+      description: 'Spring launch',
+      docIds: ['Pages/about', 'Pages/home'],
+    });
+    expect(preview.after).toEqual({
+      id: 'spring-launch',
+      description: 'Updated description',
+      docIds: ['BlogPosts/launch', 'Pages/home'],
+    });
+    expect(mocks.updateRelease).not.toHaveBeenCalled();
+  });
+
+  it('previews an error for a scheduled release', async () => {
+    mocks.getRelease.mockResolvedValue(
+      unpublishedRelease({scheduledAt: {toMillis: () => 1234}})
+    );
+    const preview = await previewCmsWriteTool('release_update', {
+      releaseId: 'spring-launch',
+      addDocIds: ['BlogPosts/launch'],
+    });
+    expect(preview.error).toBe('RELEASE_NOT_EDITABLE');
+    expect(preview.hint).toContain('unschedule');
+  });
+});

--- a/packages/root-cms/ui/components/RootAIChat/cmsToolHandlers.ts
+++ b/packages/root-cms/ui/components/RootAIChat/cmsToolHandlers.ts
@@ -12,6 +12,7 @@
  * through the browser on every chat turn.
  */
 import {
+  deleteField,
   doc,
   Firestore,
   getDoc as fbGetDoc,
@@ -27,7 +28,16 @@ import {
   resolveArrayObjectPath,
   unmarshalData as unmarshalDataBase,
 } from '../../../shared/marshal.js';
+import {isSlugValid} from '../../../shared/slug.js';
+import {fetchProjectRoles} from '../../hooks/useProjectRoles.js';
 import {fetchCollectionSchema} from '../../utils/collection.js';
+import {testCanPublish} from '../../utils/permissions.js';
+import {
+  Release,
+  addRelease,
+  getRelease as cmsGetRelease,
+  updateRelease as cmsUpdateRelease,
+} from '../../utils/release.js';
 
 /** Lazily import the validators so we don't double-bundle them. */
 type Validators = typeof import('../../../core/ai-tools.js');
@@ -45,6 +55,8 @@ export const WRITE_CMS_TOOL_NAMES = [
   'doc_updateField',
   'doc_edit',
   'doc_duplicate',
+  'release_create',
+  'release_update',
 ] as const;
 
 export type CmsWriteToolName = (typeof WRITE_CMS_TOOL_NAMES)[number];
@@ -60,6 +72,8 @@ export interface CmsToolReceipt {
   summary: string;
   docId?: string;
   adminUrl?: string;
+  /** Label for the `adminUrl` button. Defaults to "Open document". */
+  linkLabel?: string;
   details: CmsToolDetail[];
 }
 
@@ -72,6 +86,8 @@ export interface CmsToolPreview {
   before?: unknown;
   after?: unknown;
   details: CmsToolDetail[];
+  /** Label for the approve button. Defaults to "Approve draft edit". */
+  approveLabel?: string;
   error?: string;
   errors?: unknown[];
   hint?: string;
@@ -290,6 +306,10 @@ export async function previewCmsWriteTool(
       return previewDocEdit(input);
     case 'doc_duplicate':
       return previewDocDuplicate(input);
+    case 'release_create':
+      return previewReleaseCreate(input);
+    case 'release_update':
+      return previewReleaseUpdate(input);
   }
 }
 
@@ -577,13 +597,496 @@ async function previewDocDuplicate(input: {
 }
 
 // ---------------------------------------------------------------------------
+// Release tools
+// ---------------------------------------------------------------------------
+//
+// `release_create` and `release_update` group docs for the user to publish
+// later — they never publish anything themselves. Updates are limited to
+// UNPUBLISHED releases: editing the doc list of a scheduled release would
+// change what auto-publishes at the scheduled time. Publishing, scheduling,
+// archiving and deleting releases remain user-only actions in the CMS UI
+// (see the safety policy in `core/ai-tools.ts`).
+
+interface ReleaseCreateInput {
+  releaseId: string;
+  description?: string;
+  docIds?: string[];
+}
+
+interface ReleaseUpdateInput {
+  releaseId: string;
+  description?: string;
+  addDocIds?: string[];
+  removeDocIds?: string[];
+}
+
+function getReleaseAdminUrl(releaseId: string): string {
+  return `/cms/releases/${encodeURIComponent(releaseId)}`;
+}
+
+function createReleaseReceipt(options: {
+  title: string;
+  summary: string;
+  releaseId: string;
+  details?: CmsToolDetail[];
+}): CmsToolReceipt {
+  return {
+    type: 'cms-write-receipt',
+    title: options.title,
+    summary: options.summary,
+    adminUrl: getReleaseAdminUrl(options.releaseId),
+    linkLabel: 'Open release',
+    details: [
+      ...(options.details || []),
+      {label: 'Status', value: 'Release saved'},
+      {
+        label: 'Publishing',
+        value: 'Publish or schedule manually from the CMS UI',
+      },
+    ],
+  };
+}
+
+/**
+ * Returns an error message if the signed-in user lacks permission to create
+ * or edit releases (publish permissions, i.e. ADMIN or EDITOR). Fails open
+ * when the roles lookup itself errors — Firestore security rules are the
+ * authoritative gate; this pre-check just produces friendlier errors.
+ */
+async function getReleasePermissionError(): Promise<string | null> {
+  let roles: Awaited<ReturnType<typeof fetchProjectRoles>>;
+  try {
+    roles = await fetchProjectRoles();
+  } catch (err) {
+    console.error('failed to load project roles:', err);
+    return null;
+  }
+  const email = getCtx().firebase.user?.email || '';
+  if (!testCanPublish(roles, email)) {
+    return (
+      `The signed-in user (${email || 'unknown'}) does not have permission ` +
+      'to create or edit releases. Releases require the ADMIN or EDITOR role.'
+    );
+  }
+  return null;
+}
+
+/**
+ * Normalizes a doc-id list input, parsing stringified JSON, trimming and
+ * deduping entries. Returns `null` when the value is not a list of
+ * non-empty strings (so callers can reject malformed input instead of
+ * silently dropping it).
+ */
+function normalizeDocIdList(value: any): string[] | null {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  const parsed = normalizeToolValue(value);
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+  const ids = new Set<string>();
+  for (const item of parsed) {
+    if (typeof item !== 'string' || !item.trim()) {
+      return null;
+    }
+    ids.add(item.trim());
+  }
+  return Array.from(ids);
+}
+
+interface ReleaseDocIdError {
+  docId: string;
+  message: string;
+}
+
+/**
+ * Canonicalizes doc ids for release membership (normalizing nested slugs
+ * like "Pages/foo/bar" to "Pages/foo--bar", matching how the CMS stores doc
+ * ids) and verifies each doc exists as a draft. Returns the sorted canonical
+ * ids plus any per-doc errors.
+ */
+async function resolveReleaseDocIds(
+  rawDocIds: string[]
+): Promise<{docIds: string[]; errors: ReleaseDocIdError[]}> {
+  const canonical = new Set<string>();
+  const errors: ReleaseDocIdError[] = [];
+  await Promise.all(
+    rawDocIds.map(async (rawDocId) => {
+      let docId: string;
+      try {
+        const {collection, slug} = parseDocId(rawDocId);
+        docId = `${collection}/${slug}`;
+      } catch {
+        errors.push({
+          docId: rawDocId,
+          message: 'Doc id must use the form "Collection/slug".',
+        });
+        return;
+      }
+      const snap = await fbGetDoc(draftDocRef(docId));
+      if (!snap.exists()) {
+        errors.push({
+          docId: rawDocId,
+          message: 'Doc does not exist as a draft.',
+        });
+        return;
+      }
+      canonical.add(docId);
+    })
+  );
+  errors.sort((a, b) => (a.docId < b.docId ? -1 : a.docId > b.docId ? 1 : 0));
+  return {docIds: Array.from(canonical).sort(), errors};
+}
+
+/**
+ * Expands remove ids to also match their canonical "Collection/slug" form so
+ * "Pages/foo/bar" removes a stored "Pages/foo--bar" entry. Invalid ids are
+ * kept verbatim (they can still match a legacy entry). Removed docs are NOT
+ * required to exist, so stale references to deleted docs can be cleaned up.
+ */
+function expandRemoveDocIds(removeDocIds: string[]): string[] {
+  const out = new Set<string>();
+  for (const removeDocId of removeDocIds) {
+    out.add(removeDocId);
+    try {
+      const {collection, slug} = parseDocId(removeDocId);
+      out.add(`${collection}/${slug}`);
+    } catch {
+      // Keep the raw id only.
+    }
+  }
+  return Array.from(out);
+}
+
+interface ReleasePlanError {
+  ok: false;
+  error: string;
+  summary: string;
+  errors?: unknown[];
+  hint?: string;
+}
+
+interface ReleaseCreatePlanOk {
+  ok: true;
+  releaseId: string;
+  description?: string;
+  docIds: string[];
+}
+
+/**
+ * Validates a `release_create` call and computes the release payload.
+ * Shared by the approval preview and the execute handler so both apply the
+ * same checks.
+ */
+async function planReleaseCreate(
+  input: ReleaseCreateInput
+): Promise<ReleaseCreatePlanOk | ReleasePlanError> {
+  const releaseId =
+    typeof input?.releaseId === 'string' ? input.releaseId.trim() : '';
+  if (!releaseId || !isSlugValid(releaseId)) {
+    return {
+      ok: false,
+      error: 'INVALID_RELEASE_ID',
+      summary: `"${releaseId}" is not a valid release id.`,
+      hint:
+        'Release ids use lowercase letters, numbers, underscores and ' +
+        'dashes, e.g. "spring-launch".',
+    };
+  }
+  const permissionError = await getReleasePermissionError();
+  if (permissionError) {
+    return {
+      ok: false,
+      error: 'PERMISSION_DENIED',
+      summary: permissionError,
+      hint: 'Ask a project ADMIN or EDITOR to make release changes.',
+    };
+  }
+  const rawDocIds = normalizeDocIdList(input.docIds);
+  if (!rawDocIds) {
+    return {
+      ok: false,
+      error: 'INVALID_INPUT',
+      summary: '`docIds` must be an array of non-empty doc id strings.',
+      hint: 'Pass doc ids like ["Pages/home", "BlogPosts/launch"].',
+    };
+  }
+  const existing = await cmsGetRelease(releaseId);
+  if (existing) {
+    return {
+      ok: false,
+      error: 'ALREADY_EXISTS',
+      summary: `Release "${releaseId}" already exists.`,
+      hint:
+        'Choose an unused release id, or use `release_update` to modify ' +
+        'the existing release.',
+    };
+  }
+  const resolved = await resolveReleaseDocIds(rawDocIds);
+  if (resolved.errors.length > 0) {
+    return {
+      ok: false,
+      error: 'INVALID_DOC_IDS',
+      summary: 'Some docs could not be added to the release.',
+      errors: resolved.errors,
+      hint:
+        'Docs must exist before adding them to a release. Use `docs_list` ' +
+        'to find valid doc ids.',
+    };
+  }
+  const description =
+    typeof input.description === 'string'
+      ? input.description.trim() || undefined
+      : undefined;
+  return {ok: true, releaseId, description, docIds: resolved.docIds};
+}
+
+interface ReleaseUpdatePlanOk {
+  ok: true;
+  releaseId: string;
+  before: {id: string; description?: string; docIds: string[]};
+  after: {id: string; description?: string; docIds: string[]};
+  addedDocIds: string[];
+  removedDocIds: string[];
+  descriptionChanged: boolean;
+}
+
+/**
+ * Validates a `release_update` call against the current release state and
+ * computes the resulting doc list/description. Shared by the approval
+ * preview and the execute handler so both apply the same checks.
+ */
+async function planReleaseUpdate(
+  input: ReleaseUpdateInput
+): Promise<ReleaseUpdatePlanOk | ReleasePlanError> {
+  const releaseId =
+    typeof input?.releaseId === 'string' ? input.releaseId.trim() : '';
+  if (!releaseId) {
+    return {
+      ok: false,
+      error: 'INVALID_RELEASE_ID',
+      summary: 'Missing `releaseId`.',
+      hint: 'Use `releases_list` to find valid release ids.',
+    };
+  }
+  const permissionError = await getReleasePermissionError();
+  if (permissionError) {
+    return {
+      ok: false,
+      error: 'PERMISSION_DENIED',
+      summary: permissionError,
+      hint: 'Ask a project ADMIN or EDITOR to make release changes.',
+    };
+  }
+  const addRaw = normalizeDocIdList(input.addDocIds);
+  const removeRaw = normalizeDocIdList(input.removeDocIds);
+  if (!addRaw || !removeRaw) {
+    return {
+      ok: false,
+      error: 'INVALID_INPUT',
+      summary:
+        '`addDocIds` and `removeDocIds` must be arrays of non-empty doc ' +
+        'id strings.',
+      hint: 'Pass doc ids like ["Pages/home"].',
+    };
+  }
+  const description =
+    typeof input.description === 'string' ? input.description : undefined;
+  if (
+    addRaw.length === 0 &&
+    removeRaw.length === 0 &&
+    description === undefined
+  ) {
+    return {
+      ok: false,
+      error: 'NO_CHANGES',
+      summary: 'No changes were requested.',
+      hint: 'Pass `description`, `addDocIds` and/or `removeDocIds`.',
+    };
+  }
+  const release = await cmsGetRelease(releaseId);
+  if (!release) {
+    return {
+      ok: false,
+      error: 'NOT_FOUND',
+      summary: `Release "${releaseId}" does not exist.`,
+      hint:
+        'Use `releases_list` to find valid release ids, or create one ' +
+        'with `release_create`.',
+    };
+  }
+  const {computeReleaseDocIds, getReleaseStatus} = await loadValidators();
+  const status = getReleaseStatus(release);
+  if (status !== 'unpublished') {
+    const hints: Record<string, string> = {
+      scheduled:
+        'The release is scheduled for publishing. The user must ' +
+        'unschedule it from the CMS UI before it can be edited.',
+      published:
+        'The release has already been published. Create a new release ' +
+        'for further changes.',
+      archived:
+        'The release is archived. The user must unarchive it from the ' +
+        'CMS UI before it can be edited.',
+    };
+    return {
+      ok: false,
+      error: 'RELEASE_NOT_EDITABLE',
+      summary: `Release "${releaseId}" is ${status} and cannot be edited.`,
+      hint: hints[status],
+    };
+  }
+  const resolvedAdds = await resolveReleaseDocIds(addRaw);
+  if (resolvedAdds.errors.length > 0) {
+    return {
+      ok: false,
+      error: 'INVALID_DOC_IDS',
+      summary: 'Some docs could not be added to the release.',
+      errors: resolvedAdds.errors,
+      hint:
+        'Docs must exist before adding them to a release. Use `docs_list` ' +
+        'to find valid doc ids.',
+    };
+  }
+  const existingDocIds = Array.from(new Set(release.docIds || [])).sort();
+  const newDocIds = computeReleaseDocIds(
+    existingDocIds,
+    resolvedAdds.docIds,
+    expandRemoveDocIds(removeRaw)
+  );
+  const oldDescription = release.description || undefined;
+  const newDescription =
+    description !== undefined
+      ? description.trim() || undefined
+      : oldDescription;
+  const docsChanged =
+    JSON.stringify(existingDocIds) !== JSON.stringify(newDocIds);
+  const descriptionChanged = newDescription !== oldDescription;
+  if (!docsChanged && !descriptionChanged) {
+    return {
+      ok: false,
+      error: 'NO_CHANGES',
+      summary: `The requested update would not change release "${releaseId}".`,
+      hint:
+        'Check the current release contents with `release_get`, then ' +
+        'retry with docs that are not already in the requested state.',
+    };
+  }
+  return {
+    ok: true,
+    releaseId,
+    before: {
+      id: releaseId,
+      description: oldDescription,
+      docIds: existingDocIds,
+    },
+    after: {id: releaseId, description: newDescription, docIds: newDocIds},
+    addedDocIds: newDocIds.filter((id) => !existingDocIds.includes(id)),
+    removedDocIds: existingDocIds.filter((id) => !newDocIds.includes(id)),
+    descriptionChanged,
+  };
+}
+
+/** Short human-readable summary of a planned `release_update`. */
+function describeReleaseUpdate(plan: ReleaseUpdatePlanOk): string {
+  const parts: string[] = [];
+  if (plan.addedDocIds.length > 0) {
+    const n = plan.addedDocIds.length;
+    parts.push(`add ${n} doc${n === 1 ? '' : 's'}`);
+  }
+  if (plan.removedDocIds.length > 0) {
+    const n = plan.removedDocIds.length;
+    parts.push(`remove ${n} doc${n === 1 ? '' : 's'}`);
+  }
+  if (plan.descriptionChanged) {
+    parts.push('update the description');
+  }
+  return `Update release ${plan.releaseId}: ${parts.join(', ')}.`;
+}
+
+async function previewReleaseCreate(
+  input: ReleaseCreateInput
+): Promise<CmsToolPreview> {
+  const plan = await planReleaseCreate(input);
+  if (!plan.ok) {
+    return createPreviewError({
+      toolName: 'release_create',
+      title: 'Create release',
+      summary: plan.summary,
+      error: plan.error,
+      errors: plan.errors,
+      hint: plan.hint,
+    });
+  }
+  const after: Record<string, unknown> = {id: plan.releaseId};
+  if (plan.description) {
+    after.description = plan.description;
+  }
+  after.docIds = plan.docIds;
+  return {
+    toolName: 'release_create',
+    title: 'Create release',
+    summary: `Create release ${plan.releaseId} with ${plan.docIds.length} doc${
+      plan.docIds.length === 1 ? '' : 's'
+    }.`,
+    before: {},
+    after,
+    details: [
+      {label: 'Release', value: plan.releaseId},
+      {label: 'Docs', value: String(plan.docIds.length)},
+      {label: 'Operation', value: 'Create release'},
+    ],
+    approveLabel: 'Approve release change',
+  };
+}
+
+async function previewReleaseUpdate(
+  input: ReleaseUpdateInput
+): Promise<CmsToolPreview> {
+  const plan = await planReleaseUpdate(input);
+  if (!plan.ok) {
+    return createPreviewError({
+      toolName: 'release_update',
+      title: 'Update release',
+      summary: plan.summary,
+      error: plan.error,
+      errors: plan.errors,
+      hint: plan.hint,
+    });
+  }
+  const details: CmsToolDetail[] = [{label: 'Release', value: plan.releaseId}];
+  if (plan.addedDocIds.length > 0) {
+    details.push({label: 'Add docs', value: plan.addedDocIds.join(', ')});
+  }
+  if (plan.removedDocIds.length > 0) {
+    details.push({label: 'Remove docs', value: plan.removedDocIds.join(', ')});
+  }
+  if (plan.descriptionChanged) {
+    details.push({
+      label: 'Description',
+      value: plan.after.description || '(cleared)',
+    });
+  }
+  return {
+    toolName: 'release_update',
+    title: 'Update release',
+    summary: describeReleaseUpdate(plan),
+    before: plan.before,
+    after: plan.after,
+    details,
+    approveLabel: 'Approve release change',
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Handler implementations
 // ---------------------------------------------------------------------------
 //
 // Only write tools live here. Read tools (`doc_get`, `docs_list`,
 // `docs_search`, `doc_getVersion`, `doc_listVersions`, `schema_get`,
-// `collections_list`) execute server-side via the `execute` blocks in
-// `core/ai-tools.ts`.
+// `collections_list`, `releases_list`, `release_get`) execute via the
+// `execute` blocks in `core/ai-tools.ts`.
 
 async function getCachedSchema(collectionId: string): Promise<Collection> {
   return await fetchCollectionSchema(collectionId);
@@ -940,6 +1443,90 @@ async function docTranslateField(input: {
   return {translations: data.translations};
 }
 
+async function releaseCreate(input: ReleaseCreateInput) {
+  const plan = await planReleaseCreate(input);
+  if (!plan.ok) {
+    return {
+      success: false,
+      releaseId: input?.releaseId,
+      error: plan.error,
+      message: plan.summary,
+      errors: plan.errors,
+      hint: plan.hint,
+    };
+  }
+  const release: Partial<Release> = {docIds: plan.docIds};
+  if (plan.description) {
+    release.description = plan.description;
+  }
+  await addRelease(plan.releaseId, release);
+  return {
+    success: true,
+    releaseId: plan.releaseId,
+    docIds: plan.docIds,
+    receipt: createReleaseReceipt({
+      title: 'Created release',
+      summary: `Created release ${plan.releaseId} with ${
+        plan.docIds.length
+      } doc${plan.docIds.length === 1 ? '' : 's'}.`,
+      releaseId: plan.releaseId,
+      details: [
+        {label: 'Release', value: plan.releaseId},
+        {label: 'Docs', value: String(plan.docIds.length)},
+        {label: 'Operation', value: 'Create release'},
+      ],
+    }),
+  };
+}
+
+async function releaseUpdate(input: ReleaseUpdateInput) {
+  const plan = await planReleaseUpdate(input);
+  if (!plan.ok) {
+    return {
+      success: false,
+      releaseId: input?.releaseId,
+      error: plan.error,
+      message: plan.summary,
+      errors: plan.errors,
+      hint: plan.hint,
+    };
+  }
+  const updates: Record<string, unknown> = {docIds: plan.after.docIds};
+  if (plan.descriptionChanged) {
+    updates.description =
+      plan.after.description !== undefined
+        ? plan.after.description
+        : deleteField();
+  }
+  await cmsUpdateRelease(plan.releaseId, updates as Partial<Release>);
+  const details: CmsToolDetail[] = [{label: 'Release', value: plan.releaseId}];
+  if (plan.addedDocIds.length > 0) {
+    details.push({label: 'Added', value: plan.addedDocIds.join(', ')});
+  }
+  if (plan.removedDocIds.length > 0) {
+    details.push({label: 'Removed', value: plan.removedDocIds.join(', ')});
+  }
+  if (plan.descriptionChanged) {
+    details.push({
+      label: 'Description',
+      value: plan.after.description || '(cleared)',
+    });
+  }
+  return {
+    success: true,
+    releaseId: plan.releaseId,
+    docIds: plan.after.docIds,
+    addedDocIds: plan.addedDocIds,
+    removedDocIds: plan.removedDocIds,
+    receipt: createReleaseReceipt({
+      title: 'Updated release',
+      summary: describeReleaseUpdate(plan),
+      releaseId: plan.releaseId,
+      details,
+    }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -951,6 +1538,8 @@ const HANDLERS: Record<string, (input: any) => Promise<unknown>> = {
   doc_edit: docEdit,
   doc_duplicate: docDuplicate,
   doc_translateField: docTranslateField,
+  release_create: releaseCreate,
+  release_update: releaseUpdate,
 };
 
 /**

--- a/packages/root-cms/ui/components/RootAIChat/toolLabels.ts
+++ b/packages/root-cms/ui/components/RootAIChat/toolLabels.ts
@@ -33,6 +33,14 @@ export function prettyToolName(toolName: string, input: any): string {
       return 'Translate field text';
     case 'schema_get':
       return `Read ${input?.collectionId || 'collection'} schema`;
+    case 'releases_list':
+      return 'List releases';
+    case 'release_get':
+      return `Read release ${input?.releaseId || ''}`.trim();
+    case 'release_create':
+      return `Create release ${input?.releaseId || ''}`.trim();
+    case 'release_update':
+      return `Update release ${input?.releaseId || ''}`.trim();
     default:
       return toolName;
   }

--- a/packages/root-cms/ui/hooks/useProjectRoles.ts
+++ b/packages/root-cms/ui/hooks/useProjectRoles.ts
@@ -6,7 +6,12 @@ import {withTimeout} from '../utils/with-timeout.js';
 /** Module-level cache so the Firestore fetch happens at most once. */
 let cachedRolesPromise: Promise<Record<string, UserRole>> | null = null;
 
-function fetchRoles(): Promise<Record<string, UserRole>> {
+/**
+ * Fetches the roles defined for the current project, sharing the same cached
+ * result as the `useProjectRoles()` hook. Exported for non-component callers
+ * (e.g. the Root AI tool handlers) that need to check permissions.
+ */
+export function fetchProjectRoles(): Promise<Record<string, UserRole>> {
   if (!cachedRolesPromise) {
     cachedRolesPromise = (async () => {
       const db = window.firebase.db;
@@ -39,7 +44,7 @@ export function useProjectRoles() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchRoles()
+    fetchProjectRoles()
       .then((roles) => {
         setRoles(roles);
       })


### PR DESCRIPTION
## Summary

This PR adds two new AI tools to Root CMS for managing releases: `release_create` and `release_update`. These tools allow the AI to group documents into releases for coordinated publishing, while maintaining safety by restricting edits to unpublished releases and requiring appropriate user permissions.

## Key Changes

- **New Release Write Tools**: Added `release_create` and `release_update` tools that enable AI-assisted release management
  - `release_create`: Creates a new release with an optional description and list of documents
  - `release_update`: Modifies an unpublished release by adding/removing documents or updating the description

- **Release Tool Handlers** (`cmsToolHandlers.ts`):
  - Implemented `planReleaseCreate()` and `planReleaseUpdate()` for validation and planning
  - Added `previewReleaseCreate()` and `previewReleaseUpdate()` for user approval previews
  - Implemented `releaseCreate()` and `releaseUpdate()` execution handlers
  - Added helper functions for doc ID canonicalization, validation, and permission checking
  - Integrated with existing release utilities (`addRelease`, `updateRelease`, `getRelease`)

- **Core Tool Definitions** (`core/ai-tools.ts`):
  - Added `CmsToolRelease` interface for model-ready release representation
  - Added `getReleaseStatus()` utility to derive release lifecycle status (unpublished/scheduled/published/archived)
  - Added `computeReleaseDocIds()` utility for computing doc list changes
  - Extended `CmsToolReadBackend` with `listReleases()` and `getRelease()` methods
  - Added read-only release tools (`releases_list`, `release_get`) with server-side execution

- **Client-Side Integration** (`clientCmsTools.ts`):
  - Implemented `shapeRelease()` to convert Firestore releases to model-ready format
  - Wired up release read tools to the backend

- **Safety & Validation**:
  - Permission checks ensure only ADMIN/EDITOR users can create/edit releases
  - Doc ID validation and canonicalization (e.g., "Pages/foo/bar" → "Pages/foo--bar")
  - Prevents editing of scheduled/published/archived releases
  - Validates that docs exist as drafts before adding to releases
  - Comprehensive error handling with user-friendly messages

- **UI Enhancements**:
  - Added `linkLabel` and `approveLabel` fields to tool receipts/previews for customizable button labels
  - Updated tool labels to display release-specific names
  - Integrated custom approval labels in the approval card

- **Testing**:
  - Added comprehensive test suite (`cmsToolHandlers.release.test.ts`) covering:
    - Release creation with doc deduplication and canonicalization
    - Release updates with add/remove operations
    - Permission validation
    - Release state validation (unpublished-only edits)
    - Error cases and edge conditions
  - Added core utility tests for `getReleaseStatus()` and `computeReleaseDocIds()`
  - Added tool wiring tests to verify read/write tool registration

## Notable Implementation Details

- **Safety Policy**: Release tools are intentionally limited to draft-mode operations. Publishing, scheduling, archiving, and deleting releases remain user-only actions in the CMS UI, preventing the AI from making irreversible changes to production state.

- **Doc ID Canonicalization**: The implementation handles both slash-separated ("Pages/foo/bar") and dash-separated ("Pages/foo--bar") doc ID formats, normalizing them for consistent storage and matching.

- **Unpublished-Only Edits**: The `release_update` tool explicitly checks release status and rejects updates to scheduled/published/archived releases, preventing unintended changes to what will auto-publish.

- **Shared Validation**: Planning functions (`planReleaseCreate`, `planReleaseUpdate`) are shared between preview and execution handlers to ensure consistent validation logic.

https://claude.ai/code/session_01QcFggiRxQn5HdnjRHdxbZk