### PR TITLE
fix: update the dependency graph at publish time to avoid stale references

### DIFF
--- a/.changeset/violet-buses-shake.md
+++ b/.changeset/violet-buses-shake.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: update the dependency graph at publish time to avoid stale references

--- a/.changeset/violet-buses-shake.md
+++ b/.changeset/violet-buses-shake.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-feat: update the dependency graph at publish time to avoid stale references
+fix: update the dependency graph at publish time to avoid stale references

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -505,6 +505,68 @@ export function api(server: Server, options: ApiOptions) {
   );
 
   /**
+   * Syncs the published-mode dependency graph edges for specific docs by
+   * re-reading them from the `Published` collection (missing docs have their
+   * edges removed). The CMS UI calls this after publishing, unpublishing, or
+   * deleting docs client-side, so the graph reflects new references
+   * immediately instead of waiting for the next cron tick. Idempotent — the
+   * graph is synced to whatever is currently in the database.
+   *
+   * Authentication: any signed-in CMS user.
+   *
+   * Sample request:
+   *
+   * ```
+   * POST /cms/api/dependency_graph.sync_published
+   * {"docIds": ["Pages/index"]}
+   * ```
+   */
+  server.use(
+    '/cms/api/dependency_graph.sync_published',
+    async (req: Request, res: Response) => {
+      if (
+        req.method !== 'POST' ||
+        !String(req.get('content-type')).startsWith('application/json')
+      ) {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const body = req.body || {};
+      const docIds = Array.isArray(body.docIds)
+        ? body.docIds.filter((id: any) => typeof id === 'string')
+        : [];
+      if (docIds.length === 0) {
+        res.status(400).json({
+          success: false,
+          error: 'MISSING_REQUIRED_FIELD',
+          field: 'docIds',
+        });
+        return;
+      }
+      if (docIds.length > 1000) {
+        res.status(400).json({success: false, error: 'TOO_MANY_DOC_IDS'});
+        return;
+      }
+      try {
+        const service = new DependencyGraphService(req.rootConfig!);
+        if (!service.isEnabled()) {
+          res.status(404).json({success: false, error: 'NOT_ENABLED'});
+          return;
+        }
+        const result = await service.syncPublishedDocs(docIds);
+        res.status(200).json({success: true, ...result});
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
    * Accepts a JSON object containing {headers: [...], rows: [...]} and sends
    * an HTTP response with a corresponding CSV file as an attachment.
    *

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -149,6 +149,9 @@ export async function renderApp(
     excludeLocalesFromTranslations:
       cmsConfig.excludeLocalesFromTranslations || [],
     allowedIframeOrigins: cmsConfig.allowedIframeOrigins || [],
+    // Matches `resolveDependencyGraphConfig()`: `true` or a config object
+    // enables the feature.
+    dependencyGraphEnabled: Boolean(cmsConfig.dependencyGraph),
   };
   const projectName = cmsConfig.name || cmsConfig.id || '';
   const title = getCmsTitle(projectName, cmsConfig.minimalBranding);

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -11,7 +11,11 @@ import {
 import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {isCronDue} from './cron-schedule.js';
-import type {DependencyGraph} from './dependency-graph.js';
+import type {
+  DependencyGraph,
+  DependencyGraphBatchOp,
+  DependencyGraphService,
+} from './dependency-graph.js';
 import {CMSPlugin} from './plugin.js';
 import {Collection} from './schema.js';
 import {
@@ -805,6 +809,17 @@ export class RootCMSClient {
       );
     }
 
+    // If the dependency graph is enabled, update the published-mode edges in
+    // the same batch as the publish so new references are queryable
+    // immediately (without waiting for the next cron tick).
+    const depGraphOps = await this.buildDependencyGraphPublishOps(
+      docs.map((doc) => ({
+        collection: doc.collection,
+        slug: doc.slug,
+        fields: doc.fields,
+      }))
+    );
+
     // Each transaction or batch can write a max of 500 ops, so commit the
     // batch in chunks, starting a new batch after each commit.
     // https://firebase.google.com/docs/firestore/manage-data/transactions
@@ -905,6 +920,16 @@ export class RootCMSClient {
       }
     }
 
+    for (const op of depGraphOps) {
+      if (batchCount >= 400) {
+        await batch.commit();
+        batch = this.db.batch();
+        batchCount = 0;
+      }
+      op(batch);
+      batchCount += 1;
+    }
+
     if (batchCount > 0) {
       await batch.commit();
     }
@@ -966,6 +991,12 @@ export class RootCMSClient {
         ]);
     }
 
+    // If the dependency graph is enabled, remove the published-mode edges in
+    // the same batch as the unpublish.
+    const depGraphOps = await this.buildDependencyGraphUnpublishOps(
+      docs.map((doc) => ({collection: doc.collection, slug: doc.slug}))
+    );
+
     let batchCount = 0;
     let batch = options?.batch || this.db.batch();
     const unpublishedDocs: any[] = [];
@@ -1024,6 +1055,16 @@ export class RootCMSClient {
         batch = this.db.batch();
         batchCount = 0;
       }
+    }
+
+    for (const op of depGraphOps) {
+      if (batchCount >= 400) {
+        await batch.commit();
+        batch = this.db.batch();
+        batchCount = 0;
+      }
+      op(batch);
+      batchCount += 1;
     }
 
     if (batchCount > 0) {
@@ -1088,6 +1129,16 @@ export class RootCMSClient {
         'draft'
       );
     }
+
+    // If the dependency graph is enabled, update the published-mode edges in
+    // the same batch as the publish.
+    const depGraphOps = await this.buildDependencyGraphPublishOps(
+      docs.map((doc) => ({
+        collection: doc.collection || '',
+        slug: doc.slug || '',
+        fields: doc.data?.fields,
+      }))
+    );
 
     // Each transaction or batch can write a max of 500 ops, so commit the
     // batch in chunks, starting a new batch after each commit.
@@ -1186,6 +1237,16 @@ export class RootCMSClient {
         batch = this.db.batch();
         batchCount = 0;
       }
+    }
+
+    for (const op of depGraphOps) {
+      if (batchCount >= 400) {
+        await batch.commit();
+        batch = this.db.batch();
+        batchCount = 0;
+      }
+      op(batch);
+      batchCount += 1;
     }
 
     if (batchCount > 0) {
@@ -2171,6 +2232,58 @@ export class RootCMSClient {
   ): Promise<string[]> {
     const graph = await this.getDependencyGraph({mode: options.mode});
     return graph.getDependencies(docIds, {transitive: options.transitive});
+  }
+
+  /**
+   * Returns the dependency graph service when the feature is enabled, or
+   * `null` otherwise.
+   */
+  private async getDependencyGraphService(): Promise<DependencyGraphService | null> {
+    const {DependencyGraphService} = await import('./dependency-graph.js');
+    const service = new DependencyGraphService(this.rootConfig);
+    return service.isEnabled() ? service : null;
+  }
+
+  /**
+   * Builds the dependency graph writes for a set of docs being published.
+   * Returns an empty list when the feature is disabled or the graph is not in
+   * use. Errors are logged and swallowed so a graph failure never blocks
+   * publishing (the CMS cron reconciles the graph).
+   */
+  private async buildDependencyGraphPublishOps(
+    docs: Array<{collection: string; slug: string; fields?: any}>
+  ): Promise<DependencyGraphBatchOp[]> {
+    try {
+      const service = await this.getDependencyGraphService();
+      if (!service) {
+        return [];
+      }
+      return await service.buildPublishBatchOps(docs);
+    } catch (err) {
+      console.error('failed to build dependency graph updates:');
+      console.error(String(err.stack || err));
+      return [];
+    }
+  }
+
+  /**
+   * Builds the dependency graph writes for a set of docs being unpublished.
+   * See `buildDependencyGraphPublishOps()`.
+   */
+  private async buildDependencyGraphUnpublishOps(
+    docs: Array<{collection: string; slug: string}>
+  ): Promise<DependencyGraphBatchOp[]> {
+    try {
+      const service = await this.getDependencyGraphService();
+      if (!service) {
+        return [];
+      }
+      return await service.buildUnpublishBatchOps(docs);
+    } catch (err) {
+      console.error('failed to build dependency graph updates:');
+      console.error(String(err.stack || err));
+      return [];
+    }
   }
 
   /**

--- a/packages/root-cms/core/dependency-graph.test.ts
+++ b/packages/root-cms/core/dependency-graph.test.ts
@@ -541,6 +541,149 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
       });
     });
 
+    it('updates published edges in the publish batch (no cron)', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+      const statusBefore = await service.getStatus();
+
+      // Load (and cache) the published graph before publishing.
+      let publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({});
+
+      // Change the draft's refs, then publish — without running the cron.
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/bob')});
+      await cmsClient.publishDocs(['Pages/index'], {publishedBy: 'test'});
+
+      publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({'Pages/index': ['Authors/bob']});
+
+      // The fast-path bumps the cache stamp without moving the cron's
+      // incremental watermark.
+      const statusAfter = await service.getStatus();
+      expect(statusAfter.lastRun).toBe(statusBefore.lastRun);
+    });
+
+    it('removes published edges in the unpublish batch (no cron)', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+      await cmsClient.publishDocs(['Pages/index'], {publishedBy: 'test'});
+      let publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({'Pages/index': ['Authors/alice']});
+
+      await cmsClient.unpublishDocs(['Pages/index'], {unpublishedBy: 'test'});
+      publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({});
+    });
+
+    it('updates published edges when scheduled docs are published', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      const service = createService();
+      await service.rebuildGraph();
+
+      // Seed a scheduled doc whose scheduledAt is in the past.
+      await cmsClient.db
+        .doc(
+          `Projects/${cmsClient.projectId}/Collections/Pages/Scheduled/index`
+        )
+        .set({
+          id: 'Pages/index',
+          collection: 'Pages',
+          slug: 'index',
+          sys: {
+            createdAt: Timestamp.now(),
+            createdBy: 'test',
+            modifiedAt: Timestamp.now(),
+            modifiedBy: 'test',
+            scheduledAt: Timestamp.fromMillis(Date.now() - 60 * 1000),
+            scheduledBy: 'test',
+            locales: ['en'],
+          },
+          fields: marshalData({author: ref('Authors/bob')}),
+        });
+      await cmsClient.publishScheduledDocs();
+
+      const publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({'Pages/index': ['Authors/bob']});
+    });
+
+    it('skips the publish fast-path until the graph is built', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});
+      await cmsClient.publishDocs(['Pages/index'], {publishedBy: 'test'});
+
+      const service = createService();
+      const status = await service.getStatus();
+      expect(status.lastRun).toBe(null);
+      const graphDocs = await cmsClient.db
+        .collection(`Projects/${cmsClient.projectId}/DependencyGraph`)
+        .get();
+      expect(graphDocs.empty).toBe(true);
+    });
+
+    it('does not write graph docs when the feature is disabled', async () => {
+      const disabled = createTestProject({dependencyGraph: false});
+      await seedDoc(disabled.cmsClient, 'Pages/index', {
+        author: ref('Authors/alice'),
+      });
+      await disabled.cmsClient.publishDocs(['Pages/index'], {
+        publishedBy: 'test',
+      });
+      const graphDocs = await disabled.cmsClient.db
+        .collection(`Projects/${disabled.cmsClient.projectId}/DependencyGraph`)
+        .get();
+      expect(graphDocs.empty).toBe(true);
+    });
+
+    it('syncs published docs on demand (UI publish path)', async () => {
+      const {cmsClient, createService} = project;
+      await seedDoc(cmsClient, 'Pages/index', {title: 'No refs yet'});
+      const service = createService();
+      await service.rebuildGraph();
+
+      // Simulate a client-side (CMS UI) publish by writing the published doc
+      // directly, then sync.
+      await seedDoc(
+        cmsClient,
+        'Pages/index',
+        {author: ref('Authors/alice')},
+        {mode: 'published'}
+      );
+      let result = await service.syncPublishedDocs(['Pages/index']);
+      expect(result.synced).toBe(1);
+      let publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({'Pages/index': ['Authors/alice']});
+
+      // Simulate a client-side unpublish/delete — the published doc is gone,
+      // so its edges are removed on the next sync.
+      await cmsClient.db
+        .doc(
+          `Projects/${cmsClient.projectId}/Collections/Pages/Published/index`
+        )
+        .delete();
+      result = await service.syncPublishedDocs(['Pages/index']);
+      expect(result.synced).toBe(1);
+      publishedGraph = await service.getGraph('published');
+      expect(publishedGraph.edges).toEqual({});
+    });
+
+    it('ignores invalid and untracked doc ids in syncPublishedDocs', async () => {
+      const scoped = createTestProject({
+        dependencyGraph: {includeCollections: ['Pages']},
+      });
+      const service = scoped.createService();
+      await service.rebuildGraph();
+      const result = await service.syncPublishedDocs([
+        'no-slash',
+        'Posts/untracked',
+      ]);
+      expect(result.synced).toBe(0);
+    });
+
     it('picks up collections added after the initial build', async () => {
       const {cmsClient, rootConfig, createService} = project;
       await seedDoc(cmsClient, 'Pages/index', {author: ref('Authors/alice')});

--- a/packages/root-cms/core/dependency-graph.ts
+++ b/packages/root-cms/core/dependency-graph.ts
@@ -42,12 +42,21 @@
  *     the last run, and reconcile deletions by diffing tracked slugs against
  *     the live doc-id set per collection.
  *   - `force: true` — drop everything and re-extract every doc.
+ *
+ * Publish fast-path: to avoid a staleness window between publishing a doc and
+ * the next cron tick, publish/unpublish flows update the published-mode edges
+ * directly — server-side publishes weave `buildPublishBatchOps()` /
+ * `buildUnpublishBatchOps()` into the publish write batch, and the CMS UI
+ * (which publishes client-side) calls `/cms/api/dependency_graph.sync_published`
+ * after committing, which runs `syncPublishedDocs()`. The cron remains the
+ * source of truth and reconciles anything the fast-path misses.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import {RootConfig} from '@blinkk/root';
 import {
+  FieldValue,
   Firestore,
   Query,
   Timestamp,
@@ -83,7 +92,18 @@ interface DependencyGraphMeta {
   refDocCounts: Record<DocMode, number>;
   /** Total number of outgoing reference edges, per mode. */
   refCounts: Record<DocMode, number>;
+  /**
+   * Timestamp of the last edge write, bumped by publish-time fast-path
+   * updates (which leave `lastRun` — the cron's incremental watermark —
+   * untouched). Used only as the in-process cache validation stamp; cron
+   * rebuilds rewrite the meta doc without this field, falling back to
+   * `lastRun` as the stamp.
+   */
+  updatedAt?: Timestamp;
 }
+
+/** A single buffered write produced for a caller-managed Firestore batch. */
+export type DependencyGraphBatchOp = (batch: WriteBatch) => void;
 
 /**
  * A `{mode}--{collectionId}` doc in the DependencyGraph subcollection, holding
@@ -612,6 +632,192 @@ export class DependencyGraphService {
   }
 
   /**
+   * Returns true when the graph has been built at least once. Publish-time
+   * fast-path updates are skipped until the cron (or a manual rebuild)
+   * bootstraps the graph, so a partial graph is never served.
+   */
+  private async isGraphBuilt(): Promise<boolean> {
+    const meta = await this.readMeta();
+    return Boolean(meta?.lastRun);
+  }
+
+  /**
+   * Builds the writes that update `published--<collection>` edge docs for a
+   * set of entries. A `null` refIds removes the doc's edges (unpublish /
+   * delete). The final op bumps `_meta.updatedAt` so in-process graph caches
+   * revalidate, without moving `lastRun` (the cron's incremental watermark).
+   *
+   * NOTE: a cron rebuild racing with these writes can momentarily overwrite
+   * them; the next cron tick re-extracts the affected docs (their
+   * `sys.publishedAt` is past the cron's watermark), so the graph converges
+   * within one tick in the worst case.
+   */
+  private buildPublishedRefsOps(
+    entries: Array<{collection: string; slug: string; refIds: string[] | null}>
+  ): DependencyGraphBatchOp[] {
+    const refsByCollection = new Map<
+      string,
+      Record<string, string[] | FieldValue>
+    >();
+    for (const entry of entries) {
+      let refs = refsByCollection.get(entry.collection);
+      if (!refs) {
+        refs = {};
+        refsByCollection.set(entry.collection, refs);
+      }
+      refs[entry.slug] =
+        entry.refIds && entry.refIds.length > 0
+          ? entry.refIds
+          : FieldValue.delete();
+    }
+    const ops: DependencyGraphBatchOp[] = [];
+    for (const [collectionId, refs] of refsByCollection) {
+      const ref = this.db.doc(
+        this.graphDocPath(this.edgeDocId('published', collectionId))
+      );
+      ops.push((batch) =>
+        batch.set(
+          ref,
+          {mode: 'published', collection: collectionId, refs},
+          {merge: true}
+        )
+      );
+    }
+    const metaRef = this.db.doc(this.graphDocPath(META_DOC_ID));
+    const updatedAt = Timestamp.now();
+    ops.push((batch) => batch.set(metaRef, {updatedAt}, {merge: true}));
+    return ops;
+  }
+
+  /**
+   * Builds the writes that sync the published-mode edges for docs being
+   * published, so new references are queryable immediately (without waiting
+   * for the next cron tick). Callers weave the returned ops into the same
+   * batch as the publish writes. Returns an empty list when the feature is
+   * disabled, no tracked docs are affected, or the graph has never been
+   * built.
+   */
+  async buildPublishBatchOps(
+    docs: Array<{collection: string; slug: string; fields?: any}>
+  ): Promise<DependencyGraphBatchOp[]> {
+    if (!this.isEnabled()) {
+      return [];
+    }
+    const entries: Array<{
+      collection: string;
+      slug: string;
+      refIds: string[] | null;
+    }> = [];
+    for (const doc of docs) {
+      if (!doc.collection || !doc.slug) {
+        continue;
+      }
+      if (!this.isCollectionTracked(doc.collection)) {
+        continue;
+      }
+      entries.push({
+        collection: doc.collection,
+        slug: normalizeSlug(doc.slug),
+        refIds: extractRefDocIds(doc.fields || {}),
+      });
+    }
+    if (entries.length === 0 || !(await this.isGraphBuilt())) {
+      return [];
+    }
+    return this.buildPublishedRefsOps(entries);
+  }
+
+  /**
+   * Builds the writes that remove the published-mode edges for docs being
+   * unpublished. See `buildPublishBatchOps()`.
+   */
+  async buildUnpublishBatchOps(
+    docs: Array<{collection: string; slug: string}>
+  ): Promise<DependencyGraphBatchOp[]> {
+    if (!this.isEnabled()) {
+      return [];
+    }
+    const entries: Array<{
+      collection: string;
+      slug: string;
+      refIds: string[] | null;
+    }> = [];
+    for (const doc of docs) {
+      if (!doc.collection || !doc.slug) {
+        continue;
+      }
+      if (!this.isCollectionTracked(doc.collection)) {
+        continue;
+      }
+      entries.push({
+        collection: doc.collection,
+        slug: normalizeSlug(doc.slug),
+        refIds: null,
+      });
+    }
+    if (entries.length === 0 || !(await this.isGraphBuilt())) {
+      return [];
+    }
+    return this.buildPublishedRefsOps(entries);
+  }
+
+  /**
+   * Re-reads the given docs from the `Published` collection and syncs their
+   * published-mode edges: existing docs get their refs re-extracted, missing
+   * docs (unpublished or deleted) get their edges removed. Used by the
+   * `/cms/api/dependency_graph.sync_published` endpoint, which the CMS UI
+   * calls after client-side publishes. Idempotent — the graph is synced to
+   * whatever is currently in the database.
+   */
+  async syncPublishedDocs(docIds: string[]): Promise<{synced: number}> {
+    this.assertEnabled();
+    const targets: Array<{collection: string; slug: string}> = [];
+    const seen = new Set<string>();
+    for (const docId of docIds) {
+      let parsed: {collection: string; slug: string};
+      try {
+        parsed = parseDocId(docId);
+      } catch {
+        continue;
+      }
+      if (!this.isCollectionTracked(parsed.collection)) {
+        continue;
+      }
+      const key = `${parsed.collection}/${parsed.slug}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      targets.push(parsed);
+    }
+    if (targets.length === 0 || !(await this.isGraphBuilt())) {
+      return {synced: 0};
+    }
+    const docRefs = targets.map((target) =>
+      this.db.doc(
+        `${this.docsCollectionPath('published', target.collection)}/${target.slug}`
+      )
+    );
+    const snaps: FirebaseFirestore.DocumentSnapshot[] = [];
+    for (let i = 0; i < docRefs.length; i += 300) {
+      const chunk = docRefs.slice(i, i + 300);
+      snaps.push(...(await this.db.getAll(...chunk)));
+    }
+    const entries = targets.map((target, i) => {
+      const snap = snaps[i];
+      const data = (snap.exists ? snap.data() : null) as CmsDocData | null;
+      return {
+        collection: target.collection,
+        slug: target.slug,
+        refIds: data ? extractRefDocIds(data.fields || {}) : null,
+      };
+    });
+    const ops = this.buildPublishedRefsOps(entries);
+    await this.commitInChunks(ops);
+    return {synced: targets.length};
+  }
+
+  /**
    * Orchestrates a graph rebuild (incremental by default; full when
    * `force: true`).
    */
@@ -825,9 +1031,12 @@ export class DependencyGraphService {
       return new DependencyGraph(mode, {}, null);
     }
     const lastRunMillis = meta.lastRun.toMillis();
+    // Publish-time fast-path updates bump `updatedAt` without moving
+    // `lastRun`, so the cache is validated against `updatedAt` when present.
+    const cacheStamp = meta.updatedAt?.toMillis() ?? lastRunMillis;
     const cacheKey = `${this.projectId}::${mode}`;
     const cached = graphCache.get(cacheKey);
-    if (cached && cached.lastRunMillis === lastRunMillis) {
+    if (cached && cached.lastRunMillis === cacheStamp) {
       return cached.graph;
     }
     const snap = await this.db
@@ -849,7 +1058,7 @@ export class DependencyGraphService {
       }
     });
     const graph = new DependencyGraph(mode, edges, lastRunMillis);
-    graphCache.set(cacheKey, {lastRunMillis, graph});
+    graphCache.set(cacheKey, {lastRunMillis: cacheStamp, graph});
     return graph;
   }
 

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -259,6 +259,12 @@ declare global {
        * lifecycle messages from the embedded editor.
        */
       allowedIframeOrigins?: string[];
+      /**
+       * Whether the dependency graph is enabled via the `dependencyGraph`
+       * cmsPlugin option. When enabled, the UI notifies the server after
+       * client-side publishes so the graph is updated immediately.
+       */
+      dependencyGraphEnabled?: boolean;
     };
     firebase: FirebaseContextObject;
   }

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -151,6 +151,8 @@ export async function cmsDeleteDoc(docId: string) {
   await batch.commit();
   console.log(`deleted doc: ${docId}`);
   logAction('doc.delete', {metadata: {docId}});
+  // Remove the doc's edges from the dependency graph.
+  await cmsSyncDependencyGraph([docId]);
 }
 
 export async function cmsPublishDoc(
@@ -220,7 +222,8 @@ export async function cmsPublishDocs(
       addPublishTranslationsOpsToBatch(batch, translationsLocaleDocs);
     }
   });
-  if (!options?.batch || options?.commitBatch) {
+  const commitsBatch = !options?.batch || options?.commitBatch;
+  if (commitsBatch) {
     await batch.commit();
   }
 
@@ -240,6 +243,13 @@ export async function cmsPublishDocs(
 
   // Reset doc cache for published docs.
   removeDocsFromCache(docIds);
+
+  // Update the dependency graph for the published docs. When a shared batch
+  // was provided (e.g. release publishing), the caller is responsible for
+  // syncing after it commits the batch.
+  if (commitsBatch) {
+    await cmsSyncDependencyGraph(docIds);
+  }
 }
 
 /**
@@ -343,6 +353,38 @@ function updatePublishedDocDataInBatch(
     versionData.publishMessage = publishMessage;
   }
   batch.set(versionRef, versionData);
+}
+
+/**
+ * Notifies the server to re-sync the published-mode dependency graph edges
+ * for the given docs. No-op unless the `dependencyGraph` cmsPlugin option is
+ * enabled. Publishing happens client-side, so without this call the graph
+ * would only pick up new references on the next server cron tick. Failures
+ * are logged and ignored — the CMS cron reconciles the graph automatically.
+ */
+export async function cmsSyncDependencyGraph(docIds: string[]) {
+  if (!window.__ROOT_CTX.dependencyGraphEnabled || docIds.length === 0) {
+    return;
+  }
+  try {
+    // The endpoint caps the number of doc ids per request, so sync in chunks
+    // (relevant when publishing large releases).
+    for (let i = 0; i < docIds.length; i += 500) {
+      const chunk = docIds.slice(i, i + 500);
+      const res = await fetch('/cms/api/dependency_graph.sync_published', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({docIds: chunk}),
+      });
+      if (res.status !== 200) {
+        const err = await res.text();
+        console.error('failed to sync dependency graph:', err);
+        return;
+      }
+    }
+  } catch (err) {
+    console.error('failed to sync dependency graph:', err);
+  }
 }
 
 /**
@@ -466,6 +508,8 @@ export async function cmsUnpublishDoc(docId: string) {
   console.log(`unpublished ${docId}`);
   logAction('doc.unpublish', {metadata: {docId}});
   removeDocFromCache(docId);
+  // Remove the doc's edges from the dependency graph.
+  await cmsSyncDependencyGraph([docId]);
 }
 
 export async function cmsRevertDraft(docId: string) {

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -16,7 +16,7 @@ import {renderAutoSlug} from '../../shared/auto-slug.js';
 import {logAction} from './actions.js';
 import {MultiBatch} from './batch.js';
 import {cmsPublishDataSources} from './data-source.js';
-import {cmsPublishDocs} from './doc.js';
+import {cmsPublishDocs, cmsSyncDependencyGraph} from './doc.js';
 
 export interface Release {
   id: string;
@@ -163,6 +163,9 @@ export async function publishRelease(id: string) {
   });
   await batch.commit();
   console.log(`published release: ${id}`);
+  // Update the dependency graph for the released docs (cmsPublishDocs skips
+  // the sync when writing to a shared batch, since the batch commits here).
+  await cmsSyncDependencyGraph(docIds);
   const metadata: Record<string, unknown> = {
     releaseId: id,
     docIds,


### PR DESCRIPTION
## Summary

Follow-up to #1314. The dependency graph was only updated by the CMS cron, so a doc published immediately after adding a new reference would not report that reference as a dependency until the next cron tick (up to ~1 minute). Anything fetching the doc's dependencies in that window (e.g. SSR resolving referenced docs) would miss the newly referenced doc.

This closes the window by updating the published-mode graph edges as part of publishing itself.

## Key Changes

- **Server-side publishes ride the publish batch** (`client.ts`): `publishDocs()` (which releases also go through), `publishScheduledDocs()`, and `unpublishDocs()` now weave dependency graph writes into the same Firestore write batch as the publish. The doc fields are already in memory at that point, so refs are extracted with no extra reads; each affected collection gets one merged edge-doc write. Graph op-building failures are logged and swallowed so they can never block publishing.

- **UI publishes sync via a new endpoint** (`api.ts`, `ui/utils/doc.ts`, `ui/utils/release.ts`): the CMS UI publishes directly from the browser (not through `publishDocs()`), so after committing a publish/unpublish/delete/release it calls `POST /cms/api/dependency_graph.sync_published`. The endpoint re-reads the docs from the `Published` collection server-side and syncs their edges — missing docs (unpublished/deleted) have their edges removed, making it idempotent. Requests are chunked for large releases, and failures are logged and ignored.

- **`dependencyGraphEnabled` flag in `__ROOT_CTX`** (`app.tsx`, `ui/ui.tsx`): gates the UI sync call so projects without the feature make no extra requests.

- **Cache stamp without moving the cron watermark** (`dependency-graph.ts`): fast-path writes bump a new `_meta.updatedAt` field, which in-process graph caches revalidate against, while `lastRun` (the cron's incremental watermark) stays untouched. If a fast-path write fails or races a cron rebuild, the next cron tick re-extracts the affected docs (their `sys.publishedAt` is past the watermark), so the graph always converges — worst case degrades to the previous one-tick staleness, never a permanently wrong graph.

- **No partial graphs**: the fast-path is skipped until the graph has been built at least once (the cron bootstraps it), so enabling the feature on an existing project can't serve a graph containing only recently published docs.

## Testing

- 7 new Firestore emulator tests: publish/unpublish/scheduled-publish update edges without running the cron (including cache revalidation and the watermark staying put), the `syncPublishedDocs()` UI path (publish + unpublish/delete), the never-built guard, invalid/untracked doc id handling, and the disabled case.
- Full suites green: 555 core/shared/cli tests + 389 UI tests. Core and UI bundles build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nc76DzgvTv83fvhucLXGcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nc76DzgvTv83fvhucLXGcr)_