### PR TITLE
fix: keep the cms sidebar icons from shifting when toggled

### DIFF
--- a/packages/root-cms/ui/layout/Layout.css
+++ b/packages/root-cms/ui/layout/Layout.css
@@ -1,6 +1,19 @@
 .Layout {
   --side-button-height: 36px;
   --side-button-icon-size: 22px;
+  /**
+   * Distance from the left edge of the sidebar to the left edge of the sidebar
+   * icons. When collapsed, the icons are centered within the sidebar's content
+   * box, which excludes the sidebar's right border. Expanded rows indent by the
+   * same amount so that the icons stay put when the sidebar is toggled.
+   */
+  --side-icon-offset: calc(
+    (
+        var(--sidebar-width-collapsed) - var(--sidebar-border-width) -
+          var(--side-button-icon-size)
+      ) /
+      2
+  );
   display: grid;
   grid-template-areas:
     'top top'
@@ -83,7 +96,7 @@
 
 .Layout__side {
   grid-area: side;
-  border-right: 1px solid var(--color-border);
+  border-right: var(--sidebar-border-width) solid var(--color-border);
   height: calc(100vh - 48px);
   max-height: 100vh;
   display: flex;
@@ -199,7 +212,7 @@
 .Layout--sidebar-expanded .Layout__side__button a {
   justify-content: flex-start;
   gap: 12px;
-  padding: 0 12px;
+  padding: 0 12px 0 var(--side-icon-offset);
 }
 
 .Layout__side__toggle {
@@ -248,7 +261,7 @@
 
 .Layout--sidebar-expanded .Layout__side__toggle__button {
   justify-content: flex-start;
-  padding: 0 12px;
+  padding: 0 12px 0 var(--side-icon-offset);
 }
 
 .Layout__side__user {
@@ -259,7 +272,7 @@
 
 .Layout--sidebar-expanded .Layout__side__user {
   justify-content: flex-start;
-  padding: 0 12px;
+  padding: 0 12px 0 var(--side-icon-offset);
 }
 
 .Layout__side__user__button {

--- a/packages/root-cms/ui/layout/Layout.visual.test.tsx
+++ b/packages/root-cms/ui/layout/Layout.visual.test.tsx
@@ -54,6 +54,24 @@ describe('Layout', () => {
     expect(labels).toContain('Settings');
   });
 
+  it('keeps the sidebar icons in place when toggled', async () => {
+    const {container} = renderLayout();
+    const iconPositions = () =>
+      Array.from(
+        container.querySelectorAll(
+          '.Layout__side__button__icon, .Layout__side__toggle__icon, .Layout__side__user__button'
+        )
+      ).map((el) => el.getBoundingClientRect().left);
+    const collapsed = iconPositions();
+    expect(collapsed.length).toBeGreaterThan(1);
+    const toggle = container.querySelector(
+      '.Layout__side__toggle__button'
+    ) as HTMLElement;
+    toggle.click();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(iconPositions()).toEqual(collapsed);
+  });
+
   it('does not overflow the page when the viewport is short', async () => {
     const {container} = renderLayout();
     const side = container.querySelector('.Layout__side') as HTMLElement;

--- a/packages/root-cms/ui/styles/global.css
+++ b/packages/root-cms/ui/styles/global.css
@@ -19,8 +19,10 @@
   --chip-background: #efefef;
   --chip-text-color: #000;
   --header-height: 48px;
-  --sidebar-width: 48px;
+  --sidebar-width-collapsed: 48px;
   --sidebar-width-expanded: 208px;
+  --sidebar-border-width: 1px;
+  --sidebar-width: var(--sidebar-width-collapsed);
 }
 
 html {


### PR DESCRIPTION
Follow-up to #1320.

## Problem

Toggling the sidebar between its collapsed and expanded states shifted the icons horizontally by half a pixel, which rounds to a visible 1px jump.

`.Layout__side` is 48px wide with `border-right: 1px` *inside* that width (`box-sizing: border-box`), so its content box is 47px. The collapsed rows center a 22px icon in that box, landing at `(47 - 22) / 2 = 12.5px`, while the expanded rows used a flat `padding-left: 12px`. The nav icons, the expand/collapse button and the user avatar were all affected.

Measured in a browser, before:

| | collapsed | expanded |
| --- | --- | --- |
| nav icons | 12.5px | 12px |
| toggle icon | 12.5px | 12px |
| avatar | 12.5px | 12px |

## Fix

Derive the expanded indent from the same centering calculation instead of hard-coding `12px`. `--sidebar-width-collapsed` and `--sidebar-border-width` are added to `global.css`, and `.Layout` computes:

```css
--side-icon-offset: calc(
  (var(--sidebar-width-collapsed) - var(--sidebar-border-width) - var(--side-button-icon-size)) / 2
);
```

which is used as the left padding on the expanded nav link, toggle button and user rows. `.Layout__side`'s border now uses `--sidebar-border-width` too, so the two stay in sync if the border width ever changes.

After the fix all three sit at 12.5px in both states. Vertical positions were already stable and are unchanged.

## Testing

- Added a regression test to `Layout.visual.test.tsx` that compares the icon x-positions across the toggle. Confirmed it fails against the old CSS and passes with the fix.
- `ui/layout` visual tests: 6/6 passing.
- eslint, prettier and `tsc --noEmit` clean (the pre-existing `TS2880` on the `assert {type: 'json'}` import is unrelated).

Note: these visual tests only run under `pnpm test:visual`; `pnpm test` excludes `*.visual.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016BxjuZWqLmsRYpjD5JeZuJ)_