### PR TITLE
fix: default listDocs() ordering to slug instead of sys.sortKey

### DIFF
--- a/.changeset/lucky-pears-search.md
+++ b/.changeset/lucky-pears-search.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: default `listDocs()` ordering to slug instead of `sys.sortKey`

--- a/packages/root-cms/core/client.test.ts
+++ b/packages/root-cms/core/client.test.ts
@@ -771,7 +771,7 @@ describe('RootCMSClient Validation', () => {
     });
   });
 
-  describe('listDocs custom sorting', () => {
+  describe('listDocs ordering', () => {
     /**
      * Creates a chainable firestore query mock that records `orderBy()` calls
      * and returns an empty result set.
@@ -798,7 +798,17 @@ describe('RootCMSClient Validation', () => {
       return client;
     }
 
-    it('defaults to orderBy sys.sortKey when customSorting is enabled', async () => {
+    it('defaults to orderBy slug', async () => {
+      const {queryMock, orderByCalls} = createQueryMock();
+      const client = await createClient(queryMock);
+      mockGetCollectionSchema.mockResolvedValue({name: 'Pages', fields: []});
+
+      await client.listDocs('Pages', {mode: 'published'});
+
+      expect(orderByCalls).toEqual([['slug', undefined]]);
+    });
+
+    it('defaults to orderBy slug even when customSorting is enabled', async () => {
       const {queryMock, orderByCalls} = createQueryMock();
       const client = await createClient(queryMock);
       mockGetCollectionSchema.mockResolvedValue({
@@ -809,29 +819,15 @@ describe('RootCMSClient Validation', () => {
 
       await client.listDocs('Products', {mode: 'published'});
 
-      expect(orderByCalls).toEqual([['sys.sortKey', undefined]]);
+      expect(orderByCalls).toEqual([['slug', undefined]]);
     });
 
-    it('does not order when customSorting is not enabled', async () => {
+    it('explicit orderBy takes precedence over the default', async () => {
       const {queryMock, orderByCalls} = createQueryMock();
       const client = await createClient(queryMock);
       mockGetCollectionSchema.mockResolvedValue({name: 'Pages', fields: []});
 
-      await client.listDocs('Pages', {mode: 'published'});
-
-      expect(orderByCalls).toEqual([]);
-    });
-
-    it('explicit orderBy takes precedence over the custom sorting default', async () => {
-      const {queryMock, orderByCalls} = createQueryMock();
-      const client = await createClient(queryMock);
-      mockGetCollectionSchema.mockResolvedValue({
-        name: 'Products',
-        customSorting: true,
-        fields: [],
-      });
-
-      await client.listDocs('Products', {
+      await client.listDocs('Pages', {
         mode: 'published',
         orderBy: 'sys.createdAt',
         orderByDirection: 'desc',
@@ -840,7 +836,7 @@ describe('RootCMSClient Validation', () => {
       expect(orderByCalls).toEqual([['sys.createdAt', 'desc']]);
     });
 
-    it('skips the custom sorting default when a query fn is provided', async () => {
+    it('supports an explicit orderBy of sys.sortKey', async () => {
       const {queryMock, orderByCalls} = createQueryMock();
       const client = await createClient(queryMock);
       mockGetCollectionSchema.mockResolvedValue({
@@ -851,6 +847,19 @@ describe('RootCMSClient Validation', () => {
 
       await client.listDocs('Products', {
         mode: 'published',
+        orderBy: 'sys.sortKey',
+      });
+
+      expect(orderByCalls).toEqual([['sys.sortKey', undefined]]);
+    });
+
+    it('skips the default when a query fn is provided', async () => {
+      const {queryMock, orderByCalls} = createQueryMock();
+      const client = await createClient(queryMock);
+      mockGetCollectionSchema.mockResolvedValue({name: 'Pages', fields: []});
+
+      await client.listDocs('Pages', {
+        mode: 'published',
         query: (q: any) => q.where('sys.locales', 'array-contains', 'en'),
       });
 
@@ -858,30 +867,30 @@ describe('RootCMSClient Validation', () => {
       expect(queryMock.where).toHaveBeenCalled();
     });
 
-    it('degrades to no default when the collection schema fails to load', async () => {
+    it('applies an explicit orderBy alongside a query fn', async () => {
       const {queryMock, orderByCalls} = createQueryMock();
+      const client = await createClient(queryMock);
+      mockGetCollectionSchema.mockResolvedValue({name: 'Pages', fields: []});
+
+      await client.listDocs('Pages', {
+        mode: 'published',
+        orderBy: 'slug',
+        query: (q: any) => q.where('sys.locales', 'array-contains', 'en'),
+      });
+
+      expect(orderByCalls).toEqual([['slug', undefined]]);
+      expect(queryMock.where).toHaveBeenCalled();
+    });
+
+    it('does not load the collection schema', async () => {
+      const {queryMock} = createQueryMock();
       const client = await createClient(queryMock);
       mockGetCollectionSchema.mockRejectedValue(new Error('no schemas'));
 
       await expect(
         client.listDocs('Products', {mode: 'published'})
       ).resolves.toEqual({docs: []});
-      expect(orderByCalls).toEqual([]);
-    });
-
-    it('memoizes the customSorting lookup per collection', async () => {
-      const {queryMock} = createQueryMock();
-      const client = await createClient(queryMock);
-      mockGetCollectionSchema.mockResolvedValue({
-        name: 'Products',
-        customSorting: true,
-        fields: [],
-      });
-
-      await client.listDocs('Products', {mode: 'published'});
-      await client.listDocs('Products', {mode: 'draft'});
-
-      expect(mockGetCollectionSchema).toHaveBeenCalledTimes(1);
+      expect(mockGetCollectionSchema).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -217,11 +217,9 @@ export interface ListDocsOptions {
   offset?: number;
   limit?: number;
   /**
-   * DB field path to order results by, e.g. `sys.createdAt`.
-   *
-   * For collections with the `customSorting` option, when `orderBy` and
-   * `query` are both unset, results default to the custom order (i.e.
-   * `orderBy: 'sys.sortKey'`). Pass an explicit `orderBy` to override.
+   * DB field path to order results by, e.g. `sys.createdAt`. Defaults to
+   * `slug`. The default is skipped when a `query` fn is provided, since the
+   * query fn may supply its own ordering.
    */
   orderBy?: string;
   orderByDirection?: 'asc' | 'desc';
@@ -354,8 +352,6 @@ export class RootCMSClient {
   readonly projectId: string;
   readonly app: App;
   readonly db: Firestore;
-  /** Memoized `customSorting` collection option, see `hasCustomSorting()`. */
-  private _customSortingCache = new Map<string, boolean>();
 
   constructor(rootConfig: RootConfig) {
     this.rootConfig = rootConfig;
@@ -476,26 +472,6 @@ export class RootCMSClient {
     // when the client is initialized (the project module loads all schema files).
     const project = await import('./project.js');
     return await project.getCollectionSchema(collectionId);
-  }
-
-  /**
-   * Returns whether a collection has the `customSorting` option enabled.
-   * The result is memoized per collection since this is called on the
-   * `listDocs()` hot path. Returns false when the collection schema cannot
-   * be loaded (e.g. in standalone scripts outside the vite server).
-   */
-  private async hasCustomSorting(collectionId: string): Promise<boolean> {
-    let customSorting = this._customSortingCache.get(collectionId);
-    if (customSorting === undefined) {
-      try {
-        const collection = await this.getCollection(collectionId);
-        customSorting = Boolean(collection?.customSorting);
-      } catch {
-        customSorting = false;
-      }
-      this._customSortingCache.set(collectionId, customSorting);
-    }
-    return customSorting;
   }
 
   /**
@@ -713,18 +689,17 @@ export class RootCMSClient {
     if (options.offset) {
       query = query.offset(options.offset);
     }
-    let orderBy = options.orderBy;
-    // Collections with `customSorting` default to the custom order. The
-    // default is skipped when a `query` fn is provided, since adding an
-    // orderBy to a filtered query may require a composite index (and would
-    // exclude docs that don't have a `sys.sortKey`).
-    if (
-      !orderBy &&
-      !options.query &&
-      (await this.hasCustomSorting(collectionId))
-    ) {
-      orderBy = 'sys.sortKey';
-    }
+    // Default to ordering by slug. The default is skipped when a `query` fn is
+    // provided, since the fn is applied after this orderBy (which would take
+    // precedence over any ordering the fn adds) and since adding an orderBy to
+    // a filtered query may require a composite index.
+    //
+    // NOTE: don't default to `sys.sortKey` for collections using the
+    // `customSorting` option. A firestore `orderBy('sys.sortKey')` query
+    // silently excludes docs that don't have a sort key yet (e.g. docs created
+    // before the option was enabled). Callers that want the custom order should
+    // pass `orderBy: 'sys.sortKey'` explicitly.
+    const orderBy = options.orderBy || (options.query ? '' : 'slug');
     if (orderBy) {
       query = query.orderBy(orderBy, options.orderByDirection);
     }


### PR DESCRIPTION
## Summary

Changes the default ordering behavior of `listDocs()` to use `slug` instead of `sys.sortKey`, and removes the collection schema lookup that was previously needed to check the `customSorting` option.

## Key Changes

- **Default ordering**: `listDocs()` now defaults to `orderBy: 'slug'` instead of checking the collection's `customSorting` option and defaulting to `sys.sortKey`.
- **Removed schema lookup**: Eliminated the `hasCustomSorting()` method and `_customSortingCache` since the collection schema is no longer needed for the default ordering logic.
- **Explicit opt-in for custom sort**: Collections that want to use `sys.sortKey` ordering must now pass `orderBy: 'sys.sortKey'` explicitly.
- **Query function behavior**: The default ordering is still skipped when a `query` function is provided, maintaining the existing behavior to avoid composite index requirements.

## Implementation Details

The change addresses a subtle issue where `orderBy('sys.sortKey')` silently excludes documents that don't have a sort key yet (e.g., docs created before the `customSorting` option was enabled). By defaulting to `slug` instead, all documents are included in results by default, and callers that specifically want the custom sort order can opt in explicitly.

The test suite was updated to reflect the new behavior:
- Tests now verify that `slug` is the default ordering
- Tests confirm that explicit `orderBy` values take precedence
- Tests verify that the schema is no longer loaded during `listDocs()` calls

https://claude.ai/code/session_0128MPc4Rj72K6E86rMRK9XX