### PR TITLE
fix: apply the cms doc editor deeplink on client-side url changes

### DIFF
--- a/.changeset/tidy-planes-glow.md
+++ b/.changeset/tidy-planes-glow.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: apply the cms doc editor deeplink on client-side url changes

--- a/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
+++ b/packages/root-cms/ui/components/DocEditor/DocEditor.tsx
@@ -863,8 +863,7 @@ DocEditor.FieldHeader = (props: FieldProps & {className?: string}) => {
               title="Link to field"
               onClick={(e) => {
                 e.preventDefault();
-                window.history.replaceState({}, '', deeplinkUrl);
-                deeplink.setValue(props.deepKey!);
+                deeplink.setUrlValue(props.deepKey!);
               }}
             >
               #

--- a/packages/root-cms/ui/hooks/useDeeplink.test.tsx
+++ b/packages/root-cms/ui/hooks/useDeeplink.test.tsx
@@ -1,0 +1,132 @@
+import {cleanup, render, waitFor} from '@testing-library/preact';
+import {LocationProvider, useLocation} from 'preact-iso';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {DeeplinkProvider, DeeplinkContext, useDeeplink} from './useDeeplink.js';
+
+interface TestAppProps {
+  /** Called on every render with preact-iso's `route()`. */
+  onRoute?: (route: (url: string) => void) => void;
+  /** Called on every render with the deeplink context. */
+  onDeeplink?: (deeplink: DeeplinkContext) => void;
+}
+
+function TestApp(props: TestAppProps) {
+  return (
+    <LocationProvider>
+      <DeeplinkProvider>
+        <DeeplinkValue {...props} />
+      </DeeplinkProvider>
+    </LocationProvider>
+  );
+}
+
+function DeeplinkValue(props: TestAppProps) {
+  const deeplink = useDeeplink();
+  const location = useLocation();
+  props.onRoute?.(location.route);
+  props.onDeeplink?.(deeplink);
+  return (
+    // `scrollToDeeplink()` scrolls `.DocumentPage__side`, the doc editor's
+    // scroll container.
+    <div className="DocumentPage__side">
+      <div data-testid="value">{deeplink.value}</div>
+      <div id="fields.hero.title" />
+    </div>
+  );
+}
+
+describe('DeeplinkProvider', () => {
+  let scroll: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/cms/content/Pages/index');
+    scroll = vi.fn();
+    // jsdom has no layout engine and doesn't implement scrolling.
+    Element.prototype.scroll = scroll as any;
+  });
+
+  afterEach(() => cleanup());
+
+  it('reads the deeplink from the url on load', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/cms/content/Pages/index?deeplink=fields.hero.title'
+    );
+    const {getByTestId} = render(<TestApp />);
+    await waitFor(() => {
+      expect(getByTestId('value').textContent).toEqual('fields.hero.title');
+    });
+  });
+
+  it('picks up a deeplink added by a client-side url change', async () => {
+    let route!: (url: string) => void;
+    const {getByTestId} = render(<TestApp onRoute={(r) => (route = r)} />);
+    expect(getByTestId('value').textContent).toEqual('');
+
+    route('/cms/content/Pages/index?deeplink=fields.hero.title');
+
+    await waitFor(() => {
+      expect(getByTestId('value').textContent).toEqual('fields.hero.title');
+    });
+    // The targeted field is scrolled into view even though the editor may
+    // already be scrolled from wherever the user navigated from.
+    await waitFor(() => {
+      expect(scroll).toHaveBeenCalled();
+    });
+  });
+
+  it('clears the deeplink when the url no longer has one', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/cms/content/Pages/index?deeplink=fields.hero.title'
+    );
+    let route!: (url: string) => void;
+    const {getByTestId} = render(<TestApp onRoute={(r) => (route = r)} />);
+    await waitFor(() => {
+      expect(getByTestId('value').textContent).toEqual('fields.hero.title');
+    });
+
+    route('/cms/content/Pages/index');
+
+    await waitFor(() => {
+      expect(getByTestId('value').textContent).toEqual('');
+    });
+  });
+
+  it('setUrlValue() mirrors the deeplink into the url', async () => {
+    let deeplink!: DeeplinkContext;
+    const {getByTestId} = render(
+      <TestApp onDeeplink={(d) => (deeplink = d)} />
+    );
+
+    deeplink.setUrlValue('fields.hero.title');
+
+    await waitFor(() => {
+      expect(getByTestId('value').textContent).toEqual('fields.hero.title');
+    });
+    expect(window.location.search).toEqual('?deeplink=fields.hero.title');
+  });
+
+  it('does not re-apply a deeplink set by setUrlValue()', async () => {
+    let deeplink!: DeeplinkContext;
+    let route!: (url: string) => void;
+    render(
+      <TestApp
+        onDeeplink={(d) => (deeplink = d)}
+        onRoute={(r) => (route = r)}
+      />
+    );
+
+    deeplink.setUrlValue('fields.hero.title');
+    await waitFor(() => expect(deeplink.value).toEqual('fields.hero.title'));
+    scroll.mockClear();
+
+    // A later navigation that keeps the same deeplink shouldn't yank the
+    // editor's scroll position back to the field.
+    route('/cms/content/Pages/index?deeplink=fields.hero.title&locale=de');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(scroll).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/ui/hooks/useDeeplink.tsx
+++ b/packages/root-cms/ui/hooks/useDeeplink.tsx
@@ -1,11 +1,25 @@
 import {ComponentChildren, createContext} from 'preact';
-import {useContext, useEffect, useState} from 'preact/hooks';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'preact/hooks';
+import {useLocation} from 'preact-iso';
 import {isScrollToDeeplinkMessage} from '../../shared/embed-protocol.js';
 import {isAllowedOrigin} from '../utils/embed-bridge.js';
 
 export interface DeeplinkContext {
   value: string;
+  /** Sets the targeted field without touching the URL. */
   setValue: (value: string) => void;
+  /**
+   * Sets the targeted field and mirrors it into the `deeplink` URL param,
+   * replacing the current history entry. Use this instead of `setValue()`
+   * whenever the URL should reflect the newly targeted field.
+   */
+  setUrlValue: (value: string) => void;
 }
 
 interface ScrollToDeeplinkOptions {
@@ -15,22 +29,99 @@ interface ScrollToDeeplinkOptions {
   behavior: 'auto' | 'smooth';
 }
 
+/** Max time to wait for a deeplinked field to render before giving up. */
+const DEEPLINK_ELEMENT_TIMEOUT_MS = 3000;
+
+/** How often to re-check for the deeplinked field while waiting for it. */
+const DEEPLINK_ELEMENT_POLL_MS = 50;
+
 function getDeeplinkFromUrl(): string {
   const params = new URLSearchParams(window.location.search);
   return params.get('deeplink') || '';
 }
 
+/** Updates the `deeplink` param in the URL without adding a history entry. */
+function replaceDeeplinkInUrl(deepKey: string) {
+  const url = new URL(window.location.href);
+  if (deepKey) {
+    url.searchParams.set('deeplink', deepKey);
+  } else {
+    url.searchParams.delete('deeplink');
+  }
+  // Preserve the existing history state so the router isn't disrupted.
+  window.history.replaceState(window.history.state, '', url.toString());
+}
+
+/**
+ * Waits for the field element for a deep key to exist in the DOM and then
+ * invokes the callback. A deeplink that arrives through a client-side URL
+ * change can land before the targeted field has rendered (e.g. when the same
+ * navigation also switches docs), so the element is polled for a short while.
+ * Returns a function that cancels the wait.
+ */
+function whenDeeplinkElementReady(
+  deepKey: string,
+  callback: (element: HTMLElement) => void
+): () => void {
+  const deadline = Date.now() + DEEPLINK_ELEMENT_TIMEOUT_MS;
+  let timer = 0;
+  const check = () => {
+    const element = document.getElementById(deepKey);
+    if (element) {
+      callback(element);
+      return;
+    }
+    if (Date.now() < deadline) {
+      timer = window.setTimeout(check, DEEPLINK_ELEMENT_POLL_MS);
+    }
+  };
+  // Defer the first check so any re-render triggered by the deeplink change
+  // (e.g. collapsed drawers re-opening) has been flushed to the DOM.
+  timer = window.setTimeout(check, 0);
+  return () => window.clearTimeout(timer);
+}
+
 const DEEPLINK_CONTEXT = createContext<DeeplinkContext | null>(null);
 
 export function DeeplinkProvider(props: {children: ComponentChildren}) {
-  const deeplinkFromUrl = getDeeplinkFromUrl();
-  const [value, setValue] = useState(deeplinkFromUrl);
-  const deeplinkCtx = {value, setValue};
+  // NOTE: `useLocation()` is what makes the URL check below reactive. Reading
+  // `window.location` alone would only pick up the deeplink on a full page
+  // load, since client-side navigations within the CMS never re-mount the doc
+  // editor.
+  const {url} = useLocation();
+  const [value, setValue] = useState(getDeeplinkFromUrl);
 
-  // When navigating between docs (URL changes), update the deeplink.
+  // The deeplink last seen in (or written to) the URL. In-app updates rewrite
+  // the URL themselves and do their own scrolling, so tracking it here keeps
+  // the URL watcher below from re-applying a deeplink already handled.
+  const urlDeeplinkRef = useRef(value);
+
+  const setUrlValue = useCallback((newValue: string) => {
+    urlDeeplinkRef.current = newValue;
+    replaceDeeplinkInUrl(newValue);
+    setValue(newValue);
+  }, []);
+
+  const deeplinkCtx = {value, setValue, setUrlValue};
+
+  // Apply deeplinks that arrive via a client-side URL change, e.g. a sidebar
+  // tool or global search linking to a field on a doc.
   useEffect(() => {
-    setValue(deeplinkFromUrl);
-  }, [deeplinkFromUrl]);
+    const urlDeeplink = getDeeplinkFromUrl();
+    if (urlDeeplink === urlDeeplinkRef.current) {
+      return;
+    }
+    urlDeeplinkRef.current = urlDeeplink;
+    setValue(urlDeeplink);
+    if (!urlDeeplink) {
+      return;
+    }
+    // The scroll is forced because the editor is likely already scrolled from
+    // wherever the user navigated from, which would otherwise suppress it.
+    return whenDeeplinkElementReady(urlDeeplink, (element) => {
+      scrollToDeeplink(element, {behavior: 'smooth', force: true});
+    });
+  }, [url]);
 
   //  Enable posting messages from the preview frame to the DocEditor so that
   // fields can be focused.
@@ -45,12 +136,8 @@ export function DeeplinkProvider(props: {children: ComponentChildren}) {
         const deepKey = event.data.scrollToDeeplink.deepKey;
         const element = document.getElementById(deepKey);
         if (element) {
-          setValue(deepKey);
+          setUrlValue(deepKey);
           scrollToDeeplink(element, {behavior: 'smooth', force: true});
-          // Update the URL without modifying the history.
-          const url = new URL(window.location.href);
-          url.searchParams.set('deeplink', deepKey);
-          window.history.replaceState({}, '', url.toString());
         }
       }
     };
@@ -58,7 +145,7 @@ export function DeeplinkProvider(props: {children: ComponentChildren}) {
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, []);
+  }, [setUrlValue]);
 
   return (
     <DEEPLINK_CONTEXT.Provider value={deeplinkCtx}>


### PR DESCRIPTION
## Summary
This PR fixes the CMS doc editor's deeplink functionality to properly apply deeplinks when navigating via client-side URL changes (e.g., from sidebar tools or global search), not just on initial page load.

## Key Changes
- **Added `setUrlValue()` method** to `DeeplinkContext` that updates both the deeplink state and the URL simultaneously, replacing the previous pattern of separate calls
- **Implemented URL-aware deeplink tracking** using `useLocation()` from preact-iso to reactively detect client-side URL changes
- **Added element polling logic** (`whenDeeplinkElementReady()`) to wait for deeplinked fields to render before scrolling, since client-side navigations may land before the target field is in the DOM
- **Prevented duplicate scroll application** by tracking the last deeplink seen in the URL (`urlDeeplinkRef`) to avoid re-applying deeplinks that were already handled by `setUrlValue()`
- **Updated field header linking** in DocEditor to use the new `setUrlValue()` method instead of manually managing URL and state updates
- **Added comprehensive test coverage** with 4 test cases covering initial load, client-side navigation, clearing deeplinks, and preventing duplicate applications

## Implementation Details
- The deeplink watcher now uses `useLocation().url` to trigger on client-side navigations
- Polling for the deeplinked element uses a 50ms interval with a 3-second timeout to handle async rendering
- URL updates use `history.replaceState()` to avoid adding history entries
- The `urlDeeplinkRef` prevents the watcher from re-applying a deeplink that was just set by `setUrlValue()`

https://claude.ai/code/session_01L3Sa5JA28L16o1XikN8Ynn