### PR TITLE
feat: add a "Publish" action to the collection list

### DIFF
--- a/.changeset/quiet-eggs-shine.md
+++ b/.changeset/quiet-eggs-shine.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add a "Publish" action to the collection list

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
@@ -15,6 +15,7 @@ import {
   IconLock,
   IconLockOpen,
   IconPackage,
+  IconRocket,
   IconTrash,
 } from '@tabler/icons-preact';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
@@ -36,6 +37,7 @@ import {useAddToReleaseModal} from '../AddToReleaseModal/AddToReleaseModal.js';
 import {useCopyDocModal} from '../CopyDocModal/CopyDocModal.js';
 import {DocIdBadge} from '../DocIdBadge/DocIdBadge.js';
 import {useLockPublishingModal} from '../LockPublishingModal/LockPublishingModal.js';
+import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Text} from '../Text/Text.js';
 import {useVersionHistoryModal} from '../VersionHistoryModal/VersionHistoryModal.js';
 
@@ -46,7 +48,9 @@ export interface DocActionEvent {
     | 'archive'
     | 'copy'
     | 'delete'
+    | 'publish'
     | 'revert-draft'
+    | 'schedule'
     | 'unarchive'
     | 'unpublish'
     | 'unschedule'
@@ -66,6 +70,12 @@ export interface DocActionsMenuProps {
    * requested position.
    */
   onMoveTo?: (position: 'top' | 'bottom') => void;
+  /**
+   * Renders a "Publish" menu item. Enabled in contexts that have no dedicated
+   * publish button of their own (e.g. the collection list); the doc editor has
+   * its own publish button in the status bar.
+   */
+  showPublish?: boolean;
 }
 
 export function DocActionsMenu(props: DocActionsMenuProps) {
@@ -91,6 +101,16 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
   const versionHistoryModal = useVersionHistoryModal({docId});
   const lockPublishingModal = useLockPublishingModal({docId});
   const addToReleaseModal = useAddToReleaseModal({docIds: [docId]});
+  const publishDocModal = usePublishDocModal({
+    docId,
+    onSuccess: (event) => {
+      if (props.onAction) {
+        props.onAction({
+          action: event.publishType === 'scheduled' ? 'schedule' : 'publish',
+        });
+      }
+    },
+  });
 
   const onRevertDraft = () => {
     const notificationId = `revert-draft-${docId}`;
@@ -390,6 +410,19 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
           disabled={!canEdit}
         >
           Move to bottom
+        </Menu.Item>
+      )}
+      {props.showPublish && !isArchived && (
+        <Menu.Item
+          icon={<IconRocket size={20} />}
+          onClick={() => publishDocModal.open()}
+          // A doc with a pending scheduled publish or a publishing lock can't
+          // be published until it's unscheduled or unlocked.
+          disabled={
+            !canPublish || testIsScheduled(data) || testPublishingLocked(data)
+          }
+        >
+          Publish
         </Menu.Item>
       )}
       {!isArchived && (

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -30,6 +30,8 @@ export type PublishType = 'now' | 'scheduled' | '';
 export interface PublishDocModalProps {
   [key: string]: unknown;
   docId: string;
+  /** Called after the doc is successfully published or scheduled. */
+  onSuccess?: (event: {publishType: 'now' | 'scheduled'}) => void;
 }
 
 export function usePublishDocModal(props: PublishDocModalProps) {
@@ -73,12 +75,12 @@ export function PublishDocModal(
       await cmsPublishDoc(props.docId, {
         publishMessage: publishMessage.trim() || undefined,
       });
-      setLoading(false);
       showNotification({
         title: 'Published!',
         message: `Succesfully published ${props.docId}.`,
         autoClose: 10000,
       });
+      props.onSuccess?.({publishType: 'now'});
       modals.closeAll();
     } catch (err) {
       console.error(err);
@@ -89,6 +91,8 @@ export function PublishDocModal(
         color: 'red',
         autoClose: false,
       });
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -99,12 +103,12 @@ export function PublishDocModal(
       await cmsScheduleDoc(props.docId, millis, {
         publishMessage: publishMessage.trim() || undefined,
       });
-      setLoading(false);
       showNotification({
         title: 'Scheduled!',
         message: `${props.docId} will go live ${scheduledDate}.`,
         autoClose: 10000,
       });
+      props.onSuccess?.({publishType: 'scheduled'});
       modals.closeAll();
     } catch (err) {
       console.error(err);
@@ -115,6 +119,8 @@ export function PublishDocModal(
         color: 'red',
         autoClose: false,
       });
+    } finally {
+      setLoading(false);
     }
   }
 

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -730,6 +730,8 @@ CollectionPage.DocsList = (props: {
       e.action === 'copy' ||
       e.action === 'unarchive' ||
       e.action === 'delete' ||
+      e.action === 'publish' ||
+      e.action === 'schedule' ||
       e.action === 'unpublish' ||
       e.action === 'locked' ||
       e.action === 'unlocked'
@@ -934,6 +936,7 @@ CollectionPage.DocsList = (props: {
                           )
                       : undefined
                   }
+                  showPublish
                 />
               </div>
             </ReorderableRow>
@@ -1013,6 +1016,7 @@ CollectionPage.DocsList = (props: {
                         )
                     : undefined
                 }
+                showPublish
               />
             </div>
           </ReorderableRow>


### PR DESCRIPTION
Adds a "Publish" menu item to the document actions menu in the collection list view, allowing users to publish or schedule documents directly from the list without opening the editor.

Fixes #1365

## Changes

- **DocActionsMenu**: Added `showPublish` prop to conditionally render a "Publish" menu item with a rocket icon. The item is disabled when the document cannot be published (archived, scheduled, or has a publishing lock).
- **PublishDocModal**: Added `onSuccess` callback that fires after a document is successfully published or scheduled, allowing parent components to respond to the action. Improved error handling by moving `setLoading(false)` to a `finally` block.
- **CollectionPage**: Enabled the publish action in the collection list by passing `showPublish` to both grid and list view variants of DocActionsMenu, and added handling for `'publish'` and `'schedule'` action events.
- **Changeset**: Added patch-level changelog entry for the new feature.

## Implementation Details

The publish action integrates with the existing `PublishDocModal` component, which already handles both immediate publishing and scheduled publishing. The modal's new `onSuccess` callback distinguishes between the two publish types (`'now'` vs `'scheduled'`) and notifies the parent component accordingly, enabling proper UI updates in the collection list.

https://claude.ai/code/session_01XY9UxYTUT6BPpvgC3CzvcF