### PR TITLE
fix: don't log rejected sign-in tokens as server errors

### DIFF
--- a/.changeset/olive-donuts-shave.md
+++ b/.changeset/olive-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: don't log rejected sign-in tokens as server errors

--- a/packages/root-cms/core/auth-errors.test.ts
+++ b/packages/root-cms/core/auth-errors.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it} from 'vitest';
+import {getInvalidTokenErrorCode} from './auth-errors.js';
+
+function authError(code: string) {
+  return Object.assign(new Error('token rejected'), {code});
+}
+
+describe('getInvalidTokenErrorCode', () => {
+  it('returns the code for rejected tokens', () => {
+    const codes = [
+      'auth/argument-error',
+      'auth/id-token-expired',
+      'auth/id-token-revoked',
+      'auth/invalid-id-token',
+      'auth/session-cookie-expired',
+      'auth/session-cookie-revoked',
+      'auth/user-disabled',
+      'auth/user-not-found',
+    ];
+    for (const code of codes) {
+      expect(getInvalidTokenErrorCode(authError(code))).toBe(code);
+    }
+  });
+
+  it('returns null for backend failures', () => {
+    expect(getInvalidTokenErrorCode(authError('auth/internal-error'))).toBe(
+      null
+    );
+    expect(getInvalidTokenErrorCode(authError('auth/invalid-credential'))).toBe(
+      null
+    );
+  });
+
+  it('returns null for errors without a string code', () => {
+    expect(getInvalidTokenErrorCode(new Error('boom'))).toBe(null);
+    expect(getInvalidTokenErrorCode({code: 42})).toBe(null);
+    expect(getInvalidTokenErrorCode(null)).toBe(null);
+    expect(getInvalidTokenErrorCode(undefined)).toBe(null);
+  });
+});

--- a/packages/root-cms/core/auth-errors.ts
+++ b/packages/root-cms/core/auth-errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Firebase Auth error codes that mean "the caller sent a token we can't
+ * accept", as opposed to a backend failure. `verifyIdToken()` and
+ * `verifySessionCookie()` reject with these for malformed, expired, or
+ * revoked tokens, all of which are ordinary sign-in failures.
+ */
+const INVALID_TOKEN_ERROR_CODES = new Set([
+  'auth/argument-error',
+  'auth/id-token-expired',
+  'auth/id-token-revoked',
+  'auth/invalid-id-token',
+  'auth/session-cookie-expired',
+  'auth/session-cookie-revoked',
+  'auth/user-disabled',
+  'auth/user-not-found',
+]);
+
+/**
+ * Returns the Firebase Auth error code if the error means the token itself was
+ * rejected, rather than the verification failing for an infrastructure reason
+ * (network, credentials, etc.). Callers use this to log expected sign-in
+ * failures without reporting them as server errors.
+ */
+export function getInvalidTokenErrorCode(err: unknown): string | null {
+  const code = (err as {code?: unknown} | null)?.code;
+  if (typeof code === 'string' && INVALID_TOKEN_ERROR_CODES.has(code)) {
+    return code;
+  }
+  return null;
+}

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -26,6 +26,7 @@ import sirv from 'sirv';
 import {SSEEvent, SSESchemaChangedEvent} from '../shared/sse.js';
 import {type AiConfig} from './ai.js';
 import {api} from './api.js';
+import {getInvalidTokenErrorCode} from './auth-errors.js';
 import {writeBuildInfo} from './build-info.js';
 import {type CMSCheck} from './checks.js';
 import {Action, RootCMSClient, UserRole} from './client.js';
@@ -759,7 +760,7 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
     req: Request
   ): Promise<{authorized: boolean; reason?: string}> {
     const idToken = req.body?.idToken;
-    if (!idToken) {
+    if (typeof idToken !== 'string' || !idToken) {
       console.log('login failed: no id token');
       return {authorized: false, reason: 'no token'};
     }
@@ -774,7 +775,7 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
     try {
       if (process.env.NODE_ENV === 'development') {
         const jwt = jsonwebtoken.decode(idToken) as jsonwebtoken.JwtPayload;
-        if (!jwt.email || !jwt.email_verified) {
+        if (!jwt?.email || !jwt?.email_verified) {
           console.log('login failed: email unverified');
           return {authorized: false, reason: 'login failed'};
         }
@@ -811,6 +812,14 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
         return {authorized: false, reason: 'not authorized'};
       }
     } catch (err) {
+      // A rejected token is a normal sign-in failure (and a common one, since
+      // bots probe this endpoint with junk payloads), so log it without
+      // reporting it as a server error.
+      const invalidTokenCode = getInvalidTokenErrorCode(err);
+      if (invalidTokenCode) {
+        console.log(`login failed: invalid id token (${invalidTokenCode})`);
+        return {authorized: false, reason: 'login failed'};
+      }
       console.error('failed to verify jwt token');
       console.error(err);
       return {authorized: false, reason: 'unknown error'};
@@ -874,6 +883,11 @@ export function cmsPlugin(options: CMSPluginOptions): CMSPlugin {
       // instead of bouncing an authenticated user to the login page.
       jwt = await auth.verifySessionCookie(sessionCookie, true);
     } catch (err) {
+      const invalidTokenCode = getInvalidTokenErrorCode(err);
+      if (invalidTokenCode) {
+        console.log(`session failed: invalid cookie (${invalidTokenCode})`);
+        return null;
+      }
       console.error('failed to verify jwt token');
       console.error(err);
       return null;


### PR DESCRIPTION
`verifyUserLogin()` and `getCurrentUser()` both `console.error()` any error thrown while verifying a token. But `firebase-admin` *throws* on a malformed, expired, or revoked token rather than returning a verification failure, so an ordinary rejected sign-in is logged as if it were a server fault.

This is noisy in production: unauthenticated clients can `PUT /cms/login` with any JSON body, and `req.body.idToken` is passed straight to `auth.verifyIdToken()`. Anything that isn't a well-formed Firebase ID token produces a stack trace such as:

```
FirebaseAuthError: First argument to verifyIdToken() must be a Firebase ID token string.
    at FirebaseTokenVerifier.verifyJWT (.../firebase-admin/lib/auth/token-verifier.js:116:19)
    at Auth.verifyIdToken (.../firebase-admin/lib/auth/base-auth.js:116:37)
    at verifyUserLogin (.../@blinkk/root-cms/dist/plugin.js:1892:32)
```

(also `Firebase ID token has no "kid" claim` and `Decoding Firebase ID token failed`). The request still correctly ends in a `401`, but on a site with any error-reporting integration each probe files a new production error report — so a routine scanner sweep buries real errors under noise.

## Changes

- Add `core/auth-errors.ts` with `getInvalidTokenErrorCode()`, which recognizes the Firebase Auth codes that mean "the caller sent a token we can't accept" (`auth/argument-error`, `auth/id-token-expired`, `auth/id-token-revoked`, `auth/invalid-id-token`, `auth/session-cookie-expired`, `auth/session-cookie-revoked`, `auth/user-disabled`, `auth/user-not-found`).
- `verifyUserLogin()` and `getCurrentUser()` now `console.log()` those as sign-in failures and keep `console.error()` for genuine backend failures (bad credentials, network, etc.), which should still be reported.
- Reject a non-string `idToken` up front, and null-guard the decoded JWT on the dev path (`jsonwebtoken.decode()` returns `null` for a non-JWT string, so a junk body previously threw a `TypeError` in dev).

No behavior change for callers: the same `{authorized: false}` / `null` results and the same HTTP responses are returned in every case — only the log level and the ability to distinguish the two failure classes change.

## Testing

- `vitest run core/auth-errors.test.ts` (added, 3 tests covering rejected codes, backend failures, and non-Error/codeless inputs).
- `pnpm build:core` and `eslint` pass on the changed files.
