### PR TITLE
feat: add admin publish notification service

### DIFF
--- a/docs/plugins/admin-publish-notifications.ts
+++ b/docs/plugins/admin-publish-notifications.ts
@@ -1,0 +1,107 @@
+import {
+  emailNotifications,
+  type CMSNotificationService,
+  type NotificationServiceContext,
+} from '@blinkk/root-cms/plugin';
+
+/** Options for {@link adminPublishNotifications}. */
+interface AdminPublishNotificationsOptions {
+  /**
+   * Sender email address. The sender must be authorized to send email via the
+   * App Engine Mail API. Defaults to
+   * `noreply@<gcp-project-id>.appspotmail.com`.
+   */
+  from?: string;
+  /**
+   * Additional recipients that always receive the notification, on top of the
+   * project's admins.
+   */
+  cc?: string[];
+}
+
+/** Template data rendered into the publish notification email. */
+interface PublishEmailData {
+  /** Doc id that was published, e.g. `Pages/index`. */
+  docId: string;
+  /** Email of the user that published the doc, or `system`. */
+  by: string;
+  /** Time the doc was published, as an ISO timestamp. */
+  publishedAt: string;
+  /** Publish message entered by the user, or `(none)` when empty. */
+  publishMessage: string;
+  /** URL to the doc in the CMS. */
+  cmsUrl: string;
+}
+
+/**
+ * Returns the email addresses of every user with the `ADMIN` role in the
+ * project's ACL. Wildcard domain entries (e.g. `*@example.com`) are ignored
+ * since they aren't deliverable addresses.
+ */
+async function getAdminEmails(
+  ctx: NotificationServiceContext
+): Promise<string[]> {
+  const cmsClient = ctx.cmsClient;
+  const docRef = cmsClient.db.doc(`Projects/${cmsClient.projectId}`);
+  const snapshot = await docRef.get();
+  const roles: Record<string, string> = snapshot.data()?.roles || {};
+  return Object.entries(roles)
+    .filter(([email, role]) => role === 'ADMIN' && !email.startsWith('*@'))
+    .map(([email]) => email);
+}
+
+/**
+ * Email notification service that notifies the project's admins whenever a doc
+ * is published.
+ *
+ * Emails are queued in the `Projects/${projectId}/Emails` collection in
+ * firestore and delivered by the Root.js email service.
+ */
+export function adminPublishNotifications(
+  options?: AdminPublishNotificationsOptions
+): CMSNotificationService {
+  return emailNotifications<PublishEmailData>({
+    id: 'admin-publish-email',
+    label: 'Publish Notifications',
+    from: options?.from,
+    // `doc.scheduled_publish` is logged by the CMS cron when a scheduled doc
+    // goes live, and shares the same metadata shape as `doc.publish`.
+    actions: ['doc.publish', 'doc.scheduled_publish'],
+    to: async (action, ctx) => {
+      const admins = await getAdminEmails(ctx);
+      return [...admins, ...(options?.cc || [])];
+    },
+    transformData: (action, ctx) => {
+      const docId = action.metadata?.docId || 'unknown';
+      const domain = ctx.rootConfig.domain || '';
+      return {
+        docId: docId,
+        by: action.by || 'system',
+        publishedAt: action.timestamp.toDate().toISOString(),
+        publishMessage: action.metadata?.publishMessage || '(none)',
+        cmsUrl: `${domain}/cms/content/${docId}`,
+      };
+    },
+    template: {
+      subject: '[Root.js CMS] {docId} was published by {by}',
+      body: [
+        '{docId} was published by {by}.',
+        '',
+        'Time: {publishedAt}',
+        'Message: {publishMessage}',
+        '',
+        'View in the CMS: {cmsUrl}',
+      ].join('\n'),
+      html: [
+        '<p><strong>{docId}</strong> was published by {by}.</p>',
+        '<p>Time: {publishedAt}<br>Message: {publishMessage}</p>',
+        '<p><a href="{cmsUrl}">View in the CMS</a></p>',
+      ].join('\n'),
+    },
+    // Notify the email service so the email is sent immediately instead of
+    // waiting for the service's cron to process the queue.
+    emailService: true,
+    // Publish notifications lose their value if they arrive hours late.
+    expireAfterMinutes: 60,
+  });
+}

--- a/docs/root.config.ts
+++ b/docs/root.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import {URL} from 'node:url';
 import {defineConfig} from '@blinkk/root';
 import {cmsPlugin} from '@blinkk/root-cms/plugin';
+import {adminPublishNotifications} from './plugins/admin-publish-notifications.js';
 import {crowdinTranslationService} from './plugins/crowdin-translations.js';
 import {deeplTranslationService} from './plugins/deepl-translations.js';
 import {exampleToolPod} from './plugins/example-tools-pod.js';
@@ -106,6 +107,7 @@ export default defineConfig({
         }),
         deeplTranslationService({apiKey: process.env.DEEPL_API_KEY}),
       ],
+      notifications: [adminPublishNotifications()],
       checks: [
         {
           id: 'custom/green-check',


### PR DESCRIPTION
Adds a new notification service that emails project admins whenever a document is published in the CMS.

## Summary

Introduces `adminPublishNotifications`, a reusable email notification plugin that automatically notifies all users with the `ADMIN` role when a doc is published (including scheduled publishes). Emails are queued in Firestore and delivered by the Root.js email service.

## Changes

- **New plugin**: `docs/plugins/admin-publish-notifications.ts`
  - Exports `adminPublishNotifications()` function that returns a configured `CMSNotificationService`
  - Listens to `doc.publish` and `doc.scheduled_publish` actions
  - Dynamically fetches admin email addresses from the project's ACL, filtering out wildcard domain entries
  - Supports optional `cc` recipients and custom `from` address
  - Includes both plain text and HTML email templates with publish metadata (doc ID, publisher, timestamp, message, CMS link)
  - Configures 60-minute expiration to ensure timely delivery

- **Updated config**: `docs/root.config.ts`
  - Imports and registers the new notification service in the CMS plugin configuration

## Implementation Details

- Admin emails are retrieved by querying the project document's `roles` field and filtering for `ADMIN` entries
- Wildcard domain entries (e.g., `*@example.com`) are excluded since they aren't deliverable addresses
- Email templates use placeholder substitution for dynamic content (docId, by, publishedAt, publishMessage, cmsUrl)
- The service immediately notifies the email service to avoid queue delays

https://claude.ai/code/session_01MTebQ65gnDnUq5qbhcUNH2