### PR TITLE
feat: add opt-in dependency graph api for tracking reference field usages between docs

### DIFF
--- a/.changeset/spicy-planets-attack.md
+++ b/.changeset/spicy-planets-attack.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add opt-in dependency graph api for tracking reference field usages between docs

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -21,6 +21,10 @@ import {type CMSCheck} from './checks.js';
 import {RootCMSClient, parseDocId, unmarshalData} from './client.js';
 import {runCronJobs} from './cron.js';
 import {arrayToCsv, csvToArray} from './csv.js';
+import {
+  DependencyGraphService,
+  DependencyGraphRebuildResult,
+} from './dependency-graph.js';
 import {SearchIndexService, RebuildResult} from './search-index.js';
 import {type CMSTranslationService} from './translations.js';
 import {assertPublicHttpUrl, UnsafeUrlError} from './url-safety.js';
@@ -344,6 +348,161 @@ export function api(server: Server, options: ApiOptions) {
     searchRebuildJobs.set(projectId, job);
     res.status(202).json({success: true, started: true, force});
   });
+
+  // Tracks in-flight dependency graph rebuilds, keyed by projectId. Only one
+  // rebuild per project may run at a time.
+  const dependencyGraphRebuildJobs = new Map<
+    string,
+    Promise<DependencyGraphRebuildResult>
+  >();
+
+  /**
+   * Queries the dependency graph for the docs referenced by one or more docs.
+   * Requires the `dependencyGraph` cmsPlugin option to be enabled.
+   *
+   * Authentication: any signed-in CMS user.
+   *
+   * Sample request:
+   *
+   * ```
+   * POST /cms/api/dependency_graph.query
+   * {"docIds": ["Pages/index"], "mode": "draft", "transitive": true}
+   * ```
+   */
+  server.use(
+    '/cms/api/dependency_graph.query',
+    async (req: Request, res: Response) => {
+      if (
+        req.method !== 'POST' ||
+        !String(req.get('content-type')).startsWith('application/json')
+      ) {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const body = req.body || {};
+      const docIds = Array.isArray(body.docIds)
+        ? body.docIds.filter((id: any) => typeof id === 'string')
+        : [];
+      if (docIds.length === 0) {
+        res.status(400).json({
+          success: false,
+          error: 'MISSING_REQUIRED_FIELD',
+          field: 'docIds',
+        });
+        return;
+      }
+      const mode = body.mode === 'published' ? 'published' : 'draft';
+      const transitive = body.transitive !== false;
+      try {
+        const service = new DependencyGraphService(req.rootConfig!);
+        if (!service.isEnabled()) {
+          res.status(404).json({success: false, error: 'NOT_ENABLED'});
+          return;
+        }
+        const graph = await service.getGraph(mode);
+        const deps = graph.getDependencies(docIds, {transitive});
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(200).json({
+          success: true,
+          mode,
+          deps,
+          lastRun: graph.lastRun,
+        });
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
+   * Returns the dependency graph's current status (last run, ref counts).
+   * Authentication: any signed-in CMS user.
+   */
+  server.use(
+    '/cms/api/dependency_graph.status',
+    async (req: Request, res: Response) => {
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      try {
+        const cmsClient = new RootCMSClient(req.rootConfig!);
+        const service = new DependencyGraphService(req.rootConfig!);
+        const status = await service.getStatus();
+        const running = dependencyGraphRebuildJobs.has(cmsClient.projectId);
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(200).json({success: true, status, running});
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
+   * Triggers a rebuild of the dependency graph. ADMIN-only.
+   *
+   * Sample request:
+   *
+   * ```
+   * POST /cms/api/dependency_graph.rebuild
+   * {"force": true}
+   * ```
+   */
+  server.use(
+    '/cms/api/dependency_graph.rebuild',
+    async (req: Request, res: Response) => {
+      if (req.method !== 'POST') {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      try {
+        const role = await cmsClient.getUserRole(req.user.email);
+        if (role !== 'ADMIN') {
+          res.status(403).json({success: false, error: 'FORBIDDEN'});
+          return;
+        }
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+        return;
+      }
+
+      const service = new DependencyGraphService(req.rootConfig!);
+      if (!service.isEnabled()) {
+        res.status(404).json({success: false, error: 'NOT_ENABLED'});
+        return;
+      }
+      const body = req.body || {};
+      const force = !!body.force;
+      const projectId = cmsClient.projectId;
+      if (dependencyGraphRebuildJobs.has(projectId)) {
+        res.status(202).json({success: true, alreadyRunning: true});
+        return;
+      }
+      const job = service
+        .rebuildGraph({force})
+        .catch((err) => {
+          console.error('dependency_graph.rebuild failed:', err.stack || err);
+          throw err;
+        })
+        .finally(() => {
+          dependencyGraphRebuildJobs.delete(projectId);
+        });
+      dependencyGraphRebuildJobs.set(projectId, job);
+      res.status(202).json({success: true, started: true, force});
+    }
+  );
 
   /**
    * Accepts a JSON object containing {headers: [...], rows: [...]} and sends

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -11,6 +11,7 @@ import {
 import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {isCronDue} from './cron-schedule.js';
+import type {DependencyGraph} from './dependency-graph.js';
 import {CMSPlugin} from './plugin.js';
 import {Collection} from './schema.js';
 import {
@@ -2121,6 +2122,55 @@ export class RootCMSClient {
       .catch((err) => {
         console.error('failed to notify the email service:', err);
       });
+  }
+
+  /**
+   * Returns the dependency graph for a given mode, which tracks reference
+   * field usages between docs. Requires the `dependencyGraph` option to be
+   * enabled on the cmsPlugin config (the graph is kept up to date by the CMS
+   * cron job).
+   *
+   * Example:
+   * ```ts
+   * const graph = await cmsClient.getDependencyGraph({mode: 'published'});
+   * const depIds = graph.getDependencies(['Pages/index']);
+   * // => ['Authors/alice', 'BlogPosts/hello-world', ...]
+   * ```
+   */
+  async getDependencyGraph(options: {mode: DocMode}): Promise<DependencyGraph> {
+    // Lazy load the dependency graph module to minimize the amount of code
+    // loaded when the client is initialized.
+    const {DependencyGraphService} = await import('./dependency-graph.js');
+    const service = new DependencyGraphService(this.rootConfig);
+    return service.getGraph(options.mode);
+  }
+
+  /**
+   * Returns the ids of the docs referenced by the given doc(s), i.e. the
+   * additional docs that need to be fetched when fetching the given docs.
+   * Dependencies are resolved transitively by default (pass
+   * `transitive: false` for direct references only).
+   *
+   * Requires the `dependencyGraph` option to be enabled on the cmsPlugin
+   * config.
+   *
+   * Example:
+   * ```ts
+   * const depIds = await cmsClient.getDocDependencies(['Pages/index'], {
+   *   mode: 'published',
+   * });
+   * const req = cmsClient.createBatchRequest({mode: 'published'});
+   * req.addDoc('Pages/index');
+   * depIds.forEach((docId) => req.addDoc(docId));
+   * const res = await req.fetch();
+   * ```
+   */
+  async getDocDependencies(
+    docIds: string | string[],
+    options: {mode: DocMode; transitive?: boolean}
+  ): Promise<string[]> {
+    const graph = await this.getDependencyGraph({mode: options.mode});
+    return graph.getDependencies(docIds, {transitive: options.transitive});
   }
 
   /**

--- a/packages/root-cms/core/core.ts
+++ b/packages/root-cms/core/core.ts
@@ -1,5 +1,6 @@
 export * from '../shared/sort-key.js';
 export * from './client.js';
+export * from './dependency-graph.js';
 export * from './middleware.js';
 export * from './route.js';
 export * from './runtime.js';

--- a/packages/root-cms/core/cron.ts
+++ b/packages/root-cms/core/cron.ts
@@ -1,6 +1,7 @@
 import {RootConfig} from '@blinkk/root';
 import {Timestamp} from 'firebase-admin/firestore';
 import {RootCMSClient} from './client.js';
+import {DependencyGraphService} from './dependency-graph.js';
 import {LoadSchemaFn, SearchIndexService} from './search-index.js';
 import {VersionsService} from './versions.js';
 
@@ -10,6 +11,13 @@ import {VersionsService} from './versions.js';
  * every tick.
  */
 export const SEARCH_INDEX_MIN_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * The minimum interval between incremental dependency graph updates. Kept
+ * short (one cron tick) so that reference changes are reflected in the graph
+ * shortly after docs are saved or published.
+ */
+export const DEPENDENCY_GRAPH_MIN_INTERVAL_MS = 60 * 1000;
 
 export interface RunCronJobsOptions {
   /**
@@ -40,6 +48,7 @@ export async function runCronJobs(
       rootConfig,
       options.loadSchema
     ),
+    runCronJob('updateDependencyGraph', runUpdateDependencyGraph, rootConfig),
   ]);
 }
 
@@ -71,6 +80,20 @@ async function runSyncScheduledDataSources(rootConfig: RootConfig) {
 async function runSaveVersions(rootConfig: RootConfig) {
   const service = new VersionsService(rootConfig);
   await service.saveVersions();
+}
+
+/**
+ * Incrementally updates the dependency graph. No-op unless the feature is
+ * enabled via the `dependencyGraph` cmsPlugin option.
+ */
+async function runUpdateDependencyGraph(rootConfig: RootConfig) {
+  const service = new DependencyGraphService(rootConfig);
+  if (!service.isEnabled()) {
+    return;
+  }
+  await service.runCronUpdate({
+    minIntervalMs: DEPENDENCY_GRAPH_MIN_INTERVAL_MS,
+  });
 }
 
 async function runIncrementalSearchIndex(

--- a/packages/root-cms/core/dependency-graph.test.ts
+++ b/packages/root-cms/core/dependency-graph.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Tests for the dependency graph: pure extraction/traversal units, plus
+ * Firestore emulator-backed integration tests for DependencyGraphService
+ * (see translations-manager.test.ts for details on the emulator setup).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {getApps, initializeApp} from 'firebase-admin/app';
+import {Timestamp, getFirestore} from 'firebase-admin/firestore';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {RootCMSClient, marshalData} from './client.js';
+import {
+  DependencyGraph,
+  DependencyGraphService,
+  extractRefDocIds,
+  getReferenceDocId,
+  isCollectionTracked,
+  resolveDependencyGraphConfig,
+  resolveDependencyGraphFilters,
+} from './dependency-graph.js';
+
+describe('resolveDependencyGraphConfig', () => {
+  it('treats `true` as enabled with default options', () => {
+    expect(resolveDependencyGraphConfig(true)).toEqual({});
+  });
+
+  it('treats a config object as enabled', () => {
+    const config = {includeCollections: ['Pages']};
+    expect(resolveDependencyGraphConfig(config)).toBe(config);
+  });
+
+  it('treats unset/false as disabled', () => {
+    expect(resolveDependencyGraphConfig(undefined)).toBe(null);
+    expect(resolveDependencyGraphConfig(false)).toBe(null);
+  });
+});
+
+describe('dependency graph filters', () => {
+  it('treats unset/empty config as "track everything"', () => {
+    const filters = resolveDependencyGraphFilters(undefined);
+    expect(isCollectionTracked(filters, 'Pages')).toBe(true);
+    const emptyFilters = resolveDependencyGraphFilters({
+      includeCollections: [],
+    });
+    expect(isCollectionTracked(emptyFilters, 'Pages')).toBe(true);
+  });
+
+  it('respects includeCollections and excludeCollections', () => {
+    const filters = resolveDependencyGraphFilters({
+      includeCollections: ['Pages', 'Posts'],
+      excludeCollections: ['Posts'],
+    });
+    expect(isCollectionTracked(filters, 'Pages')).toBe(true);
+    expect(isCollectionTracked(filters, 'Posts')).toBe(false);
+    expect(isCollectionTracked(filters, 'Other')).toBe(false);
+  });
+});
+
+describe('getReferenceDocId', () => {
+  it('matches values saved by reference fields', () => {
+    expect(
+      getReferenceDocId({id: 'Pages/foo', collection: 'Pages', slug: 'foo'})
+    ).toBe('Pages/foo');
+  });
+
+  it('normalizes slugs with slashes', () => {
+    expect(
+      getReferenceDocId({
+        id: 'Pages/foo/bar',
+        collection: 'Pages',
+        slug: 'foo/bar',
+      })
+    ).toBe('Pages/foo--bar');
+    expect(
+      getReferenceDocId({
+        id: 'Pages/foo--bar',
+        collection: 'Pages',
+        slug: 'foo--bar',
+      })
+    ).toBe('Pages/foo--bar');
+  });
+
+  it('rejects values with an inconsistent id', () => {
+    expect(
+      getReferenceDocId({id: 'Other/foo', collection: 'Pages', slug: 'foo'})
+    ).toBe(null);
+    expect(
+      getReferenceDocId({id: 'Pages/other', collection: 'Pages', slug: 'foo'})
+    ).toBe(null);
+  });
+
+  it('rejects values without the reference shape', () => {
+    expect(getReferenceDocId(null)).toBe(null);
+    expect(getReferenceDocId('Pages/foo')).toBe(null);
+    expect(getReferenceDocId(['Pages/foo'])).toBe(null);
+    expect(getReferenceDocId({id: 'Pages/foo'})).toBe(null);
+    expect(getReferenceDocId({id: 'Pages/foo', collection: 'Pages'})).toBe(
+      null
+    );
+    expect(getReferenceDocId({id: 'foo', collection: '', slug: 'foo'})).toBe(
+      null
+    );
+    expect(getReferenceDocId({id: 123, collection: 'Pages', slug: 'foo'})).toBe(
+      null
+    );
+  });
+});
+
+describe('extractRefDocIds', () => {
+  it('extracts a top-level reference field', () => {
+    const fields = {
+      author: {id: 'Authors/alice', collection: 'Authors', slug: 'alice'},
+    };
+    expect(extractRefDocIds(fields)).toEqual(['Authors/alice']);
+  });
+
+  it('extracts refs from plain arrays (references field)', () => {
+    const fields = {
+      related: [
+        {id: 'Posts/a', collection: 'Posts', slug: 'a'},
+        {id: 'Posts/b', collection: 'Posts', slug: 'b'},
+      ],
+    };
+    expect(extractRefDocIds(fields)).toEqual(['Posts/a', 'Posts/b']);
+  });
+
+  it('extracts refs from marshaled data (_array objects)', () => {
+    const fields = marshalData({
+      blocks: [
+        {
+          _type: 'RelatedPosts',
+          posts: [
+            {id: 'Posts/a', collection: 'Posts', slug: 'a'},
+            {id: 'Posts/b', collection: 'Posts', slug: 'b'},
+          ],
+        },
+        {
+          _type: 'Hero',
+          cta: {
+            link: {id: 'Pages/about', collection: 'Pages', slug: 'about'},
+          },
+        },
+      ],
+    });
+    expect(extractRefDocIds(fields)).toEqual([
+      'Pages/about',
+      'Posts/a',
+      'Posts/b',
+    ]);
+  });
+
+  it('dedupes and sorts extracted ids', () => {
+    const ref = {id: 'Posts/a', collection: 'Posts', slug: 'a'};
+    const fields = {
+      one: {...ref},
+      two: {...ref},
+      zed: {id: 'Authors/z', collection: 'Authors', slug: 'z'},
+    };
+    expect(extractRefDocIds(fields)).toEqual(['Authors/z', 'Posts/a']);
+  });
+
+  it('ignores non-reference data', () => {
+    const fields = {
+      title: 'Hello',
+      count: 3,
+      enabled: true,
+      empty: null,
+      meta: {description: 'World'},
+      richtext: {
+        time: 123,
+        version: '2.28.2',
+        blocks: [{type: 'paragraph', data: {text: 'hi'}}],
+      },
+      // Same keys as a reference but inconsistent id.
+      notARef: {id: 'foo', collection: 'Pages', slug: 'bar'},
+    };
+    expect(extractRefDocIds(fields)).toEqual([]);
+    expect(extractRefDocIds(null)).toEqual([]);
+    expect(extractRefDocIds(undefined)).toEqual([]);
+    expect(extractRefDocIds('string')).toEqual([]);
+  });
+
+  it('guards against pathological nesting depth', () => {
+    let node: any = {
+      ref: {id: 'Posts/deep', collection: 'Posts', slug: 'deep'},
+    };
+    for (let i = 0; i < 150; i++) {
+      node = {child: node};
+    }
+    // The deeply-buried ref is beyond the depth cap and ignored; the walk
+    // terminates without a stack overflow.
+    expect(extractRefDocIds(node)).toEqual([]);
+  });
+});
+
+describe('DependencyGraph', () => {
+  const edges = {
+    'Pages/index': ['Posts/a', 'Posts/b'],
+    'Posts/a': ['Authors/alice'],
+    'Posts/b': ['Authors/alice', 'Authors/bob'],
+    'Authors/alice': [],
+    'Cycles/a': ['Cycles/b'],
+    'Cycles/b': ['Cycles/a'],
+  };
+
+  function createGraph() {
+    return new DependencyGraph('draft', edges, 123);
+  }
+
+  it('resolves direct dependencies with transitive: false', () => {
+    const graph = createGraph();
+    expect(graph.getDependencies('Pages/index', {transitive: false})).toEqual([
+      'Posts/a',
+      'Posts/b',
+    ]);
+  });
+
+  it('resolves transitive dependencies by default', () => {
+    const graph = createGraph();
+    expect(graph.getDependencies('Pages/index')).toEqual([
+      'Authors/alice',
+      'Authors/bob',
+      'Posts/a',
+      'Posts/b',
+    ]);
+  });
+
+  it('accepts multiple input docs and excludes them from the result', () => {
+    const graph = createGraph();
+    expect(graph.getDependencies(['Pages/index', 'Posts/a'])).toEqual([
+      'Authors/alice',
+      'Authors/bob',
+      'Posts/b',
+    ]);
+  });
+
+  it('handles reference cycles', () => {
+    const graph = createGraph();
+    expect(graph.getDependencies('Cycles/a')).toEqual(['Cycles/b']);
+    expect(graph.getDependencies(['Cycles/a', 'Cycles/b'])).toEqual([]);
+  });
+
+  it('returns an empty list for unknown docs', () => {
+    const graph = createGraph();
+    expect(graph.getDependencies('Pages/unknown')).toEqual([]);
+  });
+
+  it('normalizes input doc ids', () => {
+    const graph = new DependencyGraph(
+      'draft',
+      {'Pages/foo--bar': ['Posts/a']},
+      123
+    );
+    expect(graph.getDependencies('Pages/foo/bar')).toEqual(['Posts/a']);
+  });
+
+  it('resolves direct dependents', () => {
+    const graph = createGraph();
+    expect(graph.getDependents('Authors/alice', {transitive: false})).toEqual([
+      'Posts/a',
+      'Posts/b',
+    ]);
+  });
+
+  it('resolves transitive dependents by default', () => {
+    const graph = createGraph();
+    expect(graph.getDependents('Authors/alice')).toEqual([
+      'Pages/index',
+      'Posts/a',
+      'Posts/b',
+    ]);
+  });
+});
+
+const FIREBASE_PROJECT_ID = 'rootjs-cms-admin-tests';
+
+function getTestApp() {
+  const existing = getApps().find((app) => app.name === 'dependency-test');
+  if (existing) {
+    return existing;
+  }
+  return initializeApp({projectId: FIREBASE_PROJECT_ID}, 'dependency-test');
+}
+
+let projectCounter = 0;
+
+interface TestProject {
+  rootConfig: any;
+  cmsClient: RootCMSClient;
+  /** Creates a service using the project's plugin config. */
+  createService: () => DependencyGraphService;
+}
+
+/**
+ * Creates an isolated test project backed by the Firestore emulator, with a
+ * temp rootDir containing empty schema files for the given collections.
+ */
+function createTestProject(options?: {
+  collections?: string[];
+  dependencyGraph?: any;
+}): TestProject {
+  const app = getTestApp();
+  const db = getFirestore(app);
+  const projectId = `dep-test-${Date.now()}-${projectCounter++}`;
+  const collections = options?.collections ?? ['Pages', 'Posts', 'Authors'];
+  // Default to enabled, unless the caller explicitly sets the option
+  // (including an explicit `undefined`, which tests the unset config path).
+  const dependencyGraph =
+    options && 'dependencyGraph' in options ? options.dependencyGraph : true;
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-cms-dep-test-'));
+  fs.mkdirSync(path.join(rootDir, 'collections'));
+  for (const collectionId of collections) {
+    fs.writeFileSync(
+      path.join(rootDir, 'collections', `${collectionId}.schema.ts`),
+      ''
+    );
+  }
+  const plugin = {
+    name: 'root-cms',
+    getConfig: () => ({
+      id: projectId,
+      firebaseConfig: {
+        apiKey: 'test',
+        authDomain: 'test',
+        projectId: FIREBASE_PROJECT_ID,
+        storageBucket: 'test',
+      },
+      dependencyGraph,
+    }),
+    getFirebaseApp: () => app,
+    getFirestore: () => db,
+  };
+  const rootConfig: any = {
+    rootDir,
+    i18n: {locales: ['en']},
+    plugins: [plugin],
+  };
+  return {
+    rootConfig,
+    cmsClient: new RootCMSClient(rootConfig),
+    createService: () => new DependencyGraphService(rootConfig),
+  };
+}
+
+async function seedDoc(
+  cmsClient: RootCMSClient,
+  docId: string,
+  fields: any,
+  options?: {mode?: 'draft' | 'published'; modifiedAt?: Timestamp}
+) {
+  const mode = options?.mode ?? 'draft';
+  const modeCollection = mode === 'draft' ? 'Drafts' : 'Published';
+  const [collection, slug] = docId.split('/');
+  const now = options?.modifiedAt ?? Timestamp.now();
+  const sys: any = {
+    createdAt: now,
+    createdBy: 'test',
+    modifiedAt: now,
+    modifiedBy: 'test',
+    locales: ['en'],
+  };
+  if (mode === 'published') {
+    sys.publishedAt = now;
+    sys.publishedBy = 'test';
+  }
+  await cmsClient.db
+    .doc(
+      `Projects/${cmsClient.projectId}/Collections/${collection}/${modeCollection}/${slug}`
+    )
+    .set({
+      id: docId,
+      collection,
+      slug,
+      sys,
+      fields: marshalData(fields),
+    });
+}
+
+function ref(docId: string) {
+  const [collection, slug] = docId.split('/');
+  return {id: docId, collection, slug};
+}
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
+  'DependencyGraphService',
+  () => {
+    let project: TestProject;
+
+    beforeEach(() => {
+      project = createTestProject();
+    });
+
+    it('is disabled unless the dependencyGraph option is set', async () => {
+      const disabled = createTestProject({dependencyGraph: undefined});
+      const service = disabled.createService();
+      expect(service.isEnabled()).toBe(false);
+      expect(await service.runCronUpdate()).toBe(null);
+      await expect(service.getGraph('draft')).rejects.toThrow(/not enabled/);
+      const status = await service.getStatus();
+      expect(status.enabled).toBe(false);
+      expect(status.lastRun).toBe(null);
+    });
+
+    it('builds the graph from draft and published docs', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {
+        blocks: [{_type: 'Featured', posts: [ref('Posts/a'), ref('Posts/b')]}],
+      });
+      await seedDoc(cmsClient, 'Posts/a', {author: ref('Authors/alice')});
+      await seedDoc(cmsClient, 'Posts/b', {title: 'No refs'});
+      await seedDoc(
+        cmsClient,
+        'Pages/index',
+        {blocks: [{_type: 'Featured', posts: [ref('Posts/a')]}]},
+        {mode: 'published'}
+      );
+
+      const service = createService();
+      const result = await service.rebuildGraph();
+      expect(result.skipped).toBe(false);
+      expect(result.refDocCounts).toEqual({draft: 2, published: 1});
+      expect(result.refCounts).toEqual({draft: 3, published: 1});
+
+      const draftGraph = await service.getGraph('draft');
+      expect(draftGraph.edges).toEqual({
+        'Pages/index': ['Posts/a', 'Posts/b'],
+        'Posts/a': ['Authors/alice'],
+      });
+      expect(draftGraph.getDependencies('Pages/index')).toEqual([
+        'Authors/alice',
+        'Posts/a',
+        'Posts/b',
+      ]);
+
+      const publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({
+        'Pages/index': ['Posts/a'],
+      });
+    });
+
+    it('resolves dependencies via the cms client', async () => {
+      const {cmsClient} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      await project.createService().rebuildGraph();
+
+      const graph = await cmsClient.getDependencyGraph({mode: 'draft'});
+      expect(graph.getDependencies('Pages/index')).toEqual(['Authors/alice']);
+      expect(
+        await cmsClient.getDocDependencies(['Pages/index'], {mode: 'draft'})
+      ).toEqual(['Authors/alice']);
+    });
+
+    it('returns an empty graph when the graph has never been built', async () => {
+      const service = project.createService();
+      const graph = await service.getGraph('draft');
+      expect(graph.edges).toEqual({});
+      expect(graph.lastRun).toBe(null);
+    });
+
+    it('incrementally updates changed docs via runCronUpdate', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      // No changes — the update is skipped.
+      expect(await service.runCronUpdate()).toBe(null);
+
+      // Re-seed the doc with different refs (bumps sys.modifiedAt).
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/bob')});
+      const result = await service.runCronUpdate();
+      expect(result).not.toBe(null);
+      expect(result!.skipped).toBe(false);
+
+      const graph = await service.getGraph('draft');
+      expect(graph.edges).toEqual({'Pages/index': ['Authors/bob']});
+    });
+
+    it('respects the min interval throttle', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/bob')});
+      // lastRun was moments ago, so a large min interval skips the update.
+      expect(await service.runCronUpdate({minIntervalMs: 60 * 60 * 1000})).toBe(
+        null
+      );
+      expect(await service.runCronUpdate()).not.toBe(null);
+    });
+
+    it('removes edges when docs are deleted', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      await seedDoc(cmsClient, 'Posts/a', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      await cmsClient.db
+        .doc(`Projects/${cmsClient.projectId}/Collections/Posts/Drafts/a`)
+        .delete();
+
+      // The deletion is detected (via count aggregation) and reconciled.
+      const result = await service.runCronUpdate();
+      expect(result).not.toBe(null);
+      const graph = await service.getGraph('draft');
+      expect(graph.edges).toEqual({'Pages/index': ['Authors/alice']});
+    });
+
+    it('removes edges when a doc no longer has refs', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      await seedDoc(cmsClient, 'Pages/index', {title: 'No more refs'});
+      await service.runCronUpdate();
+      const graph = await service.getGraph('draft');
+      expect(graph.edges).toEqual({});
+    });
+
+    it('updates published edges when docs are published', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      let publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({});
+
+      // Publishing copies the draft to Published and stamps sys.publishedAt.
+      await cmsClient.publishDocs(['Pages/index'], {publishedBy: 'test'});
+      const result = await service.runCronUpdate();
+      expect(result).not.toBe(null);
+      publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({
+        'Pages/index': ['Authors/alice'],
+      });
+    });
+
+    it('picks up collections added after the initial build', async () => {
+      const {cmsClient, rootConfig, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      // Seed docs in a collection that has no schema file yet, then add the
+      // schema file. The doc's modifiedAt pre-dates lastRun (so the changed
+      // probe misses it), but the new collection is detected via the doc
+      // count and fully scanned on the next incremental update.
+      await seedDoc(
+        cmsClient,
+        'Events/launch',
+        {page: ref('Pages/index')},
+        {modifiedAt: Timestamp.fromMillis(Date.now() - 60 * 60 * 1000)}
+      );
+      fs.writeFileSync(
+        path.join(rootConfig.rootDir, 'collections', 'Events.schema.ts'),
+        ''
+      );
+      const result = await createService().runCronUpdate();
+      expect(result).not.toBe(null);
+      const graph = await createService().getGraph('draft');
+      expect(graph.edges).toEqual({
+        'Pages/index': ['Authors/alice'],
+        'Events/launch': ['Pages/index'],
+      });
+    });
+
+    it('scopes the graph to included collections', async () => {
+      const scoped = createTestProject({
+        dependencyGraph: {includeCollections: ['Pages']},
+      });
+      await seedDoc(scoped.cmsClient, 'Pages/index', {
+        author: ref('Authors/alice'),
+      });
+      await seedDoc(scoped.cmsClient, 'Posts/a', {
+        author: ref('Authors/alice'),
+      });
+      const service = scoped.createService();
+      await service.rebuildGraph();
+      const graph = await service.getGraph('draft');
+      // Posts is not scanned for outgoing refs, but referenced ids in Pages
+      // docs are recorded as-is.
+      expect(graph.edges).toEqual({'Pages/index': ['Authors/alice']});
+    });
+
+    it('reports status counts', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {
+        related: [ref('Posts/a'), ref('Posts/b')],
+      });
+      const service = createService();
+      await service.rebuildGraph();
+      const status = await service.getStatus();
+      expect(status.enabled).toBe(true);
+      expect(status.lastRun).not.toBe(null);
+      expect(status.draft).toEqual({docsWithRefs: 1, refs: 2});
+      expect(status.published).toEqual({docsWithRefs: 0, refs: 0});
+    });
+  }
+);

--- a/packages/root-cms/core/dependency-graph.ts
+++ b/packages/root-cms/core/dependency-graph.ts
@@ -1,0 +1,893 @@
+/**
+ * Persisted dependency graph of reference field usages between CMS docs.
+ *
+ * The graph tracks, for every doc in the project, the set of docs it
+ * references via `schema.reference()` / `schema.references()` fields (at any
+ * nesting depth, including refs inside objects, arrays, and oneof fields).
+ * The primary use case is resolving the full set of docs that need to be
+ * fetched when serving one or more docs, e.g.:
+ *
+ * ```ts
+ * const cmsClient = new RootCMSClient(rootConfig);
+ * const graph = await cmsClient.getDependencyGraph({mode: 'published'});
+ * const depIds = graph.getDependencies(['Pages/index']);
+ * // => ['Authors/alice', 'BlogPosts/hello-world', ...]
+ * const req = cmsClient.createBatchRequest({mode: 'published'});
+ * req.addDoc('Pages/index');
+ * depIds.forEach((docId) => req.addDoc(docId));
+ * const res = await req.fetch();
+ * ```
+ *
+ * The feature is opt-in. Enable it in `root.config.ts` via the cmsPlugin
+ * config, e.g. `cmsPlugin({dependencyGraph: true})`. Once enabled, the graph
+ * is automatically kept up to date by the CMS cron job (`/cms/api/cron.run`),
+ * which incrementally re-extracts references for docs that changed since the
+ * last run.
+ *
+ * Extraction is data-driven (no collection schemas required): a value is
+ * treated as a reference when it has the shape saved by the CMS reference
+ * fields, i.e. `{id: '<collection>/<slug>', collection, slug}` with a
+ * consistent id. This allows the cron to run without loading schema files and
+ * catches references anywhere in the doc data.
+ *
+ * Persistence layout:
+ *   Projects/{projectId}/DependencyGraph/_meta
+ *     — {lastRun, docCounts, refDocCounts, refCounts}
+ *   Projects/{projectId}/DependencyGraph/{mode}--{collectionId}
+ *     — {mode, collection, refs: {[slug]: refDocIds[]}}
+ *
+ * Build modes:
+ *   - `force: false` (cron path) — incremental: re-extract refs for docs whose
+ *     `sys.modifiedAt` (draft) / `sys.publishedAt` (published) changed since
+ *     the last run, and reconcile deletions by diffing tracked slugs against
+ *     the live doc-id set per collection.
+ *   - `force: true` — drop everything and re-extract every doc.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {RootConfig} from '@blinkk/root';
+import {
+  Firestore,
+  Query,
+  Timestamp,
+  WriteBatch,
+} from 'firebase-admin/firestore';
+import glob from 'tiny-glob';
+import {normalizeSlug} from '../shared/slug.js';
+import {DocMode, getCmsPlugin, parseDocId} from './client.js';
+import type {CMSDependencyGraphConfig} from './plugin.js';
+
+/** Doc modes tracked by the graph. */
+const MODES: DocMode[] = ['draft', 'published'];
+
+const DEPENDENCY_GRAPH_SUBCOLLECTION = 'DependencyGraph';
+const META_DOC_ID = '_meta';
+
+/** Guard against pathological nesting when walking doc data. */
+const MAX_WALK_DEPTH = 100;
+
+/** Max ops per Firestore batch commit (hard limit is 500). */
+const BATCH_MAX_OPS = 400;
+
+interface DependencyGraphMeta {
+  /** Timestamp captured at the start of the last (non-skipped) rebuild. */
+  lastRun: Timestamp;
+  /**
+   * Live doc count per `<mode>--<collectionId>` as of `lastRun`. Used by
+   * `hasChangesSince()` to cheaply detect deletions via count() aggregation
+   * queries.
+   */
+  docCounts: Record<string, number>;
+  /** Number of docs with at least one outgoing reference, per mode. */
+  refDocCounts: Record<DocMode, number>;
+  /** Total number of outgoing reference edges, per mode. */
+  refCounts: Record<DocMode, number>;
+}
+
+/**
+ * A `{mode}--{collectionId}` doc in the DependencyGraph subcollection, holding
+ * the outgoing references for every doc in a single collection.
+ */
+interface DependencyGraphEdgeDoc {
+  mode: DocMode;
+  collection: string;
+  /** Map of doc slug to the sorted list of doc ids it references. */
+  refs: Record<string, string[]>;
+}
+
+export interface DependencyGraphModeStatus {
+  /** Number of docs with at least one outgoing reference. */
+  docsWithRefs: number;
+  /** Total number of outgoing reference edges. */
+  refs: number;
+}
+
+export interface DependencyGraphStatus {
+  /** Whether the feature is enabled via the cmsPlugin config. */
+  enabled: boolean;
+  /** Millis timestamp of the last graph update, or `null` if never built. */
+  lastRun: number | null;
+  draft: DependencyGraphModeStatus;
+  published: DependencyGraphModeStatus;
+}
+
+export interface DependencyGraphRebuildResult {
+  /** True if a full (force) rebuild was performed. */
+  forced: boolean;
+  /** True if the rebuild short-circuited (no doc changes were found). */
+  skipped: boolean;
+  refDocCounts: Record<DocMode, number>;
+  refCounts: Record<DocMode, number>;
+  durationMs: number;
+}
+
+export interface GetDependenciesOptions {
+  /**
+   * Whether to resolve dependencies transitively (i.e. also include the
+   * references of referenced docs, recursively). Defaults to `true`.
+   */
+  transitive?: boolean;
+}
+
+/**
+ * Normalized dependency graph filters. Empty arrays are treated as "unset" so
+ * a defensively-passed empty list doesn't accidentally exclude everything.
+ */
+interface ResolvedFilters {
+  includeCollections: Set<string> | null;
+  excludeCollections: Set<string> | null;
+}
+
+/**
+ * Normalizes the `dependencyGraph` cmsPlugin option. Returns the config
+ * object when the feature is enabled, or `null` when disabled.
+ */
+export function resolveDependencyGraphConfig(
+  option?: boolean | CMSDependencyGraphConfig
+): CMSDependencyGraphConfig | null {
+  if (option === true) {
+    return {};
+  }
+  if (option && typeof option === 'object') {
+    return option;
+  }
+  return null;
+}
+
+function toSetOrNull(values: string[] | undefined): Set<string> | null {
+  if (!values || values.length === 0) {
+    return null;
+  }
+  return new Set(values);
+}
+
+export function resolveDependencyGraphFilters(
+  config?: CMSDependencyGraphConfig
+): ResolvedFilters {
+  return {
+    includeCollections: toSetOrNull(config?.includeCollections),
+    excludeCollections: toSetOrNull(config?.excludeCollections),
+  };
+}
+
+export function isCollectionTracked(
+  filters: ResolvedFilters,
+  collectionId: string
+): boolean {
+  if (
+    filters.includeCollections &&
+    !filters.includeCollections.has(collectionId)
+  ) {
+    return false;
+  }
+  if (filters.excludeCollections?.has(collectionId)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns the normalized doc id (`<collection>/<slug>`) when a value has the
+ * shape saved by the CMS reference fields (`{id, collection, slug}` with a
+ * consistent id), or `null` otherwise. Requiring the id to agree with the
+ * collection/slug pair avoids false positives on arbitrary user data that
+ * happens to use the same keys.
+ */
+export function getReferenceDocId(value: any): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const id = value.id;
+  const collection = value.collection;
+  const slug = value.slug;
+  if (
+    typeof id !== 'string' ||
+    typeof collection !== 'string' ||
+    typeof slug !== 'string'
+  ) {
+    return null;
+  }
+  if (!id.includes('/') || !collection || !slug) {
+    return null;
+  }
+  let parsed: {collection: string; slug: string};
+  try {
+    parsed = parseDocId(id);
+  } catch {
+    return null;
+  }
+  if (parsed.collection !== collection) {
+    return null;
+  }
+  if (parsed.slug !== normalizeSlug(slug)) {
+    return null;
+  }
+  return `${parsed.collection}/${parsed.slug}`;
+}
+
+/**
+ * Extracts the doc ids referenced by a doc's fields data. Accepts the raw
+ * (marshaled) data as stored in Firestore or unmarshaled data — both plain
+ * arrays and `_array` objects are traversed. Returns a sorted, de-duped list.
+ */
+export function extractRefDocIds(fieldsData: any): string[] {
+  const refIds = new Set<string>();
+  walkForRefs(fieldsData, refIds, 0);
+  return Array.from(refIds).sort();
+}
+
+function walkForRefs(node: any, out: Set<string>, depth: number) {
+  if (depth > MAX_WALK_DEPTH || !node || typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkForRefs(item, out, depth + 1);
+    }
+    return;
+  }
+  const refId = getReferenceDocId(node);
+  if (refId) {
+    out.add(refId);
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    walkForRefs(node[key], out, depth + 1);
+  }
+}
+
+/**
+ * Normalizes a doc id to the `<collection>/<slug>` format used by graph keys
+ * (slug slashes are encoded as `--`). Invalid ids are returned unchanged so
+ * lookups simply miss instead of throwing.
+ */
+function normalizeDocId(docId: string): string {
+  try {
+    const parsed = parseDocId(docId);
+    return `${parsed.collection}/${parsed.slug}`;
+  } catch {
+    return docId;
+  }
+}
+
+/**
+ * An in-memory snapshot of the dependency graph for a single doc mode,
+ * providing forward (dependencies) and reverse (dependents) lookups.
+ */
+export class DependencyGraph {
+  readonly mode: DocMode;
+  /** Millis timestamp of the last graph update, or `null` if never built. */
+  readonly lastRun: number | null;
+  /** Map of doc id to the sorted list of doc ids it references. */
+  readonly edges: Record<string, string[]>;
+  /** Lazily-built reverse index (doc id to the doc ids that reference it). */
+  private reverseEdges: Record<string, string[]> | null = null;
+
+  constructor(
+    mode: DocMode,
+    edges: Record<string, string[]>,
+    lastRun: number | null
+  ) {
+    this.mode = mode;
+    this.edges = edges;
+    this.lastRun = lastRun;
+  }
+
+  /**
+   * Returns the doc ids referenced by the given doc(s), i.e. the additional
+   * docs that need to be fetched when fetching the given docs. Resolves
+   * transitively by default (references of referenced docs are included,
+   * recursively; cycles are handled). The input doc ids themselves are
+   * excluded from the result.
+   */
+  getDependencies(
+    docIds: string | string[],
+    options?: GetDependenciesOptions
+  ): string[] {
+    return this.collect(docIds, this.edges, options);
+  }
+
+  /**
+   * Returns the doc ids that reference the given doc(s). Useful for finding
+   * which docs are affected when a doc changes (e.g. for cache invalidation).
+   * Resolves transitively by default.
+   */
+  getDependents(
+    docIds: string | string[],
+    options?: GetDependenciesOptions
+  ): string[] {
+    if (this.reverseEdges === null) {
+      const reverse: Record<string, string[]> = {};
+      for (const docId of Object.keys(this.edges)) {
+        for (const refId of this.edges[docId]) {
+          (reverse[refId] ??= []).push(docId);
+        }
+      }
+      this.reverseEdges = reverse;
+    }
+    return this.collect(docIds, this.reverseEdges, options);
+  }
+
+  private collect(
+    docIds: string | string[],
+    edgeMap: Record<string, string[]>,
+    options?: GetDependenciesOptions
+  ): string[] {
+    const transitive = options?.transitive ?? true;
+    const inputIds = (Array.isArray(docIds) ? docIds : [docIds]).map(
+      normalizeDocId
+    );
+    const result = new Set<string>();
+    const visited = new Set<string>(inputIds);
+    let frontier = inputIds;
+    while (frontier.length > 0) {
+      const next: string[] = [];
+      for (const docId of frontier) {
+        for (const refId of edgeMap[docId] || []) {
+          if (!visited.has(refId)) {
+            visited.add(refId);
+            result.add(refId);
+            next.push(refId);
+          }
+        }
+      }
+      if (!transitive) {
+        break;
+      }
+      frontier = next;
+    }
+    return Array.from(result).sort();
+  }
+}
+
+/**
+ * In-process cache of loaded graphs, keyed by `<projectId>::<mode>`. Entries
+ * are invalidated when the persisted `_meta.lastRun` changes (checked on every
+ * `getGraph()` call) or when a rebuild runs in this process.
+ */
+const graphCache = new Map<
+  string,
+  {lastRunMillis: number; graph: DependencyGraph}
+>();
+
+interface CmsDocData {
+  fields?: any;
+  [key: string]: any;
+}
+
+/**
+ * Service for building, updating, and reading the persisted dependency graph.
+ */
+export class DependencyGraphService {
+  private readonly rootConfig: RootConfig;
+  private readonly projectId: string;
+  private readonly db: Firestore;
+  private readonly config: CMSDependencyGraphConfig | null;
+  private readonly filters: ResolvedFilters;
+
+  constructor(
+    rootConfig: RootConfig,
+    configOverride?: boolean | CMSDependencyGraphConfig
+  ) {
+    this.rootConfig = rootConfig;
+    const cmsPlugin = getCmsPlugin(rootConfig);
+    const cmsPluginOptions = cmsPlugin.getConfig();
+    this.projectId = cmsPluginOptions.id || 'default';
+    this.db = cmsPlugin.getFirestore();
+    this.config = resolveDependencyGraphConfig(
+      configOverride ?? cmsPluginOptions.dependencyGraph
+    );
+    this.filters = resolveDependencyGraphFilters(this.config || undefined);
+  }
+
+  /** Returns true if the dependency graph feature is enabled. */
+  isEnabled(): boolean {
+    return this.config !== null;
+  }
+
+  private assertEnabled() {
+    if (!this.isEnabled()) {
+      throw new Error(
+        'the dependency graph is not enabled for this project. enable it in ' +
+          'root.config.ts, e.g. `cmsPlugin({dependencyGraph: true})`.'
+      );
+    }
+  }
+
+  /** Returns true if the given collection passes the include/exclude filter. */
+  isCollectionTracked(collectionId: string): boolean {
+    return isCollectionTracked(this.filters, collectionId);
+  }
+
+  private graphDocPath(docId: string): string {
+    return `Projects/${this.projectId}/${DEPENDENCY_GRAPH_SUBCOLLECTION}/${docId}`;
+  }
+
+  private graphCollectionPath(): string {
+    return `Projects/${this.projectId}/${DEPENDENCY_GRAPH_SUBCOLLECTION}`;
+  }
+
+  private docsCollectionPath(mode: DocMode, collectionId: string): string {
+    const modeCollection = mode === 'draft' ? 'Drafts' : 'Published';
+    return `Projects/${this.projectId}/Collections/${collectionId}/${modeCollection}`;
+  }
+
+  /**
+   * The sys timestamp that indicates a doc changed in the given mode. Draft
+   * docs bump `sys.modifiedAt` on every save; published docs get a fresh
+   * `sys.publishedAt` on every publish.
+   */
+  private changedAtField(mode: DocMode): string {
+    return mode === 'draft' ? 'sys.modifiedAt' : 'sys.publishedAt';
+  }
+
+  private edgeDocId(mode: DocMode, collectionId: string): string {
+    return `${mode}--${collectionId}`;
+  }
+
+  /**
+   * Lists collection ids by globbing `<rootDir>/collections/*.schema.ts`,
+   * filtered by the include/exclude config.
+   */
+  async listCollectionIds(): Promise<string[]> {
+    const collectionsDir = path.join(this.rootConfig.rootDir, 'collections');
+    if (!fs.existsSync(collectionsDir)) {
+      return [];
+    }
+    const fileNames = await glob('*.schema.ts', {cwd: collectionsDir});
+    return fileNames
+      .map((f) => f.slice(0, -10))
+      .filter((id) => this.isCollectionTracked(id))
+      .sort();
+  }
+
+  private async readMeta(): Promise<DependencyGraphMeta | null> {
+    const snap = await this.db.doc(this.graphDocPath(META_DOC_ID)).get();
+    if (!snap.exists) {
+      return null;
+    }
+    return (snap.data() as DependencyGraphMeta) || null;
+  }
+
+  /** Reads every edge doc in the DependencyGraph subcollection. */
+  private async readEdgeDocs(): Promise<Map<string, DependencyGraphEdgeDoc>> {
+    const snap = await this.db.collection(this.graphCollectionPath()).get();
+    const edgeDocs = new Map<string, DependencyGraphEdgeDoc>();
+    snap.forEach((doc) => {
+      if (doc.id === META_DOC_ID) {
+        return;
+      }
+      const data = doc.data() as DependencyGraphEdgeDoc;
+      if (!data?.mode || !data?.collection) {
+        return;
+      }
+      edgeDocs.set(doc.id, {
+        mode: data.mode,
+        collection: data.collection,
+        refs: data.refs || {},
+      });
+    });
+    return edgeDocs;
+  }
+
+  /** Commits a set of doc writes/deletes in chunked batches. */
+  private async commitInChunks(
+    ops: Array<(batch: WriteBatch) => void>
+  ): Promise<void> {
+    for (let i = 0; i < ops.length; i += BATCH_MAX_OPS) {
+      const batch = this.db.batch();
+      for (const op of ops.slice(i, i + BATCH_MAX_OPS)) {
+        op(batch);
+      }
+      await batch.commit();
+    }
+  }
+
+  private countRefs(edgeDocs: Map<string, DependencyGraphEdgeDoc>): {
+    refDocCounts: Record<DocMode, number>;
+    refCounts: Record<DocMode, number>;
+  } {
+    const refDocCounts: Record<DocMode, number> = {draft: 0, published: 0};
+    const refCounts: Record<DocMode, number> = {draft: 0, published: 0};
+    for (const edgeDoc of edgeDocs.values()) {
+      for (const refIds of Object.values(edgeDoc.refs)) {
+        if (refIds.length > 0) {
+          refDocCounts[edgeDoc.mode] += 1;
+          refCounts[edgeDoc.mode] += refIds.length;
+        }
+      }
+    }
+    return {refDocCounts, refCounts};
+  }
+
+  /**
+   * Returns true when any doc changed (created, updated, published, or
+   * deleted) since `lastRun`. Uses limit(1) probes for modifications and
+   * count() aggregations (compared against the doc counts captured at
+   * `lastRun`) for deletions, so the no-change case stays cheap.
+   */
+  async hasChangesSince(meta: {
+    lastRun: Timestamp;
+    docCounts: Record<string, number>;
+  }): Promise<boolean> {
+    const collectionIds = await this.listCollectionIds();
+    const keys: Array<{mode: DocMode; collectionId: string; key: string}> = [];
+    for (const mode of MODES) {
+      for (const collectionId of collectionIds) {
+        keys.push({
+          mode,
+          collectionId,
+          key: this.edgeDocId(mode, collectionId),
+        });
+      }
+    }
+
+    // Probe for docs modified/published since the last run.
+    const probeSnaps = await Promise.all(
+      keys.map((item) =>
+        this.db
+          .collection(this.docsCollectionPath(item.mode, item.collectionId))
+          .where(this.changedAtField(item.mode), '>=', meta.lastRun)
+          .limit(1)
+          .get()
+      )
+    );
+    if (probeSnaps.some((snap) => !snap.empty)) {
+      return true;
+    }
+
+    // No modified docs — compare live doc counts to detect deletions.
+    const docCounts = meta.docCounts || {};
+    const countSnaps = await Promise.all(
+      keys.map((item) =>
+        this.db
+          .collection(this.docsCollectionPath(item.mode, item.collectionId))
+          .count()
+          .get()
+      )
+    );
+    for (let i = 0; i < keys.length; i++) {
+      const liveCount = countSnaps[i].data().count;
+      if (liveCount !== (docCounts[keys[i].key] || 0)) {
+        return true;
+      }
+    }
+
+    // Detect collections that were removed (or newly excluded) but still have
+    // tracked docs from a previous run.
+    const currentKeys = new Set(keys.map((item) => item.key));
+    for (const key of Object.keys(docCounts)) {
+      if (!currentKeys.has(key) && docCounts[key] > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Cron entrypoint: incrementally updates the graph when the feature is
+   * enabled, the min interval has elapsed, and any doc changed since the last
+   * run. Returns `null` when the update was skipped.
+   */
+  async runCronUpdate(options?: {
+    minIntervalMs?: number;
+  }): Promise<DependencyGraphRebuildResult | null> {
+    if (!this.isEnabled()) {
+      return null;
+    }
+    const meta = await this.readMeta();
+    if (meta) {
+      const minIntervalMs = options?.minIntervalMs || 0;
+      const elapsed = Date.now() - meta.lastRun.toMillis();
+      if (minIntervalMs > 0 && elapsed < minIntervalMs) {
+        return null;
+      }
+      const hasChanges = await this.hasChangesSince(meta);
+      if (!hasChanges) {
+        return null;
+      }
+    }
+    return this.rebuildGraph({force: false});
+  }
+
+  /**
+   * Orchestrates a graph rebuild (incremental by default; full when
+   * `force: true`).
+   */
+  async rebuildGraph(
+    opts: {force?: boolean} = {}
+  ): Promise<DependencyGraphRebuildResult> {
+    this.assertEnabled();
+    const start = Date.now();
+    const force = !!opts.force;
+    const collectionIds = await this.listCollectionIds();
+    // Capture the run timestamp before querying so that docs modified while
+    // the rebuild is in flight are re-processed on the next run.
+    const runStartedAt = Timestamp.now();
+
+    let result: {skipped: boolean};
+    if (force) {
+      result = await this.fullRebuild(collectionIds, runStartedAt);
+    } else {
+      const meta = await this.readMeta();
+      if (meta) {
+        result = await this.incrementalRebuild(
+          collectionIds,
+          meta,
+          runStartedAt
+        );
+      } else {
+        // No existing graph — bootstrap with a full build.
+        result = await this.fullRebuild(collectionIds, runStartedAt);
+      }
+    }
+
+    const meta = await this.readMeta();
+    return {
+      forced: force,
+      skipped: result.skipped,
+      refDocCounts: meta?.refDocCounts || {draft: 0, published: 0},
+      refCounts: meta?.refCounts || {draft: 0, published: 0},
+      durationMs: Date.now() - start,
+    };
+  }
+
+  private async fullRebuild(collectionIds: string[], runStartedAt: Timestamp) {
+    const existingEdgeDocs = await this.readEdgeDocs();
+    const edgeDocs = new Map<string, DependencyGraphEdgeDoc>();
+    const docCounts: Record<string, number> = {};
+
+    for (const mode of MODES) {
+      for (const collectionId of collectionIds) {
+        const key = this.edgeDocId(mode, collectionId);
+        const snap = await this.db
+          .collection(this.docsCollectionPath(mode, collectionId))
+          .get();
+        docCounts[key] = snap.size;
+        const refs: Record<string, string[]> = {};
+        snap.forEach((doc) => {
+          const data = (doc.data() || {}) as CmsDocData;
+          const refIds = extractRefDocIds(data.fields || {});
+          if (refIds.length > 0) {
+            refs[doc.id] = refIds;
+          }
+        });
+        edgeDocs.set(key, {mode, collection: collectionId, refs});
+      }
+    }
+
+    const ops: Array<(batch: WriteBatch) => void> = [];
+    // Delete edge docs that no longer correspond to a tracked collection.
+    for (const key of existingEdgeDocs.keys()) {
+      if (!edgeDocs.has(key)) {
+        const ref = this.db.doc(this.graphDocPath(key));
+        ops.push((batch) => batch.delete(ref));
+      }
+    }
+    for (const [key, edgeDoc] of edgeDocs) {
+      const ref = this.db.doc(this.graphDocPath(key));
+      ops.push((batch) => batch.set(ref, edgeDoc));
+    }
+    const {refDocCounts, refCounts} = this.countRefs(edgeDocs);
+    const metaRef = this.db.doc(this.graphDocPath(META_DOC_ID));
+    const meta: DependencyGraphMeta = {
+      lastRun: runStartedAt,
+      docCounts,
+      refDocCounts,
+      refCounts,
+    };
+    ops.push((batch) => batch.set(metaRef, meta));
+    await this.commitInChunks(ops);
+    this.invalidateCache();
+    return {skipped: false};
+  }
+
+  private async incrementalRebuild(
+    collectionIds: string[],
+    prevMeta: DependencyGraphMeta,
+    runStartedAt: Timestamp
+  ) {
+    const edgeDocs = await this.readEdgeDocs();
+    const dirtyKeys = new Set<string>();
+    const docCounts: Record<string, number> = {};
+    const currentKeys = new Set<string>();
+    const prevDocCounts = prevMeta.docCounts || {};
+
+    for (const mode of MODES) {
+      for (const collectionId of collectionIds) {
+        const key = this.edgeDocId(mode, collectionId);
+        currentKeys.add(key);
+        const docsPath = this.docsCollectionPath(mode, collectionId);
+
+        let edgeDoc = edgeDocs.get(key);
+        if (!edgeDoc) {
+          edgeDoc = {mode, collection: collectionId, refs: {}};
+          edgeDocs.set(key, edgeDoc);
+        }
+
+        // Re-extract refs for docs that changed since the last run. When the
+        // graph hasn't seen this collection before (e.g. a newly added or
+        // newly included collection with pre-existing docs), scan every doc
+        // instead — the docs may pre-date `lastRun`.
+        const isNewKey = !(key in prevDocCounts);
+        let changedQuery: Query = this.db.collection(docsPath);
+        if (!isNewKey) {
+          changedQuery = changedQuery.where(
+            this.changedAtField(mode),
+            '>=',
+            prevMeta.lastRun
+          );
+        }
+        const changedSnap = await changedQuery.get();
+        changedSnap.forEach((doc) => {
+          const data = (doc.data() || {}) as CmsDocData;
+          const refIds = extractRefDocIds(data.fields || {});
+          const prevRefIds = edgeDoc!.refs[doc.id];
+          if (refIds.length > 0) {
+            if (!prevRefIds || !stringArraysEqual(prevRefIds, refIds)) {
+              edgeDoc!.refs[doc.id] = refIds;
+              dirtyKeys.add(key);
+            }
+          } else if (prevRefIds) {
+            delete edgeDoc!.refs[doc.id];
+            dirtyKeys.add(key);
+          }
+        });
+
+        // Reconcile deletions by diffing tracked slugs against live doc ids.
+        const liveSnap = await this.db.collection(docsPath).select().get();
+        docCounts[key] = liveSnap.size;
+        const liveIds = new Set(liveSnap.docs.map((doc) => doc.id));
+        for (const slug of Object.keys(edgeDoc.refs)) {
+          if (!liveIds.has(slug)) {
+            delete edgeDoc.refs[slug];
+            dirtyKeys.add(key);
+          }
+        }
+      }
+    }
+
+    // Drop edge docs for collections that are no longer tracked.
+    const staleKeys: string[] = [];
+    for (const key of edgeDocs.keys()) {
+      if (!currentKeys.has(key)) {
+        staleKeys.push(key);
+      }
+    }
+    for (const key of staleKeys) {
+      edgeDocs.delete(key);
+    }
+
+    const skipped = dirtyKeys.size === 0 && staleKeys.length === 0;
+    const ops: Array<(batch: WriteBatch) => void> = [];
+    for (const key of staleKeys) {
+      const ref = this.db.doc(this.graphDocPath(key));
+      ops.push((batch) => batch.delete(ref));
+    }
+    for (const key of dirtyKeys) {
+      const edgeDoc = edgeDocs.get(key)!;
+      const ref = this.db.doc(this.graphDocPath(key));
+      ops.push((batch) => batch.set(ref, edgeDoc));
+    }
+    const {refDocCounts, refCounts} = this.countRefs(edgeDocs);
+    const metaRef = this.db.doc(this.graphDocPath(META_DOC_ID));
+    const meta: DependencyGraphMeta = {
+      lastRun: runStartedAt,
+      docCounts,
+      refDocCounts,
+      refCounts,
+    };
+    ops.push((batch) => batch.set(metaRef, meta));
+    await this.commitInChunks(ops);
+    if (!skipped) {
+      this.invalidateCache();
+    }
+    return {skipped};
+  }
+
+  private invalidateCache() {
+    for (const mode of MODES) {
+      graphCache.delete(`${this.projectId}::${mode}`);
+    }
+  }
+
+  /**
+   * Returns the dependency graph for the given mode, loading it from
+   * Firestore if necessary. Loaded graphs are cached in-process and
+   * re-validated against `_meta.lastRun` on every call, so repeated calls
+   * only cost a single meta doc read until the graph changes.
+   */
+  async getGraph(mode: DocMode): Promise<DependencyGraph> {
+    this.assertEnabled();
+    const meta = await this.readMeta();
+    if (!meta) {
+      return new DependencyGraph(mode, {}, null);
+    }
+    const lastRunMillis = meta.lastRun.toMillis();
+    const cacheKey = `${this.projectId}::${mode}`;
+    const cached = graphCache.get(cacheKey);
+    if (cached && cached.lastRunMillis === lastRunMillis) {
+      return cached.graph;
+    }
+    const snap = await this.db
+      .collection(this.graphCollectionPath())
+      .where('mode', '==', mode)
+      .get();
+    const edges: Record<string, string[]> = {};
+    snap.forEach((doc) => {
+      const data = doc.data() as DependencyGraphEdgeDoc;
+      if (!data?.collection) {
+        return;
+      }
+      const refs = data.refs || {};
+      for (const slug of Object.keys(refs)) {
+        const refIds = refs[slug];
+        if (Array.isArray(refIds) && refIds.length > 0) {
+          edges[`${data.collection}/${slug}`] = refIds.map(String);
+        }
+      }
+    });
+    const graph = new DependencyGraph(mode, edges, lastRunMillis);
+    graphCache.set(cacheKey, {lastRunMillis, graph});
+    return graph;
+  }
+
+  /** Lightweight metadata read for status endpoints. */
+  async getStatus(): Promise<DependencyGraphStatus> {
+    const enabled = this.isEnabled();
+    const meta = enabled ? await this.readMeta() : null;
+    if (!meta) {
+      return {
+        enabled,
+        lastRun: null,
+        draft: {docsWithRefs: 0, refs: 0},
+        published: {docsWithRefs: 0, refs: 0},
+      };
+    }
+    return {
+      enabled,
+      lastRun: meta.lastRun.toMillis(),
+      draft: {
+        docsWithRefs: meta.refDocCounts?.draft || 0,
+        refs: meta.refCounts?.draft || 0,
+      },
+      published: {
+        docsWithRefs: meta.refDocCounts?.published || 0,
+        refs: meta.refCounts?.published || 0,
+      },
+    };
+  }
+}
+
+function stringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -243,6 +243,30 @@ export interface CMSSearchIndexConfig {
   excludeDocIds?: string[];
 }
 
+/**
+ * Configuration options for the dependency graph. Pass `true` (or an empty
+ * object) to the `dependencyGraph` plugin option to enable the feature with
+ * default options.
+ */
+export interface CMSDependencyGraphConfig {
+  /**
+   * Collections to track in the dependency graph. If specified, only docs in
+   * these collections are scanned for outgoing references. If unset, all
+   * collections are scanned (subject to `excludeCollections`).
+   *
+   * Note that these filters only control which docs are scanned for outgoing
+   * references — referenced doc ids are always recorded as-is, even when the
+   * referenced doc lives in a collection that is not scanned.
+   */
+  includeCollections?: string[];
+
+  /**
+   * Collections to exclude from the dependency graph. Applied after
+   * `includeCollections`.
+   */
+  excludeCollections?: string[];
+}
+
 export interface CMSSidebarTool {
   /** URL for the sidebar icon image. */
   icon?: string;
@@ -568,6 +592,25 @@ export type CMSPluginOptions = {
    * include or exclude specific collections or docs from being indexed.
    */
   searchIndex?: CMSSearchIndexConfig;
+
+  /**
+   * Enables the dependency graph, which tracks reference field usages
+   * (`schema.reference()` / `schema.references()`) between docs. The graph is
+   * kept up to date automatically by the CMS cron job and can be queried via
+   * `RootCMSClient.getDependencyGraph()` to resolve the full set of
+   * referenced docs that need to be fetched when fetching one or more docs.
+   *
+   * Disabled by default. Pass `true` to enable with default options, or a
+   * config object to scope the graph to specific collections.
+   *
+   * Example:
+   * ```ts
+   * cmsPlugin({
+   *   dependencyGraph: true,
+   * });
+   * ```
+   */
+  dependencyGraph?: boolean | CMSDependencyGraphConfig;
 
   /**
    * Default UI variant for `oneOf` fields. Individual fields can still


### PR DESCRIPTION
## Summary

This PR introduces an opt-in dependency graph feature that tracks reference field usages between CMS documents. The graph enables efficient resolution of document dependencies, allowing clients to fetch all required documents when serving a particular document.

## Key Changes

- **New `DependencyGraphService` class** (`dependency-graph.ts`): Core service for building, updating, and querying the persisted dependency graph
  - Supports both incremental (cron-based) and full rebuilds
  - Extracts references from doc fields data using data-driven detection (no schema required)
  - Persists graph state to Firestore with metadata tracking
  - Provides forward (dependencies) and reverse (dependents) lookups

- **`DependencyGraph` class**: In-memory snapshot providing efficient graph queries
  - `getDependencies()`: Returns docs referenced by given doc(s), with optional transitive resolution
  - `getDependents()`: Returns docs that reference given doc(s)
  - Handles cycles and normalizes doc IDs

- **CMS API endpoints** (`api.ts`):
  - `POST /cms/api/dependency_graph.query`: Query dependencies for one or more docs
  - `GET /cms/api/dependency_graph.status`: Get graph status and last run timestamp
  - `POST /cms/api/dependency_graph.rebuild`: Trigger manual graph rebuild (admin-only)

- **Client integration** (`client.ts`):
  - `getDependencyGraph()`: Async method to load graph for a given mode
  - `getDocDependencies()`: Convenience method to resolve dependencies for docs

- **Cron integration** (`cron.ts`): Automatic incremental graph updates via existing cron job

- **Configuration** (`plugin.ts`):
  - New `CMSDependencyGraphConfig` interface with `includeCollections` and `excludeCollections` filters
  - Enable via `cmsPlugin({dependencyGraph: true})` in `root.config.ts`

- **Comprehensive test suite** (`dependency-graph.test.ts`): 
  - Unit tests for reference extraction and graph traversal
  - Firestore emulator-backed integration tests for the service

## Notable Implementation Details

- **Data-driven extraction**: References are detected by shape (`{id, collection, slug}` with consistent id) rather than schema, allowing the cron to run without loading schema files
- **Incremental updates**: Tracks doc modification timestamps to efficiently re-extract only changed docs
- **Deletion handling**: Uses count aggregation queries to detect deletions via diff against tracked slugs
- **Cycle handling**: Graph traversal safely handles reference cycles
- **Depth protection**: Guards against pathological nesting (max 100 levels) when walking doc data
- **Batched persistence**: Firestore writes are chunked to respect the 500-operation batch limit
- **In-process caching**: Loaded graphs are cached and invalidated when persisted metadata changes

https://claude.ai/code/session_01Nc76DzgvTv83fvhucLXGcr