### PR TITLE
feat: show the server build timestamp in a tooltip on the cms version number

### DIFF
--- a/.changeset/nervous-mugs-clap.md
+++ b/.changeset/nervous-mugs-clap.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: show the server build timestamp in a tooltip on the cms version number

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -4,6 +4,7 @@ import {Request, Response, RootConfig} from '@blinkk/root';
 import {renderJsxToString} from '@blinkk/root/jsx';
 import {serializeJsonForScript} from '../shared/safe-json.js';
 import {serializeAiConfig} from './ai.js';
+import {getBuildInfo} from './build-info.js';
 import {CMSPluginOptions} from './plugin.js';
 import {getCollectionSchema, getProjectSchemas} from './project.js';
 import {Collection} from './schema.js';
@@ -110,6 +111,8 @@ export async function renderApp(
   if (gci === true) {
     gci = 'https://services.rootjs.dev';
   }
+  // Only set on prebuilt (deployed) servers; `null` on the dev server.
+  const buildInfo = await getBuildInfo(rootConfig.rootDir);
   const ctx = {
     rootConfig: {
       projectId: cmsConfig.id || 'default',
@@ -123,6 +126,7 @@ export async function renderApp(
         trailingSlash: rootConfig.server?.trailingSlash,
       },
     },
+    build: buildInfo,
     firebaseConfig: cmsConfig.firebaseConfig,
     gapi: cmsConfig.gapi,
     collections: collections,

--- a/packages/root-cms/core/build-info.test.ts
+++ b/packages/root-cms/core/build-info.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  clearBuildInfoCache,
+  getBuildInfo,
+  writeBuildInfo,
+} from './build-info.js';
+
+describe('build-info', () => {
+  let rootDir: string;
+  const nodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-cms-build-info-'));
+    clearBuildInfoCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, {recursive: true, force: true});
+    process.env.NODE_ENV = nodeEnv;
+  });
+
+  it('saves the build timestamp to dist/.root-cms/build.json', async () => {
+    await writeBuildInfo(rootDir, {timestamp: 1700000000000});
+    const filePath = path.join(rootDir, 'dist/.root-cms/build.json');
+    expect(JSON.parse(fs.readFileSync(filePath, 'utf-8'))).toEqual({
+      timestamp: 1700000000000,
+    });
+  });
+
+  it('reads the build timestamp back', async () => {
+    await writeBuildInfo(rootDir, {timestamp: 1700000000000});
+    expect(await getBuildInfo(rootDir)).toEqual({timestamp: 1700000000000});
+  });
+
+  it('returns null when the app was not built', async () => {
+    expect(await getBuildInfo(rootDir)).toBe(null);
+  });
+
+  it('returns null when the build file is malformed', async () => {
+    const dir = path.join(rootDir, 'dist/.root-cms');
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(path.join(dir, 'build.json'), 'not json', 'utf-8');
+    expect(await getBuildInfo(rootDir)).toBe(null);
+  });
+
+  it('returns null on the dev server', async () => {
+    await writeBuildInfo(rootDir, {timestamp: 1700000000000});
+    process.env.NODE_ENV = 'development';
+    expect(await getBuildInfo(rootDir)).toBe(null);
+  });
+});

--- a/packages/root-cms/core/build-info.ts
+++ b/packages/root-cms/core/build-info.ts
@@ -1,0 +1,76 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Path of the build metadata file, relative to the project's `dist` dir. The
+ * file is written by the CMS plugin's `postBuild` hook and read back by the
+ * prod server, so it needs to be part of the deployed build output.
+ */
+const BUILD_INFO_PATH = '.root-cms/build.json';
+
+export interface BuildInfo {
+  /** Epoch millis for when `root build` finished. */
+  timestamp: number;
+}
+
+function getBuildInfoFilePath(rootDir: string): string {
+  return path.join(rootDir, 'dist', BUILD_INFO_PATH);
+}
+
+/**
+ * Saves build metadata to `dist/.root-cms/build.json`. Called from the CMS
+ * plugin's `postBuild` hook so that prebuilt servers can report when they
+ * were built.
+ */
+export async function writeBuildInfo(
+  rootDir: string,
+  options?: {timestamp?: number}
+): Promise<BuildInfo> {
+  const buildInfo: BuildInfo = {
+    timestamp: options?.timestamp ?? new Date().getTime(),
+  };
+  const filePath = getBuildInfoFilePath(rootDir);
+  await fs.mkdir(path.dirname(filePath), {recursive: true});
+  await fs.writeFile(filePath, JSON.stringify(buildInfo, null, 2), 'utf-8');
+  return buildInfo;
+}
+
+const buildInfoCache = new Map<string, Promise<BuildInfo | null>>();
+
+/**
+ * Returns the build metadata saved by `root build`, or `null` when the app
+ * isn't prebuilt (e.g. the dev server) or the file is missing (e.g. the app
+ * was built by an older version of Root CMS). The result is cached for the
+ * lifetime of the server process.
+ */
+export function getBuildInfo(rootDir: string): Promise<BuildInfo | null> {
+  // The dev server serves from source, so any `dist/` files lying around are
+  // from an unrelated build and shouldn't be reported.
+  if (process.env.NODE_ENV === 'development') {
+    return Promise.resolve(null);
+  }
+  let buildInfo = buildInfoCache.get(rootDir);
+  if (!buildInfo) {
+    buildInfo = readBuildInfo(rootDir);
+    buildInfoCache.set(rootDir, buildInfo);
+  }
+  return buildInfo;
+}
+
+async function readBuildInfo(rootDir: string): Promise<BuildInfo | null> {
+  try {
+    const data = await fs.readFile(getBuildInfoFilePath(rootDir), 'utf-8');
+    const timestamp = Number(JSON.parse(data)?.timestamp);
+    if (!Number.isFinite(timestamp) || timestamp <= 0) {
+      return null;
+    }
+    return {timestamp};
+  } catch {
+    return null;
+  }
+}
+
+/** Clears the in-memory cache used by `getBuildInfo()`. Used by tests. */
+export function clearBuildInfoCache() {
+  buildInfoCache.clear();
+}

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -26,6 +26,7 @@ import sirv from 'sirv';
 import {SSEEvent, SSESchemaChangedEvent} from '../shared/sse.js';
 import {type AiConfig} from './ai.js';
 import {api} from './api.js';
+import {writeBuildInfo} from './build-info.js';
 import {type CMSCheck} from './checks.js';
 import {Action, RootCMSClient, UserRole} from './client.js';
 import {type CMSNotificationService} from './services-notifications.js';
@@ -938,6 +939,14 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
             throw err;
           }
         }
+      },
+
+      /**
+       * Saves build metadata to `dist/.root-cms/build.json` so that prebuilt
+       * servers can report when they were built.
+       */
+      postBuild: async (rootConfig: RootConfig) => {
+        await writeBuildInfo(rootConfig.rootDir);
       },
     },
 

--- a/packages/root-cms/ui/layout/Layout.css
+++ b/packages/root-cms/ui/layout/Layout.css
@@ -51,6 +51,12 @@
   background-color: #e5e5e5;
 }
 
+/* Wrapper added by the tooltip around the version badge. */
+.Layout__top__version__tooltip {
+  display: flex;
+  align-items: center;
+}
+
 .Layout__top__project {
   font-size: 14px;
   line-height: 16px;

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -113,14 +113,7 @@ Layout.Top = () => {
           <a className="Layout__top__logo" href="/cms">
             <RootCMSLogo />
           </a>
-          <a
-            className="Layout__top__version"
-            href="https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            v{packageJson.version}
-          </a>
+          <Layout.Version />
           <div className="Layout__top__project">{projectName}</div>
         </>
       ) : (
@@ -128,14 +121,7 @@ Layout.Top = () => {
           <a className="Layout__top__logo" href="/cms">
             {projectName}
           </a>
-          <a
-            className="Layout__top__version"
-            href="https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            v{packageJson.version}
-          </a>
+          <Layout.Version />
         </>
       )}
       {showSearchBar && (
@@ -146,6 +132,51 @@ Layout.Top = () => {
     </div>
   );
 };
+
+/**
+ * The Root CMS version badge in the top bar, which links to the changelog.
+ * When the app is prebuilt (i.e. deployed, not the dev server), a tooltip
+ * shows when the server was built.
+ */
+Layout.Version = () => {
+  const buildTimestamp = window.__ROOT_CTX.build?.timestamp;
+  const version = (
+    <a
+      className="Layout__top__version"
+      href="https://github.com/blinkk/rootjs/blob/main/packages/root-cms/CHANGELOG.md"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      v{packageJson.version}
+    </a>
+  );
+  if (!buildTimestamp) {
+    return version;
+  }
+  return (
+    <Tooltip
+      className="Layout__top__version__tooltip"
+      label={`Built ${formatBuildTime(buildTimestamp)}`}
+      position="bottom"
+      withArrow
+    >
+      {version}
+    </Tooltip>
+  );
+};
+
+/** Formats a build timestamp in the user's local time zone. */
+function formatBuildTime(timestamp: number) {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+}
 
 Layout.Side = () => {
   const {url} = useLocation();

--- a/packages/root-cms/ui/layout/Layout.visual.test.tsx
+++ b/packages/root-cms/ui/layout/Layout.visual.test.tsx
@@ -1,7 +1,7 @@
 import '../styles/global.css';
 import '../styles/theme.css';
 import {MantineProvider} from '@mantine/core';
-import {render} from '@testing-library/preact';
+import {fireEvent, render, waitFor} from '@testing-library/preact';
 import {LocationProvider} from 'preact-iso';
 import {describe, it, beforeEach, expect} from 'vitest';
 import {Layout} from './Layout.js';
@@ -67,5 +67,31 @@ describe('Layout', () => {
     expect(buttons.clientHeight).toBeLessThanOrEqual(
       side.getBoundingClientRect().height
     );
+  });
+
+  it('does not add a build tooltip to the version when not prebuilt', async () => {
+    const {container} = renderLayout();
+    expect(container.querySelector('.Layout__top__version')).not.toBeNull();
+    expect(
+      container.querySelector('.Layout__top__version__tooltip')
+    ).toBeNull();
+  });
+
+  it('shows the build timestamp on hover when the app is prebuilt', async () => {
+    (window as any).__ROOT_CTX.build = {
+      timestamp: new Date('2026-07-27T12:00:00Z').getTime(),
+    };
+    const {container} = renderLayout();
+    const tooltip = container.querySelector(
+      '.Layout__top__version__tooltip'
+    ) as HTMLElement;
+    expect(tooltip).not.toBeNull();
+    fireEvent.pointerEnter(tooltip);
+    const label = await waitFor(() => {
+      const el = document.querySelector('.mantine-Tooltip-body');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(label.textContent).toMatch(/^Built .*2026/);
   });
 });

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -189,6 +189,14 @@ declare global {
           trailingSlash?: boolean;
         };
       };
+      /**
+       * Metadata about the deployed build. Only set when the app is prebuilt
+       * (i.e. `root build` + `root start`); `null` on the dev server.
+       */
+      build?: {
+        /** Epoch millis for when `root build` finished. */
+        timestamp: number;
+      } | null;
       firebaseConfig: Record<string, string>;
       gapi?: {
         apiKey: string;


### PR DESCRIPTION
## Summary
This PR adds the ability to display when a prebuilt Root CMS server was built by showing a tooltip on the version number in the top navigation bar. This is useful for deployed applications to verify they're running the expected build.

## Key Changes
- **New `build-info` module** (`packages/root-cms/core/build-info.ts`): Handles writing and reading build metadata
  - `writeBuildInfo()`: Saves build timestamp to `dist/.root-cms/build.json` during the build process
  - `getBuildInfo()`: Reads the build metadata with caching; returns `null` on dev server or if file is missing
  - Includes proper error handling for malformed or missing files

- **CMS plugin integration** (`packages/root-cms/core/plugin.ts`): Added `postBuild` hook to automatically save build metadata after each build

- **UI updates** (`packages/root-cms/ui/layout/Layout.tsx`):
  - Extracted version badge into a new `Layout.Version` component
  - Added tooltip that displays formatted build timestamp when hovering over the version number
  - Only shows tooltip on prebuilt servers (not on dev server)
  - Includes `formatBuildTime()` helper to format timestamps in user's local timezone

- **Context updates** (`packages/root-cms/ui/ui.tsx`): Added `build` property to `__ROOT_CTX` global to pass build metadata to the frontend

- **Server-side rendering** (`packages/root-cms/core/app.tsx`): Reads build info and passes it to the frontend context

- **Styling** (`packages/root-cms/ui/layout/Layout.css`): Added CSS for tooltip wrapper alignment

- **Tests**: Comprehensive test coverage for build-info module and visual tests for the new tooltip behavior

## Implementation Details
- Build metadata is only written during production builds and only read on non-dev servers
- The build info is cached in-memory for the lifetime of the server process
- Gracefully handles missing or malformed build files by returning `null`
- The dev server always returns `null` for build info, preventing confusion with unrelated dist files

https://claude.ai/code/session_01WfJVMhXjAv3oFgmaN13fj6