### PR TITLE
feat: automatically sign users back in on session expiry

### DIFF
--- a/.changeset/olive-hounds-signin.md
+++ b/.changeset/olive-hounds-signin.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: sign users back in automatically instead of showing the sign-in screen

--- a/packages/root-cms/core/dev-session.test.ts
+++ b/packages/root-cms/core/dev-session.test.ts
@@ -1,0 +1,70 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {
+  decodeDevAuthCookie,
+  encodeDevAuthCookie,
+  isDevSharedAuthEnabled,
+} from './dev-session.js';
+
+const SECRET = 'test-secret';
+
+describe('dev-session', () => {
+  const nodeEnv = process.env.NODE_ENV;
+  const flag = process.env.ROOT_CMS_DEV_SHARED_AUTH;
+
+  afterEach(() => {
+    process.env.NODE_ENV = nodeEnv;
+    if (flag === undefined) {
+      delete process.env.ROOT_CMS_DEV_SHARED_AUTH;
+    } else {
+      process.env.ROOT_CMS_DEV_SHARED_AUTH = flag;
+    }
+  });
+
+  test('round-trips a token', () => {
+    const value = encodeDevAuthCookie('token123', SECRET, 1000);
+    expect(decodeDevAuthCookie(value, SECRET, 2000)).toBe('token123');
+  });
+
+  test('rejects a tampered payload', () => {
+    const value = encodeDevAuthCookie('token123', SECRET, 1000);
+    const [encoded, signature] = value.split('.');
+    const forged = Buffer.from(
+      JSON.stringify({token: 'evil', exp: 9e12}),
+      'utf-8'
+    ).toString('base64url');
+    expect(encoded).not.toBe(forged);
+    expect(decodeDevAuthCookie(`${forged}.${signature}`, SECRET, 2000)).toBe(
+      null
+    );
+  });
+
+  test('rejects a value signed with a different secret', () => {
+    const value = encodeDevAuthCookie('token123', 'other-secret', 1000);
+    expect(decodeDevAuthCookie(value, SECRET, 2000)).toBe(null);
+  });
+
+  test('rejects an expired value', () => {
+    const value = encodeDevAuthCookie('token123', SECRET, 1000);
+    expect(decodeDevAuthCookie(value, SECRET, 9e12)).toBe(null);
+  });
+
+  test('rejects a malformed value', () => {
+    expect(decodeDevAuthCookie('', SECRET)).toBe(null);
+    expect(decodeDevAuthCookie('nodot', SECRET)).toBe(null);
+    expect(decodeDevAuthCookie('.sig', SECRET)).toBe(null);
+  });
+
+  test('is only enabled during development', () => {
+    delete process.env.ROOT_CMS_DEV_SHARED_AUTH;
+    process.env.NODE_ENV = 'production';
+    expect(isDevSharedAuthEnabled()).toBe(false);
+    process.env.NODE_ENV = 'development';
+    expect(isDevSharedAuthEnabled()).toBe(true);
+    process.env.ROOT_CMS_DEV_SHARED_AUTH = '0';
+    expect(isDevSharedAuthEnabled()).toBe(false);
+    process.env.ROOT_CMS_DEV_SHARED_AUTH = 'false';
+    expect(isDevSharedAuthEnabled()).toBe(false);
+    process.env.ROOT_CMS_DEV_SHARED_AUTH = '1';
+    expect(isDevSharedAuthEnabled()).toBe(true);
+  });
+});

--- a/packages/root-cms/core/dev-session.ts
+++ b/packages/root-cms/core/dev-session.ts
@@ -1,0 +1,185 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {Request, Response} from '@blinkk/root';
+
+/**
+ * A dev-only login session shared by every Root project running on localhost.
+ *
+ * Root's `__session` cookie is signed with a per-project secret, so switching
+ * between local sites (or restarting on a different project) invalidates the
+ * cookie and forces a fresh sign-in each time. Since cookies ignore the port,
+ * this module stores the CMS auth token in its own cookie signed with a
+ * machine-local secret, letting every local Root project reuse the same login.
+ *
+ * This only ever runs when `NODE_ENV === 'development'`; production sessions
+ * are untouched. Access is still authorized per project: the token is only
+ * used to identify the user, and the project's `isUserAuthorized()` config and
+ * Firestore ACL are checked on every request. Set `ROOT_CMS_DEV_SHARED_AUTH=0`
+ * to opt out.
+ */
+
+/** Cookie holding the dev login shared across local Root projects. */
+const DEV_AUTH_COOKIE = 'root-cms-dev-auth';
+
+/** How long a shared dev login lasts (5 days, matching the CMS session). */
+const DEV_AUTH_MAX_AGE_MS = 60 * 60 * 24 * 5 * 1000;
+
+/** Directory holding the machine-local secret. */
+const DEV_SECRET_DIR = '.root-cms';
+
+/** File holding the machine-local secret used to sign the dev auth cookie. */
+const DEV_SECRET_FILE = 'dev-session-secret';
+
+/** Request with the cookies parsed by `cookie-parser`. */
+type RequestWithCookies = Request & {cookies?: Record<string, string>};
+
+interface DevAuthPayload {
+  /** The Firebase ID token identifying the signed-in user. */
+  token: string;
+  /** Expiration timestamp, in millis. */
+  exp: number;
+}
+
+let cachedSecret: string | null = null;
+
+/**
+ * Returns true if the shared dev login is enabled. Only enabled during local
+ * development, and can be disabled with `ROOT_CMS_DEV_SHARED_AUTH=0`.
+ */
+export function isDevSharedAuthEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') {
+    return false;
+  }
+  const flag = String(process.env.ROOT_CMS_DEV_SHARED_AUTH || '').toLowerCase();
+  return flag !== '0' && flag !== 'false';
+}
+
+/**
+ * Returns the machine-local secret used to sign the dev auth cookie, creating
+ * it on first use. The secret is persisted to the user's home directory so it
+ * survives server restarts and is shared by every local Root project. If the
+ * file can't be read or written (e.g. a read-only home directory), a
+ * process-local secret is used instead, which degrades to the previous
+ * behavior of signing in once per server process.
+ */
+function getDevSecret(): string {
+  if (cachedSecret) {
+    return cachedSecret;
+  }
+  const secretDir = path.join(os.homedir(), DEV_SECRET_DIR);
+  const secretPath = path.join(secretDir, DEV_SECRET_FILE);
+  try {
+    const secret = fs.readFileSync(secretPath, 'utf-8').trim();
+    if (secret) {
+      cachedSecret = secret;
+      return secret;
+    }
+  } catch {
+    // Fall through and create the secret below.
+  }
+  const secret = crypto.randomBytes(32).toString('hex');
+  try {
+    fs.mkdirSync(secretDir, {recursive: true, mode: 0o700});
+    fs.writeFileSync(secretPath, secret, {encoding: 'utf-8', mode: 0o600});
+  } catch {
+    console.warn(
+      `[root cms] unable to save the dev session secret to ${secretPath}, ` +
+        'the CMS login will not be shared across local projects'
+    );
+  }
+  cachedSecret = secret;
+  return secret;
+}
+
+function sign(value: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(value).digest('hex');
+}
+
+/** Serializes and signs a dev auth cookie value. */
+export function encodeDevAuthCookie(
+  idToken: string,
+  secret: string,
+  now = Date.now()
+): string {
+  const payload: DevAuthPayload = {
+    token: idToken,
+    exp: now + DEV_AUTH_MAX_AGE_MS,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString(
+    'base64url'
+  );
+  return `${encoded}.${sign(encoded, secret)}`;
+}
+
+/**
+ * Verifies a dev auth cookie value and returns the ID token it holds, or
+ * `null` if the value was tampered with or has expired.
+ */
+export function decodeDevAuthCookie(
+  value: string,
+  secret: string,
+  now = Date.now()
+): string | null {
+  const index = value.lastIndexOf('.');
+  if (index <= 0) {
+    return null;
+  }
+  const encoded = value.slice(0, index);
+  const signature = value.slice(index + 1);
+  const expected = sign(encoded, secret);
+  if (
+    signature.length !== expected.length ||
+    !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+  ) {
+    return null;
+  }
+  try {
+    const payload: DevAuthPayload = JSON.parse(
+      Buffer.from(encoded, 'base64url').toString('utf-8')
+    );
+    if (!payload?.token || !payload.exp || payload.exp < now) {
+      return null;
+    }
+    return payload.token;
+  } catch {
+    return null;
+  }
+}
+
+/** Saves the shared dev login to a cookie. */
+export function setDevAuthCookie(res: Response, idToken: string) {
+  if (!isDevSharedAuthEnabled()) {
+    return;
+  }
+  res.cookie(DEV_AUTH_COOKIE, encodeDevAuthCookie(idToken, getDevSecret()), {
+    maxAge: DEV_AUTH_MAX_AGE_MS,
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
+    path: '/',
+  });
+}
+
+/** Returns the ID token from the shared dev login, if any. */
+export function getDevAuthCookie(req: Request): string | null {
+  if (!isDevSharedAuthEnabled()) {
+    return null;
+  }
+  const value = (req as RequestWithCookies).cookies?.[DEV_AUTH_COOKIE];
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  return decodeDevAuthCookie(value, getDevSecret());
+}
+
+/** Clears the shared dev login. */
+export function clearDevAuthCookie(res: Response) {
+  // Not gated on `isDevSharedAuthEnabled()` so that a cookie saved before the
+  // feature was turned off is still cleared on sign out.
+  if (process.env.NODE_ENV !== 'development') {
+    return;
+  }
+  res.clearCookie(DEV_AUTH_COOKIE, {path: '/'});
+}

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -29,6 +29,12 @@ import {api} from './api.js';
 import {writeBuildInfo} from './build-info.js';
 import {type CMSCheck} from './checks.js';
 import {Action, RootCMSClient, UserRole} from './client.js';
+import {
+  clearDevAuthCookie,
+  getDevAuthCookie,
+  isDevSharedAuthEnabled,
+  setDevAuthCookie,
+} from './dev-session.js';
 import {type CMSNotificationService} from './services-notifications.js';
 import {sse, SSEBroadcastFn} from './sse.js';
 import {type CMSTranslationService} from './translations.js';
@@ -819,7 +825,12 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
    * email is verified to have access to Root CMS, otherwise returns `null`.
    */
   async function getCurrentUser(req: Request): Promise<CMSUser | null> {
-    const sessionCookie = req.session.getItem(SESSION_COOKIE_AUTH);
+    let sessionCookie = req.session.getItem(SESSION_COOKIE_AUTH);
+    if (!sessionCookie && isDevSharedAuthEnabled()) {
+      // Fall back to the login shared between local Root projects so that
+      // switching sites during development doesn't require signing in again.
+      sessionCookie = getDevAuthCookie(req);
+    }
     if (!sessionCookie) {
       if (logLevel === 'debug') {
         console.log('no login session cookie');
@@ -1100,6 +1111,9 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
             let sessionCookie: string;
             if (process.env.NODE_ENV === 'development') {
               sessionCookie = idToken;
+              // Also save the login to the cookie shared by every local Root
+              // project so switching sites doesn't require signing in again.
+              setDevAuthCookie(res, idToken);
             } else {
               sessionCookie = await auth.createSessionCookie(idToken, {
                 expiresIn,
@@ -1139,7 +1153,11 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       server.use('/cms/logout', async (req: Request, res: Response) => {
         res.session.removeItem(SESSION_COOKIE_AUTH);
         res.saveSession();
-        res.redirect('/cms/login');
+        clearDevAuthCookie(res);
+        // The `signedOut` param tells the sign-in page not to automatically
+        // sign the user back in with the credentials the Firebase SDK persists
+        // in the browser.
+        res.redirect('/cms/login?signedOut=1');
       });
 
       // Serve the CMS UI's static assets before any auth middleware runs.

--- a/packages/root-cms/shared/auth-hints.test.ts
+++ b/packages/root-cms/shared/auth-hints.test.ts
@@ -1,0 +1,55 @@
+import {beforeEach, describe, expect, test} from 'vitest';
+import {
+  AUTO_SIGN_IN_COOLDOWN_MS,
+  clearAutoSignInAttempt,
+  clearLastSignIn,
+  getLastSignIn,
+  isAutoSignInAllowed,
+  markAutoSignInAttempt,
+  setLastSignIn,
+} from './auth-hints.js';
+
+describe('auth-hints', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test('remembers the last sign-in', () => {
+    expect(getLastSignIn()).toBe(null);
+    setLastSignIn('user@example.com', 1000);
+    expect(getLastSignIn()).toEqual({email: 'user@example.com', at: 1000});
+    clearLastSignIn();
+    expect(getLastSignIn()).toBe(null);
+  });
+
+  test('ignores an unusable last sign-in record', () => {
+    window.localStorage.setItem('root-cms::last-sign-in', 'not json');
+    expect(getLastSignIn()).toBe(null);
+    window.localStorage.setItem('root-cms::last-sign-in', '{"at": 1000}');
+    expect(getLastSignIn()).toBe(null);
+  });
+
+  test('ignores an empty email', () => {
+    setLastSignIn('', 1000);
+    expect(getLastSignIn()).toBe(null);
+  });
+
+  test('allows an automatic sign-in by default', () => {
+    expect(isAutoSignInAllowed(1000)).toBe(true);
+  });
+
+  test('blocks repeat automatic sign-ins within the cooldown', () => {
+    markAutoSignInAttempt(1000);
+    expect(isAutoSignInAllowed(1000)).toBe(false);
+    expect(isAutoSignInAllowed(1000 + AUTO_SIGN_IN_COOLDOWN_MS)).toBe(false);
+    expect(isAutoSignInAllowed(1001 + AUTO_SIGN_IN_COOLDOWN_MS)).toBe(true);
+  });
+
+  test('clearing the attempt allows an automatic sign-in again', () => {
+    markAutoSignInAttempt(1000);
+    expect(isAutoSignInAllowed(1000)).toBe(false);
+    clearAutoSignInAttempt();
+    expect(isAutoSignInAllowed(1000)).toBe(true);
+  });
+});

--- a/packages/root-cms/shared/auth-hints.ts
+++ b/packages/root-cms/shared/auth-hints.ts
@@ -1,0 +1,149 @@
+/**
+ * Browser-side hints used to speed up the Root CMS sign-in flow.
+ *
+ * Only non-sensitive metadata is stored here (never tokens or credentials).
+ * The hints let the sign-in page tell a first-time visitor apart from someone
+ * whose session simply expired, and let the Google account chooser be skipped
+ * when the user's account is already known.
+ *
+ * Every function is a no-op when web storage is unavailable, e.g. during
+ * server-side rendering or in a browser with storage disabled.
+ */
+
+/** `localStorage` key holding the last successful sign-in. */
+const LAST_SIGN_IN_KEY = 'root-cms::last-sign-in';
+
+/** `sessionStorage` key holding the timestamp of the last auto sign-in. */
+const AUTO_SIGN_IN_KEY = 'root-cms::auto-sign-in';
+
+/**
+ * How long to wait before allowing another automatic sign-in attempt. This
+ * guards against a redirect loop between the CMS and the sign-in page in the
+ * case where a session is created but immediately rejected (e.g. a cookie the
+ * browser refuses to store).
+ */
+export const AUTO_SIGN_IN_COOLDOWN_MS = 30 * 1000;
+
+/** Metadata about the browser's last successful CMS sign-in. */
+export interface LastSignIn {
+  /** Email address used for the last successful sign-in. */
+  email: string;
+  /** Timestamp (in millis) of the last successful sign-in. */
+  at: number;
+}
+
+function getStorage(kind: 'local' | 'session'): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return kind === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    // Storage access throws in some privacy modes.
+    return null;
+  }
+}
+
+/**
+ * Returns the last successful sign-in recorded by this browser, or `null` if
+ * the user has never signed in here (or the record is unusable).
+ */
+export function getLastSignIn(): LastSignIn | null {
+  const storage = getStorage('local');
+  if (!storage) {
+    return null;
+  }
+  try {
+    const value = storage.getItem(LAST_SIGN_IN_KEY);
+    if (!value) {
+      return null;
+    }
+    const data = JSON.parse(value);
+    if (!data || typeof data.email !== 'string' || !data.email) {
+      return null;
+    }
+    return {email: data.email, at: Number(data.at) || 0};
+  } catch {
+    return null;
+  }
+}
+
+/** Records a successful sign-in for the given email address. */
+export function setLastSignIn(email: string, now = Date.now()) {
+  const storage = getStorage('local');
+  if (!storage || !email) {
+    return;
+  }
+  try {
+    const data: LastSignIn = {email, at: now};
+    storage.setItem(LAST_SIGN_IN_KEY, JSON.stringify(data));
+  } catch {
+    // Ignore quota and permission errors, the hint is best-effort.
+  }
+}
+
+/**
+ * Forgets the last sign-in. Called when the user signs out or when their
+ * account is rejected, so the next sign-in shows the account chooser.
+ */
+export function clearLastSignIn() {
+  const storage = getStorage('local');
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(LAST_SIGN_IN_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+/**
+ * Returns true if the sign-in page is allowed to automatically sign the user
+ * back in. Returns false while an earlier attempt is still within the cooldown
+ * window, which breaks redirect loops between the CMS and the sign-in page.
+ */
+export function isAutoSignInAllowed(now = Date.now()): boolean {
+  const storage = getStorage('session');
+  if (!storage) {
+    return true;
+  }
+  try {
+    const value = Number(storage.getItem(AUTO_SIGN_IN_KEY));
+    if (!value) {
+      return true;
+    }
+    return now - value > AUTO_SIGN_IN_COOLDOWN_MS;
+  } catch {
+    return true;
+  }
+}
+
+/** Records that an automatic sign-in attempt is in flight. */
+export function markAutoSignInAttempt(now = Date.now()) {
+  const storage = getStorage('session');
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(AUTO_SIGN_IN_KEY, String(now));
+  } catch {
+    // Ignore.
+  }
+}
+
+/**
+ * Clears the automatic sign-in marker. Called once the CMS app successfully
+ * boots, which proves the session created by the last attempt works.
+ */
+export function clearAutoSignInAttempt() {
+  const storage = getStorage('session');
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(AUTO_SIGN_IN_KEY);
+  } catch {
+    // Ignore.
+  }
+}

--- a/packages/root-cms/signin/signin.tsx
+++ b/packages/root-cms/signin/signin.tsx
@@ -1,8 +1,21 @@
 import {FirebaseApp, initializeApp} from 'firebase/app';
-import {GoogleAuthProvider, signInWithPopup} from 'firebase/auth';
-import {Auth, getAuth} from 'firebase/auth';
+import {
+  GoogleAuthProvider,
+  User,
+  signInWithPopup,
+  signOut,
+} from 'firebase/auth';
+import {Auth, getAuth, onAuthStateChanged} from 'firebase/auth';
 import {render} from 'preact';
 import {useEffect, useRef, useState} from 'preact/hooks';
+import {
+  clearAutoSignInAttempt,
+  clearLastSignIn,
+  getLastSignIn,
+  isAutoSignInAllowed,
+  markAutoSignInAttempt,
+  setLastSignIn,
+} from '../shared/auth-hints.js';
 import './styles/global.css';
 import './styles/signin.css';
 
@@ -26,14 +39,140 @@ declare global {
   }
 }
 
+/**
+ * Max time to wait for Firebase Auth to report whether a previous session is
+ * still persisted in this browser. Past the deadline the sign-in button is
+ * shown so the user is never stuck watching a spinner.
+ */
+const RESTORE_TIMEOUT_MS = 8 * 1000;
+
+/** Tracks the current phase of the sign-in flow. */
+type SignInStatus =
+  /** Checking whether the user is already signed in with Firebase. */
+  | 'restoring'
+  /** No sign-in in progress; the button is clickable. */
+  | 'idle'
+  /** The Google auth popup is open and we're waiting for the user. */
+  | 'popup'
+  /** A token was obtained; we're validating it with the server. */
+  | 'verifying'
+  /** Server validated the token; navigating to the app. */
+  | 'redirecting';
+
+/**
+ * Returns the phase the sign-in page should start in. Browsers that have
+ * signed in before start in "restoring" so returning users see progress
+ * instead of a button they'd have to click; everyone else goes straight to the
+ * sign-in button.
+ */
+function getInitialStatus(): SignInStatus {
+  if (signedOutOfCms()) {
+    return 'idle';
+  }
+  if (getLastSignIn() && isAutoSignInAllowed()) {
+    return 'restoring';
+  }
+  return 'idle';
+}
+
+/** Result of exchanging a Firebase ID token for a CMS session cookie. */
+interface SessionResult {
+  success: boolean;
+  /** User-facing error message, set when `success` is false. */
+  error?: string;
+  /** True when the server rejected the account itself (vs. a transient error). */
+  rejected?: boolean;
+}
+
 function SignIn() {
   const [errorMsg, setErrorMsg] = useState('');
+  const [status, setStatus] = useState<SignInStatus>(getInitialStatus);
   const title = window.__ROOT_CTX.name;
   const warning = window.__ROOT_CTX.warning;
+
+  // Tracks the active sign-in attempt. Bumped by both the automatic and the
+  // manual flows so that a stale attempt can't overwrite newer state.
+  const attemptRef = useRef(0);
 
   function onError(msg: string) {
     setErrorMsg(msg);
   }
+
+  // Attempt to sign the user back in without any interaction. The Firebase SDK
+  // persists the signed-in user (and its refresh token) in browser storage, so
+  // an expired CMS session cookie can usually be re-minted silently.
+  useEffect(() => {
+    if (signedOutOfCms()) {
+      // The user explicitly signed out. Drop the persisted Firebase user so
+      // they aren't immediately signed back in.
+      signOut(window.firebase.auth).catch((err) => console.error(err));
+      return;
+    }
+    if (!isAutoSignInAllowed()) {
+      // A previous automatic attempt didn't stick. Fall back to the button
+      // instead of bouncing between the CMS and this page.
+      setStatus('idle');
+      onError('Your session could not be restored. Please sign in again.');
+      return;
+    }
+
+    const attempt = ++attemptRef.current;
+    let done = false;
+    const timeoutId = window.setTimeout(() => {
+      if (!done && attemptRef.current === attempt) {
+        done = true;
+        setStatus('idle');
+      }
+    }, RESTORE_TIMEOUT_MS);
+
+    const unsubscribe = onAuthStateChanged(
+      window.firebase.auth,
+      async (user) => {
+        if (done || attemptRef.current !== attempt) {
+          return;
+        }
+        done = true;
+        window.clearTimeout(timeoutId);
+        if (!user) {
+          // Nothing persisted, the user has to sign in manually.
+          setStatus('idle');
+          return;
+        }
+        setStatus('verifying');
+        const result = await createSession(user);
+        if (attemptRef.current !== attempt) {
+          return;
+        }
+        if (result.success) {
+          setStatus('redirecting');
+          loginSuccessRedirect();
+          return;
+        }
+        if (result.rejected) {
+          // The account is no longer allowed into this project, forget it so
+          // the next manual sign-in offers the account chooser.
+          clearLastSignIn();
+        }
+        onError(result.error || 'Sign in failed.');
+        setStatus('idle');
+      },
+      (err) => {
+        if (done || attemptRef.current !== attempt) {
+          return;
+        }
+        done = true;
+        window.clearTimeout(timeoutId);
+        console.error(err);
+        setStatus('idle');
+      }
+    );
+
+    return () => {
+      done = true;
+      window.clearTimeout(timeoutId);
+      unsubscribe();
+    };
+  }, []);
 
   return (
     <div className="signin">
@@ -44,31 +183,48 @@ function SignIn() {
         </p>
       </div>
       {warning && <div className="signin__warning">{warning}</div>}
-      <SignIn.Button onError={onError} />
+      {status === 'restoring' ? (
+        <SignIn.Restoring />
+      ) : (
+        <SignIn.Button
+          status={status}
+          setStatus={setStatus}
+          attemptRef={attemptRef}
+          onError={onError}
+        />
+      )}
       {errorMsg && <p className="signin__error">{errorMsg}</p>}
     </div>
   );
 }
 
+SignIn.Restoring = () => {
+  const lastSignIn = getLastSignIn();
+  return (
+    <div className="signin__restoring">
+      <div className="signin__restoring__icon">
+        <SignIn.Spinner />
+      </div>
+      <div className="signin__restoring__label">
+        {lastSignIn
+          ? `Signing you back in as ${lastSignIn.email}…`
+          : 'Signing you back in…'}
+      </div>
+    </div>
+  );
+};
+
 interface ButtonProps {
+  status: SignInStatus;
+  setStatus: (status: SignInStatus) => void;
+  attemptRef: {current: number};
   onError: (msg: string) => void;
 }
 
-/** Tracks the current phase of the sign-in flow. */
-type SignInStatus =
-  /** No sign-in in progress; the button is clickable. */
-  | 'idle'
-  /** The Google auth popup is open and we're waiting for the user. */
-  | 'popup'
-  /** The popup closed successfully; we're validating the token with the server. */
-  | 'verifying'
-  /** Server validated the token; navigating to the app. */
-  | 'redirecting';
-
 SignIn.Button = (props: ButtonProps) => {
-  const [status, setStatus] = useState<SignInStatus>('idle');
-  const attemptRef = useRef(0);
+  const {status, setStatus, attemptRef} = props;
   const popupRef = useRef<Window | null>(null);
+  const lastSignIn = getLastSignIn();
 
   // Poll for popup closure while waiting for the Google auth popup.
   useEffect(() => {
@@ -82,16 +238,7 @@ SignIn.Button = (props: ButtonProps) => {
     return () => clearInterval(id);
   }, [status]);
 
-  async function getResData(res: Response): Promise<any> {
-    try {
-      return await res.json();
-    } catch (err) {
-      console.error(err);
-    }
-    return {};
-  }
-
-  async function signIn() {
+  async function signIn(options?: {selectAccount?: boolean}) {
     if (status !== 'idle') return;
     props.onError('');
     const attempt = ++attemptRef.current;
@@ -123,6 +270,13 @@ SignIn.Button = (props: ButtonProps) => {
       const provider = new GoogleAuthProvider();
       provider.addScope('profile');
       provider.addScope('email');
+      // Pre-select the account used the last time this browser signed in so
+      // returning users skip the account chooser entirely.
+      if (options?.selectAccount) {
+        provider.setCustomParameters({prompt: 'select_account'});
+      } else if (lastSignIn?.email) {
+        provider.setCustomParameters({login_hint: lastSignIn.email});
+      }
       result = await signInWithPopup(window.firebase.auth, provider);
     } catch (err: any) {
       const code = err?.code || '';
@@ -146,57 +300,17 @@ SignIn.Button = (props: ButtonProps) => {
 
     updateStatus('verifying');
 
-    try {
-      const user = result.user;
-      const idToken = await user.getIdToken();
-      const res = await fetch('/cms/login', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({idToken}),
-      });
-      const data = await getResData(res);
-
-      if (res.status === 401) {
-        const email = user?.email || '(no email)';
-        if (data.reason) {
-          updateError(
-            `Login failed for: ${email}. Reason: ${data.reason}. If you believe this is a mistake, please contact a developer to help resolve the issue.`
-          );
-        } else {
-          updateError(
-            `Login failed for: ${email}. If you believe this is a mistake, please contact a developer to help resolve the issue.`
-          );
-        }
-        updateStatus('idle');
-        return;
-      }
-      if (res.status !== 200) {
-        console.error('login failed');
-        console.log(res.status, data);
-        updateError('An unknown error has occurred.');
-        updateStatus('idle');
-        return;
-      }
-      if (!data.success) {
-        console.error('login failed');
-        console.log(res.status, data);
-        if (data.reason) {
-          updateError(`Login failed. Reason: ${data.reason}`);
-        } else {
-          updateError('Login failed.');
-        }
-        updateStatus('idle');
-        return;
-      }
+    const sessionResult = await createSession(result.user);
+    if (sessionResult.success) {
       updateStatus('redirecting');
       loginSuccessRedirect();
-    } catch (err: any) {
-      console.error(err);
-      updateError('An unexpected error occurred. Please try again.');
-      updateStatus('idle');
+      return;
     }
+    if (sessionResult.rejected) {
+      clearLastSignIn();
+    }
+    updateError(sessionResult.error || 'Sign in failed.');
+    updateStatus('idle');
   }
 
   const busy = status !== 'idle';
@@ -210,19 +324,32 @@ SignIn.Button = (props: ButtonProps) => {
           : 'Sign in with Google';
 
   return (
-    <button
-      className={joinClassNames(
-        'signin__button',
-        busy && 'signin__button--busy'
+    <div className="signin__actions">
+      <button
+        className={joinClassNames(
+          'signin__button',
+          busy && 'signin__button--busy'
+        )}
+        onClick={() => signIn()}
+        disabled={busy}
+      >
+        <div className="signin__button__icon">
+          {busy ? <SignIn.Spinner /> : <SignIn.GLogo />}
+        </div>
+        <div className="signin__button__label">{label}</div>
+      </button>
+      {lastSignIn?.email && !busy && (
+        <button
+          className="signin__switch-account"
+          onClick={() => {
+            clearLastSignIn();
+            signIn({selectAccount: true});
+          }}
+        >
+          Use a different account
+        </button>
       )}
-      onClick={signIn}
-      disabled={busy}
-    >
-      <div className="signin__button__icon">
-        {busy ? <SignIn.Spinner /> : <SignIn.GLogo />}
-      </div>
-      <div className="signin__button__label">{label}</div>
-    </button>
+    </div>
   );
 };
 
@@ -268,6 +395,79 @@ SignIn.GLogo = () => (
     </g>
   </svg>
 );
+
+async function getResData(res: Response): Promise<any> {
+  try {
+    return await res.json();
+  } catch (err) {
+    console.error(err);
+  }
+  return {};
+}
+
+/**
+ * Exchanges a signed-in Firebase user's ID token for a Root CMS session
+ * cookie. Shared by the automatic and the manual sign-in flows.
+ */
+async function createSession(user: User): Promise<SessionResult> {
+  try {
+    const idToken = await user.getIdToken();
+    // Record the attempt before the session is created so that a session which
+    // the browser or server refuses to honor can't cause a redirect loop
+    // between the CMS and this page. Cleared once the CMS app boots.
+    markAutoSignInAttempt();
+    const res = await fetch('/cms/login', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({idToken}),
+    });
+    const data = await getResData(res);
+
+    if (res.status === 401) {
+      const email = user?.email || '(no email)';
+      const reason = data.reason ? ` Reason: ${data.reason}.` : '';
+      return {
+        success: false,
+        rejected: true,
+        error: `Login failed for: ${email}.${reason} If you believe this is a mistake, please contact a developer to help resolve the issue.`,
+      };
+    }
+    if (res.status !== 200) {
+      console.error('login failed');
+      console.log(res.status, data);
+      return {success: false, error: 'An unknown error has occurred.'};
+    }
+    if (!data.success) {
+      console.error('login failed');
+      console.log(res.status, data);
+      return {
+        success: false,
+        rejected: true,
+        error: data.reason
+          ? `Login failed. Reason: ${data.reason}`
+          : 'Login failed.',
+      };
+    }
+    if (user.email) {
+      setLastSignIn(user.email);
+    }
+    return {success: true};
+  } catch (err: any) {
+    console.error(err);
+    return {
+      success: false,
+      error: 'An unexpected error occurred. Please try again.',
+    };
+  }
+}
+
+/** True when the user landed here by signing out of the CMS. */
+function signedOutOfCms(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('signedOut') === '1';
+}
 
 function loginSuccessRedirect() {
   const params = new URLSearchParams(window.location.search);
@@ -323,6 +523,12 @@ try {
   const app = initializeApp(window.__ROOT_CTX.firebaseConfig);
   const auth = getAuth(app);
   window.firebase = {app, auth};
+  // Forget the previous session before the first render so a user who just
+  // signed out isn't offered their old account or signed back in.
+  if (signedOutOfCms()) {
+    clearLastSignIn();
+    clearAutoSignInAttempt();
+  }
   root.innerHTML = '';
   render(<SignIn />, root);
 } catch (err) {

--- a/packages/root-cms/signin/styles/signin.css
+++ b/packages/root-cms/signin/styles/signin.css
@@ -85,6 +85,53 @@
   background-color: rgba(66, 133, 244, 0.04);
 }
 
+.signin__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.signin__switch-account {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.25px;
+  color: #5f6368;
+  text-decoration: underline;
+}
+
+.signin__switch-account:hover {
+  color: #3c4043;
+}
+
+.signin__restoring {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 40px;
+}
+
+.signin__restoring__icon {
+  width: 18px;
+  height: 18px;
+}
+
+.signin__restoring__label {
+  font-size: 14px;
+  line-height: 1;
+  letter-spacing: 0.25px;
+  font-weight: 500;
+  color: #3c4043;
+}
+
 .signin__spinner {
   width: 18px;
   height: 18px;

--- a/packages/root-cms/signin/tsconfig.json
+++ b/packages/root-cms/signin/tsconfig.json
@@ -13,6 +13,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2020",
+    "rootDir": "..",
     "outDir": "dist",
     "types": [
       "vite/client"
@@ -29,5 +30,6 @@
     "**/*.ts",
     "*.tsx",
     "**/*.tsx",
+    "../shared/*.ts"
   ]
 }

--- a/packages/root-cms/ui/layout/Layout.tsx
+++ b/packages/root-cms/ui/layout/Layout.tsx
@@ -26,6 +26,7 @@ import {useCallback, useContext, useMemo} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import type {CMSBuiltInSidebarTool} from '../../core/plugin.js';
 import packageJson from '../../package.json' assert {type: 'json'};
+import {clearLastSignIn} from '../../shared/auth-hints.js';
 import {RootCMSLogo} from '../components/RootCMSLogo/RootCMSLogo.js';
 import {SearchBar} from '../components/SearchBar/SearchBar.js';
 import {useLocalStorage} from '../hooks/useLocalStorage.js';
@@ -192,8 +193,11 @@ Layout.Side = () => {
   const experiments = window.__ROOT_CTX.experiments || {};
 
   const onSignOut = async () => {
+    clearLastSignIn();
     await window.firebase.auth.signOut();
-    window.location.href = '/cms/login';
+    // Go through the logout handler so the server session cookie is cleared
+    // too, otherwise the session would stay valid until it expires.
+    window.location.href = '/cms/logout';
   };
 
   return (

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -18,6 +18,7 @@ import {render} from 'preact';
 import {LocationProvider, Router, Route} from 'preact-iso';
 import type {CMSBuiltInSidebarTool} from '../core/plugin.js';
 import {Collection} from '../core/schema.js';
+import {clearAutoSignInAttempt, setLastSignIn} from '../shared/auth-hints.js';
 import {AddToReleaseModal} from './components/AddToReleaseModal/AddToReleaseModal.js';
 import {AiEditModal} from './components/AiEditModal/AiEditModal.js';
 import {AppErrorBoundary} from './components/AppErrorBoundary/AppErrorBoundary.js';
@@ -503,6 +504,9 @@ const root = document.getElementById('root')!;
  */
 const AUTH_STATE_TIMEOUT_MS = 15 * 1000;
 
+/** The last ID token successfully exchanged for a session cookie. */
+let lastSyncedIdToken = '';
+
 function getStartupErrorMessage(err: any): string {
   const code = err?.code || '';
   if (code === 'auth/invalid-api-key') {
@@ -569,6 +573,18 @@ try {
       )
     );
   }, AUTH_STATE_TIMEOUT_MS);
+  // Keep the server session in sync with the Firebase ID token. The listener
+  // fires with the current token and again whenever the SDK refreshes it
+  // (roughly hourly), which pushes out the session cookie's expiration so
+  // long-lived tabs don't get bounced to the sign-in page mid-edit.
+  auth.onIdTokenChanged((user) => {
+    if (!user) {
+      return;
+    }
+    updateSession(user).catch((err) => {
+      console.error('failed to update login session:', err);
+    });
+  });
   auth.onAuthStateChanged(
     (user) => {
       window.clearTimeout(authWatchdog);
@@ -580,9 +596,13 @@ try {
       root.innerHTML = '';
       render(<App />, root);
 
-      updateSession(user).catch((err) => {
-        console.error('failed to update login session:', err);
-      });
+      // The app booted, which proves the session cookie works. Remember the
+      // account so the sign-in page can restore this session automatically the
+      // next time it expires.
+      clearAutoSignInAttempt();
+      if (user.email) {
+        setLastSignIn(user.email);
+      }
       saveUserProfile(user, db);
     },
     (err) => {
@@ -594,8 +614,15 @@ try {
   showStartupError(err);
 }
 
+/**
+ * Exchanges the user's current Firebase ID token for a fresh CMS session
+ * cookie. No-ops when the session was already updated with the same token.
+ */
 async function updateSession(user: User) {
   const idToken = await user.getIdToken();
+  if (idToken === lastSyncedIdToken) {
+    return;
+  }
   const res = await fetch('/cms/login', {
     method: 'PUT',
     headers: {
@@ -614,6 +641,7 @@ async function updateSession(user: User) {
     console.log(res);
     return;
   }
+  lastSyncedIdToken = idToken;
 }
 
 /**


### PR DESCRIPTION
Implements automatic sign-in for returning users whose CMS sessions have expired, eliminating the need to manually click the sign-in button when the Firebase session is still valid.

## Summary

This change enhances the sign-in flow to detect when a user has previously signed in and automatically restore their session without requiring manual interaction. If automatic restoration fails, users fall back to the manual sign-in button. The feature includes safeguards against redirect loops and integrates with a new shared dev-mode login system for local development.

## Key Changes

- **Auto-restore flow**: Added `restoring` status to the sign-in page that checks Firebase's persisted session on load. If a valid session exists, it's automatically exchanged for a CMS session cookie without user interaction.

- **Auth hints module** (`shared/auth-hints.ts`): New browser-side storage utilities that track:
  - Last successful sign-in email (localStorage) to pre-fill the Google account chooser
  - Auto sign-in attempt timestamp (sessionStorage) with a 30-second cooldown to prevent redirect loops

- **Session creation refactor**: Extracted token-to-session-cookie exchange into a shared `createSession()` function used by both automatic and manual sign-in flows, reducing duplication and ensuring consistent error handling.

- **Dev-mode shared auth** (`core/dev-session.ts`): New module that persists login across local Root projects using a machine-local secret stored in `~/.root-cms/`. Enabled by default in development, can be disabled with `ROOT_CMS_DEV_SHARED_AUTH=0`. Includes comprehensive tests.

- **UI updates**:
  - Sign-in page now shows a spinner with "Signing you back in as [email]…" during restoration
  - Added "Use a different account" button to skip the account chooser and force account selection
  - Refactored button component to accept status and attempt tracking from parent

- **Session sync**: CMS app now keeps the server session in sync with Firebase's ID token refresh (roughly hourly), extending the session cookie's expiration so long-lived tabs don't get bounced to sign-in mid-edit.

- **Sign-out handling**: When users explicitly sign out, both the Firebase session and auth hints are cleared to prevent automatic re-sign-in.

## Implementation Details

- The `RESTORE_TIMEOUT_MS` (8 seconds) ensures users never get stuck on a spinner if Firebase takes too long to report session state.
- Automatic sign-in attempts are tracked with a ref counter to prevent stale attempts from overwriting newer state.
- The dev-mode secret is created once per machine and persisted to the home directory, surviving server restarts.
- All storage operations gracefully degrade when web storage is unavailable (SSR, privacy modes).

https://claude.ai/code/session_01QSLWaLZ8eLPDfyJtwLijZQ