### PR TITLE
feat: add `grid` data format for csv-style data source sync

### DIFF
--- a/.changeset/tall-crabs-tickle.md
+++ b/.changeset/tall-crabs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add `grid` data format for csv-style data source sync

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -10,7 +10,6 @@ import {
 } from 'firebase-admin/firestore';
 import {
   GsheetDataFormat,
-  isGridDataFormat,
   marshalDataSourceData,
   unmarshalDataSourceData,
 } from '../shared/data-source.js';
@@ -146,8 +145,7 @@ export interface DataSource {
   /**
    * Currently only used by gsheet. `map` returns the sheet as an array of
    * objects keyed by the header row, `grid` returns the sheet as an array of
-   * arrays of strings (including the header row). `array` is a deprecated
-   * alias for `grid`.
+   * arrays of strings (including the header row).
    */
   dataFormat?: GsheetDataFormat;
   /**
@@ -1920,7 +1918,7 @@ export class RootCMSClient {
     const headers = values[0];
     const rows = values.slice(1);
 
-    if (isGridDataFormat(dataSource.dataFormat)) {
+    if (dataSource.dataFormat === 'grid') {
       // Grid data includes the header row so that the data mirrors the sheet.
       return {data: [headers, ...rows], headers};
     }

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -8,6 +8,12 @@ import {
   Timestamp,
   WriteBatch,
 } from 'firebase-admin/firestore';
+import {
+  GsheetDataFormat,
+  isGridDataFormat,
+  marshalDataSourceData,
+  unmarshalDataSourceData,
+} from '../shared/data-source.js';
 import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {isCronDue} from './cron-schedule.js';
@@ -127,16 +133,23 @@ export interface DataSourceCron {
   autoPublish?: boolean;
 }
 
+export type {
+  DataSourceGridRow,
+  GsheetDataFormat,
+} from '../shared/data-source.js';
+
 export interface DataSource {
   id: string;
   description?: string;
   type: 'http' | 'gsheet';
   url: string;
   /**
-   * Currently only used by gsheet. `array` returns the sheet as an array of
-   * arrays, `map` returns the sheet as an array of objects.
+   * Currently only used by gsheet. `map` returns the sheet as an array of
+   * objects keyed by the header row, `grid` returns the sheet as an array of
+   * arrays of strings (including the header row). `array` is a deprecated
+   * alias for `grid`.
    */
-  dataFormat?: 'array' | 'map';
+  dataFormat?: GsheetDataFormat;
   /**
    * Options for HTTP requests.
    */
@@ -1634,7 +1647,7 @@ export class RootCMSClient {
     const batch = this.db.batch();
     batch.set(dataDocRef, {
       dataSource: updatedDataSource,
-      data: result.data,
+      data: marshalDataSourceData(dataSource.dataFormat, result.data),
       ...(result.headers ? {headers: result.headers} : {}),
     });
     batch.update(dataSourceDocRef, {
@@ -1662,12 +1675,12 @@ export class RootCMSClient {
     const dataSourceDocRef = this.db.doc(
       `Projects/${this.projectId}/DataSources/${dataSourceId}`
     );
-    const dataDocRefDraft = this.db.doc(
-      `Projects/${this.projectId}/DataSources/${dataSourceId}/draft`
-    );
-    const dataDocRefPublished = this.db.doc(
-      `Projects/${this.projectId}/DataSources/${dataSourceId}/published`
-    );
+    const dataDocRefDraft = this.dbDataSourceDataRef(dataSourceId, {
+      mode: 'draft',
+    });
+    const dataDocRefPublished = this.dbDataSourceDataRef(dataSourceId, {
+      mode: 'published',
+    });
 
     const dataRes = await this.getFromDataSource(dataSourceId, {mode: 'draft'});
 
@@ -1682,7 +1695,7 @@ export class RootCMSClient {
     const batch = this.db.batch();
     batch.set(dataDocRefPublished, {
       dataSource: updatedDataSource,
-      data: dataRes?.data || null,
+      data: marshalDataSourceData(dataSource.dataFormat, dataRes?.data ?? null),
       ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
     });
     batch.update(dataDocRefDraft, {
@@ -1755,12 +1768,10 @@ export class RootCMSClient {
       const dataSourceDocRef = this.db.doc(
         `Projects/${this.projectId}/DataSources/${id}`
       );
-      const dataDocRefDraft = this.db.doc(
-        `Projects/${this.projectId}/DataSources/${id}/draft`
-      );
-      const dataDocRefPublished = this.db.doc(
-        `Projects/${this.projectId}/DataSources/${id}/published`
-      );
+      const dataDocRefDraft = this.dbDataSourceDataRef(id, {mode: 'draft'});
+      const dataDocRefPublished = this.dbDataSourceDataRef(id, {
+        mode: 'published',
+      });
       const dataRes = await this.getFromDataSource(id, {mode: 'draft'});
       const updatedDataSource = {
         ...dataSource,
@@ -1769,7 +1780,10 @@ export class RootCMSClient {
       };
       batch.set(dataDocRefPublished, {
         dataSource: updatedDataSource,
-        data: dataRes?.data || null,
+        data: marshalDataSourceData(
+          dataSource.dataFormat,
+          dataRes?.data ?? null
+        ),
         ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
       });
       batch.update(dataDocRefDraft, {dataSource: updatedDataSource});
@@ -1906,8 +1920,8 @@ export class RootCMSClient {
     const headers = values[0];
     const rows = values.slice(1);
 
-    const dataFormat = dataSource.dataFormat || 'map';
-    if (dataFormat === 'array') {
+    if (isGridDataFormat(dataSource.dataFormat)) {
+      // Grid data includes the header row so that the data mirrors the sheet.
       return {data: [headers, ...rows], headers};
     }
 
@@ -1951,7 +1965,15 @@ export class RootCMSClient {
             (archivedBy ? ` (archived by ${archivedBy})` : '')
         );
       }
-      return dataSourceData;
+      // `grid` data is stored as an array of `{cells}` maps since Firestore
+      // doesn't allow nested arrays.
+      return {
+        ...dataSourceData,
+        data: unmarshalDataSourceData(
+          dataSourceData.dataSource?.dataFormat,
+          dataSourceData.data
+        ),
+      };
     }
     return null;
   }

--- a/packages/root-cms/core/data-source-grid.integration.test.ts
+++ b/packages/root-cms/core/data-source-grid.integration.test.ts
@@ -158,25 +158,6 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
       expect(res!.data).toEqual(GRID);
     });
 
-    it('stores the deprecated "array" format as a grid', async () => {
-      const id = 'array-sync';
-      const client = createTestClient(db, projectId);
-      await seedDataSource(db, client, projectId, id, 'array', {
-        data: GRID,
-        headers: GRID[0],
-      });
-
-      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
-
-      const stored = await db
-        .doc(`Projects/${projectId}/DataSources/${id}/Data/draft`)
-        .get();
-      expect(stored.data()!.data).toEqual(STORED_GRID);
-
-      const res = await client.getFromDataSource(id, {mode: 'draft'});
-      expect(res!.data).toEqual(GRID);
-    });
-
     it('leaves map data unchanged', async () => {
       const id = 'map-sync';
       const client = createTestClient(db, projectId);

--- a/packages/root-cms/core/data-source-grid.integration.test.ts
+++ b/packages/root-cms/core/data-source-grid.integration.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+/**
+ * Integration test for csv-style data sources that use the `grid` data format.
+ *
+ * Firestore doesn't allow an array to be nested directly within another array,
+ * so grid data (a `string[][]`) is stored as an array of `{cells: string[]}`
+ * maps. These tests run the real `RootCMSClient` sync/publish flow against the
+ * firestore emulator to verify grid data can be written, read back as a 2d
+ * array, and published.
+ *
+ * Requires the firestore emulator (run via `firebase emulators:exec`).
+ */
+
+import {App, deleteApp, initializeApp} from 'firebase-admin/app';
+import {Firestore, Timestamp, getFirestore} from 'firebase-admin/firestore';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import {DataSource, RootCMSClient} from './client.js';
+
+const GRID = [
+  ['name', 'meal'],
+  ['grogu', 'frog'],
+  ['mando', 'soup'],
+];
+
+const STORED_GRID = [
+  {cells: ['name', 'meal']},
+  {cells: ['grogu', 'frog']},
+  {cells: ['mando', 'soup']},
+];
+
+/**
+ * Creates a `RootCMSClient` bound to the emulator db without requiring a full
+ * root config / CMS plugin setup. The data source methods under test only use
+ * `db`, `projectId` and the cms plugin config.
+ */
+function createTestClient(db: Firestore, projectId: string): RootCMSClient {
+  const client = Object.create(RootCMSClient.prototype);
+  Object.assign(client, {
+    projectId,
+    db,
+    cmsPlugin: {getConfig: () => ({})},
+  });
+  return client as RootCMSClient;
+}
+
+/**
+ * Seeds a data source doc and stubs the network fetch so that `syncDataSource()`
+ * returns `data` without hitting the Google Sheets API.
+ */
+async function seedDataSource(
+  db: Firestore,
+  client: RootCMSClient,
+  projectId: string,
+  id: string,
+  dataFormat: DataSource['dataFormat'],
+  fetched: {data: any; headers?: string[]}
+) {
+  await db.doc(`Projects/${projectId}/DataSources/${id}`).set({
+    id: id,
+    type: 'gsheet',
+    url: 'https://docs.google.com/spreadsheets/d/abc123/edit#gid=0',
+    dataFormat: dataFormat,
+    createdAt: Timestamp.now(),
+    createdBy: 'seed@example.com',
+  });
+  (client as any).fetchData = async () => fetched;
+}
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
+  'data source grid format',
+  () => {
+    const projectId = 'datasource-grid-test';
+    let app: App;
+    let db: Firestore;
+
+    beforeAll(() => {
+      app = initializeApp(
+        {projectId: 'demo-datasource-grid'},
+        'datasource-grid'
+      );
+      db = getFirestore(app);
+    });
+
+    afterAll(async () => {
+      await deleteApp(app);
+    });
+
+    it('firestore rejects arrays nested within arrays', async () => {
+      const docRef = db.doc(
+        `Projects/${projectId}/DataSources/nested/Data/draft`
+      );
+      let err: unknown = null;
+      try {
+        await docRef.set({data: GRID});
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('syncs grid data and reads it back as a 2d array', async () => {
+      const id = 'grid-sync';
+      const client = createTestClient(db, projectId);
+      await seedDataSource(db, client, projectId, id, 'grid', {
+        data: GRID,
+        headers: GRID[0],
+      });
+
+      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
+
+      // The stored doc must not contain arrays nested within arrays.
+      const stored = await db
+        .doc(`Projects/${projectId}/DataSources/${id}/Data/draft`)
+        .get();
+      expect(stored.data()!.data).toEqual(STORED_GRID);
+
+      // Reads convert the stored data back into a 2d array of strings.
+      const res = await client.getFromDataSource(id, {mode: 'draft'});
+      expect(res!.data).toEqual(GRID);
+      expect(res!.headers).toEqual(['name', 'meal']);
+    });
+
+    it('publishes grid data', async () => {
+      const id = 'grid-publish';
+      const client = createTestClient(db, projectId);
+      await seedDataSource(db, client, projectId, id, 'grid', {
+        data: GRID,
+        headers: GRID[0],
+      });
+
+      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
+      await client.publishDataSource(id, {publishedBy: 'tester@example.com'});
+
+      const stored = await db
+        .doc(`Projects/${projectId}/DataSources/${id}/Data/published`)
+        .get();
+      expect(stored.data()!.data).toEqual(STORED_GRID);
+
+      const res = await client.getFromDataSource(id, {mode: 'published'});
+      expect(res!.data).toEqual(GRID);
+      expect(res!.headers).toEqual(['name', 'meal']);
+    });
+
+    it('publishes grid data as part of a release', async () => {
+      const id = 'grid-release';
+      const client = createTestClient(db, projectId);
+      await seedDataSource(db, client, projectId, id, 'grid', {
+        data: GRID,
+        headers: GRID[0],
+      });
+
+      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
+      await client.publishDataSources([id], {
+        publishedBy: 'tester@example.com',
+      });
+
+      const res = await client.getFromDataSource(id, {mode: 'published'});
+      expect(res!.data).toEqual(GRID);
+    });
+
+    it('stores the deprecated "array" format as a grid', async () => {
+      const id = 'array-sync';
+      const client = createTestClient(db, projectId);
+      await seedDataSource(db, client, projectId, id, 'array', {
+        data: GRID,
+        headers: GRID[0],
+      });
+
+      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
+
+      const stored = await db
+        .doc(`Projects/${projectId}/DataSources/${id}/Data/draft`)
+        .get();
+      expect(stored.data()!.data).toEqual(STORED_GRID);
+
+      const res = await client.getFromDataSource(id, {mode: 'draft'});
+      expect(res!.data).toEqual(GRID);
+    });
+
+    it('leaves map data unchanged', async () => {
+      const id = 'map-sync';
+      const client = createTestClient(db, projectId);
+      const mapData = [
+        {name: 'grogu', meal: 'frog'},
+        {name: 'mando', meal: 'soup'},
+      ];
+      await seedDataSource(db, client, projectId, id, 'map', {
+        data: mapData,
+        headers: ['name', 'meal'],
+      });
+
+      await client.syncDataSource(id, {syncedBy: 'tester@example.com'});
+
+      const stored = await db
+        .doc(`Projects/${projectId}/DataSources/${id}/Data/draft`)
+        .get();
+      expect(stored.data()!.data).toEqual(mapData);
+
+      const res = await client.getFromDataSource(id, {mode: 'draft'});
+      expect(res!.data).toEqual(mapData);
+    });
+  }
+);

--- a/packages/root-cms/shared/data-source.test.ts
+++ b/packages/root-cms/shared/data-source.test.ts
@@ -1,36 +1,10 @@
 import {describe, it, expect} from 'vitest';
 import {
-  isGridDataFormat,
   marshalDataSourceData,
   marshalGridData,
-  normalizeDataFormat,
   unmarshalDataSourceData,
   unmarshalGridData,
 } from './data-source.js';
-
-describe('isGridDataFormat', () => {
-  it('returns true for grid formats', () => {
-    expect(isGridDataFormat('grid')).toBe(true);
-    expect(isGridDataFormat('array')).toBe(true);
-  });
-
-  it('returns false for other formats', () => {
-    expect(isGridDataFormat('map')).toBe(false);
-    expect(isGridDataFormat(undefined)).toBe(false);
-  });
-});
-
-describe('normalizeDataFormat', () => {
-  it('converts the deprecated array alias to grid', () => {
-    expect(normalizeDataFormat('array')).toBe('grid');
-    expect(normalizeDataFormat('grid')).toBe('grid');
-  });
-
-  it('defaults to map', () => {
-    expect(normalizeDataFormat('map')).toBe('map');
-    expect(normalizeDataFormat(undefined)).toBe('map');
-  });
-});
 
 describe('marshalGridData', () => {
   it('converts a 2d array into firestore-safe maps', () => {
@@ -121,14 +95,15 @@ describe('unmarshalGridData', () => {
 });
 
 describe('marshalDataSourceData', () => {
-  it('marshals grid formats', () => {
+  it('marshals the grid format', () => {
     const grid = [
       ['header1', 'header2'],
       ['foo', 'bar'],
     ];
-    const stored = [{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}];
-    expect(marshalDataSourceData('grid', grid)).toEqual(stored);
-    expect(marshalDataSourceData('array', grid)).toEqual(stored);
+    expect(marshalDataSourceData('grid', grid)).toEqual([
+      {cells: ['header1', 'header2']},
+      {cells: ['foo', 'bar']},
+    ]);
   });
 
   it('returns other formats as-is', () => {
@@ -144,14 +119,12 @@ describe('marshalDataSourceData', () => {
 });
 
 describe('unmarshalDataSourceData', () => {
-  it('unmarshals grid formats', () => {
+  it('unmarshals the grid format', () => {
     const stored = [{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}];
-    const grid = [
+    expect(unmarshalDataSourceData('grid', stored)).toEqual([
       ['header1', 'header2'],
       ['foo', 'bar'],
-    ];
-    expect(unmarshalDataSourceData('grid', stored)).toEqual(grid);
-    expect(unmarshalDataSourceData('array', stored)).toEqual(grid);
+    ]);
   });
 
   it('returns other formats as-is', () => {

--- a/packages/root-cms/shared/data-source.test.ts
+++ b/packages/root-cms/shared/data-source.test.ts
@@ -1,0 +1,167 @@
+import {describe, it, expect} from 'vitest';
+import {
+  isGridDataFormat,
+  marshalDataSourceData,
+  marshalGridData,
+  normalizeDataFormat,
+  unmarshalDataSourceData,
+  unmarshalGridData,
+} from './data-source.js';
+
+describe('isGridDataFormat', () => {
+  it('returns true for grid formats', () => {
+    expect(isGridDataFormat('grid')).toBe(true);
+    expect(isGridDataFormat('array')).toBe(true);
+  });
+
+  it('returns false for other formats', () => {
+    expect(isGridDataFormat('map')).toBe(false);
+    expect(isGridDataFormat(undefined)).toBe(false);
+  });
+});
+
+describe('normalizeDataFormat', () => {
+  it('converts the deprecated array alias to grid', () => {
+    expect(normalizeDataFormat('array')).toBe('grid');
+    expect(normalizeDataFormat('grid')).toBe('grid');
+  });
+
+  it('defaults to map', () => {
+    expect(normalizeDataFormat('map')).toBe('map');
+    expect(normalizeDataFormat(undefined)).toBe('map');
+  });
+});
+
+describe('marshalGridData', () => {
+  it('converts a 2d array into firestore-safe maps', () => {
+    expect(
+      marshalGridData([
+        ['header1', 'header2'],
+        ['foo', 'bar'],
+      ])
+    ).toEqual([{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}]);
+  });
+
+  it('never nests an array directly within an array', () => {
+    const stored = marshalGridData([['foo'], ['bar']]);
+    expect(Array.isArray(stored)).toBe(true);
+    for (const row of stored) {
+      expect(Array.isArray(row)).toBe(false);
+      expect(Array.isArray(row.cells)).toBe(true);
+      for (const cell of row.cells) {
+        expect(typeof cell).toBe('string');
+      }
+    }
+  });
+
+  it('pads rows to the width of the widest row', () => {
+    expect(
+      marshalGridData([['header1', 'header2', 'header3'], ['foo', 'bar'], []])
+    ).toEqual([
+      {cells: ['header1', 'header2', 'header3']},
+      {cells: ['foo', 'bar', '']},
+      {cells: ['', '', '']},
+    ]);
+  });
+
+  it('coerces cell values to strings', () => {
+    expect(marshalGridData([[1, true, null, undefined, 'foo']])).toEqual([
+      {cells: ['1', 'true', '', '', 'foo']},
+    ]);
+  });
+
+  it('passes through rows that are already marshaled', () => {
+    const stored = marshalGridData([
+      ['header1', 'header2'],
+      ['foo', 'bar'],
+    ]);
+    expect(marshalGridData(stored)).toEqual(stored);
+  });
+
+  it('handles empty data', () => {
+    expect(marshalGridData([])).toEqual([]);
+  });
+});
+
+describe('unmarshalGridData', () => {
+  it('converts stored maps back into a 2d array', () => {
+    expect(
+      unmarshalGridData([
+        {cells: ['header1', 'header2']},
+        {cells: ['foo', 'bar']},
+      ])
+    ).toEqual([
+      ['header1', 'header2'],
+      ['foo', 'bar'],
+    ]);
+  });
+
+  it('returns an empty array for empty or non-array data', () => {
+    expect(unmarshalGridData([])).toEqual([]);
+    expect(unmarshalGridData(null)).toEqual([]);
+    expect(unmarshalGridData('foo')).toEqual([]);
+  });
+
+  it('returns an empty row for malformed rows', () => {
+    expect(unmarshalGridData([null, {}, {cells: ['foo']}])).toEqual([
+      [],
+      [],
+      ['foo'],
+    ]);
+  });
+
+  it('round-trips grid data through firestore storage', () => {
+    const grid = [
+      ['name', 'meal'],
+      ['grogu', 'frog'],
+      ['mando', 'soup'],
+    ];
+    expect(unmarshalGridData(marshalGridData(grid))).toEqual(grid);
+  });
+});
+
+describe('marshalDataSourceData', () => {
+  it('marshals grid formats', () => {
+    const grid = [
+      ['header1', 'header2'],
+      ['foo', 'bar'],
+    ];
+    const stored = [{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}];
+    expect(marshalDataSourceData('grid', grid)).toEqual(stored);
+    expect(marshalDataSourceData('array', grid)).toEqual(stored);
+  });
+
+  it('returns other formats as-is', () => {
+    const mapData = [{header1: 'foo', header2: 'bar'}];
+    expect(marshalDataSourceData('map', mapData)).toBe(mapData);
+    expect(marshalDataSourceData(undefined, mapData)).toBe(mapData);
+  });
+
+  it('returns non-array values as-is', () => {
+    expect(marshalDataSourceData('grid', null)).toBe(null);
+    expect(marshalDataSourceData('grid', 'foo')).toBe('foo');
+  });
+});
+
+describe('unmarshalDataSourceData', () => {
+  it('unmarshals grid formats', () => {
+    const stored = [{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}];
+    const grid = [
+      ['header1', 'header2'],
+      ['foo', 'bar'],
+    ];
+    expect(unmarshalDataSourceData('grid', stored)).toEqual(grid);
+    expect(unmarshalDataSourceData('array', stored)).toEqual(grid);
+  });
+
+  it('returns other formats as-is', () => {
+    const mapData = [{header1: 'foo', header2: 'bar'}];
+    expect(unmarshalDataSourceData('map', mapData)).toBe(mapData);
+    expect(unmarshalDataSourceData(undefined, mapData)).toBe(mapData);
+  });
+
+  it('returns non-array values as-is', () => {
+    expect(unmarshalDataSourceData('grid', null)).toBe(null);
+    expect(unmarshalDataSourceData('grid', 'foo')).toBe('foo');
+  });
+});

--- a/packages/root-cms/shared/data-source.ts
+++ b/packages/root-cms/shared/data-source.ts
@@ -16,9 +16,8 @@
  *   `[{header1: 'foo', header2: 'bar'}]`.
  * - `grid`: an array of arrays of strings, including the header row, e.g.
  *   `[['header1', 'header2'], ['foo', 'bar']]`.
- * - `array`: deprecated alias for `grid`.
  */
-export type GsheetDataFormat = 'map' | 'grid' | 'array';
+export type GsheetDataFormat = 'map' | 'grid';
 
 /**
  * A single row of `grid` data as stored in Firestore. Rows are wrapped in a map
@@ -26,24 +25,6 @@ export type GsheetDataFormat = 'map' | 'grid' | 'array';
  */
 export interface DataSourceGridRow {
   cells: string[];
-}
-
-/**
- * Returns true if the data format stores data as an array of arrays of strings.
- */
-export function isGridDataFormat(dataFormat?: string): boolean {
-  return dataFormat === 'grid' || dataFormat === 'array';
-}
-
-/**
- * Normalizes a data format, converting the deprecated `array` alias to `grid`
- * and defaulting to `map`.
- */
-export function normalizeDataFormat(dataFormat?: string): GsheetDataFormat {
-  if (isGridDataFormat(dataFormat)) {
-    return 'grid';
-  }
-  return 'map';
 }
 
 /**
@@ -95,7 +76,7 @@ export function marshalDataSourceData(
   dataFormat: string | undefined,
   data: any
 ) {
-  if (!isGridDataFormat(dataFormat) || !Array.isArray(data)) {
+  if (dataFormat !== 'grid' || !Array.isArray(data)) {
     return data;
   }
   return marshalGridData(data);
@@ -109,7 +90,7 @@ export function unmarshalDataSourceData(
   dataFormat: string | undefined,
   data: any
 ) {
-  if (!isGridDataFormat(dataFormat) || !Array.isArray(data)) {
+  if (dataFormat !== 'grid' || !Array.isArray(data)) {
     return data;
   }
   return unmarshalGridData(data);

--- a/packages/root-cms/shared/data-source.ts
+++ b/packages/root-cms/shared/data-source.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared helpers for csv-style data source formats (e.g. a Google Sheet).
+ * These are pure functions with no Firebase dependency so they can run on both
+ * the client and the server.
+ *
+ * Firestore doesn't allow an array to be nested directly within another array,
+ * so `grid` data is stored as an array of `{cells: string[]}` maps. Data is
+ * marshaled on write and unmarshaled on read so that callers always work with
+ * a plain `string[][]`.
+ */
+
+/**
+ * Format used to store data synced from a csv-style data source.
+ *
+ * - `map`: an array of objects keyed by the sheet's header row, e.g.
+ *   `[{header1: 'foo', header2: 'bar'}]`.
+ * - `grid`: an array of arrays of strings, including the header row, e.g.
+ *   `[['header1', 'header2'], ['foo', 'bar']]`.
+ * - `array`: deprecated alias for `grid`.
+ */
+export type GsheetDataFormat = 'map' | 'grid' | 'array';
+
+/**
+ * A single row of `grid` data as stored in Firestore. Rows are wrapped in a map
+ * because Firestore doesn't support arrays nested directly within arrays.
+ */
+export interface DataSourceGridRow {
+  cells: string[];
+}
+
+/**
+ * Returns true if the data format stores data as an array of arrays of strings.
+ */
+export function isGridDataFormat(dataFormat?: string): boolean {
+  return dataFormat === 'grid' || dataFormat === 'array';
+}
+
+/**
+ * Normalizes a data format, converting the deprecated `array` alias to `grid`
+ * and defaulting to `map`.
+ */
+export function normalizeDataFormat(dataFormat?: string): GsheetDataFormat {
+  if (isGridDataFormat(dataFormat)) {
+    return 'grid';
+  }
+  return 'map';
+}
+
+/**
+ * Converts an array of arrays of strings into the Firestore-safe representation
+ * used to store `grid` data. Cell values are coerced to strings and rows are
+ * padded so that every row has the same number of cells, e.g.:
+ *
+ * ```
+ * marshalGridData([['header1', 'header2'], ['foo']]);
+ * // => [{cells: ['header1', 'header2']}, {cells: ['foo', '']}]
+ * ```
+ *
+ * Rows that are already in the stored `{cells}` format are passed through,
+ * which makes the function safe to call on data that's being copied from one
+ * doc to another (e.g. when publishing).
+ */
+export function marshalGridData(rows: any[]): DataSourceGridRow[] {
+  const grid = rows.map((row) => toCells(row));
+  const width = grid.reduce((max, cells) => Math.max(max, cells.length), 0);
+  return grid.map((cells) => {
+    while (cells.length < width) {
+      cells.push('');
+    }
+    return {cells};
+  });
+}
+
+/**
+ * Converts `grid` data stored in Firestore back into an array of arrays of
+ * strings, e.g.:
+ *
+ * ```
+ * unmarshalGridData([{cells: ['header1', 'header2']}, {cells: ['foo', 'bar']}]);
+ * // => [['header1', 'header2'], ['foo', 'bar']]
+ * ```
+ */
+export function unmarshalGridData(data: any): string[][] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  return data.map((row) => toCells(row));
+}
+
+/**
+ * Converts data into the format stored in Firestore for a given data format.
+ * Non-grid formats are returned as-is.
+ */
+export function marshalDataSourceData(
+  dataFormat: string | undefined,
+  data: any
+) {
+  if (!isGridDataFormat(dataFormat) || !Array.isArray(data)) {
+    return data;
+  }
+  return marshalGridData(data);
+}
+
+/**
+ * Converts data read from Firestore into the format callers expect for a given
+ * data format. Non-grid formats are returned as-is.
+ */
+export function unmarshalDataSourceData(
+  dataFormat: string | undefined,
+  data: any
+) {
+  if (!isGridDataFormat(dataFormat) || !Array.isArray(data)) {
+    return data;
+  }
+  return unmarshalGridData(data);
+}
+
+/** Returns true if the value looks like a stored grid row, e.g. `{cells: []}`. */
+function isGridRow(value: any): value is DataSourceGridRow {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Array.isArray(value.cells)
+  );
+}
+
+/** Converts a row in either representation into an array of cell values. */
+function toCells(row: any): string[] {
+  if (isGridRow(row)) {
+    return row.cells.map(toCellValue);
+  }
+  if (Array.isArray(row)) {
+    return row.map(toCellValue);
+  }
+  return [];
+}
+
+/** Coerces a cell value to a string. */
+function toCellValue(value: any): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}

--- a/packages/root-cms/ui/components/DataSourceForm/DataSourceForm.tsx
+++ b/packages/root-cms/ui/components/DataSourceForm/DataSourceForm.tsx
@@ -11,6 +11,10 @@ import {showNotification} from '@mantine/notifications';
 import {useEffect, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {isValidCronExpression} from '../../../core/cron-schedule.js';
+import {
+  isGridDataFormat,
+  normalizeDataFormat,
+} from '../../../shared/data-source.js';
 import {isSlugValid} from '../../../shared/slug.js';
 import {useGapiClient} from '../../hooks/useGapiClient.js';
 import {
@@ -75,7 +79,8 @@ export function DataSourceForm(props: DataSourceFormProps) {
       const dataSource = await getDataSource(id);
       setDataSource(dataSource);
       setDataSourceType(dataSource?.type || 'http');
-      setDataFormat(dataSource?.dataFormat || 'map');
+      // Normalize the deprecated `array` format to `grid`.
+      setDataFormat(normalizeDataFormat(dataSource?.dataFormat));
       if (dataSource?.cron) {
         const cron = dataSource.cron;
         const schedule = cron.schedule || 'interval';
@@ -179,7 +184,7 @@ export function DataSourceForm(props: DataSourceFormProps) {
         return;
       }
 
-      dataSource.dataFormat = (dataFormat || 'map') as any;
+      dataSource.dataFormat = dataFormat || 'map';
     }
 
     const cron: DataSourceCron = {
@@ -347,9 +352,8 @@ export function DataSourceForm(props: DataSourceFormProps) {
             name="dataFormat"
             label="Data Format"
             data={[
-              // NOTE(stevenle): firestore doesn't support nested arrays.
-              // {value: 'array', label: 'array'},
               {value: 'map', label: 'map'},
+              {value: 'grid', label: 'grid'},
             ]}
             value={dataFormat}
             onChange={(e: GsheetDataFormat) => setDataFormat(e)}
@@ -358,13 +362,14 @@ export function DataSourceForm(props: DataSourceFormProps) {
             // Due to issues with preact/compat, use a div for the dropdown el.
             dropdownComponent="div"
           />
-          {dataFormat === 'array' && (
+          {isGridDataFormat(dataFormat) && (
             <div className="DataSourceForm__input__example">
-              Data is stored as an array of arrays, e.g.
+              Data is stored as an array of arrays, including the header row,
+              e.g.
               <code>[[header1, header2], [foo, bar]]</code>
             </div>
           )}
-          {dataFormat === 'map' && (
+          {!isGridDataFormat(dataFormat) && (
             <div className="DataSourceForm__input__example">
               Data is stored as an array of maps, e.g.
               <code>

--- a/packages/root-cms/ui/components/DataSourceForm/DataSourceForm.tsx
+++ b/packages/root-cms/ui/components/DataSourceForm/DataSourceForm.tsx
@@ -11,10 +11,6 @@ import {showNotification} from '@mantine/notifications';
 import {useEffect, useRef, useState} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {isValidCronExpression} from '../../../core/cron-schedule.js';
-import {
-  isGridDataFormat,
-  normalizeDataFormat,
-} from '../../../shared/data-source.js';
 import {isSlugValid} from '../../../shared/slug.js';
 import {useGapiClient} from '../../hooks/useGapiClient.js';
 import {
@@ -79,8 +75,7 @@ export function DataSourceForm(props: DataSourceFormProps) {
       const dataSource = await getDataSource(id);
       setDataSource(dataSource);
       setDataSourceType(dataSource?.type || 'http');
-      // Normalize the deprecated `array` format to `grid`.
-      setDataFormat(normalizeDataFormat(dataSource?.dataFormat));
+      setDataFormat(dataSource?.dataFormat || 'map');
       if (dataSource?.cron) {
         const cron = dataSource.cron;
         const schedule = cron.schedule || 'interval';
@@ -362,14 +357,14 @@ export function DataSourceForm(props: DataSourceFormProps) {
             // Due to issues with preact/compat, use a div for the dropdown el.
             dropdownComponent="div"
           />
-          {isGridDataFormat(dataFormat) && (
+          {dataFormat === 'grid' && (
             <div className="DataSourceForm__input__example">
               Data is stored as an array of arrays, including the header row,
               e.g.
               <code>[[header1, header2], [foo, bar]]</code>
             </div>
           )}
-          {!isGridDataFormat(dataFormat) && (
+          {dataFormat === 'map' && (
             <div className="DataSourceForm__input__example">
               Data is stored as an array of maps, e.g.
               <code>

--- a/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
@@ -11,7 +11,6 @@ import {
 import {IconSettings, IconTable} from '@tabler/icons-preact';
 import {ComponentChildren} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
-import {isGridDataFormat} from '../../../shared/data-source.js';
 import {DataSourceStatusButton} from '../../components/DataSourceStatusButton/DataSourceStatusButton.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Surface} from '../../components/Surface/Surface.js';
@@ -165,7 +164,7 @@ DataSourcePage.DataSection = (props: {
   if (dataSource.type === 'gsheet') {
     let headers: string[] | undefined = storedHeaders;
     let rows: any[] = [];
-    if (isGridDataFormat(dataSource.dataFormat)) {
+    if (dataSource.dataFormat === 'grid') {
       // The first row of a grid contains the column headers.
       const grid = (data as string[][]) || [];
       headers = storedHeaders || grid[0] || [];

--- a/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
+++ b/packages/root-cms/ui/pages/DataSourcePage/DataSourcePage.tsx
@@ -11,6 +11,7 @@ import {
 import {IconSettings, IconTable} from '@tabler/icons-preact';
 import {ComponentChildren} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
+import {isGridDataFormat} from '../../../shared/data-source.js';
 import {DataSourceStatusButton} from '../../components/DataSourceStatusButton/DataSourceStatusButton.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Surface} from '../../components/Surface/Surface.js';
@@ -161,13 +162,15 @@ DataSourcePage.DataSection = (props: {
     return null;
   }
 
-  const dataFormat = dataSource.dataFormat || 'map';
   if (dataSource.type === 'gsheet') {
     let headers: string[] | undefined = storedHeaders;
     let rows: any[] = [];
-    if (dataFormat === 'array') {
-      rows = data as string[][];
-    } else if (dataFormat === 'map') {
+    if (isGridDataFormat(dataSource.dataFormat)) {
+      // The first row of a grid contains the column headers.
+      const grid = (data as string[][]) || [];
+      headers = storedHeaders || grid[0] || [];
+      rows = grid.slice(1);
+    } else {
       const items = data as any[];
       if (!headers) {
         // Reformat Array<Record<string, string>> to string[][]. Preserve key order

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -11,6 +11,12 @@ import {
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
+import {
+  GsheetDataFormat,
+  isGridDataFormat,
+  marshalDataSourceData,
+  unmarshalDataSourceData,
+} from '../../shared/data-source.js';
 import {logAction} from './actions.js';
 import {MultiBatch} from './batch.js';
 import {GSpreadsheet, parseSpreadsheetUrl} from './gsheets.js';
@@ -19,7 +25,7 @@ export type DataSourceType = 'http' | 'gsheet';
 
 export type HttpMethod = 'GET' | 'POST';
 
-export type GsheetDataFormat = 'array' | 'map';
+export type {GsheetDataFormat};
 
 export type CronUnit = 'minutes' | 'hours' | 'days';
 
@@ -63,8 +69,10 @@ export interface DataSource {
   type: 'http' | 'gsheet';
   url: string;
   /**
-   * Currently only used by gsheet. `array` returns the sheet as an array of
-   * arrays, `map` returns the sheet as an array of objects.
+   * Currently only used by gsheet. `map` returns the sheet as an array of
+   * objects keyed by the header row, `grid` returns the sheet as an array of
+   * arrays of strings (including the header row). `array` is a deprecated
+   * alias for `grid`.
    */
   dataFormat?: GsheetDataFormat;
   /**
@@ -92,6 +100,20 @@ export interface DataSourceData<T = any> {
   data: T;
   /** Optional list of column headers (for gsheet sources). */
   headers?: string[];
+}
+
+/**
+ * Converts data from the format stored in the db. `grid` data is stored as an
+ * array of `{cells}` maps since Firestore doesn't allow nested arrays.
+ */
+function unmarshalData(dataSourceData: DataSourceData): DataSourceData {
+  return {
+    ...dataSourceData,
+    data: unmarshalDataSourceData(
+      dataSourceData.dataSource?.dataFormat,
+      dataSourceData.data
+    ),
+  };
 }
 
 export async function addDataSource(
@@ -161,7 +183,9 @@ export async function getFromDataSource<T = any>(
   );
   const snapshot = await getDoc(dataDocRef);
   if (snapshot.exists()) {
-    return snapshot.data() as DataSourceData<T>;
+    return unmarshalData(
+      snapshot.data() as DataSourceData
+    ) as DataSourceData<T>;
   }
   return null;
 }
@@ -250,7 +274,7 @@ export async function syncDataSource(id: string) {
     const batch = writeBatch(db);
     batch.set(dataDocRef, {
       dataSource: updatedDataSource,
-      data: data,
+      data: marshalDataSourceData(dataSource.dataFormat, data),
       ...(headers ? {headers} : {}),
     });
     batch.update(dataSourceDocRef, {
@@ -306,7 +330,7 @@ export async function publishDataSource(id: string) {
   const batch = writeBatch(db);
   batch.set(dataDocRefPublished, {
     dataSource: updatedDataSource,
-    data: dataRes?.data || null,
+    data: marshalDataSourceData(dataSource.dataFormat, dataRes?.data ?? null),
     ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
   });
   batch.update(dataDocRefDraft, {
@@ -422,7 +446,7 @@ export async function cmsPublishDataSources(
     };
     batch.set(dataDocRefPublished, {
       dataSource: updatedDataSource,
-      data: dataRes?.data || null,
+      data: marshalDataSourceData(dataSource.dataFormat, dataRes?.data ?? null),
       ...(dataRes?.headers ? {headers: dataRes.headers} : {}),
     });
     batch.update(dataDocRefDraft, {dataSource: updatedDataSource});
@@ -496,10 +520,13 @@ async function fetchGsheetData(dataSource: DataSource): Promise<FetchedData> {
     throw new Error(`could not find sheet: ${dataSource.url}`);
   }
 
-  const dataFormat = dataSource.dataFormat || 'map';
   const [headers, rows] = await gsheet.getValues();
-  if (dataFormat === 'array') {
-    return {data: [headers, rows], headers};
+  if (headers.length === 0 && rows.length === 0) {
+    return {data: [], headers: []};
+  }
+  if (isGridDataFormat(dataSource.dataFormat)) {
+    // Grid data includes the header row so that the data mirrors the sheet.
+    return {data: [headers, ...rows], headers};
   }
   const mapData = rows.map((row) => {
     const item: Record<string, string> = {};

--- a/packages/root-cms/ui/utils/data-source.ts
+++ b/packages/root-cms/ui/utils/data-source.ts
@@ -13,7 +13,6 @@ import {
 } from 'firebase/firestore';
 import {
   GsheetDataFormat,
-  isGridDataFormat,
   marshalDataSourceData,
   unmarshalDataSourceData,
 } from '../../shared/data-source.js';
@@ -71,8 +70,7 @@ export interface DataSource {
   /**
    * Currently only used by gsheet. `map` returns the sheet as an array of
    * objects keyed by the header row, `grid` returns the sheet as an array of
-   * arrays of strings (including the header row). `array` is a deprecated
-   * alias for `grid`.
+   * arrays of strings (including the header row).
    */
   dataFormat?: GsheetDataFormat;
   /**
@@ -524,7 +522,7 @@ async function fetchGsheetData(dataSource: DataSource): Promise<FetchedData> {
   if (headers.length === 0 && rows.length === 0) {
     return {data: [], headers: []};
   }
-  if (isGridDataFormat(dataSource.dataFormat)) {
+  if (dataSource.dataFormat === 'grid') {
     // Grid data includes the header row so that the data mirrors the sheet.
     return {data: [headers, ...rows], headers};
   }


### PR DESCRIPTION
## Summary

Adds a `grid` data format for csv-style data sources (e.g. Google Sheets) that syncs a sheet as an array of arrays of strings, alongside the existing `map` format.

This shape was already half-present as `array`, but it was dead code: it was commented out of the CMS form with the note *"firestore doesn't support nested arrays"*, and both fetchers produced a `string[][]` that Firestore rejects on write. This makes it actually work by marshaling at the storage boundary, under the name `grid`.

## Storage format

Firestore doesn't allow an array nested directly within another array — but an array inside a map inside an array is fine. So grid rows get wrapped:

```
[['name', 'meal'], ['grogu', 'frog']]   ⇄   [{cells: ['name', 'meal']}, {cells: ['grogu', 'frog']}]
```

Marshal on write, unmarshal on read, so callers of `getFromDataSource()` always work with a plain `string[][]` and never see the storage shape. Both directions are idempotent, which matters because publishing reads the draft doc and writes it back.

Grid data includes the header row so the data mirrors the sheet. `headers` is still stored alongside it, and the CMS data table renders row 0 as the header.

## Changes

- **`shared/data-source.ts`** (new) — isomorphic `marshalGridData()` / `unmarshalGridData()`, plus `marshalDataSourceData()` / `unmarshalDataSourceData()` wrappers that no-op for `map`. Pads rows to uniform width and coerces cells to strings.
- **`core/client.ts`** — marshals on sync, publish, and release publish; unmarshals in `getFromDataSource()`.
- **`ui/utils/data-source.ts`** — the same four paths on the browser side. Also fixes the gsheet fetcher, which built `[headers, rows]` instead of `[headers, ...rows]`.
- **`DataSourceForm.tsx`** — re-enables the Data Format dropdown, now offering `map` and `grid`.
- **`DataSourcePage.tsx`** — renders grid data with row 0 as the table header.

### Drive-by bug fix

`publishDataSource()` and `publishDataSources()` built their draft/published doc refs as `.../DataSources/{id}/draft`, missing the `Data` segment. Those are collection paths, so `db.doc()` throws — both methods always failed, including release publishing. Switched them to the existing `dbDataSourceDataRef()` helper. Happy to split this into its own PR if you'd prefer it reviewed separately.

## Compatibility

No migration needed. Nothing can have grid data stored today, because any write that would have carried it was rejected by Firestore. `array` is removed outright rather than kept as an alias.

## Testing

- `shared/data-source.test.ts` — 16 unit tests covering both directions, row padding, cell coercion, malformed rows, and round-tripping.
- `core/data-source-grid.integration.test.ts` — 5 emulator tests covering sync, publish, release publish, and `map` passthrough. One asserts that Firestore *does* reject the raw nested array, so the encoding's reason for existing is pinned by a test rather than a comment.

Full suite passes against the Firestore emulator: 1050 tests across 85 files. Lint adds no new errors over the baseline on `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018joJ6J5PspMpQ93Mt4TE7t