### PR TITLE
fix: cache and bound schema pattern resolution to prevent dev server OOMs

### DIFF
--- a/.changeset/olive-buses-brake.md
+++ b/.changeset/olive-buses-brake.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: cache and bound schema pattern resolution to prevent dev server OOMs

--- a/packages/root-cms/core/project.test.ts
+++ b/packages/root-cms/core/project.test.ts
@@ -1,5 +1,10 @@
-import {describe, expect, test} from 'vitest';
-import {convertOneOfTypes, SchemaModule} from './project.js';
+import {afterEach, describe, expect, test} from 'vitest';
+import {
+  convertOneOfTypes,
+  getProjectSchemas,
+  resolveOneOfPatterns,
+  SchemaModule,
+} from './project.js';
 import * as schema from './schema.js';
 
 describe('convertOneOfTypes', () => {
@@ -76,5 +81,191 @@ describe('convertOneOfTypes', () => {
     // Source Container must be left untouched.
     const containerOneOf = Container.fields[0] as schema.OneOfField;
     expect(containerOneOf.types).toEqual([InlineChild]);
+  });
+});
+
+describe('resolveOneOfPatterns', () => {
+  test('resolves schema.glob() patterns to schema objects', () => {
+    const ModuleA = schema.define({
+      name: 'ModuleA',
+      fields: [schema.string({id: 'title'})],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/ModuleA.schema.ts': {default: ModuleA},
+    };
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+      ],
+    });
+
+    const resolved = resolveOneOfPatterns(Container, schemaModules);
+    const arrayField = resolved.fields[0] as schema.ArrayField;
+    const oneOf = arrayField.of as schema.OneOfField;
+    expect(Array.isArray(oneOf.types)).toBe(true);
+    const types = oneOf.types as schema.Schema[];
+    expect(types.map((t) => t.name)).toEqual(['ModuleA']);
+    // The resolved schema is a clone; the source module must be untouched.
+    expect(types[0]).not.toBe(ModuleA);
+    expect(ModuleA.fields).toHaveLength(1);
+  });
+
+  test('clones each referenced schema once per pass', () => {
+    const ModuleA = schema.define({
+      name: 'ModuleA',
+      fields: [schema.string({id: 'title'})],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/ModuleA.schema.ts': {default: ModuleA},
+    };
+    // Two separate pattern occurrences referencing the same schema.
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.array({
+          id: 'main',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+        schema.array({
+          id: 'sidebar',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+      ],
+    });
+
+    const resolved = resolveOneOfPatterns(Container, schemaModules);
+    const main = (resolved.fields[0] as schema.ArrayField)
+      .of as schema.OneOfField;
+    const sidebar = (resolved.fields[1] as schema.ArrayField)
+      .of as schema.OneOfField;
+    // Consumers treat resolved schemas as read-only, so both occurrences
+    // share a single clone instead of materializing one clone per occurrence.
+    expect((main.types as schema.Schema[])[0]).toBe(
+      (sidebar.types as schema.Schema[])[0]
+    );
+  });
+
+  test('applies omitFields per pattern occurrence', () => {
+    const ModuleA = schema.define({
+      name: 'ModuleA',
+      fields: [schema.string({id: 'title'}), schema.string({id: 'internal'})],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/ModuleA.schema.ts': {default: ModuleA},
+    };
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.array({
+          id: 'main',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+        schema.array({
+          id: 'trimmed',
+          of: schema.oneOf({
+            types: schema.glob('/modules/*.schema.ts', {
+              omitFields: ['internal'],
+            }),
+          }),
+        }),
+      ],
+    });
+
+    const resolved = resolveOneOfPatterns(Container, schemaModules);
+    const main = (resolved.fields[0] as schema.ArrayField)
+      .of as schema.OneOfField;
+    const trimmed = (resolved.fields[1] as schema.ArrayField)
+      .of as schema.OneOfField;
+    const mainType = (main.types as schema.Schema[])[0];
+    const trimmedType = (trimmed.types as schema.Schema[])[0];
+    expect(mainType.fields.map((f) => f.id)).toEqual(['title', 'internal']);
+    expect(trimmedType.fields.map((f) => f.id)).toEqual(['title']);
+    // Different omitFields must not share a clone.
+    expect(mainType).not.toBe(trimmedType);
+  });
+});
+
+describe('schema resolution node budget', () => {
+  afterEach(() => {
+    delete process.env.ROOT_CMS_MAX_SCHEMA_NODES;
+  });
+
+  /** Builds a schema with enough nodes to trip a small budget. */
+  function fatSchema(name: string, numFields: number): schema.Schema {
+    const fields: schema.Field[] = [];
+    for (let i = 0; i < numFields; i++) {
+      fields.push(schema.string({id: `field${i}`, label: `Field ${i}`}));
+    }
+    return schema.define({name, fields});
+  }
+
+  test('convertOneOfTypes fails fast with an actionable error', () => {
+    process.env.ROOT_CMS_MAX_SCHEMA_NODES = '50';
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/Fat.schema.ts': {default: fatSchema('Fat', 100)},
+    };
+    const collection: schema.Collection = {
+      id: 'pages',
+      name: 'Pages',
+      url: '/[...slug]',
+      fields: [
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+      ],
+    };
+    expect(() => convertOneOfTypes(collection, schemaModules)).toThrowError(
+      /schema resolution exceeded 50 nodes/
+    );
+  });
+
+  test('resolveOneOfPatterns fails fast with an actionable error', () => {
+    process.env.ROOT_CMS_MAX_SCHEMA_NODES = '50';
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/Fat.schema.ts': {default: fatSchema('Fat', 100)},
+    };
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+      ],
+    });
+    expect(() => resolveOneOfPatterns(Container, schemaModules)).toThrowError(
+      /ROOT_CMS_MAX_SCHEMA_NODES/
+    );
+  });
+
+  test('budget does not trip on reasonable schemas', () => {
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/Fat.schema.ts': {default: fatSchema('Fat', 100)},
+    };
+    const collection: schema.Collection = {
+      id: 'pages',
+      name: 'Pages',
+      url: '/[...slug]',
+      fields: [
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({types: schema.glob('/modules/*.schema.ts')}),
+        }),
+      ],
+    };
+    expect(() => convertOneOfTypes(collection, schemaModules)).not.toThrow();
+  });
+});
+
+describe('getProjectSchemas', () => {
+  test('memoizes the resolved schema map per module instance', () => {
+    const first = getProjectSchemas();
+    const second = getProjectSchemas();
+    expect(second).toBe(first);
   });
 });

--- a/packages/root-cms/core/project.ts
+++ b/packages/root-cms/core/project.ts
@@ -25,38 +25,219 @@ try {
 export const SCHEMA_MODULES = _SCHEMA_MODULES as Record<string, SchemaModule>;
 
 /**
- * Returns a map of all `schema.ts` files defined in the project as
- * fileId => schema. This is used by `generate-types.ts` to build the
- * `root-cms.d.ts` file.
+ * Default ceiling on the number of objects a single schema resolution pass is
+ * allowed to materialize (clones of pattern/string-referenced schemas). Legit
+ * projects resolve to a few hundred thousand nodes at most; runaway schema
+ * graphs (e.g. schema files that import other schema modules and embed their
+ * fields/types, multiplying the graph each time it is cloned) will otherwise
+ * grind through gigabytes of heap and eventually OOM the server. Overridable
+ * via the `ROOT_CMS_MAX_SCHEMA_NODES` env var.
  */
-export function getProjectSchemas(): Record<string, schema.Schema> {
-  const schemas: Record<string, schema.Schema> = {};
+const DEFAULT_MAX_RESOLUTION_NODES = 2_000_000;
 
-  for (const fileId in SCHEMA_MODULES) {
-    const schemaModule = SCHEMA_MODULES[fileId];
-    if (schemaModule.default) {
-      // Resolve SchemaPatterns in oneOf fields so type generation works.
-      const resolved = resolveOneOfPatterns(schemaModule.default);
-      schemas[fileId] = resolved;
+function maxResolutionNodes(): number {
+  const raw = process.env.ROOT_CMS_MAX_SCHEMA_NODES;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
     }
   }
-  return schemas;
+  return DEFAULT_MAX_RESOLUTION_NODES;
+}
+
+/**
+ * Memoized node counts for raw schema objects. Keyed by object identity so a
+ * schema module edit (which re-evaluates the module and produces a new object)
+ * naturally invalidates its entry.
+ */
+const nodeCountCache = new WeakMap<object, number>();
+
+/**
+ * Counts the objects/arrays reachable from a schema object. Shared subtrees
+ * are counted once (matching what `structuredClone()` materializes, since the
+ * clone preserves sharing). Cycle-safe.
+ */
+function countSchemaNodes(root: unknown): number {
+  if (typeof root !== 'object' || root === null) {
+    return 0;
+  }
+  const cached = nodeCountCache.get(root);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let count = 0;
+  const seen = new Set<object>();
+  const stack: object[] = [root];
+  seen.add(root);
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    count++;
+    const values = Array.isArray(current) ? current : Object.values(current);
+    for (const value of values) {
+      if (typeof value === 'object' && value !== null && !seen.has(value)) {
+        seen.add(value);
+        stack.push(value);
+      }
+    }
+  }
+  nodeCountCache.set(root, count);
+  return count;
+}
+
+/**
+ * Tracks how many nodes a single top-level resolution pass has materialized,
+ * and dedupes clones so each referenced schema is cloned at most once per
+ * pass (keyed by name + omitFields).
+ */
+interface ResolutionContext {
+  /** Human-readable description of what started the pass (for errors). */
+  origin: string;
+  nodesUsed: number;
+  nodeLimit: number;
+  cloneCache: Map<string, schema.Schema>;
+}
+
+function createResolutionContext(origin: string): ResolutionContext {
+  return {
+    origin,
+    nodesUsed: 0,
+    nodeLimit: maxResolutionNodes(),
+    cloneCache: new Map(),
+  };
+}
+
+function chargeResolutionBudget(
+  ctx: ResolutionContext,
+  nodes: number,
+  detail: string
+) {
+  ctx.nodesUsed += nodes;
+  if (ctx.nodesUsed > ctx.nodeLimit) {
+    throw new Error(
+      `schema resolution exceeded ${ctx.nodeLimit} nodes while resolving ` +
+        `"${detail}" (started from "${ctx.origin}"). This usually means ` +
+        'schema files import other schema modules and embed their ' +
+        'fields/types, which multiplies the schema graph every time it is ' +
+        'cloned. Prefer schema.glob() patterns or string-name references ' +
+        'over importing schema modules directly. If the project schema ' +
+        'graph is legitimately this large, raise the limit with the ' +
+        'ROOT_CMS_MAX_SCHEMA_NODES environment variable.'
+    );
+  }
+}
+
+/**
+ * Clones a referenced schema for resolution, charging the pass budget and
+ * deduping so the same schema (with the same omitFields) is cloned at most
+ * once per pass.
+ */
+function cloneReferencedSchema(
+  ctx: ResolutionContext,
+  name: string,
+  raw: schema.Schema,
+  omitFields?: string[]
+): schema.Schema {
+  const cacheKey =
+    omitFields && omitFields.length > 0
+      ? `${name}|${[...omitFields].sort().join(',')}`
+      : name;
+  const cached = ctx.cloneCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  chargeResolutionBudget(ctx, countSchemaNodes(raw), name);
+  const cloned = structuredClone(raw);
+  if (omitFields && omitFields.length > 0) {
+    const omitSet = new Set(omitFields);
+    cloned.fields = cloned.fields.filter(
+      (f: schema.Field) => !omitSet.has(f.id || '')
+    );
+  }
+  ctx.cloneCache.set(cacheKey, cloned);
+  return cloned;
+}
+
+/**
+ * Cached result of `getProjectSchemas()`. Resolving patterns for every schema
+ * file is expensive (each `schema.glob()` clones all matching schemas), and
+ * the CMS app calls `getProjectSchemas()` on every `/cms` page render. The
+ * cache lives for the lifetime of this module instance: in dev, editing any
+ * schema file invalidates `virtual:root/schemas` and re-evaluates this module
+ * (clearing the cache); in prod builds and one-shot CLI runs (generate-types)
+ * the schemas cannot change within the process.
+ */
+let cachedProjectSchemas: Record<string, schema.Schema> | null = null;
+
+/**
+ * Returns a map of all `schema.ts` files defined in the project as
+ * fileId => schema. This is used by `generate-types.ts` to build the
+ * `root-cms.d.ts` file and by the CMS app to list collections.
+ */
+export function getProjectSchemas(): Record<string, schema.Schema> {
+  if (!cachedProjectSchemas) {
+    const schemas: Record<string, schema.Schema> = {};
+    // Share one resolution context (budget + clone cache) across the whole
+    // pass: consumers treat the resolved schemas as read-only, so schemas
+    // referenced from multiple files can share a single clone.
+    const ctx = createResolutionContext('getProjectSchemas()');
+    for (const fileId in SCHEMA_MODULES) {
+      const schemaModule = SCHEMA_MODULES[fileId];
+      if (schemaModule.default) {
+        // Resolve SchemaPatterns in oneOf fields so type generation works.
+        schemas[fileId] = resolveOneOfPatternsInternal(
+          schemaModule.default,
+          SCHEMA_MODULES,
+          ctx
+        );
+      }
+    }
+    cachedProjectSchemas = schemas;
+  }
+  return cachedProjectSchemas;
 }
 
 /**
  * Resolves SchemaPattern objects in oneOf fields to arrays of Schema objects.
  * This is needed for type generation which expects `field.types` to be an array.
  */
-export function resolveOneOfPatterns(schemaObj: schema.Schema): schema.Schema {
+export function resolveOneOfPatterns(
+  schemaObj: schema.Schema,
+  schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
+): schema.Schema {
+  const ctx = createResolutionContext(
+    `resolveOneOfPatterns(${schemaObj.name || 'schema'})`
+  );
+  return resolveOneOfPatternsInternal(schemaObj, schemaModules, ctx);
+}
+
+function resolveOneOfPatternsInternal(
+  schemaObj: schema.Schema,
+  schemaModules: Record<string, SchemaModule>,
+  ctx: ResolutionContext
+): schema.Schema {
+  chargeResolutionBudget(
+    ctx,
+    countSchemaNodes(schemaObj),
+    schemaObj.name || 'schema'
+  );
   const clone = structuredClone(schemaObj);
 
   function handleField(field: schema.Field) {
     if (field.type === 'oneof') {
       const oneOfField = field as schema.OneOfField;
       if (isSchemaPattern(oneOfField.types)) {
-        const resolved = resolveSchemaPattern(oneOfField.types);
+        const pattern = oneOfField.types;
+        const matched = matchSchemaPattern(pattern, schemaModules);
         // Convert names back to schema objects for type generation.
-        oneOfField.types = resolved.names.map((name) => resolved.schemas[name]);
+        oneOfField.types = matched.names.map((name) =>
+          cloneReferencedSchema(
+            ctx,
+            name,
+            matched.byName[name],
+            pattern.omitFields
+          )
+        );
       }
     } else if (field.type === 'object' && 'fields' in field) {
       (field.fields || []).forEach(handleField);
@@ -145,23 +326,26 @@ function globToRegex(pattern: string): RegExp {
 }
 
 /**
- * Resolves a SchemaPattern to an array of schema names.
+ * Matches a SchemaPattern against the project's schema modules, returning the
+ * matched schema names and their raw (uncloned) schema objects.
  *
- * Returned schemas are deep-cloned so that callers may safely mutate them
- * (e.g. by rewriting nested `oneof` `types` in place) without leaking those
- * mutations back into `SCHEMA_MODULES`.
+ * Matching allocates nothing beyond the name list — callers clone lazily via
+ * `cloneReferencedSchema()`, which lets them skip schemas they have already
+ * registered and dedupe clones across pattern occurrences. (Cloning is
+ * required before any mutation: the raw objects are the live entries in
+ * `SCHEMA_MODULES`, and mutating them corrupts subsequent calls.)
  */
-function resolveSchemaPattern(
+function matchSchemaPattern(
   pattern: schema.SchemaPattern,
   schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
 ): {
   names: string[];
-  schemas: Record<string, schema.Schema>;
+  byName: Record<string, schema.Schema>;
 } {
   const regex = globToRegex(pattern.pattern);
   const excludeSet = new Set(pattern.exclude || []);
   const names: string[] = [];
-  const schemas: Record<string, schema.Schema> = {};
+  const byName: Record<string, schema.Schema> = {};
 
   for (const fileId in schemaModules) {
     if (!regex.test(fileId)) {
@@ -175,22 +359,11 @@ function resolveSchemaPattern(
     if (excludeSet.has(schemaName)) {
       continue;
     }
-
-    const schemaObj = structuredClone(module.default);
-
-    // Apply field omissions if specified.
-    if (pattern.omitFields && pattern.omitFields.length > 0) {
-      const omitSet = new Set(pattern.omitFields);
-      schemaObj.fields = schemaObj.fields.filter(
-        (f: schema.Field) => !omitSet.has(f.id || '')
-      );
-    }
-
     names.push(schemaName);
-    schemas[schemaName] = schemaObj;
+    byName[schemaName] = module.default;
   }
 
-  return {names, schemas};
+  return {names, byName};
 }
 
 /**
@@ -209,6 +382,14 @@ export function convertOneOfTypes(
   collection: schema.Collection,
   schemaModules: Record<string, SchemaModule> = SCHEMA_MODULES
 ): schema.Collection {
+  const ctx = createResolutionContext(
+    `convertOneOfTypes(${collection.id || collection.name || 'collection'})`
+  );
+  chargeResolutionBudget(
+    ctx,
+    countSchemaNodes(collection),
+    collection.id || collection.name || 'collection'
+  );
   const clone: schema.Collection = structuredClone(collection);
   const types: Record<string, schema.Schema> = clone.types || {};
   const schemaNameMap = buildSchemaNameMap(schemaModules);
@@ -216,20 +397,28 @@ export function convertOneOfTypes(
   function handleOneOfField(field: schema.OneOfField) {
     // Handle SchemaPattern (from schema.glob()).
     if (isSchemaPattern(field.types)) {
-      const resolved = resolveSchemaPattern(field.types, schemaModules);
+      const pattern = field.types;
+      const matched = matchSchemaPattern(pattern, schemaModules);
       // Process nested oneOf fields in the resolved schemas.
-      // Only process schemas that haven't been added to types yet to prevent
-      // infinite recursion with self-referencing schemas (e.g., a Container
-      // that can contain other Containers).
-      for (const [name, schemaObj] of Object.entries(resolved.schemas)) {
+      // Only clone + process schemas that haven't been added to types yet:
+      // this prevents infinite recursion with self-referencing schemas
+      // (e.g. a Container that can contain other Containers), and avoids
+      // re-cloning the same schema for every pattern occurrence.
+      for (const name of matched.names) {
         if (!types[name]) {
+          const schemaObj = cloneReferencedSchema(
+            ctx,
+            name,
+            matched.byName[name],
+            pattern.omitFields
+          );
           types[name] = schemaObj;
           if (schemaObj.fields) {
             walk(schemaObj);
           }
         }
       }
-      field.types = resolved.names;
+      field.types = matched.names;
       return;
     }
 
@@ -239,7 +428,11 @@ export function convertOneOfTypes(
         names.push(sub);
         // Resolve string references from the project schemas.
         if (!types[sub] && schemaNameMap[sub]) {
-          const resolvedSchema = structuredClone(schemaNameMap[sub]);
+          const resolvedSchema = cloneReferencedSchema(
+            ctx,
+            sub,
+            schemaNameMap[sub]
+          );
           types[sub] = resolvedSchema;
           if (resolvedSchema.fields) {
             walk(resolvedSchema);


### PR DESCRIPTION
## Summary

Heap snapshots from a large production project's dev server (one at a 16 GB `--max-old-space-size`, one at the default ~4 GB) showed the process dying mid-request with the heap almost entirely filled by **clones of schema field definitions** — 115M/57M plain objects respectively (43M+ `id`/`label` properties, ~400K copies of a single container schema's field set), all rooted in stack locals of an in-flight schema resolution pass. Two compounding causes in `core/project.ts`:

1. **`getProjectSchemas()` runs on every `/cms` page render** (via `renderApp()` → `getCollections()`) and re-resolves every `schema.glob()` pattern in every schema file from scratch each time.
2. **Every pattern occurrence eagerly deep-clones every matched schema.** `resolveSchemaPattern()` cloned all matches before the caller's dedup guard could skip already-registered ones, so a project with N pattern-bearing schemas × M glob matches materializes N×M clones per pass. On projects whose schema files import other schema modules and embed their fields/types (multiplying each schema's size), a single pass can materialize tens of millions of objects and OOM the server with no indication of which schema is responsible.

## Fix

- **Memoize `getProjectSchemas()`** per module instance. The cache's lifetime is exactly right by construction: in dev, editing any schema file invalidates `virtual:root/schemas`, which re-evaluates `project.js` and clears the cache; in prod builds and one-shot CLI runs (generate-types) schemas cannot change within the process. Verified live that a schema edit is reflected in `collection.get` and the dev type-regen watcher immediately after the change.
- **Clone lazily, once per pass.** `resolveSchemaPattern()` is replaced by `matchSchemaPattern()` (matching only, no clones) + `cloneReferencedSchema()`, which dedupes clones per resolution pass keyed by name + `omitFields`. `convertOneOfTypes()` now skips cloning entirely for names already registered in `types`, and `resolveOneOfPatterns()` shares one clone across pattern occurrences (consumers — dts generation, collection listing — treat resolved schemas as read-only). `getProjectSchemas()` shares a single clone cache across the whole pass.
- **Fail fast instead of OOM.** Each top-level resolution pass has a node budget (default 2M nodes, overridable via `ROOT_CMS_MAX_SCHEMA_NODES`). Node counts are computed with a cycle-safe walk that counts shared subtrees once (matching what `structuredClone` actually materializes) and are memoized per schema module object via `WeakMap`. Exceeding the budget throws an error that names the schema being cloned and the pass that started it, and points at the usual cause (schema files importing other schema modules and embedding their fields/types) — turning a multi-GB OOM crash into an immediate, actionable message.

## Verification

- `packages/root-cms$ vitest run core/project.test.ts` — 9 tests pass, including new coverage for: glob resolution correctness + source non-mutation, clone-sharing across pattern occurrences, `omitFields` handling (separate cache entries, no cross-contamination), budget errors from both `convertOneOfTypes()` and `resolveOneOfPatterns()`, no budget trip on reasonable schemas, and `getProjectSchemas()` memoization.
- `tsc --noEmit -p tsconfig.build.json`, `eslint`, and `pnpm build:core` pass.
- Live smoke test on `examples/cms` with the patched build: sign-in, `/cms` renders (second render served from the memoized schema map), `collection.get` returns the resolved schema, `generate-types` produces the same `root-cms.d.ts`, and a schema edit invalidates the cache (fresh resolution + watcher regen observed).

## Notes

- Behavior preserved: resolved `types` arrays/maps have the same shape as before; the only observable differences are object identity sharing between pattern occurrences within one pass (read-only consumers) and the new budget error for pathological schema graphs.
- `getCollectionSchema()` (per-collection path used by `collection.get`, search indexing, custom-sorting checks) still resolves per call; it now benefits from lazy cloning but could be memoized the same way as a follow-up if profiling justifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
