### PR TITLE
fix: navigate to the new doc after "copy doc"

### DIFF
--- a/.changeset/lazy-pugs-jump.md
+++ b/.changeset/lazy-pugs-jump.md
@@ -2,4 +2,4 @@
 '@blinkk/root-cms': patch
 ---
 
-fix: navigate to the new doc after "copy doc" instead of throwing
+fix: navigate to the new doc after "copy doc"

--- a/.changeset/lazy-pugs-jump.md
+++ b/.changeset/lazy-pugs-jump.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: navigate to the new doc after "copy doc" instead of throwing

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -343,29 +343,37 @@ function App() {
             <SiteSettingsProvider>
               <PendingReleasesProvider>
                 <UserPreferencesProvider>
-                  <ModalsProvider
-                    modals={{
-                      [AddToReleaseModal.id]: AddToReleaseModal,
-                      [AiEditModal.id]: AiEditModal,
-                      [AssetPickerModal.id]: AssetPickerModal,
-                      [CompareDraftModal.id]: CompareDraftModal,
-                      [ComponentPickerModal.id]: ComponentPickerModal,
-                      [CopyDocModal.id]: CopyDocModal,
-                      [DocPickerModal.id]: DocPickerModal,
-                      [DataSourceSelectModal.id]: DataSourceSelectModal,
-                      [EditJsonModal.id]: EditJsonModal,
-                      [EditTranslationsModal.id]: EditTranslationsModal,
-                      [ExportSheetModal.id]: ExportSheetModal,
-                      [LocalizationModal.id]: LocalizationModal,
-                      [LockPublishingModal.id]: LockPublishingModal,
-                      [PruneTranslationsModal.id]: PruneTranslationsModal,
-                      [PublishDocModal.id]: PublishDocModal,
-                      [ReferenceFieldEditorModal.id]: ReferenceFieldEditorModal,
-                      [ScheduleReleaseModal.id]: ScheduleReleaseModal,
-                      [VersionHistoryModal.id]: VersionHistoryModal,
-                    }}
-                  >
-                    <LocationProvider>
+                  {/*
+                    NOTE: <LocationProvider> must wrap <ModalsProvider>. The
+                    modals provider renders the currently open modal as a
+                    sibling of its children, so any modal that uses the router
+                    (e.g. `useLocation().route`) only sees the location context
+                    if the location provider is the outer one.
+                  */}
+                  <LocationProvider>
+                    <ModalsProvider
+                      modals={{
+                        [AddToReleaseModal.id]: AddToReleaseModal,
+                        [AiEditModal.id]: AiEditModal,
+                        [AssetPickerModal.id]: AssetPickerModal,
+                        [CompareDraftModal.id]: CompareDraftModal,
+                        [ComponentPickerModal.id]: ComponentPickerModal,
+                        [CopyDocModal.id]: CopyDocModal,
+                        [DocPickerModal.id]: DocPickerModal,
+                        [DataSourceSelectModal.id]: DataSourceSelectModal,
+                        [EditJsonModal.id]: EditJsonModal,
+                        [EditTranslationsModal.id]: EditTranslationsModal,
+                        [ExportSheetModal.id]: ExportSheetModal,
+                        [LocalizationModal.id]: LocalizationModal,
+                        [LockPublishingModal.id]: LockPublishingModal,
+                        [PruneTranslationsModal.id]: PruneTranslationsModal,
+                        [PublishDocModal.id]: PublishDocModal,
+                        [ReferenceFieldEditorModal.id]:
+                          ReferenceFieldEditorModal,
+                        [ScheduleReleaseModal.id]: ScheduleReleaseModal,
+                        [VersionHistoryModal.id]: VersionHistoryModal,
+                      }}
+                    >
                       <GlobalSearch>
                         <AppErrorBoundary>
                           <Router>
@@ -441,8 +449,8 @@ function App() {
                           </Router>
                         </AppErrorBoundary>
                       </GlobalSearch>
-                    </LocationProvider>
-                  </ModalsProvider>
+                    </ModalsProvider>
+                  </LocationProvider>
                 </UserPreferencesProvider>
               </PendingReleasesProvider>
             </SiteSettingsProvider>


### PR DESCRIPTION
## Summary

Fixes an issue where modals that depend on router context (e.g., `useLocation().route`) were unable to access the location context, causing navigation failures after actions like "copy doc".

## Changes

- **Reordered provider hierarchy**: Moved `<LocationProvider>` to wrap `<ModalsProvider>` instead of being nested inside it.
- **Added explanatory comment**: Documented why this ordering is necessary—modals are rendered as siblings of the provider's children, so they need the location context from an outer provider to access router state.
- **Minor formatting**: Adjusted line breaks in the modals object for consistency.

## Implementation Details

The `ModalsProvider` renders the currently open modal outside the normal component tree (as a sibling), which means modals don't inherit context from providers nested inside `ModalsProvider`. By moving `LocationProvider` to the outer level, all modals now have access to router state and can properly navigate after completing actions.

https://claude.ai/code/session_01FByEbnWgugbDE6KqC5vMVS