### PR TITLE
feat: warn or block deleting and unpublishing docs with doc references

### DIFF
--- a/.changeset/shiny-doors-listen.md
+++ b/.changeset/shiny-doors-listen.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: warn or block deleting and unpublishing docs that other docs reference

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -358,7 +358,8 @@ export function api(server: Server, options: ApiOptions) {
   >();
 
   /**
-   * Queries the dependency graph for the docs referenced by one or more docs.
+   * Queries the dependency graph for the docs referenced by one or more docs,
+   * or — with `direction: "dependents"` — the docs that reference them.
    * Requires the `dependencyGraph` cmsPlugin option to be enabled.
    *
    * Authentication: any signed-in CMS user.
@@ -368,6 +369,13 @@ export function api(server: Server, options: ApiOptions) {
    * ```
    * POST /cms/api/dependency_graph.query
    * {"docIds": ["Pages/index"], "mode": "draft", "transitive": true}
+   * ```
+   *
+   * Reverse lookup:
+   *
+   * ```
+   * POST /cms/api/dependency_graph.query
+   * {"docIds": ["Pages/index"], "direction": "dependents", "transitive": false}
    * ```
    */
   server.use(
@@ -397,6 +405,8 @@ export function api(server: Server, options: ApiOptions) {
         return;
       }
       const mode = body.mode === 'published' ? 'published' : 'draft';
+      const direction =
+        body.direction === 'dependents' ? 'dependents' : 'dependencies';
       const transitive = body.transitive !== false;
       try {
         const service = new DependencyGraphService(req.rootConfig!);
@@ -405,11 +415,15 @@ export function api(server: Server, options: ApiOptions) {
           return;
         }
         const graph = await service.getGraph(mode);
-        const deps = graph.getDependencies(docIds, {transitive});
+        const deps =
+          direction === 'dependents'
+            ? graph.getDependents(docIds, {transitive})
+            : graph.getDependencies(docIds, {transitive});
         res.setHeader('Cache-Control', 'no-store');
         res.status(200).json({
           success: true,
           mode,
+          direction,
           deps,
           lastRun: graph.lastRun,
         });

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -5,6 +5,7 @@ import {renderJsxToString} from '@blinkk/root/jsx';
 import {serializeJsonForScript} from '../shared/safe-json.js';
 import {serializeAiConfig} from './ai.js';
 import {getBuildInfo} from './build-info.js';
+import {resolveReferenceGuardMode} from './dependency-graph.js';
 import {CMSPluginOptions} from './plugin.js';
 import {getCollectionSchema, getProjectSchemas} from './project.js';
 import {Collection} from './schema.js';
@@ -156,6 +157,9 @@ export async function renderApp(
     // Matches `resolveDependencyGraphConfig()`: `true` or a config object
     // enables the feature.
     dependencyGraphEnabled: Boolean(cmsConfig.dependencyGraph),
+    dependencyGraphReferenceGuard: resolveReferenceGuardMode(
+      cmsConfig.dependencyGraph
+    ),
   };
   const projectName = cmsConfig.name || cmsConfig.id || '';
   const title = getCmsTitle(projectName, cmsConfig.minimalBranding);

--- a/packages/root-cms/core/dependency-graph.test.ts
+++ b/packages/root-cms/core/dependency-graph.test.ts
@@ -19,6 +19,7 @@ import {
   isCollectionTracked,
   resolveDependencyGraphConfig,
   resolveDependencyGraphFilters,
+  resolveReferenceGuardMode,
 } from './dependency-graph.js';
 
 describe('resolveDependencyGraphConfig', () => {
@@ -34,6 +35,28 @@ describe('resolveDependencyGraphConfig', () => {
   it('treats unset/false as disabled', () => {
     expect(resolveDependencyGraphConfig(undefined)).toBe(null);
     expect(resolveDependencyGraphConfig(false)).toBe(null);
+  });
+});
+
+describe('resolveReferenceGuardMode', () => {
+  it('is disabled by default', () => {
+    expect(resolveReferenceGuardMode(undefined)).toBe(null);
+    expect(resolveReferenceGuardMode(true)).toBe(null);
+    expect(resolveReferenceGuardMode({})).toBe(null);
+    expect(resolveReferenceGuardMode({referenceGuard: false})).toBe(null);
+  });
+
+  it('treats `true` as warn', () => {
+    expect(resolveReferenceGuardMode({referenceGuard: true})).toBe('warn');
+  });
+
+  it('accepts explicit modes', () => {
+    expect(resolveReferenceGuardMode({referenceGuard: 'warn'})).toBe('warn');
+    expect(resolveReferenceGuardMode({referenceGuard: 'block'})).toBe('block');
+  });
+
+  it('requires the dependency graph itself to be enabled', () => {
+    expect(resolveReferenceGuardMode(false)).toBe(null);
   });
 });
 

--- a/packages/root-cms/core/dependency-graph.ts
+++ b/packages/root-cms/core/dependency-graph.ts
@@ -175,6 +175,30 @@ export function resolveDependencyGraphConfig(
   return null;
 }
 
+/** Behavior of the reference guard when a doc is deleted or unpublished. */
+export type ReferenceGuardMode = 'warn' | 'block';
+
+/**
+ * Normalizes the `referenceGuard` option nested in the `dependencyGraph`
+ * cmsPlugin option. Returns the guard mode, or `null` when disabled
+ * (including when the dependency graph itself is disabled).
+ */
+export function resolveReferenceGuardMode(
+  option?: boolean | CMSDependencyGraphConfig
+): ReferenceGuardMode | null {
+  const config = resolveDependencyGraphConfig(option);
+  if (!config) {
+    return null;
+  }
+  if (config.referenceGuard === true || config.referenceGuard === 'warn') {
+    return 'warn';
+  }
+  if (config.referenceGuard === 'block') {
+    return 'block';
+  }
+  return null;
+}
+
 function toSetOrNull(values: string[] | undefined): Set<string> | null {
   if (!values || values.length === 0) {
     return null;

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -291,6 +291,19 @@ export interface CMSDependencyGraphConfig {
    * `includeCollections`.
    */
   excludeCollections?: string[];
+
+  /**
+   * Enables the reference guard: when an editor deletes or unpublishes a doc,
+   * the CMS UI checks the dependency graph for other docs that reference it.
+   * `'warn'` lists the referencing docs but allows the action to proceed;
+   * `'block'` prevents confirming until the references are removed. Pass
+   * `true` as shorthand for `'warn'`. Disabled by default.
+   *
+   * Note the guard only covers reference fields tracked by the dependency
+   * graph (`schema.reference()` / `schema.references()`); hardcoded links
+   * (e.g. URLs in text fields) are not detected.
+   */
+  referenceGuard?: boolean | 'warn' | 'block';
 }
 
 export interface CMSSidebarTool {
@@ -632,12 +645,13 @@ export type CMSPluginOptions = {
    * referenced docs that need to be fetched when fetching one or more docs.
    *
    * Disabled by default. Pass `true` to enable with default options, or a
-   * config object to scope the graph to specific collections.
+   * config object to scope the graph to specific collections or enable the
+   * reference guard (see `CMSDependencyGraphConfig`).
    *
    * Example:
    * ```ts
    * cmsPlugin({
-   *   dependencyGraph: true,
+   *   dependencyGraph: {referenceGuard: 'warn'},
    * });
    * ```
    */

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.css
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.css
@@ -1,3 +1,37 @@
 .DocActionsMenu__confirmText {
   text-wrap: pretty;
 }
+
+.DocActionsMenu__referenceGuard {
+  margin-top: 16px;
+}
+
+.DocActionsMenu__referenceGuard__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #868e96;
+  margin-bottom: 8px;
+}
+
+.DocActionsMenu__referenceGuard__list {
+  display: flex;
+  flex-direction: column;
+  border-radius: 4px;
+}
+
+.DocActionsMenu__referenceGuard__list > * {
+  padding: 8px 12px;
+}
+
+.DocActionsMenu__referenceGuard__list > *:not(:last-child) {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.DocActionsMenu__referenceGuard__more,
+.DocActionsMenu__referenceGuard__caveat {
+  font-size: 11px;
+  color: #868e96;
+  margin-top: 8px;
+}

--- a/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
+++ b/packages/root-cms/ui/components/DocActionsMenu/DocActionsMenu.tsx
@@ -22,7 +22,9 @@ import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {
   CMSDoc,
+  ReferenceGuardResult,
   cmsArchiveDoc,
+  cmsCheckReferenceGuard,
   cmsDeleteDoc,
   cmsRevertDraft,
   cmsUnarchiveDoc,
@@ -36,6 +38,7 @@ import {testCanEdit, testCanPublish} from '../../utils/permissions.js';
 import {useAddToReleaseModal} from '../AddToReleaseModal/AddToReleaseModal.js';
 import {useCopyDocModal} from '../CopyDocModal/CopyDocModal.js';
 import {DocIdBadge} from '../DocIdBadge/DocIdBadge.js';
+import {DocPreviewCard} from '../DocPreviewCard/DocPreviewCard.js';
 import {useLockPublishingModal} from '../LockPublishingModal/LockPublishingModal.js';
 import {usePublishDocModal} from '../PublishDocModal/PublishDocModal.js';
 import {Text} from '../Text/Text.js';
@@ -162,7 +165,9 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
     });
   };
 
-  const onUnpublishDoc = () => {
+  const onUnpublishDoc = async () => {
+    const guard = await cmsCheckReferenceGuard(docId, 'unpublish');
+    const blocked = guard?.mode === 'block';
     const notificationId = `unpublish-doc-${docId}`;
     const modalId = modals.openConfirmModal({
       ...modalTheme,
@@ -174,18 +179,33 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
             weight="semi-bold"
             className="DocActionsMenu__confirmText"
           >
-            Are you sure you want to unpublish the following doc? There is no
-            undo.
+            {blocked
+              ? 'This doc cannot be unpublished because other published docs reference it.'
+              : 'Are you sure you want to unpublish the following doc? There is no undo.'}
           </Text>
           <DocIdBadge docId={docId} />
+          {guard && (
+            <ReferenceGuardWarning
+              label={
+                blocked
+                  ? `To unpublish this doc, first remove the references from these published docs (${guard.dependents.length}):`
+                  : `Published docs that reference this doc and may break if it is unpublished (${guard.dependents.length}):`
+              }
+              guard={guard}
+            />
+          )}
         </>
       ),
       labels: {confirm: 'Unpublish', cancel: 'Cancel'},
       cancelProps: {size: 'xs'},
-      confirmProps: {color: 'red', size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs', disabled: blocked},
       onCancel: () => console.log('Cancel'),
       closeOnConfirm: false,
       onConfirm: async () => {
+        if (blocked) {
+          // Defensive; the confirm button is disabled.
+          return;
+        }
         showNotification({
           id: notificationId,
           title: 'Unpublishing doc',
@@ -335,7 +355,9 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
     }
   };
 
-  const onDeleteDoc = () => {
+  const onDeleteDoc = async () => {
+    const guard = await cmsCheckReferenceGuard(docId, 'delete');
+    const blocked = guard?.mode === 'block';
     const notificationId = `delete-doc-${docId}`;
     const modalId = modals.openConfirmModal({
       ...modalTheme,
@@ -347,17 +369,33 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
             weight="semi-bold"
             className="DocActionsMenu__confirmText"
           >
-            Are you sure you want to delete the following doc? There is no undo.
+            {blocked
+              ? 'This doc cannot be deleted because other docs reference it.'
+              : 'Are you sure you want to delete the following doc? There is no undo.'}
           </Text>
           <DocIdBadge docId={docId} />
+          {guard && (
+            <ReferenceGuardWarning
+              label={
+                blocked
+                  ? `To delete this doc, first remove the references from these docs (${guard.dependents.length}):`
+                  : `Docs that reference this doc and may break if it is deleted (${guard.dependents.length}):`
+              }
+              guard={guard}
+            />
+          )}
         </>
       ),
       labels: {confirm: 'Delete', cancel: 'Cancel'},
       cancelProps: {size: 'xs'},
-      confirmProps: {color: 'red', size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs', disabled: blocked},
       onCancel: () => console.log('Cancel'),
       closeOnConfirm: false,
       onConfirm: async () => {
+        if (blocked) {
+          // Defensive; the confirm button is disabled.
+          return;
+        }
         showNotification({
           id: notificationId,
           title: 'Deleting doc',
@@ -528,5 +566,46 @@ export function DocActionsMenu(props: DocActionsMenuProps) {
         Delete
       </Menu.Item>
     </Menu>
+  );
+}
+
+const REFERENCE_GUARD_MAX_LISTED = 10;
+
+/**
+ * Renders the docs that reference a doc being deleted or unpublished. Shown
+ * in the confirm modal when the `dependencyGraph.referenceGuard` cmsPlugin
+ * option is enabled.
+ */
+function ReferenceGuardWarning(props: {
+  label: string;
+  guard: ReferenceGuardResult;
+}) {
+  const listed = props.guard.dependents.slice(0, REFERENCE_GUARD_MAX_LISTED);
+  const numHidden = props.guard.dependents.length - listed.length;
+  return (
+    <div className="DocActionsMenu__referenceGuard">
+      <div className="DocActionsMenu__referenceGuard__label">{props.label}</div>
+      <div className="DocActionsMenu__referenceGuard__list">
+        {listed.map((depId) => (
+          <DocPreviewCard
+            key={depId}
+            docId={depId}
+            variant="compact"
+            statusBadges
+            clickable
+          />
+        ))}
+      </div>
+      {numHidden > 0 && (
+        <div className="DocActionsMenu__referenceGuard__more">
+          +{numHidden} more
+        </div>
+      )}
+      <div className="DocActionsMenu__referenceGuard__caveat">
+        Only doc reference fields are checked — hardcoded links are not
+        detected, and recent edits may not be reflected until the next reference
+        scan.
+      </div>
+    </div>
   );
 }

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -284,6 +284,12 @@ declare global {
        * client-side publishes so the graph is updated immediately.
        */
       dependencyGraphEnabled?: boolean;
+      /**
+       * Reference guard mode from the `dependencyGraph.referenceGuard`
+       * cmsPlugin option. When set, the UI warns ('warn') or blocks ('block')
+       * deleting or unpublishing a doc that other docs reference.
+       */
+      dependencyGraphReferenceGuard?: 'warn' | 'block' | null;
     };
     firebase: FirebaseContextObject;
   }

--- a/packages/root-cms/ui/utils/doc.test.ts
+++ b/packages/root-cms/ui/utils/doc.test.ts
@@ -1,11 +1,13 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   cmsAssignSortKeys,
+  cmsCheckReferenceGuard,
   cmsCopyDoc,
   cmsCreateDoc,
   cmsPublishDocs,
   cmsSetDocSortKey,
   getDraftDocs,
+  getReferenceGuardMode,
 } from './doc.js';
 
 const mocks = vi.hoisted(() => ({
@@ -503,5 +505,110 @@ describe('cmsPublishDocs', () => {
     await expect(
       cmsPublishDocs(['pages/exists', 'pages/missing'])
     ).rejects.toThrow('doc does not exist: pages/missing');
+  });
+});
+
+describe('cmsCheckReferenceGuard', () => {
+  const mockFetch = vi.fn();
+
+  function jsonResponse(deps: string[]) {
+    return {
+      status: 200,
+      json: async () => ({success: true, deps}),
+      text: async () => '',
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    window.__ROOT_CTX = {
+      rootConfig: {
+        projectId: 'test-project',
+      },
+      dependencyGraphEnabled: true,
+      dependencyGraphReferenceGuard: 'warn',
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null without fetching when the guard is disabled', async () => {
+    window.__ROOT_CTX.dependencyGraphReferenceGuard = undefined;
+    expect(getReferenceGuardMode()).toBe(null);
+    expect(await cmsCheckReferenceGuard('pages/foo', 'delete')).toBe(null);
+
+    window.__ROOT_CTX.dependencyGraphReferenceGuard = 'warn';
+    window.__ROOT_CTX.dependencyGraphEnabled = false;
+    expect(getReferenceGuardMode()).toBe(null);
+    expect(await cmsCheckReferenceGuard('pages/foo', 'delete')).toBe(null);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('queries published dependents for unpublish', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(['pages/bar']));
+
+    const result = await cmsCheckReferenceGuard('pages/foo', 'unpublish');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/cms/api/dependency_graph.query',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          docIds: ['pages/foo'],
+          mode: 'published',
+          direction: 'dependents',
+          transitive: false,
+        }),
+      })
+    );
+    expect(result).toEqual({mode: 'warn', dependents: ['pages/bar']});
+  });
+
+  it('unions draft and published dependents for delete', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(['pages/c', 'pages/a']))
+      .mockResolvedValueOnce(jsonResponse(['pages/b', 'pages/a']));
+
+    const result = await cmsCheckReferenceGuard('pages/foo', 'delete');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const modes = mockFetch.mock.calls.map(
+      (call) => JSON.parse(call[1].body).mode
+    );
+    expect(modes.sort()).toEqual(['draft', 'published']);
+    expect(result).toEqual({
+      mode: 'warn',
+      dependents: ['pages/a', 'pages/b', 'pages/c'],
+    });
+  });
+
+  it('returns null when no docs reference the doc', async () => {
+    mockFetch.mockResolvedValue(jsonResponse([]));
+    expect(await cmsCheckReferenceGuard('pages/foo', 'delete')).toBe(null);
+  });
+
+  it('fails open when the query fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'));
+    expect(await cmsCheckReferenceGuard('pages/foo', 'unpublish')).toBe(null);
+
+    mockFetch.mockResolvedValueOnce({
+      status: 500,
+      json: async () => ({success: false}),
+      text: async () => 'UNKNOWN',
+    });
+    expect(await cmsCheckReferenceGuard('pages/foo', 'unpublish')).toBe(null);
+  });
+
+  it('passes through block mode', async () => {
+    window.__ROOT_CTX.dependencyGraphReferenceGuard = 'block';
+    mockFetch.mockResolvedValueOnce(jsonResponse(['pages/bar']));
+
+    const result = await cmsCheckReferenceGuard('pages/foo', 'unpublish');
+    expect(result).toEqual({mode: 'block', dependents: ['pages/bar']});
   });
 });

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -387,6 +387,77 @@ export async function cmsSyncDependencyGraph(docIds: string[]) {
   }
 }
 
+/** Behavior of the reference guard when a doc is deleted or unpublished. */
+export type ReferenceGuardMode = 'warn' | 'block';
+
+/** Result of a reference guard check for a doc. */
+export interface ReferenceGuardResult {
+  mode: ReferenceGuardMode;
+  /** Doc ids that directly reference the doc. Non-empty, sorted. */
+  dependents: string[];
+}
+
+/**
+ * Returns the reference guard mode from the `dependencyGraph.referenceGuard`
+ * cmsPlugin option, or `null` when the feature is disabled.
+ */
+export function getReferenceGuardMode(): ReferenceGuardMode | null {
+  if (!window.__ROOT_CTX.dependencyGraphEnabled) {
+    return null;
+  }
+  return window.__ROOT_CTX.dependencyGraphReferenceGuard || null;
+}
+
+/**
+ * Checks the reference guard before deleting or unpublishing a doc, returning
+ * the guard mode and the docs that directly reference `docId`. Deleting a doc
+ * affects both draft and published references (union of both graph modes);
+ * unpublishing only affects published references. Returns `null` when the
+ * guard is disabled, no other docs reference the doc, or the query fails —
+ * failures are logged and the caller falls back to the standard confirmation
+ * flow (a graph outage should never prevent edits).
+ */
+export async function cmsCheckReferenceGuard(
+  docId: string,
+  action: 'delete' | 'unpublish'
+): Promise<ReferenceGuardResult | null> {
+  const mode = getReferenceGuardMode();
+  if (!mode) {
+    return null;
+  }
+  const graphModes =
+    action === 'delete' ? ['draft', 'published'] : ['published'];
+  try {
+    const results = await Promise.all(
+      graphModes.map(async (graphMode) => {
+        const res = await fetch('/cms/api/dependency_graph.query', {
+          method: 'POST',
+          headers: {'content-type': 'application/json'},
+          body: JSON.stringify({
+            docIds: [docId],
+            mode: graphMode,
+            direction: 'dependents',
+            transitive: false,
+          }),
+        });
+        if (res.status !== 200) {
+          throw new Error(await res.text());
+        }
+        const data = await res.json();
+        return (data.deps || []) as string[];
+      })
+    );
+    const dependents = Array.from(new Set(results.flat())).sort();
+    if (dependents.length === 0) {
+      return null;
+    }
+    return {mode, dependents};
+  } catch (err) {
+    console.error('reference guard check failed:', err);
+    return null;
+  }
+}
+
 /**
  * Schedules a CMS doc to be published at some time in the future.
  */


### PR DESCRIPTION
Adds an opt-in "reference guard" to the doc delete and unpublish flows. When enabled, the confirm modal checks the dependency graph for other docs that reference the doc and either warns the editor or blocks the action until the references are removed. Without this, deleting or unpublishing a still-referenced doc silently leaves dangling references and dead links on the live site.

## Usage

```ts
cmsPlugin({
  dependencyGraph: {
    referenceGuard: 'warn', // or 'block'; `true` is shorthand for 'warn'
  },
});
```

Requires the dependency graph. Disabled by default — the delete/unpublish modals are unchanged when the option is unset.

## Changes

- **Config**: Added `referenceGuard?: boolean | 'warn' | 'block'` to `CMSDependencyGraphConfig`, with a `resolveReferenceGuardMode()` normalizer alongside `resolveDependencyGraphConfig()`. The mode reaches the UI via a new `dependencyGraphReferenceGuard` field on `__ROOT_CTX`, next to the existing `dependencyGraphEnabled` flag.

- **API**: `dependency_graph.query` accepts a `direction: 'dependencies' | 'dependents'` param (default `'dependencies'`) and echoes it in the response, wiring up the previously uncalled `DependencyGraph.getDependents()` reverse lookup instead of adding a new endpoint.

- **UI**: `onDeleteDoc`/`onUnpublishDoc` in `DocActionsMenu` pre-fetch direct dependents before opening the confirm modal via a new `cmsCheckReferenceGuard()` util. Delete checks the union of the draft and published graphs; unpublish checks published only (the draft copy survives). Dependents render with `DocPreviewCard` (capped at 10, "+N more"), following the `ReferenceDocs` pattern in `PublishDocModal`. In `'block'` mode the confirm button is disabled.

- **Tests**: Coverage for the config resolver (core) and for `cmsCheckReferenceGuard()`'s request shapes, draft/published union, and fail-open paths (ui).

## Implementation Details

The check fails open: if the guard is disabled, no docs reference the doc, or the graph query errors, the existing confirm flow runs unchanged — a graph outage should never prevent edits. Only direct dependents (`transitive: false`) are shown, since those are the docs that actually contain the breaking reference. The modal notes that only reference fields are checked — hardcoded links in text fields aren't detected, and draft-mode edges can lag until the next cron scan.

Generated with Claude Code (Claude Fable 5).