### PR TITLE
feat: add sorting to asset library by name or modified date

### DIFF
--- a/.changeset/olive-crabs-shave.md
+++ b/.changeset/olive-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: sort the asset library by name or modified date

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
@@ -149,6 +149,26 @@
   white-space: nowrap;
 }
 
+.AssetBrowser__table__sortHeader {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* Reset button styles so the header matches the other table headers. */
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.AssetBrowser__table__sortHeader:hover,
+.AssetBrowser__table__sortHeader.active {
+  color: var(--color-text-default);
+}
+
 .AssetBrowser__row {
   cursor: pointer;
 }

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -17,7 +17,9 @@ import {
 } from '@mantine/notifications';
 import {
   IconAlertTriangle,
+  IconChevronDown,
   IconChevronRight,
+  IconChevronUp,
   IconCloudDownload,
   IconCopy,
   IconDotsVertical,
@@ -37,6 +39,7 @@ import {
 } from '@tabler/icons-preact';
 import {ChangeEvent} from 'preact/compat';
 import {useEffect, useMemo, useState} from 'preact/hooks';
+import {useLocalStorage} from '../../hooks/useLocalStorage.js';
 import {usePagination} from '../../hooks/usePagination.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {getSyncProvider} from '../../utils/asset-sync/registry.js';
@@ -44,6 +47,10 @@ import {
   Asset,
   AssetFile,
   AssetFolder,
+  AssetSort,
+  AssetSortDir,
+  AssetSortField,
+  DEFAULT_ASSET_SORT,
   createAssetFile,
   createAssetFolder,
   createAssetFolderPaths,
@@ -58,6 +65,7 @@ import {
   moveAsset,
   parseFolderPath,
   renameAsset,
+  sortAssets,
   syncAssetToDocs,
   updateAssetAltDisabled,
   validateFolderPath,
@@ -122,6 +130,9 @@ export interface AssetBrowserProps {
 /** Number of assets to display per page. */
 const PAGE_SIZE = 100;
 
+/** localStorage key the user's preferred sort order is remembered under. */
+const SORT_STORAGE_KEY = 'root::AssetBrowser:sort';
+
 /**
  * A Drive-like file browser for the project's asset library. Lists the
  * contents of a folder with breadcrumb navigation and supports uploading,
@@ -135,6 +146,19 @@ export function AssetBrowser(props: AssetBrowserProps) {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('');
+  // Sort order of the listing, remembered across sessions. The persisted value
+  // is normalized so an unrecognized one falls back to the default order.
+  const [storedSort, setSort] = useLocalStorage<AssetSort>(
+    SORT_STORAGE_KEY,
+    DEFAULT_ASSET_SORT
+  );
+  const sort = useMemo<AssetSort>(
+    () => ({
+      field: storedSort?.field === 'modified' ? 'modified' : 'name',
+      dir: storedSort?.dir === 'desc' ? 'desc' : 'asc',
+    }),
+    [storedSort]
+  );
   const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
   // Recursive listing of the current folder's descendants, lazily fetched the
@@ -256,14 +280,14 @@ export function AssetBrowser(props: AssetBrowserProps) {
     if (needle) {
       res = res.filter((asset) => asset.name.toLowerCase().includes(needle));
     }
-    return res;
-  }, [assets, searchIndex, filter, props.mode, props.accept]);
+    return sortAssets(res, sort);
+  }, [assets, searchIndex, filter, sort, props.mode, props.accept]);
 
-  // Paginate the listing, resetting to the first page when the folder or the
-  // search filter changes.
+  // Paginate the listing, resetting to the first page when the folder, the
+  // search filter or the sort order changes.
   const pagination = usePagination(filteredAssets, {
     pageSize: PAGE_SIZE,
-    resetDeps: [folder, filter],
+    resetDeps: [folder, filter, sort.field, sort.dir],
   });
   const pageItems = pagination.pageItems;
 
@@ -683,8 +707,19 @@ export function AssetBrowser(props: AssetBrowserProps) {
                     />
                   </th>
                 )}
-                <th>name</th>
-                <th className="AssetBrowser__table__modifiedCol">modified</th>
+                <AssetSortHeader
+                  field="name"
+                  label="name"
+                  sort={sort}
+                  onSort={setSort}
+                />
+                <AssetSortHeader
+                  className="AssetBrowser__table__modifiedCol"
+                  field="modified"
+                  label="modified"
+                  sort={sort}
+                  onSort={setSort}
+                />
                 <th className="AssetBrowser__table__actionsCol"></th>
               </tr>
             </thead>
@@ -1025,6 +1060,63 @@ function AssetSyncBar(props: {
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Direction applied when a sort header is clicked. Activating a column uses
+ * its default direction (A-Z for names, most recent first for dates);
+ * clicking the already-active column toggles the direction.
+ */
+function nextSortDir(
+  field: AssetSortField,
+  activeDir: AssetSortDir | null
+): AssetSortDir {
+  if (activeDir === 'asc') {
+    return 'desc';
+  }
+  if (activeDir === 'desc') {
+    return 'asc';
+  }
+  return field === 'modified' ? 'desc' : 'asc';
+}
+
+/** A clickable table header cell that sorts the listing by its column. */
+function AssetSortHeader(props: {
+  className?: string;
+  field: AssetSortField;
+  label: string;
+  sort: AssetSort;
+  onSort: (sort: AssetSort) => void;
+}) {
+  const active = props.sort.field === props.field;
+  const dir = active ? props.sort.dir : null;
+  return (
+    <th
+      className={props.className}
+      aria-sort={
+        dir === 'asc' ? 'ascending' : dir === 'desc' ? 'descending' : 'none'
+      }
+    >
+      <button
+        type="button"
+        className={joinClassNames(
+          'AssetBrowser__table__sortHeader',
+          active && 'active'
+        )}
+        aria-label={`Sort by ${props.label}`}
+        onClick={() =>
+          props.onSort({field: props.field, dir: nextSortDir(props.field, dir)})
+        }
+      >
+        <span>{props.label}</span>
+        {dir === 'asc' ? (
+          <IconChevronUp size={12} stroke={2.5} />
+        ) : dir === 'desc' ? (
+          <IconChevronDown size={12} stroke={2.5} />
+        ) : null}
+      </button>
+    </th>
   );
 }
 

--- a/packages/root-cms/ui/utils/assets.test.ts
+++ b/packages/root-cms/ui/utils/assets.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import {
+  Asset,
   AssetFile,
   AssetNameError,
   buildAssetFieldValue,
@@ -11,6 +12,7 @@ import {
   joinFolderPath,
   parseFolderPath,
   replaceFileExt,
+  sortAssets,
   validateAssetName,
   validateFolderPath,
 } from './assets.js';
@@ -279,5 +281,93 @@ describe('buildSyncedFieldValue', () => {
     };
     const value = buildSyncedFieldValue(testAsset(), existing, previousFile);
     expect(value.canvasBgColor).toEqual('dark');
+  });
+});
+
+describe('sortAssets', () => {
+  function testEntry(
+    type: 'file' | 'folder',
+    name: string,
+    modifiedMillis?: number
+  ): Asset {
+    return {
+      id: `${type}-${name}`,
+      type: type,
+      parent: '',
+      name: name,
+      ...(modifiedMillis === undefined
+        ? {}
+        : {modifiedAt: {toMillis: () => modifiedMillis}}),
+    } as Asset;
+  }
+
+  const assets: Asset[] = [
+    testEntry('file', 'banner.png', 300),
+    testEntry('folder', 'zebra', 100),
+    testEntry('file', 'apple.png', 200),
+    testEntry('folder', 'alpha', 400),
+  ];
+
+  function names(sorted: Asset[]): string[] {
+    return sorted.map((asset) => asset.name);
+  }
+
+  it('sorts by name with folders first', () => {
+    expect(names(sortAssets(assets))).toEqual([
+      'alpha',
+      'zebra',
+      'apple.png',
+      'banner.png',
+    ]);
+    expect(names(sortAssets(assets, {field: 'name', dir: 'desc'}))).toEqual([
+      'zebra',
+      'alpha',
+      'banner.png',
+      'apple.png',
+    ]);
+  });
+
+  it('sorts by modified date with folders first', () => {
+    expect(names(sortAssets(assets, {field: 'modified', dir: 'desc'}))).toEqual(
+      ['alpha', 'zebra', 'banner.png', 'apple.png']
+    );
+    expect(names(sortAssets(assets, {field: 'modified', dir: 'asc'}))).toEqual([
+      'zebra',
+      'alpha',
+      'apple.png',
+      'banner.png',
+    ]);
+  });
+
+  it('sorts names numerically and case-insensitively', () => {
+    const files = [
+      testEntry('file', 'img10.png'),
+      testEntry('file', 'IMG2.png'),
+      testEntry('file', 'img1.png'),
+    ];
+    expect(names(sortAssets(files))).toEqual([
+      'img1.png',
+      'IMG2.png',
+      'img10.png',
+    ]);
+  });
+
+  it('falls back to the name for assets without a timestamp', () => {
+    const files = [
+      testEntry('file', 'b.png'),
+      testEntry('file', 'a.png'),
+      testEntry('file', 'c.png', 500),
+    ];
+    expect(names(sortAssets(files, {field: 'modified', dir: 'desc'}))).toEqual([
+      'c.png',
+      'a.png',
+      'b.png',
+    ]);
+  });
+
+  it('returns a sorted copy without mutating the input', () => {
+    const input = [...assets];
+    sortAssets(input, {field: 'modified', dir: 'desc'});
+    expect(names(input)).toEqual(names(assets));
   });
 });

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -271,16 +271,57 @@ export function getFolderId(folderPath: string): string {
   return `folder-${encodeURIComponent(folderPath)}`;
 }
 
-function sortAssets(assets: Asset[]): Asset[] {
-  return assets.sort((a, b) => {
+/** Column an asset listing can be sorted by. */
+export type AssetSortField = 'name' | 'modified';
+
+export type AssetSortDir = 'asc' | 'desc';
+
+/** Sort order of an asset listing. */
+export interface AssetSort {
+  field: AssetSortField;
+  dir: AssetSortDir;
+}
+
+/** Assets are listed alphabetically by default. */
+export const DEFAULT_ASSET_SORT: AssetSort = {field: 'name', dir: 'asc'};
+
+/** Returns the timestamp an asset is sorted by in the `modified` column. */
+function getAssetModifiedMillis(asset: Asset): number {
+  const ts = asset.modifiedAt || asset.createdAt;
+  return ts && typeof ts.toMillis === 'function' ? ts.toMillis() : 0;
+}
+
+function compareAssetNames(a: Asset, b: Asset): number {
+  return (a.name || '').localeCompare(b.name || '', undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
+/**
+ * Returns a sorted copy of an asset listing. Folders are always listed before
+ * files (Drive-style); within each group the assets are ordered by the
+ * requested column, using the name as a tiebreaker so that assets sharing a
+ * timestamp keep a stable order.
+ */
+export function sortAssets(
+  assets: Asset[],
+  sort: AssetSort = DEFAULT_ASSET_SORT
+): Asset[] {
+  const dir = sort.dir === 'desc' ? -1 : 1;
+  return [...assets].sort((a, b) => {
     // Folders are listed before files.
     if (a.type !== b.type) {
       return a.type === 'folder' ? -1 : 1;
     }
-    return (a.name || '').localeCompare(b.name || '', undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    });
+    if (sort.field === 'modified') {
+      const delta = getAssetModifiedMillis(a) - getAssetModifiedMillis(b);
+      if (delta !== 0) {
+        return dir * delta;
+      }
+      return compareAssetNames(a, b);
+    }
+    return dir * compareAssetNames(a, b);
   });
 }
 


### PR DESCRIPTION
Adds column-based sorting to the asset browser, allowing users to sort assets by name or modified date in ascending or descending order. The sort preference is persisted to localStorage across sessions.

## Changes

- **Sorting UI**: Made table headers ("name" and "modified") clickable to toggle sort order. Active columns display chevron icons (up/down) indicating direction. Clicking an inactive column activates it with its default direction (A-Z for names, most recent first for dates); clicking the active column toggles the direction.

- **Sort state management**: Added `useLocalStorage` hook integration to remember the user's preferred sort order. Unrecognized stored values fall back to the default (name, ascending).

- **Asset sorting logic**: Exported `sortAssets()` function that:
  - Always lists folders before files (Drive-style)
  - Sorts by the requested column (name or modified date)
  - Uses numeric, case-insensitive comparison for names
  - Falls back to name as a tiebreaker for assets sharing a timestamp
  - Returns a sorted copy without mutating the input

- **Type exports**: Added `AssetSort`, `AssetSortField`, `AssetSortDir` types and `DEFAULT_ASSET_SORT` constant to the public API.

- **Pagination reset**: Updated pagination to reset to the first page when sort order changes, alongside existing resets for folder/filter changes.

- **Styling**: Added `.AssetBrowser__table__sortHeader` button styles with hover/active states and icon spacing.

- **Tests**: Comprehensive test coverage for `sortAssets()` including name sorting (numeric, case-insensitive), modified date sorting, folder-first ordering, timestamp fallback behavior, and immutability.

https://claude.ai/code/session_01CMQDmDMPd95jAWTzU8V1rj