### PR TITLE
fix: surface uncaught errors in the UI as notifications

### DIFF
--- a/.changeset/quiet-moons-shout.md
+++ b/.changeset/quiet-moons-shout.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: surface uncaught errors in the UI as notifications

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
@@ -33,6 +33,7 @@ import {
   OpenRichTextInlineEventDetail,
 } from '../../../utils/doc-search.js';
 import {getDefaultFieldValue} from '../../../utils/fields.js';
+import {showErrorNotification} from '../../../utils/notifications.js';
 import {cloneData} from '../../../utils/objects.js';
 import {autokey} from '../../../utils/rand.js';
 import {BlockComponentsProvider} from './hooks/useBlockComponents.js';
@@ -86,9 +87,12 @@ const INITIAL_CONFIG: InitialConfigType = {
     InlineComponentNode,
     SpecialCharacterNode,
   ],
+  // Lexical routes errors it catches while updating, reconciling, or parsing
+  // here. Report them instead of rethrowing: rethrowing from this callback
+  // aborts lexical's own recovery (which restores the last good editor state to
+  // the DOM) and turns a recoverable error into an uncaught one.
   onError: (err: Error) => {
-    console.error('[LexicalEditor] error:', err);
-    throw err;
+    showErrorNotification(err, {title: 'Rich text editor error'});
   },
 };
 

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -43,6 +43,7 @@ import {PendingReleasesProvider} from './hooks/usePendingReleases.js';
 import {SiteSettingsProvider} from './hooks/useSiteSettings.js';
 import {SSEProvider} from './hooks/useSSE.js';
 import {UserPreferencesProvider} from './hooks/useUserPreferences.js';
+import {installGlobalErrorHandlers} from './utils/global-errors.js';
 import {lazyRoute} from './utils/lazy-route.js';
 import {installNavigationGuards} from './utils/navigation-guard.js';
 
@@ -484,6 +485,10 @@ function registerDevServerRedirectShortcut() {
 }
 
 registerDevServerRedirectShortcut();
+
+// Surface uncaught errors and unhandled rejections to the user instead of
+// letting them disappear into the devtools console.
+installGlobalErrorHandlers();
 
 // Install the unsaved-changes navigation guards before the app renders so
 // the guard listeners run ahead of preact-iso's click/popstate listeners.

--- a/packages/root-cms/ui/utils/global-errors.test.ts
+++ b/packages/root-cms/ui/utils/global-errors.test.ts
@@ -1,0 +1,87 @@
+import {showNotification} from '@mantine/notifications';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {installGlobalErrorHandlers} from './global-errors.js';
+
+vi.mock('@mantine/notifications', () => ({
+  showNotification: vi.fn(),
+}));
+
+const showNotificationMock = vi.mocked(showNotification);
+
+/**
+ * Dispatches a window `error` event. jsdom's ErrorEvent constructor doesn't
+ * populate `error` from the init dict in all versions, so it's assigned
+ * explicitly.
+ */
+function dispatchError(message: string, error?: unknown) {
+  const event = new Event('error') as any;
+  event.message = message;
+  event.error = error ?? new Error(message);
+  window.dispatchEvent(event);
+}
+
+/** Dispatches a window `unhandledrejection` event with the given reason. */
+function dispatchRejection(reason: unknown) {
+  const event = new Event('unhandledrejection') as any;
+  event.reason = reason;
+  window.dispatchEvent(event);
+}
+
+describe('installGlobalErrorHandlers', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    showNotificationMock.mockClear();
+    // The module installs its listeners once; calling it again is a no-op.
+    installGlobalErrorHandlers();
+  });
+
+  it('shows a notification for an uncaught error', () => {
+    dispatchError('kaboom');
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(showNotificationMock.mock.calls[0][0]).toMatchObject({
+      title: 'Something went wrong',
+      message: 'kaboom',
+      color: 'red',
+    });
+  });
+
+  it('shows a notification for an unhandled promise rejection', () => {
+    dispatchRejection(new Error('rejected'));
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(showNotificationMock.mock.calls[0][0]).toMatchObject({
+      title: 'Something went wrong',
+      message: 'rejected',
+    });
+  });
+
+  it('dedupes repeated identical errors', () => {
+    dispatchError('repeated failure');
+    dispatchError('repeated failure');
+    dispatchError('repeated failure');
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows distinct errors separately', () => {
+    dispatchError('first failure');
+    dispatchError('second failure');
+    expect(showNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores noisy browser-generated errors', () => {
+    dispatchError(
+      'ResizeObserver loop completed with undelivered notifications.'
+    );
+    dispatchError('Script error.');
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores resource load errors that target an element', () => {
+    const event = new Event('error') as any;
+    event.message = 'load failed';
+    Object.defineProperty(event, 'target', {
+      value: document.createElement('img'),
+    });
+    window.dispatchEvent(event);
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/ui/utils/global-errors.ts
+++ b/packages/root-cms/ui/utils/global-errors.ts
@@ -1,0 +1,60 @@
+import {errorMessage, showErrorNotification} from './notifications.js';
+
+/**
+ * Errors that are noisy, unactionable, or not ours. `ResizeObserver loop`
+ * warnings are fired by browsers during normal layout thrash and are harmless;
+ * a bare "Script error." is what cross-origin scripts report and carries no
+ * detail worth surfacing.
+ */
+const IGNORED_PATTERNS = [/^ResizeObserver loop/i, /^Script error\.?$/i];
+
+function testIsIgnored(message: string): boolean {
+  return IGNORED_PATTERNS.some((pattern) => pattern.test(message.trim()));
+}
+
+let installed = false;
+
+/**
+ * Surfaces uncaught errors and unhandled promise rejections as notifications.
+ *
+ * Without this, anything thrown outside of a render pass — an editor plugin's
+ * update listener, a DOM event handler, a floating promise — is swallowed by
+ * the browser and only visible in the devtools console, so users see a UI that
+ * silently stops updating with no indication that anything went wrong. Error
+ * boundaries don't help here: they only catch errors thrown while rendering.
+ *
+ * Safe to call more than once; handlers are only installed on the first call.
+ */
+export function installGlobalErrorHandlers() {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  window.addEventListener('error', (event: ErrorEvent) => {
+    // Resource load failures (e.g. a broken <img>) also fire an `error` event
+    // on the window, but they aren't script errors and have no useful message.
+    // Identified by their target being an element; script errors target the
+    // window itself.
+    const target = event.target as {tagName?: string} | null;
+    if (target?.tagName) {
+      return;
+    }
+    const err = event.error ?? event.message;
+    if (testIsIgnored(errorMessage(err))) {
+      return;
+    }
+    showErrorNotification(err, {title: 'Something went wrong'});
+  });
+
+  window.addEventListener(
+    'unhandledrejection',
+    (event: PromiseRejectionEvent) => {
+      const err = event.reason;
+      if (testIsIgnored(errorMessage(err))) {
+        return;
+      }
+      showErrorNotification(err, {title: 'Something went wrong'});
+    }
+  );
+}

--- a/packages/root-cms/ui/utils/notifications.ts
+++ b/packages/root-cms/ui/utils/notifications.ts
@@ -21,6 +21,66 @@ export function errorMessage(err: unknown): string {
 }
 
 /**
+ * How long an identical error is suppressed after being shown. Errors thrown
+ * from editor listeners and event handlers tend to repeat on every keystroke,
+ * which would otherwise bury the screen in identical notifications.
+ */
+const DEDUPE_WINDOW_MS = 10000;
+
+/** Timestamp of the last notification shown, keyed by title + message. */
+const lastShownAt = new Map<string, number>();
+
+export interface ShowErrorNotificationOptions {
+  /** Notification title. Defaults to "Error". */
+  title?: string;
+  /**
+   * Whether to suppress the notification if an identical one was already shown
+   * within the dedupe window. Defaults to true.
+   */
+  dedupe?: boolean;
+}
+
+/**
+ * Shows an error notification for an unknown error value. The error is always
+ * logged to the console; the notification itself is deduped so a repeating
+ * error doesn't flood the screen.
+ *
+ * Usage:
+ * ```
+ * showErrorNotification(err, {title: 'Rich text editor error'});
+ * ```
+ */
+export function showErrorNotification(
+  err: unknown,
+  options?: ShowErrorNotificationOptions
+) {
+  const title = options?.title || 'Error';
+  console.error(err);
+  const message = errorMessage(err);
+  if (options?.dedupe !== false) {
+    const key = `${title}:${message}`;
+    const now = Date.now();
+    const prev = lastShownAt.get(key);
+    if (prev !== undefined && now - prev < DEDUPE_WINDOW_MS) {
+      return;
+    }
+    lastShownAt.set(key, now);
+  }
+  // Never let a failure to notify take down the caller, which may itself be an
+  // error handler.
+  try {
+    showNotification({
+      title: title,
+      message: message,
+      color: 'red',
+      autoClose: false,
+    });
+  } catch (notifyErr) {
+    console.error('failed to show error notification:', notifyErr);
+  }
+}
+
+/**
  * Wrapper that calls a function and shows a generic error notification if any
  * exceptions occur.
  */
@@ -28,13 +88,6 @@ export async function notifyErrors(fn: () => Promise<void>) {
   try {
     await fn();
   } catch (err) {
-    console.error(err);
-    const msg = errorMessage(err);
-    showNotification({
-      title: 'Error',
-      message: msg,
-      color: 'red',
-      autoClose: false,
-    });
+    showErrorNotification(err, {dedupe: false});
   }
 }


### PR DESCRIPTION
Follow-up to #1347. That regression was invisible to users, and this makes the same class of failure visible.

## Why it was invisible

The lexical [#337](https://lexical.dev/docs/error?code=337) error was thrown from an editor update listener — outside any render pass. Nothing in the CMS was positioned to catch it:

- `AppErrorBoundary` / `FieldErrorBoundary` / `LexicalErrorBoundary` only catch errors thrown **while rendering**.
- Lexical's `onError` only receives errors it catches itself (update callbacks, reconciliation, parsing). `triggerListeners()` doesn't wrap listener calls, so the throw escaped lexical entirely.

The result: the toolbar silently stopped updating, and the only evidence was in the devtools console.

## Changes

**Global error handlers** (`ui/utils/global-errors.ts`, installed in `ui.tsx`) — `error` and `unhandledrejection` listeners that surface an uncaught error as a notification. This catches the whole class generically, including anything thrown from a DOM event handler or a floating promise, not just this one bug.

To keep it usable rather than noisy:
- Identical errors are deduped within a 10s window, so an error firing on every keystroke (exactly the #337 pattern) shows once rather than hundreds of times.
- `ResizeObserver loop` warnings and cross-origin `Script error.` are filtered — browser noise with no actionable detail.
- Resource load failures (a broken `<img>`, which also fires `error` on window) are skipped, identified by their target being an element.

**`showErrorNotification()`** (`ui/utils/notifications.ts`) — extracted the notification shape already used by `notifyErrors()`, plus dedupe. It never throws, since its callers are themselves error handlers. `notifyErrors()` now delegates to it with dedupe off, so its behavior is unchanged.

**Lexical `onError` no longer rethrows.** It previously did `console.error(...)` then `throw err`. Lexical calls `_onError` from inside its own `try`/`catch` and then restores the last good editor state to the DOM — throwing from the handler skipped that recovery and converted a recoverable error into an uncaught one. It now reports through the same notification path and lets lexical recover.

## Testing

`ui/utils/global-errors.test.ts` covers uncaught errors, unhandled rejections, dedupe, distinct errors, the ignore list, and resource-load errors.

Also verified end-to-end in real Chromium with a throwaway test (not committed): an error thrown from a timer callback — the same shape as the #337 failure, thrown outside any render pass — produces a rendered notification titled **"Something went wrong"** with the error message beneath it, a red accent bar, and no auto-close.

Full suite: `86 test files / 1056 tests passed`. `eslint` and `tsc --noEmit` clean for the changed files (the one remaining `tsc` error, `Layout.tsx` import assertions, is pre-existing on `main`).

Generated with [Claude Code](https://claude.com/claude-code)