### PR TITLE
fix: pass the editor context to lexical editor state reads

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: pass the editor context to lexical editor state reads

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
@@ -333,38 +333,44 @@ function Editor(props: EditorProps) {
       // serialized `RichTextData.blocks` array, so we can map by index.
       let targetNodeKey: NodeKey | null = null;
       let targetData: Record<string, any> | null = null;
-      editor.getEditorState().read(() => {
-        const root = $getRoot();
-        let blockIdx = -1;
-        for (const child of root.getChildren()) {
-          if ($isBlockComponentNode(child)) {
-            blockIdx += 1;
-            const childBlockName = (child as BlockComponentNode).getBlockName();
-            if (
-              blockIdx === detail.blockIndex &&
-              childBlockName === detail.blockName
-            ) {
-              targetNodeKey = child.getKey();
-              targetData = (child as BlockComponentNode).getBlockData();
-              break;
-            }
-          }
-        }
-        // Fallback: if the absolute index didn't match (e.g. document mutated),
-        // pick the first block with the same blockName.
-        if (!targetNodeKey) {
+      editor.getEditorState().read(
+        () => {
+          const root = $getRoot();
+          let blockIdx = -1;
           for (const child of root.getChildren()) {
-            if (
-              $isBlockComponentNode(child) &&
-              (child as BlockComponentNode).getBlockName() === detail.blockName
-            ) {
-              targetNodeKey = child.getKey();
-              targetData = (child as BlockComponentNode).getBlockData();
-              break;
+            if ($isBlockComponentNode(child)) {
+              blockIdx += 1;
+              const childBlockName = (
+                child as BlockComponentNode
+              ).getBlockName();
+              if (
+                blockIdx === detail.blockIndex &&
+                childBlockName === detail.blockName
+              ) {
+                targetNodeKey = child.getKey();
+                targetData = (child as BlockComponentNode).getBlockData();
+                break;
+              }
             }
           }
-        }
-      });
+          // Fallback: if the absolute index didn't match (e.g. document
+          // mutated), pick the first block with the same blockName.
+          if (!targetNodeKey) {
+            for (const child of root.getChildren()) {
+              if (
+                $isBlockComponentNode(child) &&
+                (child as BlockComponentNode).getBlockName() ===
+                  detail.blockName
+              ) {
+                targetNodeKey = child.getKey();
+                targetData = (child as BlockComponentNode).getBlockData();
+                break;
+              }
+            }
+          }
+        },
+        {editor}
+      );
       if (!targetNodeKey) {
         return;
       }
@@ -398,22 +404,25 @@ function Editor(props: EditorProps) {
       let targetNodeKey: NodeKey | null = null;
       let targetData: Record<string, any> | null = null;
       let targetComponentName: string | null = null;
-      editor.getEditorState().read(() => {
-        for (const {node} of $dfs()) {
-          if (
-            $isInlineComponentNode(node) &&
-            (node as InlineComponentNode).getComponentId() ===
-              detail.componentId
-          ) {
-            targetNodeKey = node.getKey();
-            targetData = (node as InlineComponentNode).getComponentData();
-            targetComponentName = (
-              node as InlineComponentNode
-            ).getComponentName();
-            break;
+      editor.getEditorState().read(
+        () => {
+          for (const {node} of $dfs()) {
+            if (
+              $isInlineComponentNode(node) &&
+              (node as InlineComponentNode).getComponentId() ===
+                detail.componentId
+            ) {
+              targetNodeKey = node.getKey();
+              targetData = (node as InlineComponentNode).getComponentData();
+              targetComponentName = (
+                node as InlineComponentNode
+              ).getComponentName();
+              break;
+            }
           }
-        }
-      });
+        },
+        {editor}
+      );
       if (!targetNodeKey) {
         return;
       }

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.tsx
@@ -165,9 +165,12 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
     const scrollerElem = anchorElem.parentElement;
 
     const update = () => {
-      editor.getEditorState().read(() => {
-        $updateLinkEditor();
-      });
+      editor.getEditorState().read(
+        () => {
+          $updateLinkEditor();
+        },
+        {editor}
+      );
     };
 
     window.addEventListener('resize', update);
@@ -188,9 +191,12 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
   useEffect(() => {
     return mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
-        editorState.read(() => {
-          $updateLinkEditor();
-        });
+        editorState.read(
+          () => {
+            $updateLinkEditor();
+          },
+          {editor}
+        );
       }),
 
       editor.registerCommand(
@@ -217,16 +223,22 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
   }, [editor, $updateLinkEditor, setIsLink, isLink]);
 
   useEffect(() => {
-    editor.getEditorState().read(() => {
-      $updateLinkEditor();
-    });
+    editor.getEditorState().read(
+      () => {
+        $updateLinkEditor();
+      },
+      {editor}
+    );
   }, [editor, $updateLinkEditor]);
 
   useEffect(() => {
     if (isLink) {
-      editor.getEditorState().read(() => {
-        $updateLinkEditor();
-      });
+      editor.getEditorState().read(
+        () => {
+          $updateLinkEditor();
+        },
+        {editor}
+      );
     }
   }, [isLink, editor, $updateLinkEditor]);
 
@@ -538,9 +550,12 @@ function useFloatingLinkEditorToolbar(
     }
     return mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
-        editorState.read(() => {
-          $updateToolbar();
-        });
+        editorState.read(
+          () => {
+            $updateToolbar();
+          },
+          {editor}
+        );
       }),
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingToolbarPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingToolbarPlugin.tsx
@@ -147,9 +147,12 @@ function FloatingToolbar(props: FloatingToolbarProps) {
     const scrollerElem = anchorElem.parentElement;
 
     const update = () => {
-      editor.getEditorState().read(() => {
-        $updateTextFormatFloatingToolbar();
-      });
+      editor.getEditorState().read(
+        () => {
+          $updateTextFormatFloatingToolbar();
+        },
+        {editor}
+      );
     };
 
     window.addEventListener('resize', update);
@@ -166,14 +169,20 @@ function FloatingToolbar(props: FloatingToolbarProps) {
   }, [editor, $updateTextFormatFloatingToolbar, anchorElem]);
 
   useEffect(() => {
-    editor.getEditorState().read(() => {
-      $updateTextFormatFloatingToolbar();
-    });
+    editor.getEditorState().read(
+      () => {
+        $updateTextFormatFloatingToolbar();
+      },
+      {editor}
+    );
     return mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
-        editorState.read(() => {
-          $updateTextFormatFloatingToolbar();
-        });
+        editorState.read(
+          () => {
+            $updateTextFormatFloatingToolbar();
+          },
+          {editor}
+        );
       }),
 
       editor.registerCommand(
@@ -303,63 +312,66 @@ function useFloatingTextFormatToolbar(
   const [isSuperscript, setIsSuperscript] = useState(false);
 
   const updatePopup = useCallback(() => {
-    editor.getEditorState().read(() => {
-      // Should not to pop up the floating toolbar when using IME input.
-      if (editor.isComposing()) {
-        return;
-      }
-      const selection = $getSelection();
-      const nativeSelection = getDOMSelection(editor._window);
-      const rootElement = editor.getRootElement();
+    editor.getEditorState().read(
+      () => {
+        // Should not to pop up the floating toolbar when using IME input.
+        if (editor.isComposing()) {
+          return;
+        }
+        const selection = $getSelection();
+        const nativeSelection = getDOMSelection(editor._window);
+        const rootElement = editor.getRootElement();
 
-      if (
-        nativeSelection !== null &&
-        (!$isRangeSelection(selection) ||
-          rootElement === null ||
-          !rootElement.contains(nativeSelection.anchorNode))
-      ) {
-        setIsText(false);
-        return;
-      }
+        if (
+          nativeSelection !== null &&
+          (!$isRangeSelection(selection) ||
+            rootElement === null ||
+            !rootElement.contains(nativeSelection.anchorNode))
+        ) {
+          setIsText(false);
+          return;
+        }
 
-      if (!$isRangeSelection(selection)) {
-        return;
-      }
+        if (!$isRangeSelection(selection)) {
+          return;
+        }
 
-      const node = getSelectedNode(selection);
+        const node = getSelectedNode(selection);
 
-      // Update text format
-      setIsBold(selection.hasFormat('bold'));
-      setIsCode(selection.hasFormat('code'));
-      setIsItalic(selection.hasFormat('italic'));
-      setIsUnderline(selection.hasFormat('underline'));
-      setIsStrikethrough(selection.hasFormat('strikethrough'));
-      setIsSubscript(selection.hasFormat('subscript'));
-      setIsSuperscript(selection.hasFormat('superscript'));
+        // Update text format
+        setIsBold(selection.hasFormat('bold'));
+        setIsCode(selection.hasFormat('code'));
+        setIsItalic(selection.hasFormat('italic'));
+        setIsUnderline(selection.hasFormat('underline'));
+        setIsStrikethrough(selection.hasFormat('strikethrough'));
+        setIsSubscript(selection.hasFormat('subscript'));
+        setIsSuperscript(selection.hasFormat('superscript'));
 
-      // Update links
-      const parent = node.getParent();
-      if ($isLinkNode(parent) || $isLinkNode(node)) {
-        setIsLink(true);
-      } else {
-        setIsLink(false);
-      }
+        // Update links
+        const parent = node.getParent();
+        if ($isLinkNode(parent) || $isLinkNode(node)) {
+          setIsLink(true);
+        } else {
+          setIsLink(false);
+        }
 
-      if (
-        !$isCodeHighlightNode(selection.anchor.getNode()) &&
-        selection.getTextContent() !== ''
-      ) {
-        setIsText($isTextNode(node) || $isParagraphNode(node));
-      } else {
-        setIsText(false);
-      }
+        if (
+          !$isCodeHighlightNode(selection.anchor.getNode()) &&
+          selection.getTextContent() !== ''
+        ) {
+          setIsText($isTextNode(node) || $isParagraphNode(node));
+        } else {
+          setIsText(false);
+        }
 
-      const rawTextContent = selection.getTextContent().replace(/\n/g, '');
-      if (!selection.isCollapsed() && rawTextContent === '') {
-        setIsText(false);
-        return;
-      }
-    });
+        const rawTextContent = selection.getTextContent().replace(/\n/g, '');
+        if (!selection.isCollapsed() && rawTextContent === '') {
+          setIsText(false);
+          return;
+        }
+      },
+      {editor}
+    );
   }, [editor]);
 
   useEffect(() => {

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.tsx
@@ -38,13 +38,16 @@ export function OnChangePlugin(props: OnChangePluginProps) {
     }
     // When the user enters new content, read the current lexical data, convert
     // it to RichTextData, and then call the onChange() callback.
-    editorState.read(() => {
-      const richTextData = convertToRichTextData();
-      timeSavedRef.current = richTextData?.time || 0;
-      if (props.onChange) {
-        props.onChange(richTextData);
-      }
-    });
+    editorState.read(
+      () => {
+        const richTextData = convertToRichTextData();
+        timeSavedRef.current = richTextData?.time || 0;
+        if (props.onChange) {
+          props.onChange(richTextData);
+        }
+      },
+      {editor}
+    );
   };
 
   return <LexicalOnChangePlugin onChange={onChange} ignoreSelectionChange />;

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/TableActionMenuPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/TableActionMenuPlugin.tsx
@@ -45,76 +45,81 @@ export function TableActionMenuPlugin(props: TableActionMenuPluginProps) {
       return;
     }
 
-    editor.getEditorState().read(() => {
-      try {
-        const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-        const rows = tableNode.getChildren();
+    editor.getEditorState().read(
+      () => {
+        try {
+          const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
+          const rows = tableNode.getChildren();
 
-        // Check if entire row is header
-        let targetRowIndex = -1;
-        for (let i = 0; i < rows.length; i++) {
-          const rowNode = rows[i];
-          if (!$isTableRowNode(rowNode)) continue;
-          const cells = (rowNode as TableRowNode).getChildren();
-          if (
-            cells.some((cell: any) => cell.getKey() === tableCellNode.getKey())
-          ) {
-            targetRowIndex = i;
-            break;
-          }
-        }
-
-        if (targetRowIndex !== -1) {
-          const targetRow = rows[targetRowIndex];
-          if ($isTableRowNode(targetRow)) {
-            const cellsInRow = (targetRow as TableRowNode).getChildren();
-            const firstCell = cellsInRow[0];
-            if ($isTableCellNode(firstCell)) {
-              const headerState = firstCell.getHeaderStyles();
-              setIsRowHeader(
-                (headerState & TableCellHeaderStates.ROW) ===
-                  TableCellHeaderStates.ROW
-              );
-            }
-          }
-        }
-
-        // Check if entire column is header
-        let targetColIndex = -1;
-        for (let i = 0; i < rows.length; i++) {
-          const rowNode = rows[i];
-          if (!$isTableRowNode(rowNode)) continue;
-          const cells = (rowNode as TableRowNode).getChildren();
-          for (let j = 0; j < cells.length; j++) {
-            const cell: any = cells[j];
-            if (cell.getKey() === tableCellNode.getKey()) {
-              targetColIndex = j;
+          // Check if entire row is header
+          let targetRowIndex = -1;
+          for (let i = 0; i < rows.length; i++) {
+            const rowNode = rows[i];
+            if (!$isTableRowNode(rowNode)) continue;
+            const cells = (rowNode as TableRowNode).getChildren();
+            if (
+              cells.some(
+                (cell: any) => cell.getKey() === tableCellNode.getKey()
+              )
+            ) {
+              targetRowIndex = i;
               break;
             }
           }
-          if (targetColIndex !== -1) break;
-        }
 
-        if (targetColIndex !== -1) {
-          const firstRow = rows[0];
-          if ($isTableRowNode(firstRow)) {
-            const firstRowCells = (firstRow as TableRowNode).getChildren();
-            const firstCell = firstRowCells[targetColIndex];
-            if ($isTableCellNode(firstCell)) {
-              const headerState = firstCell.getHeaderStyles();
-              setIsColumnHeader(
-                (headerState & TableCellHeaderStates.COLUMN) ===
-                  TableCellHeaderStates.COLUMN
-              );
+          if (targetRowIndex !== -1) {
+            const targetRow = rows[targetRowIndex];
+            if ($isTableRowNode(targetRow)) {
+              const cellsInRow = (targetRow as TableRowNode).getChildren();
+              const firstCell = cellsInRow[0];
+              if ($isTableCellNode(firstCell)) {
+                const headerState = firstCell.getHeaderStyles();
+                setIsRowHeader(
+                  (headerState & TableCellHeaderStates.ROW) ===
+                    TableCellHeaderStates.ROW
+                );
+              }
             }
           }
+
+          // Check if entire column is header
+          let targetColIndex = -1;
+          for (let i = 0; i < rows.length; i++) {
+            const rowNode = rows[i];
+            if (!$isTableRowNode(rowNode)) continue;
+            const cells = (rowNode as TableRowNode).getChildren();
+            for (let j = 0; j < cells.length; j++) {
+              const cell: any = cells[j];
+              if (cell.getKey() === tableCellNode.getKey()) {
+                targetColIndex = j;
+                break;
+              }
+            }
+            if (targetColIndex !== -1) break;
+          }
+
+          if (targetColIndex !== -1) {
+            const firstRow = rows[0];
+            if ($isTableRowNode(firstRow)) {
+              const firstRowCells = (firstRow as TableRowNode).getChildren();
+              const firstCell = firstRowCells[targetColIndex];
+              if ($isTableCellNode(firstCell)) {
+                const headerState = firstCell.getHeaderStyles();
+                setIsColumnHeader(
+                  (headerState & TableCellHeaderStates.COLUMN) ===
+                    TableCellHeaderStates.COLUMN
+                );
+              }
+            }
+          }
+        } catch {
+          // Handle case where table node is no longer valid
+          setIsRowHeader(false);
+          setIsColumnHeader(false);
         }
-      } catch {
-        // Handle case where table node is no longer valid
-        setIsRowHeader(false);
-        setIsColumnHeader(false);
-      }
-    });
+      },
+      {editor}
+    );
   }, [editor, tableCellNode]);
 
   // Update header states when menu opens or cell changes

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
@@ -438,9 +438,14 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
   }, [editor, $updateToolbar, setActiveEditor]);
 
   useEffect(() => {
-    activeEditor.getEditorState().read(() => {
-      $updateToolbar();
-    });
+    // The `{editor}` option is required so that lexical helpers that read from
+    // the DOM (e.g. `$isParentElementRTL()`) can resolve the active editor.
+    activeEditor.getEditorState().read(
+      () => {
+        $updateToolbar();
+      },
+      {editor: activeEditor}
+    );
   }, [activeEditor, $updateToolbar]);
 
   useEffect(() => {
@@ -449,9 +454,12 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
         setIsEditable(editable);
       }),
       activeEditor.registerUpdateListener(({editorState}) => {
-        editorState.read(() => {
-          $updateToolbar();
-        });
+        editorState.read(
+          () => {
+            $updateToolbar();
+          },
+          {editor: activeEditor}
+        );
       }),
       activeEditor.registerCommand<boolean>(
         CAN_UNDO_COMMAND,


### PR DESCRIPTION
Fixes the rich text editor regression in the latest release where lexical throws error [#337](https://lexical.dev/docs/error?code=337), "Unable to find an active editor".

## Cause

The lexical upgrade from `0.33.1` → `0.49.0` in #1342 tightened the distinction between an active *editor state* and an active *editor*. Helpers that reach into the DOM now call `$getEditor()`, which only resolves inside `editor.update()`, `editor.read()`, or `editorState.read(fn, {editor})`.

`editorState.read(fn)` sets only the active editor state — and it actively *clears* the active editor for the duration of the callback, even when one was already on the stack. So `$isParentElementRTL()` in `ToolbarPlugin`'s `$updateToolbar()` threw on every selection change and editor update:

```
$isParentElementRTL → $getComputedStyle → $getComputedStyleForElement → $getEditor() ✗
```

Because `$updateToolbar()` aborted at that line, everything after it never ran, leaving the toolbar's block type, link state and format buttons stuck on stale values.

## Fix

Pass the `{editor}` option to every editor state read in the rich text editor, so the active editor is always resolvable. This preserves the existing read semantics (committed state, no flush) and is the form the error message itself points at. Applied across `LexicalEditor`, `ToolbarPlugin`, `FloatingToolbarPlugin`, `FloatingLinkEditorPlugin`, `TableActionMenuPlugin` and `OnChangePlugin` rather than only the one currently-throwing call site, so other helpers with the same requirement don't reintroduce this.

## Testing

Reproduced with the existing visual test suite, which surfaced the error as 5 unhandled errors while the tests still reported green:

```
Error: Unable to find an active editor. This method can only be used
synchronously during the callback of editor.update(), editor.read(), or
editor.getEditorState().read(..., {editor}).
 ❯ $getComputedStyleForElement .../@lexical/selection/dist/LexicalSelection.dev.mjs:191:17
 ❯ $isParentElementRTL         .../@lexical/selection/dist/LexicalSelection.dev.mjs:983:24
 ❯ ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx:362:34
 ❯ ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx:453:10
```

After the fix: `Test Files 3 passed (3) / Tests 5 passed (5)` with **zero** errors.

Also verified `eslint` and `tsc --noEmit` are clean for the changed files. Two pre-existing issues in the suite were confirmed unrelated by checking them against an unmodified tree: the `LexicalEditor > renders html block` screenshot flake (fails 3/3 on `main` in this environment) and the `updateEditorSync` read-only-context warning (also present on `main`).

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsNkYcnFHa8W2Tw7KaRTho)_