### PR TITLE
feat: add "edit with ai" for image fields

### DIFF
--- a/.changeset/olive-pandas-invite.md
+++ b/.changeset/olive-pandas-invite.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add "edit with ai" for image fields

--- a/packages/root-cms/core/ai.test.ts
+++ b/packages/root-cms/core/ai.test.ts
@@ -17,6 +17,7 @@ import {
   sanitizeGeneratedTitle,
   serializeAiConfig,
   stripUndefined,
+  testSupportsImageEditing,
 } from './ai.js';
 
 describe('ai', () => {
@@ -73,6 +74,93 @@ describe('ai', () => {
       });
       expect((gpt as any).apiKey).toBeUndefined();
       expect((gpt as any).baseURL).toBeUndefined();
+    });
+
+    it('reports no image models when none are configured', () => {
+      const result = serializeAiConfig(config);
+      expect(result.imageGenerationEnabled).toBe(false);
+      expect(result.imageModels).toEqual([]);
+      expect(result.defaultImageModel).toBeUndefined();
+    });
+
+    it('serializes image models with their editing support', () => {
+      const result = serializeAiConfig({
+        ...config,
+        imageModels: [
+          {
+            id: 'imagen',
+            provider: 'google',
+            modelId: 'imagen-4.0-generate-001',
+          },
+          {
+            id: 'nano-banana',
+            label: 'Nano Banana',
+            provider: 'google',
+            modelId: 'gemini-3-pro-image-preview',
+            apiKey: 'test-key',
+          },
+        ],
+        defaultImageModel: 'nano-banana',
+      });
+      expect(result.imageGenerationEnabled).toBe(true);
+      expect(result.defaultImageModel).toBe('nano-banana');
+      expect(result.imageModels).toEqual([
+        {
+          id: 'imagen',
+          label: 'imagen',
+          description: undefined,
+          provider: 'google',
+          editing: false,
+        },
+        {
+          id: 'nano-banana',
+          label: 'Nano Banana',
+          description: undefined,
+          provider: 'google',
+          editing: true,
+        },
+      ]);
+      expect((result.imageModels[1] as any).apiKey).toBeUndefined();
+    });
+  });
+
+  describe('testSupportsImageEditing', () => {
+    it('accepts gemini image models but not imagen', () => {
+      expect(
+        testSupportsImageEditing({id: 'gemini-3-pro-image', provider: 'google'})
+      ).toBe(true);
+      expect(
+        testSupportsImageEditing({
+          id: 'img',
+          provider: 'google',
+          modelId: 'imagen-4.0-generate-001',
+        })
+      ).toBe(false);
+    });
+
+    it('accepts openai image models except dall-e-3', () => {
+      expect(
+        testSupportsImageEditing({id: 'gpt-image-1', provider: 'openai'})
+      ).toBe(true);
+      expect(
+        testSupportsImageEditing({id: 'dall-e-2', provider: 'openai'})
+      ).toBe(true);
+      expect(
+        testSupportsImageEditing({id: 'dall-e-3', provider: 'openai'})
+      ).toBe(false);
+    });
+
+    it('rejects providers without image support', () => {
+      expect(
+        testSupportsImageEditing({id: 'claude-opus', provider: 'anthropic'})
+      ).toBe(false);
+      expect(
+        testSupportsImageEditing({
+          id: 'local',
+          provider: 'openai-compatible',
+          baseURL: 'http://localhost:11434/v1',
+        })
+      ).toBe(false);
     });
   });
 

--- a/packages/root-cms/core/ai.ts
+++ b/packages/root-cms/core/ai.ts
@@ -33,6 +33,7 @@ import {
   normalizeExecutionMode,
   resolveImageModel,
   resolveLanguageModel,
+  testSupportsImageEditing,
 } from '../shared/ai/models.js';
 import {
   buildTitlePrompt,
@@ -58,6 +59,7 @@ export {
   normalizeExecutionMode,
   resolveImageModel,
   resolveLanguageModel,
+  testSupportsImageEditing,
   withBrowserHeaders,
 } from '../shared/ai/models.js';
 export {
@@ -92,6 +94,7 @@ export const DEFAULT_CHAT_SYSTEM_PROMPT = [
  * separately (and only for the selected model) via `serializeAiClientModel`.
  */
 export function serializeAiConfig(config: AiConfig) {
+  const imageModels = config.imageModels || [];
   return {
     defaultModel: config.defaultModel || config.models[0]?.id,
     models: config.models.map((m) => ({
@@ -105,7 +108,16 @@ export function serializeAiConfig(config: AiConfig) {
         attachments: m.capabilities?.attachments ?? false,
       },
     })),
-    imageGenerationEnabled: !!config.imageModels?.length,
+    imageGenerationEnabled: imageModels.length > 0,
+    defaultImageModel: config.defaultImageModel || imageModels[0]?.id,
+    imageModels: imageModels.map((m) => ({
+      id: m.id,
+      label: m.label || m.id,
+      description: m.description,
+      provider: m.provider,
+      /** Whether the model accepts a source image (image-to-image editing). */
+      editing: testSupportsImageEditing(m),
+    })),
   };
 }
 
@@ -777,4 +789,111 @@ export async function generateImage(
   }
   const mediaType = result.image.mediaType || 'image/png';
   return {imageUrl: `data:${mediaType};base64,${result.image.base64}`};
+}
+
+/** Maximum size of a source image accepted by `editImage()`. */
+const MAX_SOURCE_IMAGE_BYTES = 20 * 1024 * 1024;
+
+export interface EditImageOptions {
+  /**
+   * The image to edit, as an absolute `https:` URL or a `data:image/...` URL.
+   * Callers passing a URL from user input must validate it against SSRF first
+   * (see `assertPublicHttpUrl`).
+   */
+  imageUrl: string;
+  /** Instructions describing the edit to apply, e.g. "make the sky purple". */
+  prompt: string;
+  /** Specific image model id from `AiConfig.imageModels`. */
+  modelId?: string;
+  /**
+   * Aspect ratio of the result. Omit to let the model follow the source
+   * image. Ignored by providers that only accept an explicit size.
+   */
+  aspectRatio?: AspectRatio;
+}
+
+export interface EditImageResult {
+  /** Edited image as a `data:image/...` URL. */
+  imageUrl: string;
+}
+
+/**
+ * Edits an existing image from a natural language instruction using the
+ * configured `imageModels`, and returns the result as a base64-encoded data
+ * URL. The source image is passed to the model alongside the prompt, so
+ * repeated calls can be chained to iterate on a previous result.
+ *
+ * Throws if the configured/selected image model cannot accept a source image
+ * (see `testSupportsImageEditing`).
+ */
+export async function editImage(
+  rootConfig: RootConfig,
+  options: EditImageOptions
+): Promise<EditImageResult> {
+  const config = getAiConfig(rootConfig);
+  if (!config) {
+    throw new Error('AI is not configured. Set `ai` on the cmsPlugin config.');
+  }
+  const imageModelConfig = findImageModel(config, options.modelId);
+  if (!imageModelConfig) {
+    throw new Error(
+      'No image model configured. Set `ai.imageModels` on the cmsPlugin config.'
+    );
+  }
+  if (!testSupportsImageEditing(imageModelConfig)) {
+    throw new Error(
+      `image model "${imageModelConfig.id}" does not support image editing`
+    );
+  }
+
+  // Inline the source image as bytes rather than handing the provider a URL:
+  // the OpenAI and Google image APIs differ in whether (and how) they accept
+  // remote URLs, and a data URL works the same for both.
+  const sourceImage = await fetchImageAsDataUrl(options.imageUrl);
+
+  const imageModel = resolveImageModel(imageModelConfig);
+  const result = await generateImageSdk({
+    model: imageModel,
+    prompt: {images: [sourceImage], text: options.prompt},
+    aspectRatio: options.aspectRatio,
+  });
+
+  if (!result.image) {
+    throw new Error('No image generated');
+  }
+  const mediaType = result.image.mediaType || 'image/png';
+  return {imageUrl: `data:${mediaType};base64,${result.image.base64}`};
+}
+
+/**
+ * Downloads `imageUrl` and returns it as a `data:image/...` URL. Data URLs are
+ * returned as-is. Rejects non-image responses and anything larger than
+ * `MAX_SOURCE_IMAGE_BYTES`.
+ */
+async function fetchImageAsDataUrl(imageUrl: string): Promise<string> {
+  if (imageUrl.startsWith('data:')) {
+    if (!imageUrl.startsWith('data:image/')) {
+      throw new Error('source image must be an image data URL');
+    }
+    if (imageUrl.length > MAX_SOURCE_IMAGE_BYTES) {
+      throw new Error('source image is too large');
+    }
+    return imageUrl;
+  }
+  const res = await fetch(imageUrl, {redirect: 'error'});
+  if (!res.ok) {
+    throw new Error(`failed to fetch source image: ${res.status}`);
+  }
+  const mediaType = (res.headers.get('content-type') || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+  if (!mediaType.startsWith('image/')) {
+    throw new Error(`source image is not an image: ${mediaType || 'unknown'}`);
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  if (buffer.byteLength > MAX_SOURCE_IMAGE_BYTES) {
+    throw new Error('source image is too large');
+  }
+  return `data:${mediaType};base64,${buffer.toString('base64')}`;
 }

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -6,6 +6,7 @@ import {toTranslationLanguages} from '../shared/translation-languages.js';
 import {
   buildChatSystemPrompt,
   buildEditSystemPrompt,
+  editImage,
   findModel,
   generateAltText,
   generateImage,
@@ -905,6 +906,77 @@ export function api(server: Server, options: ApiOptions) {
       }
     }
   );
+
+  /**
+   * Edits an existing image from a natural language instruction using the
+   * configured image model. The image returned here can be sent back as
+   * `imageUrl` to iterate on a previous result.
+   *
+   * ```
+   * POST /cms/api/ai.edit_image
+   * {"imageUrl": "https://...", "prompt": "Make the sky purple"}
+   * ```
+   */
+  server.use('/cms/api/ai.edit_image', async (req: Request, res: Response) => {
+    if (
+      req.method !== 'POST' ||
+      !String(req.get('content-type')).startsWith('application/json')
+    ) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    if (!req.user?.email) {
+      res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      return;
+    }
+
+    const reqBody = req.body || {};
+    const imageUrl =
+      typeof reqBody.imageUrl === 'string' ? reqBody.imageUrl.trim() : '';
+    const prompt =
+      typeof reqBody.prompt === 'string' ? reqBody.prompt.trim() : '';
+    if (!imageUrl || !prompt) {
+      res.status(400).json({
+        success: false,
+        error: 'MISSING_REQUIRED_FIELD',
+        field: imageUrl ? 'prompt' : 'imageUrl',
+      });
+      return;
+    }
+
+    // Validate against SSRF: the source image is fetched server-side before
+    // it's forwarded to the provider, so an attacker-supplied URL pointed at a
+    // private/metadata address would be fetched from the CMS host's network.
+    // Data URLs carry their own bytes and need no network access.
+    if (!imageUrl.startsWith('data:')) {
+      try {
+        await assertPublicHttpUrl(imageUrl);
+      } catch (err) {
+        if (err instanceof UnsafeUrlError) {
+          res.status(400).json({success: false, error: 'INVALID_IMAGE_URL'});
+          return;
+        }
+        throw err;
+      }
+    }
+
+    try {
+      const result = await editImage(req.rootConfig!, {
+        imageUrl,
+        prompt,
+        modelId:
+          typeof reqBody.modelId === 'string' ? reqBody.modelId : undefined,
+        aspectRatio:
+          typeof reqBody.aspectRatio === 'string'
+            ? reqBody.aspectRatio
+            : undefined,
+      });
+      res.status(200).json({success: true, image: result.imageUrl});
+    } catch (err: any) {
+      console.error(err.stack || err);
+      res.status(500).json({success: false, error: err.message || 'UNKNOWN'});
+    }
+  });
 
   /**
    * Generates a concise publish message describing changes since the last

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -1035,6 +1035,10 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         ['/cms/api/ai.chat.prepare', '/cms/api/ai.edit.prepare'],
         bodyParser.json({limit: '4mb'})
       );
+      // Image editing iterates on its own output, so the request body can
+      // carry a full generated image as a data URL. Allow enough headroom for
+      // a base64-encoded PNG (`editImage()` caps the decoded source at 20MB).
+      server.use('/cms/api/ai.edit_image', bodyParser.json({limit: '12mb'}));
       server.use(bodyParser.json());
       // Handle body-parser errors (e.g. PayloadTooLargeError) gracefully
       // instead of letting them bubble up as unhandled 500 errors.

--- a/packages/root-cms/shared/ai/models.ts
+++ b/packages/root-cms/shared/ai/models.ts
@@ -219,6 +219,29 @@ export function resolveImageModel(model: AiModelConfig): ImageModel {
   }
 }
 
+/**
+ * Returns whether an image model can edit an existing image, i.e. accept one
+ * or more source images alongside the text prompt (image-to-image), rather
+ * than only generating from scratch (text-to-image).
+ *
+ * Support is provider- and model-specific:
+ * - `openai`: the `/images/edits` endpoint backs `gpt-image-*` and `dall-e-2`.
+ *   `dall-e-3` is generation-only.
+ * - `google`: only the Gemini image models accept source images. Imagen models
+ *   are generation-only on the Gemini API.
+ */
+export function testSupportsImageEditing(model: AiModelConfig): boolean {
+  const modelId = model.modelId || model.id;
+  switch (model.provider) {
+    case 'openai':
+      return !modelId.startsWith('dall-e-3');
+    case 'google':
+      return modelId.startsWith('gemini-');
+    default:
+      return false;
+  }
+}
+
 export function normalizeExecutionMode(value: unknown): AiExecutionMode {
   if (value === 'read' || value === 'approve' || value === 'auto') {
     return value;

--- a/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.css
+++ b/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.css
@@ -1,0 +1,73 @@
+.AiImageEditorDialog__Canvas {
+  align-items: center;
+  background: #333;
+  display: flex;
+  height: 400px;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+
+.AiImageEditorDialog__Canvas__Image {
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.AiImageEditorDialog__Versions {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+/* Each thumbnail is wrapped by a Tooltip, so pin the wrapper's size too. */
+.AiImageEditorDialog__Versions > * {
+  flex: none;
+}
+
+.AiImageEditorDialog__Versions__Item {
+  background: #333;
+  border: 2px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  flex: none;
+  height: 64px;
+  padding: 0;
+  position: relative;
+  width: 64px;
+}
+
+.AiImageEditorDialog__Versions__Item:disabled {
+  cursor: default;
+}
+
+.AiImageEditorDialog__Versions__Item--selected {
+  border-color: #228be6;
+}
+
+.AiImageEditorDialog__Versions__Item img {
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.AiImageEditorDialog__Versions__Item__Label {
+  background: rgba(0, 0, 0, 0.65);
+  bottom: 0;
+  color: #fff;
+  font-size: 10px;
+  left: 0;
+  line-height: 14px;
+  overflow: hidden;
+  padding: 0 3px;
+  position: absolute;
+  right: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.AiImageEditorDialog__ModelSelect {
+  max-width: 240px;
+}

--- a/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.test.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.test.tsx
@@ -1,0 +1,198 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/preact';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+// Mock Mantine. The real components need a MantineProvider context that isn't
+// available under @preact/compat in jsdom; these stubs keep the test focused
+// on the dialog's own iteration logic.
+vi.mock('@mantine/core', () => ({
+  Button: ({children, onClick, disabled, loading}: any) => (
+    <button onClick={onClick} disabled={disabled || loading}>
+      {children}
+    </button>
+  ),
+  Group: ({children}: any) => <div>{children}</div>,
+  LoadingOverlay: ({visible}: any) => (visible ? <div>Loading</div> : null),
+  Modal: ({children, opened}: any) => (opened ? <div>{children}</div> : null),
+  Select: ({value, onChange, data}: any) => (
+    <select
+      aria-label="Model"
+      value={value}
+      onChange={(e: any) => onChange(e.currentTarget.value)}
+    >
+      {data.map((item: any) => (
+        <option value={item.value}>{item.label}</option>
+      ))}
+    </select>
+  ),
+  Stack: ({children}: any) => <div>{children}</div>,
+  Text: ({children}: any) => <div>{children}</div>,
+  // Mantine's Textarea fires `onChange` on every keystroke (React semantics,
+  // via the @preact/compat alias), so bind it to `onInput` here.
+  Textarea: ({label, value, onChange, onKeyDown}: any) => (
+    <textarea
+      aria-label={label}
+      value={value}
+      onInput={onChange}
+      onKeyDown={onKeyDown}
+    />
+  ),
+  Tooltip: ({children}: any) => <div>{children}</div>,
+  useMantineTheme: () => ({colorScheme: 'light', colors: {dark: [], gray: []}}),
+}));
+
+vi.mock('@mantine/notifications', () => ({showNotification: vi.fn()}));
+
+vi.mock('../../../utils/ai.js', () => ({
+  getAiImageEditingModels: () => [{id: 'nano-banana', label: 'Nano Banana'}],
+}));
+
+// Import after mocks are registered.
+const {AiImageEditorDialog} = await import('./AiImageEditorDialog.js');
+
+const ORIGINAL_SRC = 'https://lh3.googleusercontent.com/original';
+
+/** Returns the request bodies sent to `/cms/api/ai.edit_image`, in order. */
+function editRequests(fetchMock: any): any[] {
+  return fetchMock.mock.calls
+    .filter((call: any[]) => call[0] === '/cms/api/ai.edit_image')
+    .map((call: any[]) => JSON.parse(call[1].body));
+}
+
+/** Types `text` into the prompt input and clicks Generate. */
+async function generate(text: string) {
+  fireEvent.input(screen.getByLabelText('Describe the change'), {
+    target: {value: text},
+  });
+  await waitFor(() => {
+    expect((screen.getByText('Generate') as HTMLButtonElement).disabled).toBe(
+      false
+    );
+  });
+  fireEvent.click(screen.getByText('Generate'));
+}
+
+describe('AiImageEditorDialog', () => {
+  let fetchMock: any;
+  let generation = 0;
+
+  beforeEach(() => {
+    generation = 0;
+    fetchMock = vi.fn(async (url: string) => {
+      if (url === '/cms/api/ai.edit_image') {
+        generation += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            image: `data:image/png;base64,generated${generation}`,
+          }),
+        };
+      }
+      return {ok: true, blob: async () => new Blob([''], {type: 'image/png'})};
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    window.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function renderDialog(onSave = vi.fn()) {
+    render(
+      <AiImageEditorDialog
+        opened
+        onClose={vi.fn()}
+        src={ORIGINAL_SRC}
+        filename="photo.jpg"
+        onSave={onSave}
+      />
+    );
+    return onSave;
+  }
+
+  test('sends the original image on the first generation', async () => {
+    renderDialog();
+    await generate('make the sky purple');
+
+    await waitFor(() => expect(editRequests(fetchMock)).toHaveLength(1));
+    expect(editRequests(fetchMock)[0]).toMatchObject({
+      imageUrl: ORIGINAL_SRC,
+      prompt: 'make the sky purple',
+      modelId: 'nano-banana',
+    });
+  });
+
+  test('iterates on the previous result', async () => {
+    renderDialog();
+    await generate('make the sky purple');
+    await waitFor(() => expect(editRequests(fetchMock)).toHaveLength(1));
+
+    await generate('now add a rainbow');
+    await waitFor(() => expect(editRequests(fetchMock)).toHaveLength(2));
+
+    // The second edit builds on the first result, not the original.
+    expect(editRequests(fetchMock)[1]).toMatchObject({
+      imageUrl: 'data:image/png;base64,generated1',
+      prompt: 'now add a rainbow',
+    });
+  });
+
+  test('branches from an earlier version when one is reselected', async () => {
+    renderDialog();
+    await generate('make the sky purple');
+    await waitFor(() => expect(editRequests(fetchMock)).toHaveLength(1));
+
+    // Step back to the original and edit from there instead.
+    fireEvent.click(screen.getByLabelText('Original'));
+    await generate('make the sky green');
+
+    await waitFor(() => expect(editRequests(fetchMock)).toHaveLength(2));
+    expect(editRequests(fetchMock)[1]).toMatchObject({
+      imageUrl: ORIGINAL_SRC,
+      prompt: 'make the sky green',
+    });
+  });
+
+  test('cannot save until an edit has been generated', async () => {
+    const onSave = renderDialog();
+    expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(true);
+
+    await generate('make the sky purple');
+    await waitFor(() =>
+      expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(
+        false
+      )
+    );
+
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    // The saved file is named after the original, with the generated ext.
+    expect(onSave.mock.calls[0][0].name).toBe('photo-edited.png');
+  });
+
+  test('keeps the original selectable and does not save it', async () => {
+    renderDialog();
+    await generate('make the sky purple');
+    await waitFor(() =>
+      expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(
+        false
+      )
+    );
+
+    fireEvent.click(screen.getByLabelText('Original'));
+    await waitFor(() =>
+      expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(
+        true
+      )
+    );
+  });
+});

--- a/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/AiImageEditorDialog.tsx
@@ -1,0 +1,260 @@
+import {
+  Button,
+  Group,
+  LoadingOverlay,
+  Modal,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  Tooltip,
+  useMantineTheme,
+} from '@mantine/core';
+import {showNotification} from '@mantine/notifications';
+import {IconCheck, IconSparkles} from '@tabler/icons-preact';
+import {useMemo, useState} from 'preact/hooks';
+import {getAiImageEditingModels} from '../../../utils/ai.js';
+import {joinClassNames} from '../../../utils/classes.js';
+import './AiImageEditorDialog.css';
+
+/** A single image in the edit history. */
+interface ImageVersion {
+  /** The image, as an absolute URL (the original) or a data URL (an edit). */
+  src: string;
+  /** The instruction that produced this version. Unset for the original. */
+  prompt?: string;
+}
+
+/**
+ * Props for the AiImageEditorDialog component.
+ */
+interface AiImageEditorDialogProps {
+  /** Whether the dialog is opened. */
+  opened: boolean;
+  /** Callback when the dialog is closed. */
+  onClose: () => void;
+  /** The source URL of the image to edit. */
+  src: string;
+  /** The filename of the image, used to name the saved file. */
+  filename?: string;
+  /** Callback when an edited image is accepted. */
+  onSave: (file: File) => void;
+}
+
+/**
+ * Modal for editing an image with a natural language prompt.
+ *
+ * Each generation is appended to a version history, and the selected version
+ * is used as the source for the next generation, so users can iterate on a
+ * result (or step back to an earlier one and branch off it) before saving.
+ */
+export function AiImageEditorDialog(props: AiImageEditorDialogProps) {
+  const theme = useMantineTheme();
+  const models = useMemo(() => getAiImageEditingModels(), []);
+  const [modelId, setModelId] = useState(models[0]?.id || '');
+  const [versions, setVersions] = useState<ImageVersion[]>([{src: props.src}]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [prompt, setPrompt] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const selectedVersion = versions[selectedIndex];
+  const busy = generating || saving;
+
+  async function handleGenerate() {
+    const instruction = prompt.trim();
+    if (!instruction || busy) {
+      return;
+    }
+    setGenerating(true);
+    try {
+      const res = await window.fetch('/cms/api/ai.edit_image', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({
+          imageUrl: selectedVersion.src,
+          prompt: instruction,
+          modelId: modelId || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success || !data.image) {
+        throw new Error(data.error || 'Failed to edit image');
+      }
+      setVersions([...versions, {src: data.image, prompt: instruction}]);
+      setSelectedIndex(versions.length);
+      setPrompt('');
+    } catch (err: any) {
+      console.error(err);
+      showNotification({
+        title: 'Edit failed',
+        message: err.message || 'Unknown error',
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function handleSave() {
+    if (selectedIndex === 0 || busy) {
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await window.fetch(selectedVersion.src);
+      const blob = await res.blob();
+      const filename = buildEditedFilename(props.filename, blob.type);
+      props.onSave(new File([blob], filename, {type: blob.type}));
+    } catch (err: any) {
+      console.error(err);
+      showNotification({
+        title: 'Save failed',
+        message: err.message || 'Failed to save the edited image',
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      opened={props.opened}
+      onClose={props.onClose}
+      title="Edit with AI"
+      size="xl"
+      centered
+      overlayColor={
+        theme.colorScheme === 'dark'
+          ? theme.colors.dark[9]
+          : theme.colors.gray[2]
+      }
+    >
+      <Stack spacing="md">
+        <div className="AiImageEditorDialog__Canvas">
+          <LoadingOverlay visible={generating} />
+          <img
+            className="AiImageEditorDialog__Canvas__Image"
+            src={selectedVersion.src}
+            alt={selectedVersion.prompt || 'Image being edited'}
+          />
+        </div>
+
+        {versions.length > 1 && (
+          <div className="AiImageEditorDialog__Versions">
+            {versions.map((version, index) => (
+              <Tooltip
+                key={index}
+                label={version.prompt || 'Original'}
+                position="top"
+                withArrow
+                wrapLines
+                width={220}
+              >
+                <button
+                  type="button"
+                  className={joinClassNames(
+                    'AiImageEditorDialog__Versions__Item',
+                    index === selectedIndex &&
+                      'AiImageEditorDialog__Versions__Item--selected'
+                  )}
+                  disabled={busy}
+                  onClick={() => setSelectedIndex(index)}
+                  aria-label={
+                    index === 0
+                      ? 'Original'
+                      : `Version ${index}: ${version.prompt}`
+                  }
+                  aria-pressed={index === selectedIndex}
+                >
+                  <img src={version.src} alt="" />
+                  <span className="AiImageEditorDialog__Versions__Item__Label">
+                    {index === 0 ? 'Original' : `v${index}`}
+                  </span>
+                </button>
+              </Tooltip>
+            ))}
+          </div>
+        )}
+
+        <Textarea
+          label="Describe the change"
+          placeholder="e.g. remove the background, or make the sky purple"
+          value={prompt}
+          minRows={2}
+          autosize
+          maxRows={6}
+          disabled={busy}
+          data-autofocus
+          onChange={(e: any) => setPrompt(e.currentTarget.value)}
+          onKeyDown={(e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              e.preventDefault();
+              handleGenerate();
+            }
+          }}
+        />
+
+        <Group position="apart" align="flex-end">
+          {models.length > 1 ? (
+            <Select
+              className="AiImageEditorDialog__ModelSelect"
+              label="Model"
+              size="xs"
+              data={models.map((model) => ({
+                value: model.id,
+                label: model.label,
+              }))}
+              value={modelId}
+              disabled={busy}
+              onChange={(value: string | null) => setModelId(value || '')}
+            />
+          ) : (
+            <Text size="xs" color="dimmed">
+              {selectedIndex > 0
+                ? `Editing v${selectedIndex}`
+                : 'Editing the original'}
+            </Text>
+          )}
+          <Button
+            variant="light"
+            loading={generating}
+            disabled={saving || !prompt.trim()}
+            leftIcon={<IconSparkles size={16} />}
+            onClick={handleGenerate}
+          >
+            {generating ? 'Generating...' : 'Generate'}
+          </Button>
+        </Group>
+
+        <Group position="right" mt="md">
+          <Button variant="default" onClick={props.onClose} disabled={busy}>
+            Discard
+          </Button>
+          <Button
+            loading={saving}
+            disabled={selectedIndex === 0 || generating}
+            leftIcon={<IconCheck size={16} />}
+            onClick={handleSave}
+          >
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+/**
+ * Names the edited file after the original, with the extension of the image
+ * the model returned (e.g. `photo.jpg` -> `photo-edited.png`).
+ */
+function buildEditedFilename(filename?: string, mediaType?: string): string {
+  const ext = (mediaType || '').split('/')[1]?.split(';')[0] || 'png';
+  const dotIndex = filename ? filename.lastIndexOf('.') : -1;
+  const basename = dotIndex > 0 ? filename!.slice(0, dotIndex) : filename;
+  return `${basename || 'edited-image'}-edited.${ext}`;
+}

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -45,7 +45,7 @@ import {useContext, useMemo, useRef, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
 import {useDraftDocValue} from '../../../hooks/useDraftDoc.js';
 import {useGapiClient} from '../../../hooks/useGapiClient.js';
-import {testAiEnabled} from '../../../utils/ai.js';
+import {testAiEnabled, testAiImageEditingEnabled} from '../../../utils/ai.js';
 import {
   buildAssetFieldValue,
   getAsset,
@@ -104,6 +104,7 @@ interface FileFieldContextValue {
   requestGenerateAltText: () => void;
   requestPlaceholderModalOpen: () => void;
   requestImageEditorOpen: () => void;
+  requestAiImageEditorOpen: () => void;
   /** Whether the asset picker is available (requires a ModalsProvider). */
   assetPickerEnabled: boolean;
   requestAssetPicker: () => void;
@@ -120,6 +121,12 @@ const FileFieldContext = createContext<FileFieldContextValue | null>(null);
 
 const ImageEditorDialog = lazy(() =>
   import('./ImageEditorDialog.js').then((m) => ({default: m.ImageEditorDialog}))
+);
+
+const AiImageEditorDialog = lazy(() =>
+  import('./AiImageEditorDialog.js').then((m) => ({
+    default: m.AiImageEditorDialog,
+  }))
 );
 
 function useFileField() {
@@ -158,6 +165,7 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
   const [placeholderModalOpened, setPlaceholderModalOpened] = useState(false);
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
   const [imageEditorOpened, setImageEditorOpened] = useState(false);
+  const [aiImageEditorOpened, setAiImageEditorOpened] = useState(false);
   const gapiClient = useGapiClient();
   const assetPickerModal = useAssetPickerModal();
   const allowEditing = props.allowEditing !== false;
@@ -420,6 +428,10 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
     setImageEditorOpened(true);
   }
 
+  function requestAiImageEditorOpen() {
+    setAiImageEditorOpened(true);
+  }
+
   /**
    * Opens the asset picker modal for selecting a file from the asset library.
    * The selected asset's file data is copied into the doc along with an
@@ -523,6 +535,7 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
         requestFileDownload: requestFileDownload,
         requestPlaceholderModalOpen: requestPlaceholderModalOpen,
         requestImageEditorOpen: requestImageEditorOpen,
+        requestAiImageEditorOpen: requestAiImageEditorOpen,
         assetPickerEnabled: assetPickerModal.enabled,
         requestAssetPicker: requestAssetPicker,
         unlinkAsset: unlinkAsset,
@@ -600,6 +613,21 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
             onSave={(file) => {
               uploadFile(file, value.originalSrc || value.src);
               setImageEditorOpened(false);
+            }}
+          />
+        </Suspense>
+      )}
+      {aiImageEditorOpened && value?.src && (
+        <Suspense fallback={null}>
+          <AiImageEditorDialog
+            key={value.src}
+            opened={aiImageEditorOpened}
+            onClose={() => setAiImageEditorOpened(false)}
+            src={value.src}
+            filename={value.filename}
+            onSave={(file) => {
+              uploadFile(file, value.originalSrc || value.src);
+              setAiImageEditorOpened(false);
             }}
           />
         </Suspense>
@@ -774,6 +802,7 @@ FileField.Preview = () => {
   const [dragging, setDragging] = useState(false);
   const [copied, setCopied] = useState(false);
   const aiEnabled = testAiEnabled();
+  const aiImageEditingEnabled = testAiImageEditingEnabled();
 
   // Videos and images are the only files that get the canvas preview.
   // Other types just show the info panel. Videos with zero dimensions
@@ -876,16 +905,30 @@ FileField.Preview = () => {
               )}
               {testIsImageFile(ctx.value?.src) &&
                 !ctx.value?.src?.endsWith('.svg') && (
-                  <Menu.Item
-                    disabled={!ctx.value?.src}
-                    icon={<IconCrop size={16} />}
-                    closeMenuOnClick
-                    onClick={() => {
-                      ctx.requestImageEditorOpen();
-                    }}
-                  >
-                    Edit image
-                  </Menu.Item>
+                  <>
+                    <Menu.Item
+                      disabled={!ctx.value?.src}
+                      icon={<IconCrop size={16} />}
+                      closeMenuOnClick
+                      onClick={() => {
+                        ctx.requestImageEditorOpen();
+                      }}
+                    >
+                      Edit image
+                    </Menu.Item>
+                    {aiImageEditingEnabled && (
+                      <Menu.Item
+                        disabled={!ctx.value?.src}
+                        icon={<IconSparkles size={16} />}
+                        closeMenuOnClick
+                        onClick={() => {
+                          ctx.requestAiImageEditorOpen();
+                        }}
+                      >
+                        Edit with AI
+                      </Menu.Item>
+                    )}
+                  </>
                 )}
               <Divider />
             </>

--- a/packages/root-cms/ui/components/DocEditor/fields/ImageEditorDialog.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/ImageEditorDialog.tsx
@@ -250,14 +250,15 @@ export function ImageEditorDialog(props: ImageEditorDialogProps) {
               Restore Original
             </Button>
           )}
-          <Group>
-            <Button variant="default" onClick={props.onClose} disabled={saving}>
+          <Group gap={12}>
+            <Button variant="default" size="xs" onClick={props.onClose} disabled={saving}>
               Discard
             </Button>
             <Button
+              size="xs"
               onClick={handleSave}
               loading={saving}
-              leftIcon={<IconCheck />}
+              leftIcon={<IconCheck size={20} />}
             >
               Save
             </Button>

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -224,6 +224,7 @@ declare global {
       ai?: {
         defaultModel?: string;
         imageGenerationEnabled?: boolean;
+        defaultImageModel?: string;
         models: Array<{
           id: string;
           label: string;
@@ -234,6 +235,14 @@ declare global {
             reasoning: boolean;
             attachments: boolean;
           };
+        }>;
+        imageModels?: Array<{
+          id: string;
+          label: string;
+          description?: string;
+          provider: string;
+          /** Whether the model accepts a source image (image-to-image editing). */
+          editing: boolean;
         }>;
       } | null;
       preview: {

--- a/packages/root-cms/ui/utils/ai.ts
+++ b/packages/root-cms/ui/utils/ai.ts
@@ -18,3 +18,39 @@ export function testAiImageGenerationEnabled(): boolean {
     window.__ROOT_CTX.experiments?.ai
   );
 }
+
+/** An image model that can edit an existing image, as shown in the UI. */
+export interface AiImageEditingModel {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+/**
+ * Returns the configured image models that support image-to-image editing,
+ * with the project's default image model first when it qualifies.
+ */
+export function getAiImageEditingModels(): AiImageEditingModel[] {
+  const ai = window.__ROOT_CTX.ai;
+  const models = (ai?.imageModels || [])
+    .filter((model) => model.editing)
+    .map((model) => ({
+      id: model.id,
+      label: model.label,
+      description: model.description,
+    }));
+  const defaultIndex = models.findIndex((m) => m.id === ai?.defaultImageModel);
+  if (defaultIndex > 0) {
+    const [defaultModel] = models.splice(defaultIndex, 1);
+    models.unshift(defaultModel);
+  }
+  return models;
+}
+
+/**
+ * Returns whether AI image editing is available, i.e. the project configures
+ * at least one `imageModels` entry that accepts a source image.
+ */
+export function testAiImageEditingEnabled(): boolean {
+  return getAiImageEditingModels().length > 0;
+}


### PR DESCRIPTION
Adds AI-powered image editing capabilities to the CMS, allowing users to iteratively edit images using natural language prompts.

## Summary

This change introduces a new `AiImageEditorDialog` component that lets users edit existing images through AI models that support image-to-image editing (e.g., OpenAI's DALL-E 2, Google's Gemini image models). Users can chain multiple edits together, branching from earlier versions before saving.

Fixes #1339 

## Key Changes

- **New `AiImageEditorDialog` component** (`ui/components/DocEditor/fields/AiImageEditorDialog.tsx`): Modal dialog for iterative image editing with version history. Users can:
  - Generate edits from natural language prompts
  - View and select from previous versions to branch edits
  - Save the final result back to the document
  - Includes comprehensive unit tests

- **Backend image editing support** (`core/ai.ts`):
  - New `editImage()` function that accepts a source image URL and prompt
  - Validates source images against SSRF attacks
  - Converts images to data URLs before sending to providers
  - Supports model selection and aspect ratio control

- **API endpoint** (`core/api.ts`):
  - New `POST /cms/api/ai.edit_image` endpoint with request validation and SSRF protection

- **Model capability detection** (`shared/ai/models.ts`):
  - New `testSupportsImageEditing()` function to identify which image models support image-to-image editing
  - OpenAI: `gpt-image-*` and `dall-e-2` (not `dall-e-3`)
  - Google: Gemini image models only (not Imagen)

- **UI integration** (`ui/components/DocEditor/fields/FileField.tsx`):
  - Integrated `AiImageEditorDialog` into the file field
  - Added `requestAiImageEditorOpen()` context method
  - Wired up save callback to upload edited images

- **Configuration serialization** (`core/ai.ts`):
  - Extended `serializeAiConfig()` to include image models with their editing capabilities
  - Exposes `defaultImageModel` and `imageModels` array to the browser

- **UI utilities** (`ui/utils/ai.ts`):
  - New `getAiImageEditingModels()` function to retrieve available editing models
  - New `testAiImageEditingEnabled()` function to check feature availability

## Implementation Details

- Version history is maintained client-side; each generation appends to the history, allowing users to iterate on results or branch from earlier versions
- Source images are fetched server-side and converted to base64 data URLs before being sent to AI providers, ensuring consistent handling across different provider APIs
- SSRF validation prevents attackers from using the image editing endpoint to probe private networks
- The edited filename is derived from the original with an `-edited` suffix and the provider's returned image format extension

https://claude.ai/code/session_01VTA4NMqSKdYpCX7NJbSSka