### PR TITLE
feat: add a `build.excludeElements` option for preview-only elements

### DIFF
--- a/.changeset/quiet-poets-repeat.md
+++ b/.changeset/quiet-poets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add a `build.excludeElements` option for preview-only elements

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -105,7 +105,7 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
     }
   }
 
-  const elementGraph = await getElements(rootConfig, pods);
+  const elementGraph = await getElements(rootConfig, pods, {isBuild: true});
   const elements = Object.values(elementGraph.sourceFiles).map((sourceFile) => {
     return sourceFile.filePath;
   });

--- a/packages/root/src/cli/build.ts
+++ b/packages/root/src/cli/build.ts
@@ -105,7 +105,11 @@ export async function build(rootProjectDir?: string, options?: BuildOptions) {
     }
   }
 
-  const elementGraph = await getElements(rootConfig, pods, {isBuild: true});
+  // `build.excludeElements` drops preview-only elements from the SSG output.
+  // An `--ssr-only` build renders pages on demand, so it keeps them.
+  const elementGraph = await getElements(rootConfig, pods, {
+    isSsgBuild: !ssrOnly,
+  });
   const elements = Object.values(elementGraph.sourceFiles).map((sourceFile) => {
     return sourceFile.filePath;
   });

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -266,34 +266,52 @@ export interface RootBuildConfig {
   excludeDefaultLocaleFromIntlPaths?: boolean;
 
   /**
-   * A list of RegEx patterns of custom element tag names to exclude from the
-   * SSG build. Matching elements are not bundled, their assets are not emitted
-   * to `dist/html`, and their `<script>` and `<link rel="stylesheet">` tags are
-   * not auto-injected into rendered pages.
+   * Custom elements to exclude from the SSG build. Matching elements are not
+   * bundled, their assets are not emitted to `dist/html`, and their `<script>`
+   * and `<link rel="stylesheet">` tags are not auto-injected into rendered
+   * pages.
    *
-   * This only applies to `root build`. The dev server continues to serve and
-   * auto-inject the excluded elements, which makes this useful for
-   * preview-only elements (help overlays, internal tools, etc.) that shouldn't
-   * ship to production.
+   * This only applies to the SSG phase of `root build`. The dev server and
+   * `root build --ssr-only` continue to serve and auto-inject the excluded
+   * elements, which makes this useful for preview-only elements (help
+   * overlays, internal tools, etc.) that shouldn't ship to a static site.
    *
    * Note that this excludes the element's assets, not its HTML. A
    * `<debug-panel>` tag rendered by a route or template is still present in the
    * build output, it just never upgrades into a custom element.
    *
    * Unlike `elements.exclude`, which matches file paths and applies to every
-   * command, the patterns here are matched against the element's tag name.
+   * command, this is matched against the element's tag name.
    *
    * @example
    * ```ts
    * export default defineConfig({
    *   build: {
-   *     excludeElements: [/^debug-/],
+   *     excludeElements: ['help-overlay', /^debug-/],
    *   },
    * });
    * ```
    */
-  excludeElements?: RegExp[];
+  excludeElements?: ElementTagNameMatcher;
 }
+
+/**
+ * Matches custom elements by tag name (e.g. `debug-panel`).
+ *
+ * Accepts a list of strings (matched exactly) and RegEx patterns (tested
+ * against the tag name), or a predicate function that receives the tag name
+ * and returns true to match. The function form is useful for logic that a
+ * pattern can't express, e.g. allowlisting a known set of elements.
+ *
+ * @example
+ * ```ts
+ * const previewOnly = new Set(['help-overlay', 'debug-panel']);
+ * const matcher: ElementTagNameMatcher = (tagName) => previewOnly.has(tagName);
+ * ```
+ */
+export type ElementTagNameMatcher =
+  | Array<string | RegExp>
+  | ((tagName: string) => boolean);
 
 export interface RootRedirectConfig {
   /**

--- a/packages/root/src/core/config.ts
+++ b/packages/root/src/core/config.ts
@@ -264,6 +264,35 @@ export interface RootBuildConfig {
    * Excludes the `/intl/{defaultLocale}/...` path from the SSG build.
    */
   excludeDefaultLocaleFromIntlPaths?: boolean;
+
+  /**
+   * A list of RegEx patterns of custom element tag names to exclude from the
+   * SSG build. Matching elements are not bundled, their assets are not emitted
+   * to `dist/html`, and their `<script>` and `<link rel="stylesheet">` tags are
+   * not auto-injected into rendered pages.
+   *
+   * This only applies to `root build`. The dev server continues to serve and
+   * auto-inject the excluded elements, which makes this useful for
+   * preview-only elements (help overlays, internal tools, etc.) that shouldn't
+   * ship to production.
+   *
+   * Note that this excludes the element's assets, not its HTML. A
+   * `<debug-panel>` tag rendered by a route or template is still present in the
+   * build output, it just never upgrades into a custom element.
+   *
+   * Unlike `elements.exclude`, which matches file paths and applies to every
+   * command, the patterns here are matched against the element's tag name.
+   *
+   * @example
+   * ```ts
+   * export default defineConfig({
+   *   build: {
+   *     excludeElements: [/^debug-/],
+   *   },
+   * });
+   * ```
+   */
+  excludeElements?: RegExp[];
 }
 
 export interface RootRedirectConfig {

--- a/packages/root/src/node/element-graph.ts
+++ b/packages/root/src/node/element-graph.ts
@@ -87,12 +87,21 @@ export class ElementGraph {
   }
 }
 
+export interface GetElementsOptions {
+  /**
+   * Whether the element graph is being built for the `root build` command. When
+   * true, elements matching `build.excludeElements` are left out of the graph.
+   */
+  isBuild?: boolean;
+}
+
 /**
  * Returns a map of all the element file definitions in the project.
  */
 export async function getElements(
   rootConfig: RootConfig,
-  pods?: ResolvedPod[]
+  pods?: ResolvedPod[],
+  options?: GetElementsOptions
 ): Promise<ElementGraph> {
   const rootDir = rootConfig.rootDir;
 
@@ -100,6 +109,17 @@ export async function getElements(
   const excludePatterns = rootConfig.elements?.exclude || [];
   const excludeElement = (moduleId: string) => {
     return excludePatterns.some((pattern) => Boolean(moduleId.match(pattern)));
+  };
+
+  // `build.excludeElements` matches tag names and only applies to the SSG
+  // build, which keeps preview-only elements working in the dev server.
+  const excludeTagNamePatterns = options?.isBuild
+    ? rootConfig.build?.excludeElements || []
+    : [];
+  const excludeTagName = (tagName: string) => {
+    return excludeTagNamePatterns.some((pattern) =>
+      Boolean(tagName.match(pattern))
+    );
   };
 
   const elementFilePaths: {[tagName: string]: ElementSourceFile} = {};
@@ -112,7 +132,7 @@ export async function getElements(
           const tagName = parts.name;
           const filePath = path.join(dirPath, file);
           const relPath = path.relative(rootDir, filePath);
-          if (!excludeElement(relPath)) {
+          if (!excludeElement(relPath) && !excludeTagName(tagName)) {
             elementFilePaths[tagName] = {filePath, relPath};
           }
         }

--- a/packages/root/src/node/element-graph.ts
+++ b/packages/root/src/node/element-graph.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import glob from 'tiny-glob';
 import {searchForWorkspaceRoot} from 'vite';
-import {RootConfig} from '../core/config.js';
+import {ElementTagNameMatcher, RootConfig} from '../core/config.js';
 import {isValidTagName, parseTagNames} from '../utils/elements.js';
 import {directoryContains, isDirectory, isJsFile} from '../utils/fsutils.js';
 import type {ResolvedPod} from './pod-collector.js';
@@ -89,10 +89,33 @@ export class ElementGraph {
 
 export interface GetElementsOptions {
   /**
-   * Whether the element graph is being built for the `root build` command. When
-   * true, elements matching `build.excludeElements` are left out of the graph.
+   * Whether the element graph is being built for the SSG phase of
+   * `root build`. When true, elements matching `build.excludeElements` are left
+   * out of the graph. The dev server and `root build --ssr-only` leave this
+   * unset, since both render pages on demand and should keep serving
+   * preview-only elements.
    */
-  isBuild?: boolean;
+  isSsgBuild?: boolean;
+}
+
+/**
+ * Returns true if a tag name matches an `ElementTagNameMatcher`. Strings are
+ * matched exactly, RegEx patterns are tested against the tag name, and a
+ * function is called with the tag name.
+ */
+function matchesTagName(
+  tagName: string,
+  matcher: ElementTagNameMatcher
+): boolean {
+  if (typeof matcher === 'function') {
+    return matcher(tagName);
+  }
+  return matcher.some((pattern) => {
+    if (typeof pattern === 'string') {
+      return pattern === tagName;
+    }
+    return Boolean(tagName.match(pattern));
+  });
 }
 
 /**
@@ -112,14 +135,16 @@ export async function getElements(
   };
 
   // `build.excludeElements` matches tag names and only applies to the SSG
-  // build, which keeps preview-only elements working in the dev server.
-  const excludeTagNamePatterns = options?.isBuild
-    ? rootConfig.build?.excludeElements || []
-    : [];
+  // build, which keeps preview-only elements working anywhere pages are
+  // rendered on demand (the dev server, `--ssr-only` builds).
+  const excludeElements = options?.isSsgBuild
+    ? rootConfig.build?.excludeElements
+    : undefined;
   const excludeTagName = (tagName: string) => {
-    return excludeTagNamePatterns.some((pattern) =>
-      Boolean(tagName.match(pattern))
-    );
+    if (!excludeElements) {
+      return false;
+    }
+    return matchesTagName(tagName, excludeElements);
   };
 
   const elementFilePaths: {[tagName: string]: ElementSourceFile} = {};

--- a/packages/root/test/element-graph.test.ts
+++ b/packages/root/test/element-graph.test.ts
@@ -1,41 +1,76 @@
 import path from 'node:path';
 import {expect, test} from 'vitest';
-import {RootConfig} from '../src/core/config.js';
+import {ElementTagNameMatcher, RootConfig} from '../src/core/config.js';
 import {getElements} from '../src/node/element-graph.js';
 
 const rootDir = path.resolve(__dirname, './fixtures/elements');
 
-const rootConfig = {
-  rootDir,
-  elements: {
-    exclude: [/\.stories\.tsx$/],
-  },
-  build: {
-    excludeElements: [/^debug-/],
-  },
-} as RootConfig;
+function testConfig(excludeElements?: ElementTagNameMatcher) {
+  return {
+    rootDir,
+    elements: {
+      exclude: [/\.stories\.tsx$/],
+    },
+    build: {excludeElements},
+  } as RootConfig;
+}
 
-test('build.excludeElements only applies to the build', async () => {
-  // The dev server passes no options, so preview-only elements remain in the
-  // graph and continue to be auto-injected.
-  const devGraph = await getElements(rootConfig);
-  expect(Object.keys(devGraph.sourceFiles).sort()).toEqual([
+/** Returns the tag names in the graph built for the SSG phase of a build. */
+async function ssgTagNames(excludeElements: ElementTagNameMatcher) {
+  const graph = await getElements(testConfig(excludeElements), undefined, {
+    isSsgBuild: true,
+  });
+  return Object.keys(graph.sourceFiles).sort();
+}
+
+test('build.excludeElements matches RegEx patterns', async () => {
+  expect(await ssgTagNames([/^debug-/])).toEqual([
+    'root-counter',
+    'root-label',
+  ]);
+});
+
+test('build.excludeElements matches strings exactly', async () => {
+  expect(await ssgTagNames(['debug-panel'])).toEqual([
+    'root-counter',
+    'root-label',
+  ]);
+  // A partial string is not a substring or prefix match.
+  expect(await ssgTagNames(['debug-'])).toEqual([
     'debug-panel',
     'root-counter',
     'root-label',
   ]);
+  // Strings and RegEx patterns can be mixed in the same list.
+  expect(await ssgTagNames(['root-label', /^debug-/])).toEqual([
+    'root-counter',
+  ]);
+});
 
-  const buildGraph = await getElements(rootConfig, undefined, {isBuild: true});
-  expect(Object.keys(buildGraph.sourceFiles).sort()).toEqual([
+test('build.excludeElements matches a predicate function', async () => {
+  const previewOnly = new Set(['debug-panel', 'root-label']);
+  expect(await ssgTagNames((tagName) => previewOnly.has(tagName))).toEqual([
+    'root-counter',
+  ]);
+});
+
+test('build.excludeElements only applies to the ssg build', async () => {
+  const rootConfig = testConfig([/^debug-/]);
+  // The dev server and `--ssr-only` builds pass no `isSsgBuild`, so
+  // preview-only elements remain in the graph and are still auto-injected.
+  const graph = await getElements(rootConfig);
+  expect(Object.keys(graph.sourceFiles).sort()).toEqual([
+    'debug-panel',
     'root-counter',
     'root-label',
   ]);
 });
 
 test('elements.exclude applies to every command', async () => {
+  const rootConfig = testConfig([/^debug-/]);
   const devGraph = await getElements(rootConfig);
   expect(devGraph.sourceFiles).not.toHaveProperty('root-exclude');
 
-  const buildGraph = await getElements(rootConfig, undefined, {isBuild: true});
-  expect(buildGraph.sourceFiles).not.toHaveProperty('root-exclude');
+  const ssgGraph = await getElements(rootConfig, undefined, {isSsgBuild: true});
+  expect(ssgGraph.sourceFiles).not.toHaveProperty('root-exclude');
 });

--- a/packages/root/test/element-graph.test.ts
+++ b/packages/root/test/element-graph.test.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import {expect, test} from 'vitest';
+import {RootConfig} from '../src/core/config.js';
+import {getElements} from '../src/node/element-graph.js';
+
+const rootDir = path.resolve(__dirname, './fixtures/elements');
+
+const rootConfig = {
+  rootDir,
+  elements: {
+    exclude: [/\.stories\.tsx$/],
+  },
+  build: {
+    excludeElements: [/^debug-/],
+  },
+} as RootConfig;
+
+test('build.excludeElements only applies to the build', async () => {
+  // The dev server passes no options, so preview-only elements remain in the
+  // graph and continue to be auto-injected.
+  const devGraph = await getElements(rootConfig);
+  expect(Object.keys(devGraph.sourceFiles).sort()).toEqual([
+    'debug-panel',
+    'root-counter',
+    'root-label',
+  ]);
+
+  const buildGraph = await getElements(rootConfig, undefined, {isBuild: true});
+  expect(Object.keys(buildGraph.sourceFiles).sort()).toEqual([
+    'root-counter',
+    'root-label',
+  ]);
+});
+
+test('elements.exclude applies to every command', async () => {
+  const devGraph = await getElements(rootConfig);
+  expect(devGraph.sourceFiles).not.toHaveProperty('root-exclude');
+
+  const buildGraph = await getElements(rootConfig, undefined, {isBuild: true});
+  expect(buildGraph.sourceFiles).not.toHaveProperty('root-exclude');
+});

--- a/packages/root/test/elements.test.ts
+++ b/packages/root/test/elements.test.ts
@@ -63,6 +63,39 @@ test('use custom elements from another directory', async () => {
   `);
 });
 
+test('exclude elements from the ssg build', async () => {
+  await fixture.build();
+  const htmlPath = path.join(
+    fixture.distDir,
+    'html/exclude-build-elements/index.html'
+  );
+  assert.isTrue(await fileExists(htmlPath));
+  const html = await fs.readFile(htmlPath, 'utf-8');
+  // The element's asset should not be emitted to the build output.
+  assert.isFalse(
+    await fileExists(
+      path.join(fixture.distDir, 'html/assets/debug-panel.min.js')
+    )
+  );
+  expect(html).toMatchInlineSnapshot(`
+    "<!doctype html>
+    <html>
+    <head>
+    <meta charset="utf-8">
+    <script type="module" src="/assets/root-counter.min.js"></script>
+    <script type="module" src="/assets/root-label.min.js"></script>
+    </head>
+    <body>
+    <h1>Counter</h1>
+    <root-counter start="3"></root-counter>
+    <h1>The following element deps should not be auto-injected:</h1>
+    <debug-panel></debug-panel>
+    </body>
+    </html>
+    "
+  `);
+});
+
 test('exclude elements matching a certain pattern', async () => {
   await fixture.build();
   const htmlPath = path.join(

--- a/packages/root/test/elements.test.ts
+++ b/packages/root/test/elements.test.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from 'node:fs';
 import path from 'node:path';
 import {assert, beforeEach, test, expect, afterEach} from 'vitest';
-import {fileExists} from '../src/utils/fsutils.js';
+import {fileExists, loadJson} from '../src/utils/fsutils.js';
 import {Fixture, loadFixture} from './testutils.js';
 
 let fixture: Fixture;
@@ -94,6 +94,21 @@ test('exclude elements from the ssg build', async () => {
     </html>
     "
   `);
+});
+
+test('keep excluded elements in an --ssr-only build', async () => {
+  await fixture.build({ssrOnly: true});
+  // `--ssr-only` generates the pre-built files for SSR mode, where pages are
+  // rendered on demand, so preview-only elements are kept.
+  assert.isTrue(
+    await fileExists(
+      path.join(fixture.distDir, 'html/assets/debug-panel.min.js')
+    )
+  );
+  const elementGraph = await loadJson<{sourceFiles: Record<string, unknown>}>(
+    path.join(fixture.distDir, '.root/elements.json')
+  );
+  assert.isTrue('debug-panel' in elementGraph.sourceFiles);
 });
 
 test('exclude elements matching a certain pattern', async () => {

--- a/packages/root/test/fixtures/elements/elements/debug-panel/debug-panel.tsx
+++ b/packages/root/test/fixtures/elements/elements/debug-panel/debug-panel.tsx
@@ -1,0 +1,13 @@
+// This file is meant to represent a preview-only element, which should be
+// excluded from the SSG build through a root.config.ts `build.excludeElements`
+// pattern.
+
+class DebugPanel extends HTMLElement {
+  connectedCallback() {
+    const label = document.createElement('label');
+    label.textContent = this.getAttribute('label') || this.textContent || '';
+    this.appendChild(label);
+  }
+}
+
+customElements.define('debug-panel', DebugPanel);

--- a/packages/root/test/fixtures/elements/root.config.ts
+++ b/packages/root/test/fixtures/elements/root.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     include: [path.resolve(rootDir, 'designsystem')],
     exclude: [/\.stories\.tsx$/],
   },
+  build: {
+    excludeElements: [/^debug-/],
+  },
   vite: {
     build: {
       rolldownOptions: {
@@ -23,6 +26,6 @@ export default defineConfig({
   },
   jsxRenderer: {
     mode: 'pretty',
-    blockElements: ['root-counter', 'root-exclude'],
+    blockElements: ['root-counter', 'root-exclude', 'debug-panel'],
   },
 });

--- a/packages/root/test/fixtures/elements/routes/exclude-build-elements.tsx
+++ b/packages/root/test/fixtures/elements/routes/exclude-build-elements.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  return (
+    <>
+      <h1>Counter</h1>
+      <root-counter start={3} />
+
+      <h1>The following element deps should not be auto-injected:</h1>
+      <debug-panel />
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #556.

### Problem

Some custom elements are only meant for previews — help overlays, debug grids, internal tools — and shouldn't ship in a static build.

The existing `elements.exclude` can't express that. It matches file paths and applies to every command, so an excluded element disappears from the dev server too, which is exactly where it's supposed to work.

### Change

Adds `build.excludeElements`, matched against the element's **tag name** and applied only to the SSG phase of `root build`:

```ts
export default defineConfig({
  build: {
    excludeElements: ['help-overlay', /^debug-/],
  },
});
```

Matching elements are not bundled, their assets are not emitted to `dist/html`, and their `<script>` / `<link rel="stylesheet">` tags are not auto-injected into rendered pages.

The value is an `ElementTagNameMatcher` (exported from `@blinkk/root`):

```ts
export type ElementTagNameMatcher =
  | Array<string | RegExp>
  | ((tagName: string) => boolean);
```

Strings match exactly (`'debug-'` does not match `debug-panel`), RegEx patterns are tested against the tag name, and the two can be mixed in one list. The predicate form covers logic a pattern can't express — chiefly allowlisting a known set of elements, which otherwise needs a negative-lookahead regex.

**Where it does *not* apply:**

- **The dev server** — preview-only elements keep working while developing.
- **`root build --ssr-only`** — that flag generates the pre-built files for SSR mode, where pages are rendered on demand, so those elements are kept in the output.

### Implementation

The filter lives in `getElements()`, gated on a new `isSsgBuild` option, so every downstream consumer inherits it from one place. `build.ts` derives the flag from the existing `--ssr-only` local:

```ts
const elementGraph = await getElements(rootConfig, pods, {isSsgBuild: !ssrOnly});
```

Because the elements never enter the graph, they're dropped from the vite client input (never bundled), from `dist/html` (no asset copied), and from `dist/.root/elements.json` — so the build worker threads and the prod SSR server stay consistent with the SSG output. `dev.ts` passes no options and is unchanged.

Note this excludes the element's **assets, not its HTML**. A `<debug-panel>` tag rendered by a route or template is still present in the build output, it just never upgrades into a custom element.

### Notes

- `test/element-graph.test.ts` (new) covers RegEx, exact-string, mixed, and predicate matching, the partial-string negative case, and that `elements.exclude` still applies to every command.
- `test/elements.test.ts` adds an SSG case with an inline HTML snapshot showing no injected script, plus an `--ssr-only` case asserting the `debug-panel` asset *is* emitted and present in `elements.json`. The latter fails against the first commit on this branch, so it's a real regression test for the `--ssr-only` fix.
- Full `@blinkk/root` suite passes: 39 files, 223 tests. `eslint` and `tsc --noEmit` are clean on every file touched here; the pre-existing lint/tsc errors elsewhere in the package are untouched.
- Scoped to elements, matching the issue. `bundles/` is left alone since bundles are referenced explicitly via `<Script src="/bundles/main.ts">` — excluding one would leave a dangling asset reference rather than degrading cleanly. Happy to cover them too if you want it here.

---

Generated with Claude Code (Claude Opus 5).
