### PR TITLE
feat: add `modulePreload` option for auto-injecting modulepreload tags

### DIFF
--- a/.changeset/fluffy-doors-invent.md
+++ b/.changeset/fluffy-doors-invent.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add `modulePreload` option for auto-injecting modulepreload tags

--- a/docs/root.config.ts
+++ b/docs/root.config.ts
@@ -28,10 +28,8 @@ export default defineConfig({
         },
       },
     },
-    build: {
-      modulePreload: false,
-    },
   },
+  modulePreload: true,
   server: {
     trailingSlash: true,
     sessionCookieSecret: process.env.COOKIE_SECRET,

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -55,6 +55,23 @@ export interface RootUserConfig {
   };
 
   /**
+   * Whether to auto-inject `<link rel="modulepreload">` tags for the JS chunks
+   * imported by the page's `<script type="module">` tags. Disabled by default;
+   * pass `modulePreload: true` to opt in.
+   *
+   * Root injects a `<script type="module">` tag for every custom element and
+   * bundle used on the page, but the shared chunks those scripts import are
+   * only discovered once the browser has downloaded and parsed the script.
+   * Preloading them removes that request waterfall.
+   *
+   * Chunks that are already injected as `<script>` tags are skipped, and no
+   * tags are injected by the dev server (where modules are served unbundled).
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload}
+   */
+  modulePreload?: boolean;
+
+  /**
    * Config options for localization and internationalization.
    */
   i18n?: RootI18nConfig;

--- a/packages/root/src/render/asset-map/asset-map.ts
+++ b/packages/root/src/render/asset-map/asset-map.ts
@@ -18,6 +18,14 @@ export interface Asset {
    * Recursively walks all deps and returns a list of JS asset URLs.
    */
   getJsDeps(): Promise<string[]>;
+
+  /**
+   * Recursively walks all deps and returns a list of JS chunk URLs that the
+   * browser loads as a result of importing this asset. The asset's own URL is
+   * excluded. These URLs are injected as `<link rel="modulepreload">` tags
+   * when `modulePreload` is enabled in `root.config.ts`.
+   */
+  getModulePreloadDeps(): Promise<string[]>;
 }
 
 export interface AssetMap {

--- a/packages/root/src/render/asset-map/build-asset-map.ts
+++ b/packages/root/src/render/asset-map/build-asset-map.ts
@@ -172,6 +172,13 @@ function realPathRelativeTo(rootDir: string, src: string) {
   return path.relative(rootDir, realpath);
 }
 
+/**
+ * Returns true if a serving URL points to a JS module.
+ */
+function isJsAssetUrl(assetUrl: string) {
+  return assetUrl.endsWith('.js') || assetUrl.endsWith('.mjs');
+}
+
 export class BuildAsset {
   src: string;
   assetUrl: string;
@@ -212,6 +219,15 @@ export class BuildAsset {
     return Array.from(deps);
   }
 
+  async getModulePreloadDeps(): Promise<string[]> {
+    // Seed `visited` with this asset so that the walk starts at the imported
+    // modules and this asset's own URL is left out of the results.
+    const visited = new Set<string>([this.src]);
+    const deps = new Set<string>();
+    await this.collectModulePreload(this.importedModules, deps, visited);
+    return Array.from(deps);
+  }
+
   private async collectJs(
     asset: BuildAsset | null,
     urls: Set<string>,
@@ -234,6 +250,35 @@ export class BuildAsset {
       asset.importedModules.map(async (src) => {
         const importedAsset = (await this.assetMap.get(src)) as BuildAsset;
         this.collectJs(importedAsset, urls, visited);
+      })
+    );
+  }
+
+  /**
+   * Walks `srcs` and their transitive imports, collecting the JS chunk URL of
+   * every module along the way.
+   */
+  private async collectModulePreload(
+    srcs: string[],
+    urls: Set<string>,
+    visited: Set<string>
+  ) {
+    await Promise.all(
+      srcs.map(async (src) => {
+        if (visited.has(src)) {
+          return;
+        }
+        visited.add(src);
+        const asset = (await this.assetMap.get(src)) as BuildAsset | null;
+        if (!asset || !asset.src) {
+          return;
+        }
+        // Route files have no asset URL of their own, and CSS deps are
+        // injected as stylesheets rather than preloaded.
+        if (asset.assetUrl && isJsAssetUrl(asset.assetUrl)) {
+          urls.add(asset.assetUrl);
+        }
+        await this.collectModulePreload(asset.importedModules, urls, visited);
       })
     );
   }

--- a/packages/root/src/render/asset-map/dev-asset-map.ts
+++ b/packages/root/src/render/asset-map/dev-asset-map.ts
@@ -34,6 +34,7 @@ export class DevServerAssetMap implements AssetMap {
         assetUrl: assetUrl,
         getCssDeps: async () => [],
         getJsDeps: async () => [assetUrl],
+        getModulePreloadDeps: async () => [],
       };
     }
     const workspaceRoot = searchForWorkspaceRoot(this.rootConfig.rootDir);
@@ -44,6 +45,7 @@ export class DevServerAssetMap implements AssetMap {
         assetUrl: assetUrl,
         getCssDeps: async () => [],
         getJsDeps: async () => [assetUrl],
+        getModulePreloadDeps: async () => [],
       };
     }
 
@@ -89,6 +91,15 @@ export class DevServerAsset implements Asset {
     const deps = new Set<string>();
     this.collectJs(this, deps, visited);
     return Array.from(deps);
+  }
+
+  /**
+   * The dev server serves modules unbundled and unhashed, so there are no
+   * shared chunks to preload. Returning an empty list keeps
+   * `<link rel="modulepreload">` tags out of the dev server's HTML.
+   */
+  async getModulePreloadDeps(): Promise<string[]> {
+    return [];
   }
 
   getImportedModules() {

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -239,6 +239,11 @@ export class Renderer {
 
     const jsDeps = new Set<string>();
     const cssDeps = new Set<string>();
+    // Chunks imported by the injected scripts, collected only when
+    // `modulePreload` is enabled in `root.config.ts`.
+    const preloadDeps = this.rootConfig.modulePreload
+      ? new Set<string>()
+      : null;
 
     // Walk the route's dependency tree for CSS dependencies that are added via
     // `import 'foo.scss'` or `import 'foo.module.scss'`.
@@ -262,7 +267,7 @@ export class Renderer {
 
     // Parse the HTML for custom elements that are found within the project
     // and automatically inject the script deps for them.
-    await this.collectElementDeps(mainHtml, jsDeps, cssDeps);
+    await this.collectElementDeps(mainHtml, jsDeps, cssDeps, preloadDeps);
 
     // Add user defined scripts added via the `<Script>` component.
     await Promise.all(
@@ -276,6 +281,10 @@ export class Renderer {
           jsDeps.add(scriptAsset.assetUrl);
           const scriptJsDeps = await scriptAsset.getJsDeps();
           scriptJsDeps.forEach((dep) => jsDeps.add(dep));
+          if (preloadDeps) {
+            const scriptPreloadDeps = await scriptAsset.getModulePreloadDeps();
+            scriptPreloadDeps.forEach((dep) => preloadDeps.add(dep));
+          }
         }
       })
     );
@@ -283,6 +292,13 @@ export class Renderer {
     const styleTags = Array.from(cssDeps).map((cssUrl) => {
       return <link rel="stylesheet" href={cssUrl} nonce={nonce} />;
     });
+    // Chunks that are already injected as `<script>` tags are fetched by the
+    // browser anyway, so preloading them would only duplicate the request.
+    const preloadTags = Array.from(preloadDeps || [])
+      .filter((jsUrl) => !jsDeps.has(jsUrl))
+      .map((jsUrl) => {
+        return <link rel="modulepreload" href={jsUrl} nonce={nonce} />;
+      });
     const scriptTags = Array.from(jsDeps).map((jsUrls) => {
       // TODO(stevenle): after verifying this doesn't cause any negative side
       // effects, make async the default.
@@ -299,6 +315,7 @@ export class Renderer {
       headComponents: [
         ...htmlContext.headComponents,
         ...styleTags,
+        ...preloadTags,
         ...scriptTags,
       ],
       renderMode: options.renderMode,
@@ -793,12 +810,15 @@ export class Renderer {
 
   /**
    * Parses rendered HTML for custom element tags used on the page and
-   * automatically adds the JS/CSS deps to the page.
+   * automatically adds the JS/CSS deps to the page. When `preloadDeps` is
+   * provided, the chunks imported by those elements are collected into it for
+   * `<link rel="modulepreload">` injection.
    */
   private async collectElementDeps(
     html: string,
     jsDeps: Set<string>,
-    cssDeps: Set<string>
+    cssDeps: Set<string>,
+    preloadDeps?: Set<string> | null
   ): Promise<{jsDeps: Set<string>; cssDeps: Set<string>}> {
     const elementsMap = this.elementGraph.sourceFiles;
     const assetMap = this.assetMap;
@@ -822,6 +842,10 @@ export class Renderer {
         }
         const assetJsDeps = await asset.getJsDeps();
         assetJsDeps.forEach((dep) => jsDeps.add(dep));
+        if (preloadDeps) {
+          const assetPreloadDeps = await asset.getModulePreloadDeps();
+          assetPreloadDeps.forEach((dep) => preloadDeps.add(dep));
+        }
         const assetCssDeps = await asset.getCssDeps();
         assetCssDeps.forEach((dep) => {
           // Ignore ?inline css deps.

--- a/packages/root/test/build-asset-map.test.ts
+++ b/packages/root/test/build-asset-map.test.ts
@@ -52,6 +52,48 @@ test('aliases pod route srcs to their built asset', async () => {
   expect(await asset!.getCssDeps()).toEqual(['/assets/index.abcd1234.css']);
 });
 
+test('collects module preload deps from the import graph', async () => {
+  const elementRelPath = 'elements/root-a/root-a.ts';
+  const clientManifest = {
+    [elementRelPath]: {
+      file: 'assets/root-a.min.js',
+      src: elementRelPath,
+      isEntry: true,
+      imports: ['_shared.min.js'],
+      css: ['assets/root-a.css'],
+    },
+    '_shared.min.js': {
+      file: 'chunks/shared.min.js',
+      imports: ['_deep.min.js'],
+    },
+    '_deep.min.js': {
+      file: 'chunks/deep.min.js',
+      // Cyclic imports should not cause an infinite walk.
+      imports: ['_shared.min.js'],
+    },
+  } as unknown as Manifest;
+
+  const elementGraph = new ElementGraph({
+    'root-a': {
+      filePath: path.join(rootDir, elementRelPath),
+      relPath: elementRelPath,
+    },
+  });
+  const assetMap = BuildAssetMap.fromViteManifest(
+    {rootDir} as RootConfig,
+    clientManifest,
+    elementGraph
+  );
+
+  const asset = await assetMap.get(elementRelPath);
+  // The element's own URL is injected as a `<script>` tag, so it's excluded.
+  // CSS deps are injected as stylesheets and excluded as well.
+  expect(await asset!.getModulePreloadDeps()).toEqual([
+    '/chunks/shared.min.js',
+    '/chunks/deep.min.js',
+  ]);
+});
+
 test('does not alias when the pod route has no built asset', async () => {
   const routeFilePath = path.join(rootDir, 'pods/blog/routes/api.ts');
   fs.mkdirSync(path.dirname(routeFilePath), {recursive: true});

--- a/packages/root/test/fixtures/module-preload-disabled/elements/root-a/root-a.ts
+++ b/packages/root/test/fixtures/module-preload-disabled/elements/root-a/root-a.ts
@@ -1,0 +1,9 @@
+import {renderLabel} from '../../lib/shared.js';
+
+class RootA extends HTMLElement {
+  connectedCallback() {
+    renderLabel(this, 'a');
+  }
+}
+
+customElements.define('root-a', RootA);

--- a/packages/root/test/fixtures/module-preload-disabled/elements/root-b/root-b.ts
+++ b/packages/root/test/fixtures/module-preload-disabled/elements/root-b/root-b.ts
@@ -1,0 +1,9 @@
+import {renderLabel} from '../../lib/shared.js';
+
+class RootB extends HTMLElement {
+  connectedCallback() {
+    renderLabel(this, 'b');
+  }
+}
+
+customElements.define('root-b', RootB);

--- a/packages/root/test/fixtures/module-preload-disabled/lib/shared.ts
+++ b/packages/root/test/fixtures/module-preload-disabled/lib/shared.ts
@@ -1,0 +1,4 @@
+/** Shared dep imported by more than one element, so it lands in its own chunk. */
+export function renderLabel(el: HTMLElement, label: string) {
+  el.textContent = label;
+}

--- a/packages/root/test/fixtures/module-preload-disabled/root.config.ts
+++ b/packages/root/test/fixtures/module-preload-disabled/root.config.ts
@@ -1,0 +1,23 @@
+import {defineConfig} from '../../../dist/core.js';
+
+// Same project as the `module-preload` fixture, minus the `modulePreload`
+// option, to verify that the tags are opt-in.
+export default defineConfig({
+  jsxRenderer: {
+    mode: 'pretty',
+    blockElements: ['root-a', 'root-b'],
+  },
+  vite: {
+    build: {
+      rolldownOptions: {
+        output: {
+          // For testing, avoid adding [hash] so that the builds are
+          // deterministic.
+          entryFileNames: 'assets/[name].min.js',
+          chunkFileNames: 'chunks/[name].min.js',
+          assetFileNames: 'assets/[name][extname]',
+        },
+      },
+    },
+  },
+});

--- a/packages/root/test/fixtures/module-preload-disabled/routes/index.tsx
+++ b/packages/root/test/fixtures/module-preload-disabled/routes/index.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <root-a />
+      <root-b />
+    </>
+  );
+}

--- a/packages/root/test/fixtures/module-preload/elements/root-a/root-a.ts
+++ b/packages/root/test/fixtures/module-preload/elements/root-a/root-a.ts
@@ -1,0 +1,9 @@
+import {renderLabel} from '../../lib/shared.js';
+
+class RootA extends HTMLElement {
+  connectedCallback() {
+    renderLabel(this, 'a');
+  }
+}
+
+customElements.define('root-a', RootA);

--- a/packages/root/test/fixtures/module-preload/elements/root-b/root-b.ts
+++ b/packages/root/test/fixtures/module-preload/elements/root-b/root-b.ts
@@ -1,0 +1,9 @@
+import {renderLabel} from '../../lib/shared.js';
+
+class RootB extends HTMLElement {
+  connectedCallback() {
+    renderLabel(this, 'b');
+  }
+}
+
+customElements.define('root-b', RootB);

--- a/packages/root/test/fixtures/module-preload/lib/shared.ts
+++ b/packages/root/test/fixtures/module-preload/lib/shared.ts
@@ -1,0 +1,4 @@
+/** Shared dep imported by more than one element, so it lands in its own chunk. */
+export function renderLabel(el: HTMLElement, label: string) {
+  el.textContent = label;
+}

--- a/packages/root/test/fixtures/module-preload/root.config.ts
+++ b/packages/root/test/fixtures/module-preload/root.config.ts
@@ -1,0 +1,22 @@
+import {defineConfig} from '../../../dist/core.js';
+
+export default defineConfig({
+  modulePreload: true,
+  jsxRenderer: {
+    mode: 'pretty',
+    blockElements: ['root-a', 'root-b'],
+  },
+  vite: {
+    build: {
+      rolldownOptions: {
+        output: {
+          // For testing, avoid adding [hash] so that the builds are
+          // deterministic.
+          entryFileNames: 'assets/[name].min.js',
+          chunkFileNames: 'chunks/[name].min.js',
+          assetFileNames: 'assets/[name][extname]',
+        },
+      },
+    },
+  },
+});

--- a/packages/root/test/fixtures/module-preload/routes/index.tsx
+++ b/packages/root/test/fixtures/module-preload/routes/index.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <root-a />
+      <root-b />
+    </>
+  );
+}

--- a/packages/root/test/module-preload.test.ts
+++ b/packages/root/test/module-preload.test.ts
@@ -1,0 +1,53 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {afterEach, expect, test} from 'vitest';
+import {Fixture, loadFixture} from './testutils.js';
+
+let fixture: Fixture;
+
+afterEach(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+async function buildIndexHtml(fixturePath: string) {
+  fixture = await loadFixture(fixturePath);
+  await fixture.build();
+  return await fs.readFile(
+    path.join(fixture.distDir, 'html/index.html'),
+    'utf-8'
+  );
+}
+
+test('inject modulepreload tags for shared chunks', async () => {
+  const html = await buildIndexHtml('./fixtures/module-preload');
+  expect(html).toMatchInlineSnapshot(`
+    "<!doctype html>
+    <html>
+    <head>
+    <meta charset="utf-8">
+    <link rel="modulepreload" href="/chunks/shared.min.js">
+    <script type="module" src="/assets/root-a.min.js"></script>
+    <script type="module" src="/assets/root-b.min.js"></script>
+    </head>
+    <body>
+    <root-a></root-a>
+    <root-b></root-b>
+    </body>
+    </html>
+    "
+  `);
+});
+
+test('preloaded chunks are copied to the build output', async () => {
+  await buildIndexHtml('./fixtures/module-preload');
+  const chunk = path.join(fixture.distDir, 'html/chunks/shared.min.js');
+  expect(await fs.readFile(chunk, 'utf-8')).toContain('textContent');
+});
+
+test('modulepreload tags are opt-in', async () => {
+  const html = await buildIndexHtml('./fixtures/module-preload-disabled');
+  expect(html).not.toContain('modulepreload');
+  expect(html).toContain('<script type="module" src="/assets/root-a.min.js">');
+});


### PR DESCRIPTION
## Summary

Adds a new `modulePreload` configuration option that automatically injects `<link rel="modulepreload">` tags for JS chunks imported by the page's `<script type="module">` tags. This eliminates request waterfalls by preloading shared chunks before the browser parses the entry scripts.

Fixes #182 

## Key Changes

- **New config option**: Added `modulePreload?: boolean` to `RootUserConfig` in `src/core/config.ts`. Disabled by default; pass `modulePreload: true` to opt in.
- **Asset dependency tracking**: Implemented `getModulePreloadDeps()` method on the `Asset` interface and both `BuildAsset` and `DevServerAsset` implementations to recursively collect JS chunk URLs from the import graph.
- **HTML injection**: Updated `Renderer.renderPage()` to collect preload dependencies from custom elements and script bundles, then inject `<link rel="modulepreload">` tags in the document head (skipping chunks already injected as `<script>` tags).
- **Dev server handling**: `DevServerAsset.getModulePreloadDeps()` returns an empty list since the dev server serves modules unbundled, preventing unnecessary tags in development.
- **Test coverage**: Added comprehensive tests in `test/module-preload.test.ts` and `test/build-asset-map.test.ts` with two fixture projects demonstrating the feature enabled and disabled.

## Implementation Details

- The `collectModulePreload()` method walks the import graph using a visited set to handle cyclic imports safely.
- Only JS assets (`.js` and `.mjs` files) are collected; CSS dependencies are injected as stylesheets and excluded.
- Route files without their own asset URLs are skipped during collection.
- Preload tags are filtered to exclude chunks already injected as `<script>` tags, avoiding duplicate requests.
- The feature is opt-in and only active in production builds; dev server always returns empty preload deps.

https://claude.ai/code/session_01Qg38eZjvU8KkBDHBaG2Umw