### PR TITLE
fix: update assets in place when a synced file is replaced at the source

### DIFF
--- a/.changeset/nine-donkeys-repeat.md
+++ b/.changeset/nine-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: update assets in place when a synced file is replaced at the source

--- a/packages/root-cms/docs/asset-sync-design.md
+++ b/packages/root-cms/docs/asset-sync-design.md
@@ -435,6 +435,9 @@ export async function syncFolder(
      `source.missingSince` (once). **Never auto-delete** — published docs
      may embed the asset; deletion stays a deliberate human action,
      consistent with `deleteAsset()`'s philosophy of leaving GCS blobs.
+     Unless the item was *replaced* rather than removed — a new remote
+     item with the same name takes over the existing asset instead (see
+     §6.2).
 5. **Finalize.** Update the folder doc: `lastSyncedAt/By`,
    `lastSyncResult` counts, clear `state`. Log via
    `logAction('asset.sync_source', {...})` for the audit trail.
@@ -451,6 +454,33 @@ display name), renames in the CMS stick, and moving an asset *out* of
 the folder simply causes the next sync to import a fresh copy into the
 folder (the moved asset keeps working, now unmanaged — its `source`
 could be cleared on move as a refinement).
+
+**Exception — replaced files (`matchReplacements()` in `engine.ts`).**
+Not every source has a "replace this file" operation. In Google Drive,
+updating a file usually means deleting the old one and uploading a new
+one, which produces a *different* file id. On remote id alone that reads
+as "one item removed, one unrelated item added", so the replacement would
+import as a duplicate (`logo (2).png`) next to a copy flagged missing,
+and docs embedding the asset would keep the stale file — the opposite of
+what the user meant. So before importing, the engine matches each new
+remote item against the assets whose remote item disappeared *in this
+same sync*, by name, and rebinds a match onto the existing asset:
+`replaceAssetFile` + `syncAssetToDocs` with the new `remoteId`, keeping
+the asset's own name, id, and alt text.
+
+The matching is deliberately narrow:
+
+- Only assets missing as of this sync are eligible, so a same-named file
+  added *alongside* an existing one still de-dupes to ` (2)`.
+- `source.remoteName` (the remote name at the last sync) is matched
+  before the asset's own name, so assets renamed in the CMS still rebind.
+- Each asset is claimed by at most one remote item; leftovers import
+  normally. Candidates are ordered by asset id and remote id so
+  concurrent syncs converge on the same result.
+- When the replacement's bytes are identical, the asset's `source` is
+  rebound to the new remote id (via `updateAssetSource()`) with no
+  upload, no `modifiedAt` bump, and no fan-out — without that write the
+  next sync would flag the asset missing and re-import all over again.
 
 ### 6.3 Change detection — unchanged files cause zero writes and zero fan-out
 

--- a/packages/root-cms/ui/utils/asset-sync/engine.test.ts
+++ b/packages/root-cms/ui/utils/asset-sync/engine.test.ts
@@ -84,11 +84,16 @@ function makeProvider(options: {version?: string; remote: FakeRemote[]}) {
   return {provider, downloaded, prepared};
 }
 
-/** Builds a previously-synced local asset whose bytes were `contents`. */
+/**
+ * Builds a previously-synced local asset whose bytes were `contents`.
+ * `overrides` patches the asset's `source`; `assetOverrides` patches the
+ * asset itself (e.g. its `name`).
+ */
 function makeSyncedAsset(
   remoteId: string,
   contents: string,
-  overrides: Record<string, any> = {}
+  overrides: Record<string, any> = {},
+  assetOverrides: Record<string, any> = {}
 ): AssetFile {
   return {
     id: `asset-${remoteId}`,
@@ -107,6 +112,7 @@ function makeSyncedAsset(
     createdBy: 'a@example.com',
     modifiedAt: ts(),
     modifiedBy: 'a@example.com',
+    ...assetOverrides,
   } as AssetFile;
 }
 
@@ -154,6 +160,7 @@ function makeDeps(options: {
     setFolderSyncState: vi.fn(async () => {}),
     finalizeFolderSync: vi.fn(async () => {}),
     updateAssetSourceMissing: vi.fn(async () => {}),
+    updateAssetSource: vi.fn(async () => {}),
     sha1: vi.fn(async (file: File) => `sha1:${await readFileText(file)}`),
     now: () => ts(),
     logAction: vi.fn(),
@@ -339,6 +346,195 @@ describe('syncFolder', () => {
       'asset-file:1:0',
       true
     );
+  });
+
+  it('updates the asset in place when a file is replaced at the source', async () => {
+    // Drive has no "replace file" operation: users delete the old file and
+    // upload a new one, which gets a new remote id. That must update the
+    // existing asset (and its docs), not import a `logo (2).png` duplicate.
+    const folder = makeFolder();
+    const {provider} = makeProvider({
+      remote: [
+        {
+          remoteId: 'drive-2',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'new',
+        },
+      ],
+    });
+    const existing = makeSyncedAsset(
+      'drive-1',
+      'old',
+      {remoteName: 'logo.png'},
+      {name: 'logo.png'}
+    );
+    const deps = makeDeps({folder, localAssets: [existing]});
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    expect(summary.updated).toEqual(1);
+    expect(summary.added).toEqual(0);
+    expect(summary.missing).toEqual(0);
+    expect(deps.createAssetFile).not.toHaveBeenCalled();
+    expect(deps.updateAssetSourceMissing).not.toHaveBeenCalled();
+    // The asset is updated in place and rebound to the new remote id.
+    const [replacedAsset, , replaceOptions] = (deps.replaceAssetFile as any)
+      .mock.calls[0];
+    expect(replacedAsset.id).toEqual('asset-drive-1');
+    expect(replaceOptions.source.remoteId).toEqual('drive-2');
+    expect(replaceOptions.source.contentHash).toEqual('sha1:new');
+    // Docs embedding the asset pick up the replacement.
+    expect(deps.syncAssetToDocs).toHaveBeenCalledTimes(1);
+    expect((deps.syncAssetToDocs as any).mock.calls[0][1]).toEqual({
+      previousFile: existing.file,
+    });
+  });
+
+  it('rebinds a replacement with identical bytes without touching the file', async () => {
+    // Re-uploading the same bytes still produces a new remote id; record it
+    // so the next sync doesn't flag the asset missing all over again.
+    const folder = makeFolder();
+    const {provider} = makeProvider({
+      remote: [
+        {
+          remoteId: 'drive-2',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'same',
+          contentHash: 'md5-new',
+        },
+      ],
+    });
+    const existing = makeSyncedAsset(
+      'drive-1',
+      'same',
+      {remoteName: 'logo.png', remoteHash: 'md5-old'},
+      {name: 'logo.png'}
+    );
+    const deps = makeDeps({folder, localAssets: [existing]});
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    expect(summary.unchanged).toEqual(1);
+    expect(summary.added).toEqual(0);
+    expect(summary.missing).toEqual(0);
+    expect(deps.updateAssetSource).toHaveBeenCalledTimes(1);
+    const [assetId, source] = (deps.updateAssetSource as any).mock.calls[0];
+    expect(assetId).toEqual('asset-drive-1');
+    expect(source.remoteId).toEqual('drive-2');
+    expect(source.remoteHash).toEqual('md5-new');
+    // The file itself is untouched, so no upload and no fan-out.
+    expect(deps.uploadFile).not.toHaveBeenCalled();
+    expect(deps.createAssetFile).not.toHaveBeenCalled();
+    expect(deps.replaceAssetFile).not.toHaveBeenCalled();
+    expect(deps.syncAssetToDocs).not.toHaveBeenCalled();
+  });
+
+  it('matches replacements by remote name when the asset was renamed', async () => {
+    // Renames in the CMS stick, so the remote name recorded at the last sync
+    // is what identifies the replaced file.
+    const folder = makeFolder();
+    const {provider} = makeProvider({
+      remote: [
+        {
+          remoteId: 'drive-2',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'new',
+        },
+      ],
+    });
+    const existing = makeSyncedAsset(
+      'drive-1',
+      'old',
+      {remoteName: 'logo.png'},
+      {name: 'brand-logo.png'}
+    );
+    const deps = makeDeps({folder, localAssets: [existing]});
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    expect(summary.updated).toEqual(1);
+    expect(summary.added).toEqual(0);
+    expect(deps.createAssetFile).not.toHaveBeenCalled();
+    expect((deps.replaceAssetFile as any).mock.calls[0][0].id).toEqual(
+      'asset-drive-1'
+    );
+  });
+
+  it('imports a same-named file as a copy while the original still exists', async () => {
+    // Nothing was replaced here -- both files exist at the source -- so the
+    // second one de-dupes as usual.
+    const folder = makeFolder();
+    const {provider} = makeProvider({
+      remote: [
+        {
+          remoteId: 'drive-1',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'old',
+        },
+        {
+          remoteId: 'drive-2',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'new',
+        },
+      ],
+    });
+    const existing = makeSyncedAsset(
+      'drive-1',
+      'old',
+      {remoteName: 'logo.png'},
+      {name: 'logo.png'}
+    );
+    const deps = makeDeps({folder, localAssets: [existing]});
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    expect(summary.added).toEqual(1);
+    expect(summary.updated).toEqual(0);
+    expect(summary.unchanged).toEqual(1);
+    expect(deps.replaceAssetFile).not.toHaveBeenCalled();
+    expect((deps.createAssetFile as any).mock.calls[0][0].name).toEqual(
+      'logo (2).png'
+    );
+  });
+
+  it('claims each replaced asset at most once', async () => {
+    const folder = makeFolder();
+    const {provider} = makeProvider({
+      remote: [
+        {
+          remoteId: 'drive-2',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'new',
+        },
+        {
+          remoteId: 'drive-3',
+          name: 'logo.png',
+          filename: 'logo.png',
+          contents: 'other',
+        },
+      ],
+    });
+    const existing = makeSyncedAsset(
+      'drive-1',
+      'old',
+      {remoteName: 'logo.png'},
+      {name: 'logo.png'}
+    );
+    const deps = makeDeps({folder, localAssets: [existing]});
+    const summary = await syncFolder({folder, provider, auth: AUTH, deps});
+
+    // The first (by remote id) replaces the asset; the other is a new file.
+    expect(summary.updated).toEqual(1);
+    expect(summary.added).toEqual(1);
+    expect(summary.missing).toEqual(0);
+    expect(
+      (deps.replaceAssetFile as any).mock.calls[0][2].source.remoteId
+    ).toEqual('drive-2');
+    const created = (deps.createAssetFile as any).mock.calls[0][0];
+    expect(created.source.remoteId).toEqual('drive-3');
+    expect(created.name).toEqual('logo (2).png');
   });
 
   it('de-dupes filename collisions deterministically', async () => {

--- a/packages/root-cms/ui/utils/asset-sync/engine.ts
+++ b/packages/root-cms/ui/utils/asset-sync/engine.ts
@@ -9,12 +9,16 @@
  * assets in place: changed files go through `replaceAssetFile()` +
  * `syncAssetToDocs()` (fanning the new file out to docs that embed the
  * asset), new files are created, and files removed at the source are
- * flagged (never auto-deleted, since published docs may embed them).
+ * flagged (never auto-deleted, since published docs may embed them). A
+ * removal paired with a same-named addition is treated as a replacement of
+ * the existing asset rather than a duplicate import (see
+ * `matchReplacements()`).
  *
  * INVARIANT: a file whose exported bytes are unchanged since the last sync
  * produces no side effects -- no GCS upload, no asset doc write, and no
- * `syncAssetToDocs` fan-out. This is enforced by three tiers of checks
- * (cheapest first):
+ * `syncAssetToDocs` fan-out. (A replacement whose bytes happen to match
+ * still records its new remote id, but touches nothing else.) This is
+ * enforced by three tiers of checks (cheapest first):
  *
  *   1. Source-version fast path: when the provider's source version equals
  *      the folder's `sync.lastRemoteVersion`, the whole sync finishes
@@ -42,6 +46,7 @@ import {
   replaceAssetFile,
   setFolderSyncState,
   syncAssetToDocs,
+  updateAssetSource,
   updateAssetSourceMissing,
 } from '../assets.js';
 import {UploadedFile, sha1, uploadFileToGCS} from '../gcs.js';
@@ -100,6 +105,7 @@ export interface SyncEngineDeps {
     options?: {remoteVersion?: string}
   ): Promise<void>;
   updateAssetSourceMissing(assetId: string, missing: boolean): Promise<void>;
+  updateAssetSource(assetId: string, source: AssetSource): Promise<void>;
   sha1(file: File): Promise<string>;
   now(): Timestamp;
   logAction(action: string, options?: {metadata?: any}): void;
@@ -119,6 +125,7 @@ function defaultDeps(): SyncEngineDeps {
     setFolderSyncState: setFolderSyncState,
     finalizeFolderSync: finalizeFolderSync,
     updateAssetSourceMissing: updateAssetSourceMissing,
+    updateAssetSource: updateAssetSource,
     sha1: sha1,
     now: () => Timestamp.now(),
     logAction: logAction,
@@ -293,7 +300,17 @@ export async function syncFolder(
     const newImports = candidates
       .filter((a) => !syncedByRemoteId.has(a.remoteId))
       .sort((a, b) => a.remoteId.localeCompare(b.remoteId));
+    // Files replaced at the source arrive with a new remote id, so match
+    // them onto the asset they replaced (see `matchReplacements`). Those
+    // update in place and keep their existing name.
+    const replacements = matchReplacements(newImports, missingAssets);
+    const replacedAssetIds = new Set(
+      Array.from(replacements.values(), (asset) => asset.id)
+    );
     for (const remoteAsset of newImports) {
+      if (replacements.has(remoteAsset.remoteId)) {
+        continue;
+      }
       const name = buildUniqueAssetName(
         sanitizeAssetName(remoteAsset.filename),
         usedNames
@@ -342,7 +359,8 @@ export async function syncFolder(
     }
 
     async function syncItem(remoteAsset: RemoteAsset) {
-      const existing = syncedByRemoteId.get(remoteAsset.remoteId);
+      const replaced = replacements.get(remoteAsset.remoteId);
+      const existing = syncedByRemoteId.get(remoteAsset.remoteId) ?? replaced;
       const file = await provider!.download(
         remoteAsset,
         sync!,
@@ -350,14 +368,6 @@ export async function syncFolder(
         providerCtx
       );
       const contentHash = await deps.sha1(file);
-      // Unchanged bytes: strict no-op (no upload, no db write, no fan-out).
-      if (existing && existing.source?.contentHash === contentHash) {
-        summary.unchanged += 1;
-        if (existing.source?.missingSince) {
-          await deps.updateAssetSourceMissing(existing.id, false);
-        }
-        return;
-      }
       const source: AssetSource = {
         provider: provider!.id,
         remoteId: remoteAsset.remoteId,
@@ -370,6 +380,20 @@ export async function syncFolder(
       }
       if (remoteVersion) {
         source.remoteVersion = remoteVersion;
+      }
+      // Unchanged bytes: strict no-op (no upload, no db write, no fan-out).
+      if (existing && existing.source?.contentHash === contentHash) {
+        summary.unchanged += 1;
+        if (replaced) {
+          // Same bytes, but the item behind them is a different file now, so
+          // record the new provenance -- otherwise the next sync would flag
+          // the asset missing and re-import the replacement all over again.
+          // The file itself is untouched: no upload and no fan-out.
+          await deps.updateAssetSource(replaced.id, source);
+        } else if (existing.source?.missingSince) {
+          await deps.updateAssetSourceMissing(existing.id, false);
+        }
+        return;
       }
       const uploadedFile = await deps.uploadFile(file);
       if (existing) {
@@ -400,6 +424,11 @@ export async function syncFolder(
     // Flag synced assets whose remote item is gone. Never auto-deleted --
     // docs may embed them; deletion stays a deliberate user action.
     for (const asset of missingAssets) {
+      // Assets whose item was replaced rather than removed were updated in
+      // place above, so they aren't missing.
+      if (replacedAssetIds.has(asset.id)) {
+        continue;
+      }
       if (!asset.source?.missingSince) {
         try {
           await deps.updateAssetSourceMissing(asset.id, true);
@@ -451,6 +480,104 @@ export async function syncFolder(
     }
   }
   return summary;
+}
+
+/**
+ * Matches new remote items against previously-synced assets whose remote
+ * item is gone, returning a map of remote id -> the asset it replaces.
+ *
+ * Sources without a "replace file" operation (Google Drive being the common
+ * case) force users to delete the old file and upload a new one, which comes
+ * back with a *different* remote id. Keyed on remote id alone that reads as
+ * "one item removed, one unrelated item added", so the replacement would
+ * import as a duplicate (`logo (2).png`) beside a version flagged missing,
+ * and docs embedding the asset would keep the stale file. Matching those by
+ * name instead updates the asset in place, which is what the user meant.
+ *
+ * Matching is conservative: only assets whose remote item disappeared in
+ * this same sync are eligible, so a same-named file added *alongside* an
+ * existing one still de-dupes to ` (2)`. The remote name recorded at the
+ * last sync is preferred over the asset's own name so assets renamed in the
+ * CMS still match, and each asset is claimed at most once.
+ */
+function matchReplacements(
+  newImports: RemoteAsset[],
+  missingAssets: AssetFile[]
+): Map<string, AssetFile> {
+  const replacements = new Map<string, AssetFile>();
+  if (newImports.length === 0 || missingAssets.length === 0) {
+    return replacements;
+  }
+  // Sorted by asset id so several same-named candidates resolve the same way
+  // for every client.
+  const sorted = [...missingAssets].sort((a, b) => a.id.localeCompare(b.id));
+  const byRemoteName = new Map<string, AssetFile[]>();
+  const byAssetName = new Map<string, AssetFile[]>();
+  for (const asset of sorted) {
+    if (asset.source?.remoteName) {
+      addToNameIndex(byRemoteName, asset.source.remoteName, asset);
+    }
+    if (asset.name) {
+      addToNameIndex(byAssetName, asset.name, asset);
+    }
+  }
+  const claimed = new Set<string>();
+  // Two passes so remote-name matches win globally, regardless of the order
+  // items are visited in.
+  for (const remoteAsset of newImports) {
+    const match = takeFromNameIndex(byRemoteName, remoteAsset.name, claimed);
+    if (match) {
+      replacements.set(remoteAsset.remoteId, match);
+    }
+  }
+  for (const remoteAsset of newImports) {
+    if (replacements.has(remoteAsset.remoteId)) {
+      continue;
+    }
+    const match = takeFromNameIndex(byAssetName, remoteAsset.filename, claimed);
+    if (match) {
+      replacements.set(remoteAsset.remoteId, match);
+    }
+  }
+  return replacements;
+}
+
+/** Normalizes a name for comparison between local assets and remote items. */
+function nameKey(name: string): string {
+  return sanitizeAssetName(name).toLowerCase();
+}
+
+function addToNameIndex(
+  index: Map<string, AssetFile[]>,
+  name: string,
+  asset: AssetFile
+) {
+  const key = nameKey(name);
+  const assets = index.get(key);
+  if (assets) {
+    assets.push(asset);
+  } else {
+    index.set(key, [asset]);
+  }
+}
+
+/** Claims the first unclaimed asset indexed under `name`, if any. */
+function takeFromNameIndex(
+  index: Map<string, AssetFile[]>,
+  name: string,
+  claimed: Set<string>
+): AssetFile | null {
+  const assets = index.get(nameKey(name));
+  if (!assets) {
+    return null;
+  }
+  for (const asset of assets) {
+    if (!claimed.has(asset.id)) {
+      claimed.add(asset.id);
+      return asset;
+    }
+  }
+  return null;
 }
 
 /** Runs `fn` over `items` with at most `concurrency` in flight. */

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -789,6 +789,17 @@ export async function updateAssetSourceMissing(
 }
 
 /**
+ * Rebinds a synced asset's provenance, replacing the `source` map wholesale
+ * (so stale fields like `missingSince` are cleared). Used by the sync engine
+ * when an item is replaced at the source under a new remote id but its bytes
+ * are unchanged. Does not bump `modifiedAt` (the file itself is untouched).
+ */
+export async function updateAssetSource(assetId: string, source: AssetSource) {
+  const docRef = doc(getAssetsDbCollection(), assetId);
+  await updateDoc(docRef, {source: removeUndefinedValues(source)});
+}
+
+/**
  * Replaces the file of an asset (e.g. uploading a new version). Preserves the
  * existing alt text when the new upload doesn't define one. Returns the
  * updated asset; callers should follow up with {@link syncAssetToDocs} to fan


### PR DESCRIPTION
## Summary

When a file is replaced at the source (deleted and re-uploaded with a new remote id), the sync engine now updates the existing asset in place rather than importing it as a duplicate. This handles sources like Google Drive that don't have a native "replace file" operation.

## Changes

- **`matchReplacements()` function**: New logic to match new remote items against assets whose remote item disappeared in the same sync, by name. Matching is conservative—only assets missing as of this sync are eligible, so same-named files added alongside existing ones still de-dupe normally. Remote name (from the last sync) is preferred over the asset's own name, so renamed assets still rebind correctly.

- **`syncItem()` refactored**: Now handles both synced-by-remote-id and replaced assets. When bytes are unchanged but the item is a replacement, calls `updateAssetSource()` to record the new remote id without uploading, writing to the asset doc, or fanning out to docs.

- **New `updateAssetSource()` function** in `assets.ts`: Rebinds a synced asset's provenance by replacing the `source` map wholesale (clearing stale fields like `missingSince`). Does not bump `modifiedAt` since the file itself is untouched.

- **Test helper updates**: `makeSyncedAsset()` now accepts `assetOverrides` to patch the asset itself (e.g., its name), separate from source overrides. `makeDeps()` now includes the `updateAssetSource` mock.

- **New test cases**: Cover replacement scenarios—basic replacement with new bytes, rebinding with identical bytes, matching by remote name when asset was renamed, distinguishing replacements from same-named copies, and ensuring each replaced asset is claimed at most once.

- **Documentation**: Updated `asset-sync-design.md` with details on the replacement matching logic and its constraints.

## Implementation Details

The matching algorithm uses two passes over new imports: first matching by `source.remoteName` (the remote name at the last sync), then by asset name. This ensures assets renamed in the CMS still rebind correctly, and concurrent syncs converge on the same result. Candidates are sorted by asset id so the resolution is deterministic.

When a replacement's bytes are identical, only the `source` is updated via `updateAssetSource()` with no file upload, no `modifiedAt` bump, and no `syncAssetToDocs` fan-out—without that write the next sync would flag the asset missing and re-import all over again.

https://claude.ai/code/session_01QDqB1TB9HvwDh4PqnAekJ5