### PR TITLE
feat: add email notifications service for cms action logs

### DIFF
--- a/.changeset/email-notifications-service.md
+++ b/.changeset/email-notifications-service.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add email notifications service for cms action logs

--- a/packages/root-cms/core/client.sendEmail.test.ts
+++ b/packages/root-cms/core/client.sendEmail.test.ts
@@ -1,0 +1,193 @@
+import {RootConfig} from '@blinkk/root';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+// Mock Firebase Admin.
+vi.mock('firebase-admin/app', () => ({
+  getApp: vi.fn(),
+  initializeApp: vi.fn(),
+  applicationDefault: vi.fn(),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: vi.fn(),
+  Timestamp: {
+    now: vi.fn(() => ({toMillis: () => 1234567890})),
+    fromDate: vi.fn((date: Date) => ({
+      toMillis: () => date.getTime(),
+      toDate: () => date,
+    })),
+  },
+  FieldValue: {},
+}));
+
+// Mock project module.
+vi.mock('./project.js', () => ({
+  getCollectionSchema: vi.fn(),
+}));
+
+describe('RootCMSClient.sendEmail', () => {
+  let mockRootConfig: RootConfig;
+  let mockAdd: any;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAdd = vi.fn(async () => ({id: 'email-1'}));
+    mockFetch = vi.fn(async () => ({status: 200, text: async () => ''}));
+    vi.stubGlobal('fetch', mockFetch);
+
+    mockRootConfig = {
+      rootDir: '/test',
+      plugins: [
+        {
+          name: 'root-cms',
+          getConfig: () => ({
+            id: 'test-project',
+            firebaseConfig: {
+              apiKey: 'test',
+              authDomain: 'test',
+              projectId: 'test-gcp-project',
+              storageBucket: 'test',
+            },
+          }),
+          getFirebaseApp: vi.fn(),
+          getFirestore: vi.fn(() => ({
+            collection: vi.fn(() => ({add: mockAdd})),
+          })),
+        } as any,
+      ],
+    } as any;
+  });
+
+  it('queues a pending email in the Emails collection', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    const emailId = await client.sendEmail({
+      to: 'a@example.com',
+      subject: 'Test subject',
+      body: 'Test body',
+    });
+
+    expect(emailId).toBe('email-1');
+    expect(mockAdd).toHaveBeenCalledOnce();
+    const email = mockAdd.mock.calls[0][0];
+    expect(email.status).toBe('pending');
+    expect(email.to).toEqual(['a@example.com']);
+    expect(email.from).toBe('noreply@test-gcp-project.appspotmail.com');
+    expect(email.subject).toBe('Test subject');
+    expect(email.body).toBe('Test body');
+    expect(email.htmlBody).toBeUndefined();
+    expect(email.expiredAt).toBeUndefined();
+    expect(email.createdAt).toBeDefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('supports custom from, htmlBody, and expiresAt', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+    const expiresAt = new Date('2026-07-21T12:00:00.000Z');
+
+    await client.sendEmail({
+      to: ['a@example.com', ' b@example.com ', ''],
+      from: 'cms@example.com',
+      subject: 'Test subject',
+      body: 'Test body',
+      htmlBody: '<p>Test body</p>',
+      expiresAt: expiresAt,
+    });
+
+    const email = mockAdd.mock.calls[0][0];
+    expect(email.to).toEqual(['a@example.com', 'b@example.com']);
+    expect(email.from).toBe('cms@example.com');
+    expect(email.htmlBody).toBe('<p>Test body</p>');
+    expect(email.expiredAt.toDate()).toEqual(expiresAt);
+  });
+
+  it('derives a plain-text body from the html body', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    await client.sendEmail({
+      to: 'a@example.com',
+      subject: 'Test subject',
+      htmlBody: '<h2>Title</h2>\n<p>Tom &amp; Jerry<br>Second line</p>',
+    });
+
+    const email = mockAdd.mock.calls[0][0];
+    expect(email.body).toBe('Title\n\nTom & Jerry\nSecond line');
+  });
+
+  it('throws when required fields are missing', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    await expect(
+      client.sendEmail({to: [], subject: 'Test subject'})
+    ).rejects.toThrow('missing required: "to"');
+    await expect(
+      client.sendEmail({to: 'a@example.com', subject: ''})
+    ).rejects.toThrow('missing required: "subject"');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('notifies the default email service when emailService is true', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    await client.sendEmail({
+      to: 'a@example.com',
+      subject: 'Test subject',
+      body: 'Test body',
+      emailService: true,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://services.rootjs.dev/_/send_emails?projectId=test-project'
+    );
+  });
+
+  it('notifies a self-hosted email service by base url', async () => {
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    await client.sendEmail({
+      to: 'a@example.com',
+      subject: 'Test subject',
+      body: 'Test body',
+      emailService: 'https://services.example.com/',
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://services.example.com/_/send_emails?projectId=test-project'
+    );
+  });
+
+  it('resolves even when the email service request fails', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error('network error'));
+
+    const {RootCMSClient} = await import('./client.js');
+    const client = new RootCMSClient(mockRootConfig);
+
+    const emailId = await client.sendEmail({
+      to: 'a@example.com',
+      subject: 'Test subject',
+      body: 'Test body',
+      emailService: true,
+    });
+    expect(emailId).toBe('email-1');
+
+    // Flush the fire-and-forget request to verify the error is handled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(consoleError).toHaveBeenCalledWith(
+      'failed to notify the email service:',
+      expect.any(Error)
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -31,6 +31,16 @@ import {setValueAtPath} from './values.js';
  */
 const FIRESTORE_DOC_ID_MAX_BYTES = 1500;
 
+/**
+ * Base URL of the default hosted Root.js services backend
+ * (`apps/root-services`), which provides the email service used by
+ * `sendEmail()`.
+ */
+const DEFAULT_EMAIL_SERVICE_URL = 'https://services.rootjs.dev';
+
+/** Max time to wait for the email service to process the email queue. */
+const EMAIL_SERVICE_TIMEOUT_MS = 60 * 1000;
+
 export interface Doc<Fields = any> {
   /** The id of the doc, e.g. "Pages/foo-bar". */
   id: string;
@@ -278,6 +288,48 @@ export interface ListActionsOptions {
    * Max number of actions to return. Defaults to 100.
    */
   limit?: number;
+}
+
+/**
+ * Options for `RootCMSClient.sendEmail()`.
+ *
+ * Emails are queued in the `Projects/${projectId}/Emails` collection in
+ * firestore and delivered by the Root.js email service (`apps/root-services`),
+ * which sends pending emails using the App Engine Mail API.
+ */
+export interface SendEmailOptions {
+  /** Recipient email address(es). */
+  to: string | string[];
+  /**
+   * Sender email address. The sender must be authorized to send email via the
+   * App Engine Mail API, e.g. `noreply@<gcp-project-id>.appspotmail.com`.
+   * Defaults to `noreply@<gcp-project-id>.appspotmail.com`.
+   */
+  from?: string;
+  /** Subject line. */
+  subject: string;
+  /**
+   * Plain-text body. When omitted, a plain-text body is derived from
+   * `htmlBody`.
+   */
+  body?: string;
+  /** Optional HTML body. */
+  htmlBody?: string;
+  /**
+   * Optional expiration date. If the email is still unsent when the email
+   * service processes the queue after this date (e.g. the service was down),
+   * the email is marked as expired and skipped instead of being delivered
+   * late.
+   */
+  expiresAt?: Date;
+  /**
+   * Email service used to trigger delivery immediately after the email is
+   * queued. Setting this to `true` uses the default hosted service at
+   * https://services.rootjs.dev. Set to a base URL to use a self-hosted
+   * deployment of the service (`apps/root-services`). When unset, the email
+   * remains queued until the email service's cron next processes the queue.
+   */
+  emailService?: string | boolean;
 }
 
 export class RootCMSClient {
@@ -2005,6 +2057,73 @@ export class RootCMSClient {
   }
 
   /**
+   * Queues an email in the `Projects/${projectId}/Emails` collection in
+   * firestore, which is processed by the Root.js email service
+   * (`apps/root-services`). Returns the id of the queued email doc.
+   *
+   * Delivery is asynchronous: the email service sends pending emails when its
+   * `/_/send_emails` endpoint is called (typically via a cron). Pass the
+   * `emailService` option to notify the service right away.
+   */
+  async sendEmail(options: SendEmailOptions): Promise<string> {
+    const to = Array.isArray(options.to) ? options.to : [options.to];
+    const recipients = to.map((email) => String(email).trim()).filter(Boolean);
+    if (recipients.length === 0) {
+      throw new Error('missing required: "to"');
+    }
+    if (!options.subject) {
+      throw new Error('missing required: "subject"');
+    }
+    const gcpProjectId = this.cmsPlugin.getConfig().firebaseConfig.projectId;
+    const email: Record<string, any> = {
+      status: 'pending',
+      createdAt: Timestamp.now(),
+      from: options.from || `noreply@${gcpProjectId}.appspotmail.com`,
+      to: recipients,
+      subject: options.subject,
+      // The email service always reads the `body` field, so fall back to a
+      // plain-text version of the html body when no body is provided.
+      body: options.body ?? htmlToPlainText(options.htmlBody || ''),
+    };
+    if (options.htmlBody) {
+      email.htmlBody = options.htmlBody;
+    }
+    if (options.expiresAt) {
+      email.expiredAt = Timestamp.fromDate(options.expiresAt);
+    }
+    const colRef = this.db.collection(`Projects/${this.projectId}/Emails`);
+    const docRef = await colRef.add(email);
+    if (options.emailService) {
+      this.notifyEmailService(options.emailService);
+    }
+    return docRef.id;
+  }
+
+  /**
+   * Notifies the email service that pending emails are ready for delivery.
+   * Fire-and-forget: queued emails are eventually delivered when the email
+   * service's cron next runs, even if this request fails.
+   */
+  private notifyEmailService(emailService: string | boolean) {
+    const baseUrl =
+      typeof emailService === 'string'
+        ? emailService.replace(/\/+$/, '')
+        : DEFAULT_EMAIL_SERVICE_URL;
+    const params = new URLSearchParams({projectId: this.projectId});
+    const url = `${baseUrl}/_/send_emails?${params.toString()}`;
+    fetch(url, {signal: AbortSignal.timeout(EMAIL_SERVICE_TIMEOUT_MS)})
+      .then(async (res) => {
+        if (res.status !== 200) {
+          const err = await res.text();
+          console.error(`email service returned ${res.status}: ${err}`);
+        }
+      })
+      .catch((err) => {
+        console.error('failed to notify the email service:', err);
+      });
+  }
+
+  /**
    * Creates a batch request that is capable of fetching one or more docs,
    * corresponding translations, and dataSources.
    */
@@ -2397,6 +2516,26 @@ export function translationsForLocale(
     localeTranslations[source] = translation;
   });
   return localeTranslations;
+}
+
+/**
+ * Converts an HTML string to a rough plain-text equivalent. Used as a
+ * fallback for the plain-text body of emails that only provide an HTML body.
+ */
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<(style|script)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li|tr|table|ul|ol|blockquote|pre)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 }
 
 /** A pretty printer for JavaScript objects. */

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -47,6 +47,14 @@ export type {
   NotificationResult,
   NotificationServiceContext,
 } from './services-notifications.js';
+export {
+  emailNotifications,
+  renderEmailTemplate,
+} from './services-notifications-email.js';
+export type {
+  EmailNotificationTemplate,
+  EmailNotificationsOptions,
+} from './services-notifications-email.js';
 export type {
   CMSTranslationService,
   RootLocale,
@@ -522,7 +530,20 @@ export type CMSPluginOptions = {
    * external channels (email, Slack, webhooks, etc.). Each service defines
    * an optional server-side `onAction` handler.
    *
-   * Example:
+   * Use the built-in `emailNotifications()` service to send emails via the
+   * Root.js email service:
+   * ```ts
+   * cmsPlugin({
+   *   notifications: [
+   *     emailNotifications({
+   *       actions: ['doc.publish', 'release.*'],
+   *       to: ['cms-alerts@example.com'],
+   *     }),
+   *   ],
+   * });
+   * ```
+   *
+   * Custom services can be defined inline:
    * ```ts
    * cmsPlugin({
    *   notifications: [

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -48,6 +48,7 @@ export type {
   NotificationServiceContext,
 } from './services-notifications.js';
 export {
+  DEFAULT_EMAIL_TEMPLATE,
   emailNotifications,
   renderEmailTemplate,
 } from './services-notifications-email.js';

--- a/packages/root-cms/core/services-notifications-email.test.ts
+++ b/packages/root-cms/core/services-notifications-email.test.ts
@@ -1,0 +1,292 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {Action} from './client.js';
+import {
+  emailNotifications,
+  renderEmailTemplate,
+} from './services-notifications-email.js';
+import type {NotificationServiceContext} from './services-notifications.js';
+
+/** Returns a fake firestore `Timestamp`-like object for tests. */
+function fakeTimestamp(date: Date) {
+  return {toDate: () => date, toMillis: () => date.getTime()} as any;
+}
+
+const TEST_DATE = new Date('2026-07-21T12:00:00.000Z');
+
+function testAction(overrides?: Partial<Action>): Action {
+  return {
+    action: 'doc.publish',
+    by: 'user@example.com',
+    timestamp: fakeTimestamp(TEST_DATE),
+    metadata: {docId: 'Pages/foo'},
+    ...overrides,
+  };
+}
+
+function testContext() {
+  const sendEmail = vi.fn(async () => 'email-id-1');
+  const ctx = {
+    rootConfig: {} as any,
+    cmsClient: {sendEmail} as any,
+    user: {email: 'user@example.com'},
+  } as NotificationServiceContext;
+  return {ctx, sendEmail};
+}
+
+describe('renderEmailTemplate', () => {
+  it('replaces placeholders with values from data', () => {
+    const result = renderEmailTemplate('{action} by {by}', {
+      action: 'doc.publish',
+      by: 'user@example.com',
+    });
+    expect(result).toBe('doc.publish by user@example.com');
+  });
+
+  it('supports dot notation for nested values', () => {
+    const result = renderEmailTemplate('doc: {metadata.docId}', {
+      metadata: {docId: 'Pages/foo'},
+    });
+    expect(result).toBe('doc: Pages/foo');
+  });
+
+  it('leaves unknown placeholders untouched', () => {
+    const result = renderEmailTemplate('{action} {unknown.key}', {
+      action: 'doc.publish',
+    });
+    expect(result).toBe('doc.publish {unknown.key}');
+  });
+
+  it('formats timestamps and dates as ISO strings', () => {
+    expect(
+      renderEmailTemplate('{timestamp}', {timestamp: fakeTimestamp(TEST_DATE)})
+    ).toBe('2026-07-21T12:00:00.000Z');
+    expect(renderEmailTemplate('{date}', {date: TEST_DATE})).toBe(
+      '2026-07-21T12:00:00.000Z'
+    );
+  });
+
+  it('formats objects as json', () => {
+    const result = renderEmailTemplate('{metadata}', {
+      metadata: {docId: 'Pages/foo'},
+    });
+    expect(result).toBe('{\n  "docId": "Pages/foo"\n}');
+  });
+
+  it('stringifies primitive values', () => {
+    expect(renderEmailTemplate('{count}', {count: 42})).toBe('42');
+    expect(renderEmailTemplate('{flag}', {flag: false})).toBe('false');
+  });
+
+  it('escapes html when the escapeHtml option is set', () => {
+    const data = {title: '<b>"Tom" & Jerry\'s</b>'};
+    expect(renderEmailTemplate('{title}', data, {escapeHtml: true})).toBe(
+      '&lt;b&gt;&quot;Tom&quot; &amp; Jerry&#39;s&lt;/b&gt;'
+    );
+    expect(renderEmailTemplate('{title}', data)).toBe(data.title);
+  });
+});
+
+describe('emailNotifications', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses default id and label', () => {
+    const service = emailNotifications({to: ['a@example.com']});
+    expect(service.id).toBe('email');
+    expect(service.label).toBe('Email');
+  });
+
+  it('supports custom id, label, and icon', () => {
+    const service = emailNotifications({
+      id: 'my-email',
+      label: 'My Email',
+      icon: 'https://example.com/icon.png',
+      to: ['a@example.com'],
+    });
+    expect(service.id).toBe('my-email');
+    expect(service.label).toBe('My Email');
+    expect(service.icon).toBe('https://example.com/icon.png');
+  });
+
+  it('queues an email using the default templates', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({to: ['a@example.com']});
+    const result = await service.onAction!(ctx, testAction());
+
+    expect(sendEmail).toHaveBeenCalledOnce();
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.to).toEqual(['a@example.com']);
+    expect(email.subject).toBe('[Root CMS] doc.publish by user@example.com');
+    expect(email.body).toContain('Action: doc.publish');
+    expect(email.body).toContain('By: user@example.com');
+    expect(email.body).toContain('Time: 2026-07-21T12:00:00.000Z');
+    expect(email.body).toContain('"docId": "Pages/foo"');
+    expect(email.htmlBody).toContain('<h2>doc.publish</h2>');
+    expect(email.htmlBody).toContain(
+      '&quot;docId&quot;: &quot;Pages/foo&quot;'
+    );
+    expect(result).toEqual({
+      status: 'success',
+      message: 'queued email email-id-1 to 1 recipient(s)',
+    });
+  });
+
+  it('passes from, emailService, and expiration to sendEmail', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_DATE);
+    try {
+      const {ctx, sendEmail} = testContext();
+      const service = emailNotifications({
+        to: ['a@example.com'],
+        from: 'cms@example.com',
+        emailService: 'https://services.example.com',
+        expireAfterMinutes: 60,
+      });
+      await service.onAction!(ctx, testAction());
+
+      const email = sendEmail.mock.calls[0][0];
+      expect(email.from).toBe('cms@example.com');
+      expect(email.emailService).toBe('https://services.example.com');
+      expect(email.expiresAt).toEqual(
+        new Date(TEST_DATE.getTime() + 60 * 60 * 1000)
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('filters actions using wildcard patterns', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      actions: ['doc.publish', 'release.*'],
+    });
+
+    expect(await service.onAction!(ctx, testAction())).toMatchObject({
+      status: 'success',
+    });
+    expect(
+      await service.onAction!(ctx, testAction({action: 'release.publish'}))
+    ).toMatchObject({status: 'success'});
+    expect(
+      await service.onAction!(ctx, testAction({action: 'doc.save'}))
+    ).toEqual({status: 'info', message: 'ignored action: doc.save'});
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('matches action patterns case-insensitively and supports "?"', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      actions: ['DOC.puBLIsh', 'doc.sav?'],
+    });
+    await service.onAction!(ctx, testAction());
+    await service.onAction!(ctx, testAction({action: 'doc.save'}));
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips actions rejected by the filter option', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      filter: async (action) => action.by !== 'system',
+    });
+    expect(await service.onAction!(ctx, testAction({by: 'system'}))).toEqual({
+      status: 'info',
+      message: 'filtered action: doc.publish',
+    });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('resolves recipients using a function', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: async (action) => [`watchers-${action.metadata.docId}@example.com`],
+    });
+    await service.onAction!(ctx, testAction());
+    expect(sendEmail.mock.calls[0][0].to).toEqual([
+      'watchers-Pages/foo@example.com',
+    ]);
+  });
+
+  it('skips notifications with no recipients', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({to: async () => [' ', '']});
+    expect(await service.onAction!(ctx, testAction())).toEqual({
+      status: 'info',
+      message: 'no recipients',
+    });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('renders templates using transformed data', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      transformData: async (action) => ({
+        docUrl: `https://example.com/cms/content/${action.metadata.docId}`,
+      }),
+      template: {
+        subject: 'doc published',
+        body: 'View the doc at {docUrl}.',
+        html: '<a href="{docUrl}">View the doc</a>',
+      },
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('doc published');
+    expect(email.body).toBe(
+      'View the doc at https://example.com/cms/content/Pages/foo.'
+    );
+    expect(email.htmlBody).toBe(
+      '<a href="https://example.com/cms/content/Pages/foo">View the doc</a>'
+    );
+  });
+
+  it('falls back to default templates for missing template values', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: {subject: '{metadata.docId} published'},
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('Pages/foo published');
+    expect(email.body).toContain('Action: doc.publish');
+    expect(email.htmlBody).toContain('<h2>doc.publish</h2>');
+  });
+
+  it('uses function templates verbatim', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: (data, action) => ({
+        subject: `published ${action.metadata.docId}`,
+        html: '<p>No {rendering} or <escaping> applied.</p>',
+      }),
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('published Pages/foo');
+    expect(email.htmlBody).toBe('<p>No {rendering} or <escaping> applied.</p>');
+    expect(email.body).toBeUndefined();
+  });
+
+  it('falls back to defaults when a function template omits content', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: () => ({}),
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('[Root CMS] doc.publish by user@example.com');
+    expect(email.body).toContain('Action: doc.publish');
+    expect(email.htmlBody).toBeUndefined();
+  });
+});

--- a/packages/root-cms/core/services-notifications-email.test.ts
+++ b/packages/root-cms/core/services-notifications-email.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import type {Action} from './client.js';
 import {
+  DEFAULT_EMAIL_TEMPLATE,
   emailNotifications,
   renderEmailTemplate,
 } from './services-notifications-email.js';
@@ -255,6 +256,51 @@ describe('emailNotifications', () => {
 
     const email = sendEmail.mock.calls[0][0];
     expect(email.subject).toBe('Pages/foo published');
+    expect(email.body).toContain('Action: doc.publish');
+    expect(email.htmlBody).toContain('<h2>doc.publish</h2>');
+  });
+
+  it('sends a plain-text-only email when the template only has a body', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: {
+        subject: '{metadata.docId} published',
+        body: '{metadata.docId} was published by {by}.',
+      },
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('Pages/foo published');
+    expect(email.body).toBe('Pages/foo was published by user@example.com.');
+    expect(email.htmlBody).toBeUndefined();
+  });
+
+  it('omits the plain-text body when the template only has html', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: {html: '<p>{metadata.docId} was published.</p>'},
+    });
+    await service.onAction!(ctx, testAction());
+
+    // `sendEmail()` derives the plain-text body from the html body.
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.htmlBody).toBe('<p>Pages/foo was published.</p>');
+    expect(email.body).toBeUndefined();
+  });
+
+  it('composes custom templates with the exported defaults', async () => {
+    const {ctx, sendEmail} = testContext();
+    const service = emailNotifications({
+      to: ['a@example.com'],
+      template: {...DEFAULT_EMAIL_TEMPLATE, subject: 'custom subject'},
+    });
+    await service.onAction!(ctx, testAction());
+
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.subject).toBe('custom subject');
     expect(email.body).toContain('Action: doc.publish');
     expect(email.htmlBody).toContain('<h2>doc.publish</h2>');
   });

--- a/packages/root-cms/core/services-notifications-email.ts
+++ b/packages/root-cms/core/services-notifications-email.ts
@@ -20,6 +20,7 @@ export interface EmailNotificationTemplate {
   body?: string;
   /**
    * HTML body. Values injected into an HTML string template are HTML-escaped.
+   * Omit (while providing `body`) to send a plain-text-only email.
    */
   html?: string;
 }
@@ -78,10 +79,15 @@ export interface EmailNotificationsOptions<T = any> {
   ) => T | Promise<T>;
   /**
    * Templates used to render the email. Either an object with `{placeholder}`
-   * string templates (missing values fall back to the default templates) or a
-   * function that returns the final email content for full control. Function
-   * results are used verbatim, i.e. no placeholder rendering or HTML escaping
-   * is applied.
+   * string templates or a function that returns the final email content for
+   * full control. Function results are used verbatim, i.e. no placeholder
+   * rendering or HTML escaping is applied.
+   *
+   * A missing `subject` falls back to the default subject template. The
+   * default body and html templates (see `DEFAULT_EMAIL_TEMPLATE`) apply only
+   * when neither `body` nor `html` is provided. Providing only `body` sends a
+   * plain-text-only email; providing only `html` derives the plain-text body
+   * from the html.
    */
   template?:
     | EmailNotificationTemplate
@@ -106,25 +112,30 @@ export interface EmailNotificationsOptions<T = any> {
   expireAfterMinutes?: number;
 }
 
-/** Default subject line template. */
-const DEFAULT_SUBJECT_TEMPLATE = '[Root CMS] {action} by {by}';
-
-/** Default plain-text body template. */
-const DEFAULT_BODY_TEMPLATE = [
-  'Action: {action}',
-  'By: {by}',
-  'Time: {timestamp}',
-  '',
-  'Metadata:',
-  '{metadata}',
-].join('\n');
-
-/** Default HTML body template. */
-const DEFAULT_HTML_TEMPLATE = [
-  '<h2>{action}</h2>',
-  '<p><strong>By:</strong> {by}<br><strong>Time:</strong> {timestamp}</p>',
-  '<pre>{metadata}</pre>',
-].join('\n');
+/**
+ * Default templates used by {@link emailNotifications} when no custom
+ * template content is provided. Exported so custom templates can compose with
+ * the defaults, e.g.
+ * `template: {...DEFAULT_EMAIL_TEMPLATE, subject: 'Custom subject'}`.
+ */
+export const DEFAULT_EMAIL_TEMPLATE: Readonly<
+  Required<EmailNotificationTemplate>
+> = Object.freeze({
+  subject: '[Root CMS] {action} by {by}',
+  body: [
+    'Action: {action}',
+    'By: {by}',
+    'Time: {timestamp}',
+    '',
+    'Metadata:',
+    '{metadata}',
+  ].join('\n'),
+  html: [
+    '<h2>{action}</h2>',
+    '<p><strong>By:</strong> {by}<br><strong>Time:</strong> {timestamp}</p>',
+    '<pre>{metadata}</pre>',
+  ].join('\n'),
+});
 
 /**
  * Creates a {@link CMSNotificationService} that sends email notifications
@@ -189,28 +200,40 @@ export function emailNotifications<T = any>(
       if (typeof options.template === 'function') {
         email = {...(await options.template(data, action, ctx))};
         if (!email.subject) {
-          email.subject = renderEmailTemplate(DEFAULT_SUBJECT_TEMPLATE, data);
+          email.subject = renderEmailTemplate(
+            DEFAULT_EMAIL_TEMPLATE.subject,
+            data
+          );
         }
         if (!email.body && !email.html) {
-          email.body = renderEmailTemplate(DEFAULT_BODY_TEMPLATE, data);
+          email.body = renderEmailTemplate(DEFAULT_EMAIL_TEMPLATE.body, data);
         }
       } else {
+        // The default body and html templates apply only when the template
+        // provides neither, so that a body-only template sends a
+        // plain-text-only email (and an html-only template derives its
+        // plain-text body from the html in `sendEmail()`).
         const template = options.template || {};
         email = {
           subject: renderEmailTemplate(
-            template.subject || DEFAULT_SUBJECT_TEMPLATE,
+            template.subject || DEFAULT_EMAIL_TEMPLATE.subject,
             data
-          ),
-          body: renderEmailTemplate(
-            template.body || DEFAULT_BODY_TEMPLATE,
-            data
-          ),
-          html: renderEmailTemplate(
-            template.html || DEFAULT_HTML_TEMPLATE,
-            data,
-            {escapeHtml: true}
           ),
         };
+        if (template.body) {
+          email.body = renderEmailTemplate(template.body, data);
+        }
+        if (template.html) {
+          email.html = renderEmailTemplate(template.html, data, {
+            escapeHtml: true,
+          });
+        }
+        if (!email.body && !email.html) {
+          email.body = renderEmailTemplate(DEFAULT_EMAIL_TEMPLATE.body, data);
+          email.html = renderEmailTemplate(DEFAULT_EMAIL_TEMPLATE.html, data, {
+            escapeHtml: true,
+          });
+        }
       }
 
       // Queue the email for delivery.

--- a/packages/root-cms/core/services-notifications-email.ts
+++ b/packages/root-cms/core/services-notifications-email.ts
@@ -1,0 +1,339 @@
+import type {Action} from './client.js';
+import type {
+  CMSNotificationService,
+  NotificationServiceContext,
+} from './services-notifications.js';
+
+/**
+ * Email content used by the {@link emailNotifications} service.
+ *
+ * When provided as string templates (via the `template` option), each value
+ * supports `{placeholder}` tokens that are resolved against the template data
+ * — the action log data object, or the result of `transformData()` when
+ * configured. Tokens support dot notation for nested values, e.g.
+ * `{metadata.docId}`. Unknown placeholders are left untouched.
+ */
+export interface EmailNotificationTemplate {
+  /** Subject line. */
+  subject?: string;
+  /** Plain-text body. */
+  body?: string;
+  /**
+   * HTML body. Values injected into an HTML string template are HTML-escaped.
+   */
+  html?: string;
+}
+
+/** Options for the {@link emailNotifications} service. */
+export interface EmailNotificationsOptions<T = any> {
+  /** Unique ID for the service. Defaults to `'email'`. */
+  id?: string;
+  /** Human-readable label displayed in the UI. Defaults to `'Email'`. */
+  label?: string;
+  /** Optional icon URL displayed in the UI next to the label. */
+  icon?: string;
+  /**
+   * Recipients of the email notification. Either a static list of email
+   * addresses or a function that returns the recipients for a given action
+   * (e.g. to look up watchers of a doc). Returning an empty list skips the
+   * notification.
+   */
+  to:
+    | string[]
+    | ((
+        action: Action,
+        ctx: NotificationServiceContext
+      ) => string[] | Promise<string[]>);
+  /**
+   * Sender email address. The sender must be authorized to send email via the
+   * App Engine Mail API, e.g. `noreply@<gcp-project-id>.appspotmail.com`.
+   * Defaults to `noreply@<gcp-project-id>.appspotmail.com`.
+   */
+  from?: string;
+  /**
+   * Actions that trigger an email notification, e.g.
+   * `['doc.publish', 'release.*']`. Patterns support wildcards, where `*`
+   * matches any number of characters and `?` matches a single character.
+   * Matching is case-insensitive. When unset, all actions trigger an email
+   * notification.
+   */
+  actions?: string[];
+  /**
+   * Optional filter called after the `actions` patterns match. Return `false`
+   * to skip the notification (e.g. to ignore actions performed by certain
+   * users).
+   */
+  filter?: (
+    action: Action,
+    ctx: NotificationServiceContext
+  ) => boolean | Promise<boolean>;
+  /**
+   * Optional transformation applied to the action log data before the email
+   * templates are rendered. The returned value is passed to the templates as
+   * the template data. When unset, the action log data object is used as-is.
+   */
+  transformData?: (
+    action: Action,
+    ctx: NotificationServiceContext
+  ) => T | Promise<T>;
+  /**
+   * Templates used to render the email. Either an object with `{placeholder}`
+   * string templates (missing values fall back to the default templates) or a
+   * function that returns the final email content for full control. Function
+   * results are used verbatim, i.e. no placeholder rendering or HTML escaping
+   * is applied.
+   */
+  template?:
+    | EmailNotificationTemplate
+    | ((
+        data: T,
+        action: Action,
+        ctx: NotificationServiceContext
+      ) => EmailNotificationTemplate | Promise<EmailNotificationTemplate>);
+  /**
+   * Email service used to trigger delivery immediately after the email is
+   * queued. Setting this to `true` uses the default hosted service at
+   * https://services.rootjs.dev. Set to a base URL to use a self-hosted
+   * deployment of the service (`apps/root-services`). When unset, the email
+   * remains queued until the email service's cron next processes the queue.
+   */
+  emailService?: string | boolean;
+  /**
+   * Number of minutes after which an unsent email expires. Expired emails are
+   * skipped by the email service instead of being delivered late. When unset,
+   * queued emails never expire.
+   */
+  expireAfterMinutes?: number;
+}
+
+/** Default subject line template. */
+const DEFAULT_SUBJECT_TEMPLATE = '[Root CMS] {action} by {by}';
+
+/** Default plain-text body template. */
+const DEFAULT_BODY_TEMPLATE = [
+  'Action: {action}',
+  'By: {by}',
+  'Time: {timestamp}',
+  '',
+  'Metadata:',
+  '{metadata}',
+].join('\n');
+
+/** Default HTML body template. */
+const DEFAULT_HTML_TEMPLATE = [
+  '<h2>{action}</h2>',
+  '<p><strong>By:</strong> {by}<br><strong>Time:</strong> {timestamp}</p>',
+  '<pre>{metadata}</pre>',
+].join('\n');
+
+/**
+ * Creates a {@link CMSNotificationService} that sends email notifications
+ * when actions occur in the CMS (publishes, schema changes, etc.).
+ *
+ * Emails are queued in the `Projects/${projectId}/Emails` collection in
+ * firestore and delivered by the Root.js email service (`apps/root-services`)
+ * using the App Engine Mail API.
+ *
+ * Example:
+ * ```ts
+ * cmsPlugin({
+ *   notifications: [
+ *     emailNotifications({
+ *       actions: ['doc.publish', 'release.*'],
+ *       to: ['cms-alerts@example.com'],
+ *       template: {
+ *         subject: '[cms] {metadata.docId} published by {by}',
+ *       },
+ *       emailService: true,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function emailNotifications<T = any>(
+  options: EmailNotificationsOptions<T>
+): CMSNotificationService {
+  return {
+    id: options.id || 'email',
+    label: options.label || 'Email',
+    icon: options.icon,
+    onAction: async (ctx, action) => {
+      // Filter by the configured action patterns.
+      if (options.actions && !matchesAction(options.actions, action.action)) {
+        return {status: 'info', message: `ignored action: ${action.action}`};
+      }
+      if (options.filter && !(await options.filter(action, ctx))) {
+        return {status: 'info', message: `filtered action: ${action.action}`};
+      }
+
+      // Resolve the recipients list.
+      const to =
+        typeof options.to === 'function'
+          ? await options.to(action, ctx)
+          : options.to;
+      const recipients = (to || [])
+        .map((email) => String(email).trim())
+        .filter(Boolean);
+      if (recipients.length === 0) {
+        return {status: 'info', message: 'no recipients'};
+      }
+
+      // Build the template data from the action log data object, optionally
+      // transformed via `transformData()`.
+      const data = options.transformData
+        ? await options.transformData(action, ctx)
+        : action;
+
+      // Render the email content.
+      let email: EmailNotificationTemplate;
+      if (typeof options.template === 'function') {
+        email = {...(await options.template(data, action, ctx))};
+        if (!email.subject) {
+          email.subject = renderEmailTemplate(DEFAULT_SUBJECT_TEMPLATE, data);
+        }
+        if (!email.body && !email.html) {
+          email.body = renderEmailTemplate(DEFAULT_BODY_TEMPLATE, data);
+        }
+      } else {
+        const template = options.template || {};
+        email = {
+          subject: renderEmailTemplate(
+            template.subject || DEFAULT_SUBJECT_TEMPLATE,
+            data
+          ),
+          body: renderEmailTemplate(
+            template.body || DEFAULT_BODY_TEMPLATE,
+            data
+          ),
+          html: renderEmailTemplate(
+            template.html || DEFAULT_HTML_TEMPLATE,
+            data,
+            {escapeHtml: true}
+          ),
+        };
+      }
+
+      // Queue the email for delivery.
+      const emailId = await ctx.cmsClient.sendEmail({
+        to: recipients,
+        from: options.from,
+        subject: email.subject!,
+        body: email.body,
+        htmlBody: email.html,
+        expiresAt: options.expireAfterMinutes
+          ? new Date(Date.now() + options.expireAfterMinutes * 60 * 1000)
+          : undefined,
+        emailService: options.emailService,
+      });
+      return {
+        status: 'success',
+        message: `queued email ${emailId} to ${recipients.length} recipient(s)`,
+      };
+    },
+  };
+}
+
+/**
+ * Renders a `{placeholder}` template string using values from `data`.
+ * Placeholders support dot notation for nested lookups, e.g.
+ * `{metadata.docId}`. Unknown placeholders are left untouched. Values are
+ * stringified based on their type: firestore timestamps and dates are
+ * converted to ISO strings and objects are converted to formatted JSON. When
+ * `escapeHtml` is set, values are HTML-escaped before injection.
+ */
+export function renderEmailTemplate(
+  template: string,
+  data: any,
+  options?: {escapeHtml?: boolean}
+): string {
+  return template.replace(/\{(.+?)\}/g, (match: string, key: string) => {
+    const value = getNestedValue(data, key.trim());
+    if (!isDef(value)) {
+      return match;
+    }
+    const str = stringifyValue(value);
+    if (options?.escapeHtml) {
+      return escapeHtml(str);
+    }
+    return str;
+  });
+}
+
+/**
+ * Cache of compiled wildcard patterns. `onAction` is called for every CMS
+ * action, so we avoid recompiling the same pattern on every call.
+ */
+const wildcardRegExpCache = new Map<string, RegExp>();
+
+/**
+ * Converts a wildcard pattern (e.g. `doc.*`) to a case-insensitive RegExp.
+ * Supports `*` (matches any number of characters) and `?` (matches a single
+ * character). Compiled regexes are memoized per pattern.
+ */
+function wildcardToRegExp(pattern: string): RegExp {
+  const cached = wildcardRegExpCache.get(pattern);
+  if (cached) {
+    return cached;
+  }
+  const regexStr = pattern
+    // Escape regex special chars except `*` and `?`.
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  const regExp = new RegExp(`^${regexStr}$`, 'i');
+  wildcardRegExpCache.set(pattern, regExp);
+  return regExp;
+}
+
+/**
+ * Returns true if the action name matches any of the wildcard patterns, e.g.
+ * `matchesAction(['doc.*'], 'doc.publish')`.
+ */
+function matchesAction(patterns: string[], action: string): boolean {
+  return patterns.some((pattern) => wildcardToRegExp(pattern).test(action));
+}
+
+/** Returns true if the value is defined (not `undefined` and not `null`). */
+function isDef(value: any): boolean {
+  return value !== undefined && value !== null;
+}
+
+/** Returns a nested value from an object using dot notation. */
+function getNestedValue(data: any, key: string): any {
+  let current = data;
+  for (const part of key.split('.')) {
+    if (!isDef(current) || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return current;
+}
+
+/** Stringifies a template value for injection into an email. */
+function stringifyValue(value: any): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  // Format firestore `Timestamp` values as ISO strings.
+  if (typeof value?.toDate === 'function') {
+    return value.toDate().toISOString();
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+  return String(value);
+}
+
+/** Escapes HTML special characters. */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/root-cms/core/services-notifications.ts
+++ b/packages/root-cms/core/services-notifications.ts
@@ -24,7 +24,8 @@ export interface NotificationServiceContext extends CMSServiceContext {}
  * Notification services react to actions in the CMS (publishes, schema
  * changes, comments, etc.) and dispatch them to an external channel.
  * Initially this is intended for email, with Slack, webhooks, and other
- * transports planned.
+ * transports planned. See `emailNotifications()` for a built-in email
+ * implementation backed by the Root.js email service.
  *
  * Multiple notification services may be registered; each independently
  * decides whether and how to handle a given action.


### PR DESCRIPTION
## Summary
Adds a built-in email notifications service that allows CMS administrators to receive email alerts when actions occur in the CMS (document publishes, schema changes, etc.). Emails are queued in Firestore and delivered by the Root.js email service using the App Engine Mail API.

## Key Changes

- **New `emailNotifications()` service**: A configurable notification service that sends emails triggered by CMS actions with support for:
  - Action filtering via wildcard patterns (e.g., `doc.publish`, `release.*`)
  - Custom recipient resolution (static list or dynamic function)
  - Customizable email templates with `{placeholder}` token support and dot notation for nested values
  - Data transformation before template rendering
  - Optional expiration dates for queued emails
  - Integration with the Root.js email service for immediate delivery

- **New `RootCMSClient.sendEmail()` method**: Queues emails in the `Projects/${projectId}/Emails` Firestore collection with support for:
  - Plain-text and HTML bodies
  - Automatic plain-text fallback generation from HTML
  - Custom sender addresses
  - Email expiration handling
  - Optional notification of the email service for immediate processing

- **Template rendering utilities**:
  - `renderEmailTemplate()`: Renders `{placeholder}` templates with support for nested value access, type-aware stringification (dates as ISO strings, objects as formatted JSON), and optional HTML escaping
  - `htmlToPlainText()`: Converts HTML to plain text for email body fallback

- **Comprehensive test coverage**: Unit tests for template rendering, service configuration, action filtering, recipient resolution, and email queuing

- **Public API exports**: New types and functions exported from the plugin for use in CMS configurations

## Notable Implementation Details

- Wildcard pattern matching is case-insensitive and supports `*` (any characters) and `?` (single character) with regex compilation caching for performance
- HTML escaping is applied only when rendering HTML email bodies to prevent injection
- The email service notification is fire-and-forget with a 60-second timeout to avoid blocking email queuing
- Default email templates provide sensible defaults with action, user, timestamp, and metadata information
- Function-based templates bypass placeholder rendering for full control over email content

https://claude.ai/code/session_01N9u8JvmMrq5sCQscg6SH4j