### PR TITLE
fix: avoid rendering duplicate attributes when both `class` and `className` are set

### DIFF
--- a/.changeset/wild-pans-shave.md
+++ b/.changeset/wild-pans-shave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+fix: avoid rendering duplicate attributes when both `class` and `className` are set

--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -184,6 +184,90 @@ test('maps JSX prop names to HTML attributes', () => {
   );
 });
 
+// Duplicate attributes: `className`/`class` (and other aliases like
+// `htmlFor`/`for`) both map to the same HTML attribute. Rendering both would
+// emit invalid HTML (`<div class="a" class="b">`), so the alias yields to the
+// canonical prop, regardless of the order the props were declared in.
+
+test('dedupes class and className into a single class attribute', () => {
+  expect(
+    renderJsxToString(<div class="a" className="b" />, {mode: 'minimal'})
+  ).toBe('<div class="a"></div>');
+  // Declaration order doesn't matter: `class` always wins.
+  expect(
+    renderJsxToString(<div className="b" class="a" />, {mode: 'minimal'})
+  ).toBe('<div class="a"></div>');
+});
+
+test('dedupes class and className applied via spread props', () => {
+  // The common real-world shape: a component forwards props and adds its own
+  // class name, so both keys end up on the same element.
+  const props = {class: 'base'};
+  expect(
+    renderJsxToString(<div {...props} className="extra" />, {mode: 'minimal'})
+  ).toBe('<div class="base"></div>');
+  expect(
+    renderJsxToString(<div className="extra" {...props} />, {mode: 'minimal'})
+  ).toBe('<div class="base"></div>');
+});
+
+test('dedupes class and className within a component', () => {
+  function Card(props: {class?: string; children?: any}) {
+    return (
+      <div {...props} className="card">
+        {props.children}
+      </div>
+    );
+  }
+  expect(
+    renderJsxToString(<Card class="promo">hi</Card>, {mode: 'minimal'})
+  ).toBe('<div class="promo">hi</div>');
+  // Without a `class` prop, `className` still renders as `class`.
+  expect(renderJsxToString(<Card>hi</Card>, {mode: 'minimal'})).toBe(
+    '<div class="card">hi</div>'
+  );
+});
+
+test('falls back to className when class is null or undefined', () => {
+  // An undefined/null `class` produces no attribute, so it shouldn't suppress
+  // the `className` alias.
+  expect(
+    renderJsxToString(<div class={undefined} className="b" />, {
+      mode: 'minimal',
+    })
+  ).toBe('<div class="b"></div>');
+  expect(
+    renderJsxToString(<div class={null as any} className="b" />, {
+      mode: 'minimal',
+    })
+  ).toBe('<div class="b"></div>');
+  // An empty string is a real value and still wins over the alias.
+  expect(
+    renderJsxToString(<div class="" className="b" />, {mode: 'minimal'})
+  ).toBe('<div class=""></div>');
+});
+
+test('dedupes other aliased attributes', () => {
+  expect(
+    renderJsxToString(<label htmlFor="x" for="y" />, {mode: 'minimal'})
+  ).toBe('<label for="y"></label>');
+  expect(
+    renderJsxToString(<meta charSet="utf-8" {...{charset: 'latin1'}} />, {
+      mode: 'minimal',
+    })
+  ).toBe('<meta charset="latin1">');
+  expect(
+    renderJsxToString(<div tabIndex={0} {...{tabindex: 1}} />, {
+      mode: 'minimal',
+    })
+  ).toBe('<div tabindex="1"></div>');
+  expect(
+    renderJsxToString(<path strokeWidth="2" stroke-width="4" />, {
+      mode: 'minimal',
+    })
+  ).toBe('<path stroke-width="4"></path>');
+});
+
 test('renders functional components', () => {
   function Greeting(props: {name: string}) {
     return <span>Hello, {props.name}!</span>;

--- a/packages/root/src/jsx/jsx-render.ts
+++ b/packages/root/src/jsx/jsx-render.ts
@@ -738,7 +738,20 @@ export function renderJsxToString(
         continue;
       }
 
-      const attrName = PROP_TO_ATTR[key] || key;
+      // Prop aliases (e.g. `className`, `htmlFor`) render as an HTML attribute
+      // that may also have been passed directly (e.g. `class`, `for`), usually
+      // via a spread. Emitting both would produce a duplicate attribute, which
+      // is invalid HTML, so the alias yields to the canonical prop. This
+      // matches preact-render-to-string, where `class` wins over `className`
+      // regardless of the order the props were declared in.
+      let attrName = key;
+      const aliasedName = PROP_TO_ATTR[key];
+      if (isDef(aliasedName)) {
+        if (isDef(props[aliasedName])) {
+          continue;
+        }
+        attrName = aliasedName;
+      }
       const valueType = typeof value;
 
       // Dispatch ordered by frequency: string and numeric attribute values are


### PR DESCRIPTION
## Summary
This PR fixes a bug where duplicate HTML attributes were rendered when both a JSX prop and its aliased form were present on the same element (e.g., both `class` and `className`). This would produce invalid HTML like `<div class="a" class="b">`.

## Changes
- **jsx-render.ts**: Updated the attribute rendering logic to detect when both a prop and its alias are present, and skip rendering the aliased prop in favor of the canonical HTML attribute. This ensures that the canonical form (e.g., `class` instead of `className`) always wins, regardless of declaration order.

- **jsx-render.test.tsx**: Added comprehensive test coverage for the deduplication behavior:
  - Direct prop aliases (`class`/`className`, `htmlFor`/`for`, etc.)
  - Spread props containing aliases
  - Aliases within component props
  - Fallback behavior when the canonical form is null/undefined
  - Other aliased attributes like `charSet`, `tabIndex`, and `strokeWidth`

## Implementation Details
The fix checks if a prop has an aliased form in the `PROP_TO_ATTR` mapping. If the aliased attribute name is already defined in the props object, the original prop is skipped entirely. This matches the behavior of preact-render-to-string and ensures valid HTML output in all cases.

https://claude.ai/code/session_01EyxxvSdLBuyKpeVhnCRZgd