### PR TITLE
feat: add a preview image fit option to collections

### DIFF
--- a/.changeset/olive-lions-attend.md
+++ b/.changeset/olive-lions-attend.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add a preview image fit option to collections

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -561,6 +561,8 @@ export type Collection = SchemaWithTypes & {
     defaultImage?: {
       src: string;
     };
+    /** How the image fills its box: "cover" (default) crops, "contain" doesn't. */
+    fit?: 'cover' | 'contain';
   };
   /**
    * Regular expression used to validate document slugs. Should be provided as a

--- a/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
+++ b/packages/root-cms/ui/components/FilePreview/FilePreview.tsx
@@ -13,10 +13,13 @@ export interface FilePreviewProps {
   withPlaceholder?: boolean;
   className?: string;
   alt?: string;
+  /** How the file fills its box: "cover" (default) crops, "contain" doesn't. */
+  fit?: 'cover' | 'contain';
 }
 
 export function FilePreview(props: FilePreviewProps) {
   const {file, width, height, withPlaceholder, className, alt} = props;
+  const fit = props.fit || 'cover';
   const src = typeof file === 'string' ? file : file?.src;
 
   if (isMp4File(file)) {
@@ -26,6 +29,7 @@ export function FilePreview(props: FilePreviewProps) {
         src={src!}
         width={width}
         height={height}
+        fit={fit}
       />
     );
   }
@@ -36,6 +40,7 @@ export function FilePreview(props: FilePreviewProps) {
       src={src}
       width={width}
       height={height}
+      fit={fit}
       withPlaceholder={withPlaceholder}
       alt={alt}
     />
@@ -67,6 +72,7 @@ function VideoPreview(props: {
   src: string;
   width: number;
   height: number;
+  fit?: 'cover' | 'contain';
 }) {
   return (
     <video
@@ -81,7 +87,7 @@ function VideoPreview(props: {
         width: `${props.width}px`,
         height: `${props.height}px`,
         backgroundColor: '#f1f3f5',
-        objectFit: 'cover',
+        objectFit: props.fit || 'cover',
         display: 'block',
       }}
     />

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -895,6 +895,7 @@ CollectionPage.DocsList = (props: {
                   file={previewImage}
                   width={40}
                   height={30}
+                  fit={rootCollection.preview?.fit}
                   withPlaceholder={!previewImage?.src}
                 />
               </a>
@@ -974,6 +975,7 @@ CollectionPage.DocsList = (props: {
                   file={previewImage}
                   width={120}
                   height={90}
+                  fit={rootCollection.preview?.fit}
                   withPlaceholder={!previewImage?.src}
                 />
               </a>


### PR DESCRIPTION
### Problem

Collection list thumbnails render the doc preview image with `object-fit: cover`, so an image whose aspect ratio doesn't match the thumbnail box gets cropped to fill it. That's the right default for photography, but it crops logos and similar artwork badly — a wide wordmark in the 40x30 compact box can be reduced to two or three letters, which makes docs hard to identify from the list.

There's currently no way to change this from a collection schema, and it can't be overridden with CSS either: Mantine's `Image` writes `object-fit` as an inline style, so no stylesheet rule wins on specificity.

### Change

Adds an optional `preview.fit` to the collection schema, forwarded through `FilePreview` to Mantine's `Image`:

```ts
export default schema.collection({
  name: 'Logos',
  preview: {
    title: 'name',
    image: 'logo',
    fit: 'contain',
  },
  // ...
});
```

It defaults to `'cover'`, so every existing collection renders exactly as it does today. The video branch of `FilePreview` picks up the same option, replacing its hard-coded `objectFit: 'cover'`.

### Notes

- Scoped to the collection list. `DocPickerModal`, `DocPreviewCard` and `ReferenceField` share `FilePreview` and now accept `fit` too, but nothing passes it to them yet since they don't have the collection schema as readily to hand. Happy to thread it through those as well if you'd like it in the same PR.
- `tsc --noEmit -p tsconfig.build.json` is clean and prettier reports no changes.

---

Generated with Claude Code (Claude Opus 5).
