### PR TITLE
fix: skip hidden and OS junk files (.DS_Store, Thumbs.db, etc) in asset library syncs

### DIFF
--- a/.changeset/asset-sync-ignore-junk-files.md
+++ b/.changeset/asset-sync-ignore-junk-files.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: skip hidden and OS junk files (.DS_Store, Thumbs.db, etc) in asset library syncs

--- a/packages/root-cms/docs/asset-sync-design.md
+++ b/packages/root-cms/docs/asset-sync-design.md
@@ -407,6 +407,10 @@ export async function syncFolder(
 1. **Lease.** Set `sync.state = {status:'syncing', startedAt, startedBy}`
    on the folder doc (see §6.5).
 2. **Enumerate remote.** `provider.listRemoteAssets(folder.sync, auth)`.
+   The engine then drops hidden files and OS artifacts (`.DS_Store`,
+   `Thumbs.db`, `._*` resource forks, Office `~$` lock files, …; see
+   `isIgnoredSourceFile()` in `names.ts`) so junk that OSes drop into
+   synced Drive folders is never imported, for any provider.
 3. **Enumerate local.** `listAssets(folderPath)` → index the folder's
    `AssetFile`s by `source.remoteId` (assets without `source`, i.e.
    manually uploaded files coexisting in the folder, are ignored).

--- a/packages/root-cms/ui/utils/asset-sync/engine.test.ts
+++ b/packages/root-cms/ui/utils/asset-sync/engine.test.ts
@@ -46,6 +46,8 @@ function makeFolder(sync?: Partial<AssetFolderSync>): AssetFolder {
 
 interface FakeRemote {
   remoteId: string;
+  /** Remote display name; defaults to `remoteId`. */
+  name?: string;
   filename: string;
   /** File contents; the fake sha1 is `sha1:<contents>`. */
   contents: string;
@@ -64,7 +66,7 @@ function makeProvider(options: {version?: string; remote: FakeRemote[]}) {
       version: options.version,
       assets: options.remote.map((r) => ({
         remoteId: r.remoteId,
-        name: r.remoteId,
+        name: r.name ?? r.remoteId,
         filename: r.filename,
         ...(r.contentHash ? {contentHash: r.contentHash} : {}),
         ref: {contents: r.contents},
@@ -473,6 +475,52 @@ describe('syncFolder', () => {
       'folder-icons',
       expect.objectContaining({ok: false, error: 'no access'}),
       {remoteVersion: undefined}
+    );
+  });
+
+  it('never imports hidden or OS junk files from the source', async () => {
+    const folder = makeFolder();
+    const {provider, downloaded} = makeProvider({
+      version: 'v1',
+      remote: [
+        {
+          remoteId: 'file:1',
+          name: 'hero.png',
+          filename: 'hero.png',
+          contents: 'aaa',
+        },
+        {
+          remoteId: 'file:2',
+          name: '.DS_Store',
+          filename: '.DS_Store',
+          contents: 'junk',
+        },
+        {
+          remoteId: 'file:3',
+          name: 'Thumbs.db',
+          filename: 'Thumbs.db',
+          contents: 'junk',
+        },
+      ],
+    });
+    // A junk file imported before this rule existed is flagged missing on
+    // the next sync (never auto-deleted), like any item gone at the source.
+    const deps = makeDeps({
+      folder,
+      localAssets: [makeSyncedAsset('file:2', 'junk')],
+    });
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    expect(summary.added).toEqual(1);
+    expect(summary.missing).toEqual(1);
+    expect(downloaded).toEqual(['file:1']);
+    expect(deps.createAssetFile).toHaveBeenCalledTimes(1);
+    expect((deps.createAssetFile as any).mock.calls[0][0].name).toEqual(
+      'hero.png'
+    );
+    expect(deps.updateAssetSourceMissing).toHaveBeenCalledWith(
+      'asset-file:2',
+      true
     );
   });
 

--- a/packages/root-cms/ui/utils/asset-sync/engine.ts
+++ b/packages/root-cms/ui/utils/asset-sync/engine.ts
@@ -45,7 +45,11 @@ import {
   updateAssetSourceMissing,
 } from '../assets.js';
 import {UploadedFile, sha1, uploadFileToGCS} from '../gcs.js';
-import {buildUniqueAssetName, sanitizeAssetName} from './names.js';
+import {
+  buildUniqueAssetName,
+  isIgnoredSourceFile,
+  sanitizeAssetName,
+} from './names.js';
 import {getSyncProvider} from './registry.js';
 import {createBrowserAuthContext} from './tokens.js';
 import {
@@ -209,6 +213,13 @@ export async function syncFolder(
     onProgress({phase: 'enumerating'});
     const remoteList = await provider.listRemoteAssets(sync, auth, providerCtx);
     remoteVersion = remoteList.version;
+    // Hidden files and OS artifacts (e.g. `.DS_Store`, `Thumbs.db`) are
+    // never imported, regardless of provider. Any imported before this
+    // rule existed are flagged missing below, like items gone from the
+    // source (never auto-deleted).
+    const remoteAssets = remoteList.assets.filter(
+      (asset) => !isIgnoredSourceFile(asset.name)
+    );
 
     const folderPath = joinFolderPath(folder.parent, folder.name);
     const localAssets = await deps.listAssets(folderPath);
@@ -225,11 +236,11 @@ export async function syncFolder(
       }
     }
 
-    const remoteIds = new Set(remoteList.assets.map((a) => a.remoteId));
+    const remoteIds = new Set(remoteAssets.map((a) => a.remoteId));
     const missingAssets = Array.from(syncedByRemoteId.values()).filter(
       (asset) => !remoteIds.has(asset.source!.remoteId)
     );
-    const reappearedAssets = remoteList.assets.filter(
+    const reappearedAssets = remoteAssets.filter(
       (a) => syncedByRemoteId.get(a.remoteId)?.source?.missingSince
     );
 
@@ -241,17 +252,17 @@ export async function syncFolder(
       freshFolder.sync?.lastRemoteVersion === remoteVersion &&
       missingAssets.length === 0 &&
       reappearedAssets.length === 0 &&
-      remoteList.assets.every((a) => syncedByRemoteId.has(a.remoteId))
+      remoteAssets.every((a) => syncedByRemoteId.has(a.remoteId))
     ) {
       summary.upToDate = true;
-      summary.unchanged = remoteList.assets.length;
+      summary.unchanged = remoteAssets.length;
       return summary;
     }
 
     // Split into new imports and existing assets to check. Provider-reported
     // hashes (e.g. Drive's md5) skip unchanged items before downloading.
     const candidates: RemoteAsset[] = [];
-    for (const remoteAsset of remoteList.assets) {
+    for (const remoteAsset of remoteAssets) {
       const existing = syncedByRemoteId.get(remoteAsset.remoteId);
       if (
         existing &&

--- a/packages/root-cms/ui/utils/asset-sync/names.test.ts
+++ b/packages/root-cms/ui/utils/asset-sync/names.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it} from 'vitest';
-import {buildUniqueAssetName, sanitizeAssetName} from './names.js';
+import {
+  buildUniqueAssetName,
+  isIgnoredSourceFile,
+  sanitizeAssetName,
+} from './names.js';
 
 describe('sanitizeAssetName', () => {
   it('replaces slashes with dashes', () => {
@@ -25,6 +29,42 @@ describe('sanitizeAssetName', () => {
   it('truncates very long names', () => {
     const long = 'a'.repeat(500);
     expect(sanitizeAssetName(long).length).toBeLessThanOrEqual(190);
+  });
+});
+
+describe('isIgnoredSourceFile', () => {
+  it('ignores hidden dotfiles', () => {
+    expect(isIgnoredSourceFile('.DS_Store')).toBe(true);
+    expect(isIgnoredSourceFile('.ds_store')).toBe(true);
+    expect(isIgnoredSourceFile('._hero.png')).toBe(true);
+    expect(isIgnoredSourceFile('.localized')).toBe(true);
+    expect(isIgnoredSourceFile('.~lock.report.odt#')).toBe(true);
+    expect(isIgnoredSourceFile('.gitignore')).toBe(true);
+  });
+
+  it('ignores well-known OS artifacts case-insensitively', () => {
+    expect(isIgnoredSourceFile('Thumbs.db')).toBe(true);
+    expect(isIgnoredSourceFile('thumbs.db')).toBe(true);
+    expect(isIgnoredSourceFile('ehthumbs.db')).toBe(true);
+    expect(isIgnoredSourceFile('ehthumbs_vista.db')).toBe(true);
+    expect(isIgnoredSourceFile('Desktop.ini')).toBe(true);
+    expect(isIgnoredSourceFile('Icon\r')).toBe(true);
+    expect(isIgnoredSourceFile('__MACOSX')).toBe(true);
+  });
+
+  it('ignores tooling temp files', () => {
+    expect(isIgnoredSourceFile('~$Report.docx')).toBe(true);
+    expect(isIgnoredSourceFile('photo.jpg.crdownload')).toBe(true);
+  });
+
+  it('keeps regular asset names', () => {
+    expect(isIgnoredSourceFile('hero.png')).toBe(false);
+    expect(isIgnoredSourceFile('my.file.png')).toBe(false);
+    expect(isIgnoredSourceFile('Iconography.svg')).toBe(false);
+    expect(isIgnoredSourceFile('Icons.zip')).toBe(false);
+    expect(isIgnoredSourceFile('report.docx')).toBe(false);
+    expect(isIgnoredSourceFile('archive.tar.gz')).toBe(false);
+    expect(isIgnoredSourceFile('')).toBe(false);
   });
 });
 

--- a/packages/root-cms/ui/utils/asset-sync/names.ts
+++ b/packages/root-cms/ui/utils/asset-sync/names.ts
@@ -5,6 +5,8 @@
  * contain characters that are invalid in asset names (see
  * `validateAssetName()` in `ui/utils/assets.ts`), so they are sanitized
  * before being used, and collisions are de-duped with a ` (2)` counter.
+ * Hidden files and OS artifacts (e.g. `.DS_Store`) are recognized by
+ * `isIgnoredSourceFile()` and excluded from syncs by the engine.
  */
 
 /** Mirrors the invalid chars rejected by `validateAssetName()`. */
@@ -32,6 +34,53 @@ export function sanitizeAssetName(name: string): string {
     result = result.slice(0, MAX_NAME_LENGTH).trim();
   }
   return result;
+}
+
+/**
+ * Well-known OS/tooling artifact filenames that are never intentional
+ * assets. Compared case-insensitively against the remote name.
+ */
+const IGNORED_FILE_NAMES = new Set([
+  // Windows Explorer / Media Center thumbnail caches and folder config.
+  'thumbs.db',
+  'ehthumbs.db',
+  'ehthumbs_vista.db',
+  'desktop.ini',
+  // macOS custom folder icon resource (literally "Icon" + a carriage
+  // return) and the resource-fork folder zip tools extract.
+  'icon\r',
+  '__macosx',
+]);
+
+/**
+ * Returns true for remote file names that a sync should never import:
+ * hidden dotfiles and well-known OS/tooling artifacts. Synced sources
+ * commonly mirror someone's local disk (e.g. a Drive folder managed by
+ * Drive for desktop), which litters them with files like `.DS_Store` that
+ * are never intentional assets. The dot-prefix rule also matches design
+ * tools' "hidden/private" naming conventions (e.g. Figma excludes
+ * dot-prefixed components from publishing), so the engine applies this to
+ * every provider.
+ */
+export function isIgnoredSourceFile(name: string): boolean {
+  const normalized = String(name || '').toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  // Hidden files (.DS_Store, ._resource-forks, .localized, .~lock files,
+  // sync-tool markers, ...).
+  if (normalized.startsWith('.')) {
+    return true;
+  }
+  // MS Office owner/lock temp files, e.g. `~$Report.docx`.
+  if (normalized.startsWith('~$')) {
+    return true;
+  }
+  // In-progress Chrome downloads.
+  if (normalized.endsWith('.crdownload')) {
+    return true;
+  }
+  return IGNORED_FILE_NAMES.has(normalized);
 }
 
 /**

--- a/packages/root-cms/ui/utils/asset-sync/types.ts
+++ b/packages/root-cms/ui/utils/asset-sync/types.ts
@@ -185,7 +185,9 @@ export interface AssetSyncProvider {
   /**
    * Enumerates the exportable assets at the source. Also serves as the
    * access check: implementations should throw {@link SyncAccessError} when
-   * the user's token cannot read the source.
+   * the user's token cannot read the source. Providers don't need to
+   * filter out hidden/OS-artifact names (`.DS_Store` etc.) -- the engine
+   * drops them via `isIgnoredSourceFile()` in `names.ts`.
    */
   listRemoteAssets(
     source: SyncSourceRef,


### PR DESCRIPTION
## Summary
Prevents the asset sync engine from importing hidden files and OS artifacts (like `.DS_Store`, `Thumbs.db`, etc.) that commonly appear in synced source folders. These files are now filtered out universally across all sync providers.

## Key Changes
- **Added `isIgnoredSourceFile()` function** in `names.ts` that identifies files to skip:
  - Hidden dotfiles (`.DS_Store`, `._*` resource forks, `.gitignore`, etc.)
  - Well-known OS artifacts (`Thumbs.db`, `ehthumbs.db`, `Desktop.ini`, `Icon\r`, `__MACOSX`)
  - Tooling temp files (`~$` Office lock files, `.crdownload` Chrome downloads)
  - Case-insensitive matching for cross-platform consistency

- **Updated sync engine** in `engine.ts` to filter remote assets before processing:
  - Filters `remoteList.assets` through `isIgnoredSourceFile()` immediately after enumeration
  - Applies filtering universally regardless of provider
  - Previously imported junk files are flagged as missing on next sync (never auto-deleted)

- **Enhanced test coverage** in `engine.test.ts` and `names.test.ts`:
  - New test verifying junk files are skipped while legitimate assets are imported
  - Comprehensive tests for all ignored file patterns
  - Tests confirm previously-imported junk files are marked missing

- **Updated documentation** in `asset-sync-design.md` and `types.ts` to clarify that providers don't need to filter these files themselves

## Implementation Details
- Filtering happens at the engine level after `listRemoteAssets()` returns, so providers have no filtering burden
- The approach handles the common case of syncing from cloud storage (Drive, Dropbox) that mirrors local folders with OS-generated files
- Aligns with design tool conventions (e.g., Figma's dot-prefix exclusion for components)

https://claude.ai/code/session_01MyXcHWneMH2zjURHiGCyyq