### PR TITLE
fix: align tooltip-wrapped buttons with non-wrapped buttons

### DIFF
--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.tsx
@@ -6,7 +6,6 @@ import {
   Select,
   Table,
   TextInput,
-  Tooltip,
 } from '@mantine/core';
 import {useDebouncedValue} from '@mantine/hooks';
 import {IconSearch} from '@tabler/icons-preact';
@@ -20,6 +19,7 @@ import {notifyErrors} from '../../utils/notifications.js';
 import {withTimeout} from '../../utils/with-timeout.js';
 import {Pagination, PaginationSummary} from '../Pagination/Pagination.js';
 import {Surface} from '../Surface/Surface.js';
+import {Tooltip} from '../Tooltip/Tooltip.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 import './ActionsLogs.css';
 

--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.visual.test.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.visual.test.tsx
@@ -1,0 +1,95 @@
+import '../../styles/global.css';
+import '../../styles/theme.css';
+import {MantineProvider} from '@mantine/core';
+import {render, waitFor} from '@testing-library/preact';
+import {describe, expect, it, vi} from 'vitest';
+import {ActionLogs} from './ActionLogs.js';
+
+const MOCK_ACTIONS = vi.hoisted(() => {
+  const millis = 1647485978000; // Wed Mar 16 19:59:38 2022 -0700.
+  const timestamp = {seconds: Math.floor(millis / 1000), nanoseconds: 0};
+  return [
+    // Renders a tooltip-wrapped link ("Open doc") followed by a link with no
+    // tooltip ("Show changes").
+    {
+      action: 'cms-edit.set',
+      by: 'test@example.com',
+      metadata: {docId: 'Pages/index'},
+      links: [{label: 'Show changes', url: '/cms/compare'}],
+      timestamp: timestamp,
+    },
+    // Renders a link without a tooltip.
+    {
+      action: 'translations.export',
+      by: 'test@example.com',
+      metadata: {sheetId: 'abc123'},
+      timestamp: timestamp,
+    },
+  ];
+});
+
+vi.mock('../../utils/actions.js', () => ({
+  listActions: async () => MOCK_ACTIONS,
+}));
+
+describe('ActionLogs', () => {
+  function renderCompact() {
+    return render(
+      <MantineProvider>
+        <div style={{width: '900px'}}>
+          <ActionLogs compact />
+        </div>
+      </MantineProvider>
+    );
+  }
+
+  async function waitForRows(container: HTMLElement) {
+    return await waitFor(() => {
+      const els = container.querySelectorAll('.ActionLogsCompactItemPreview');
+      expect(els.length).toBe(MOCK_ACTIONS.length);
+      return Array.from(els) as HTMLElement[];
+    });
+  }
+
+  it('vertically aligns the action buttons within a row', async () => {
+    const {container} = renderCompact();
+    const rows = await waitForRows(container);
+    // Expand the first row to reveal its full set of quick links.
+    const control = rows[0].closest('button') as HTMLElement;
+    control.click();
+    const buttons = await waitFor(() => {
+      const details = container.querySelector(
+        '.ActionLogsCompactItemDetails'
+      ) as HTMLElement;
+      expect(details).not.toBeNull();
+      const els = details.querySelectorAll('.ActionsLogs__table__buttons a');
+      expect(els.length).toBe(2);
+      expect(els[0].getBoundingClientRect().height).toBeGreaterThan(0);
+      return Array.from(els) as HTMLElement[];
+    });
+    const rects = buttons.map((el) => el.getBoundingClientRect());
+    expect(rects[0].top).toBeCloseTo(rects[1].top, 1);
+    expect(rects[0].height).toBeCloseTo(rects[1].height, 1);
+  });
+
+  it('vertically aligns the action buttons across rows', async () => {
+    const {container} = renderCompact();
+    const rows = await waitForRows(container);
+    const offsets = rows.map((row) => {
+      const button = row.querySelector(
+        '.ActionLogsCompactItemPreview__buttons a'
+      ) as HTMLElement;
+      expect(button).not.toBeNull();
+      const rowRect = row.getBoundingClientRect();
+      const buttonRect = button.getBoundingClientRect();
+      return {
+        centerY: buttonRect.top + buttonRect.height / 2 - rowRect.top,
+        right: rowRect.right - buttonRect.right,
+        height: buttonRect.height,
+      };
+    });
+    expect(offsets[0].centerY).toBeCloseTo(offsets[1].centerY, 1);
+    expect(offsets[0].right).toBeCloseTo(offsets[1].right, 1);
+    expect(offsets[0].height).toBeCloseTo(offsets[1].height, 1);
+  });
+});

--- a/packages/root-cms/ui/components/Tooltip/Tooltip.css
+++ b/packages/root-cms/ui/components/Tooltip/Tooltip.css
@@ -1,0 +1,8 @@
+/*
+ * Shrink-wrap the tooltip's wrapper around its child. The `mantine-Tooltip-root`
+ * class is included to win over Mantine's own `display: inline-block` without
+ * relying on stylesheet order.
+ */
+.Tooltip.mantine-Tooltip-root {
+  display: inline-flex;
+}

--- a/packages/root-cms/ui/components/Tooltip/Tooltip.tsx
+++ b/packages/root-cms/ui/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,31 @@
+import './Tooltip.css';
+
+import {Tooltip as MantineTooltip, TooltipProps} from '@mantine/core';
+import {joinClassNames} from '../../utils/classes.js';
+
+export type {TooltipProps};
+
+/**
+ * Drop-in replacement for Mantine's `<Tooltip>` that keeps the wrapper element
+ * layout-neutral.
+ *
+ * Mantine wraps a tooltip's child in an `inline-block` div. That div
+ * establishes a line box, so it ends up a few pixels taller than its child
+ * (the line box reserves room for the font's descender). Whenever a
+ * tooltip-wrapped element sits next to one without a tooltip, the extra space
+ * knocks the two out of alignment. Making the wrapper a flex box removes the
+ * line box so it shrink-wraps its child exactly.
+ *
+ * Example:
+ *   <Tooltip label="Open doc">
+ *     <Button>Open</Button>
+ *   </Tooltip>
+ */
+export function Tooltip(props: TooltipProps) {
+  return (
+    <MantineTooltip
+      {...props}
+      className={joinClassNames(props.className, 'Tooltip')}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Fixes vertical alignment issues in the ActionLogs component where tooltip-wrapped buttons were misaligned with non-wrapped buttons. Mantine's `<Tooltip>` wrapper uses `display: inline-block`, which establishes a line box and adds extra vertical space. This caused buttons next to tooltips to sit at different heights.

Fixes #1340 

## Changes

- **New `Tooltip` component** (`packages/root-cms/ui/components/Tooltip/`): A drop-in replacement for Mantine's `<Tooltip>` that wraps the child in a flex box instead of an inline-block div. This shrink-wraps the wrapper around its child without establishing a line box, keeping the layout neutral.
  - `Tooltip.tsx`: Component that applies the custom CSS class to Mantine's tooltip.
  - `Tooltip.css`: Sets `display: inline-flex` on the wrapper to override Mantine's `inline-block`.

- **Updated ActionLogs**: Changed import from Mantine's `Tooltip` to the new custom `Tooltip` component.

- **Added visual test** (`ActionLogs.visual.test.tsx`): Tests that verify buttons are vertically aligned both within a row and across multiple rows, ensuring the fix works correctly.

## Implementation Details

The custom `Tooltip` component uses `joinClassNames` to apply the `Tooltip` class alongside Mantine's classes, ensuring the flex display rule wins over Mantine's inline-block without relying on stylesheet order. This maintains full compatibility with Mantine's tooltip API while fixing the alignment issue.

https://claude.ai/code/session_01RiTPcKxHMvqMR7vyy4VzSh