### PR TITLE
feat: add required publishing checks configurable per collection

### DIFF
--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add required publishing checks configurable per collection

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -2,6 +2,11 @@ import {promises as fs} from 'node:fs';
 import path from 'node:path';
 import {Server, Request, Response} from '@blinkk/root';
 import {multipartMiddleware} from '@blinkk/root/middleware';
+import {
+  normalizePublishChecks,
+  type PublishCheckLevel,
+  type PublishCheckResult,
+} from '../shared/publish-checks.js';
 import {toTranslationLanguages} from '../shared/translation-languages.js';
 import {
   buildChatSystemPrompt,
@@ -26,11 +31,44 @@ import {
   DependencyGraphService,
   DependencyGraphRebuildResult,
 } from './dependency-graph.js';
+import * as schema from './schema.js';
 import {SearchIndexService, RebuildResult} from './search-index.js';
 import {type CMSTranslationService} from './translations.js';
 import {assertPublicHttpUrl, UnsafeUrlError} from './url-safety.js';
 
 type AppModule = typeof import('./app.js');
+
+/**
+ * Maximum number of docs a single `checks.run` request may cover. Releases can
+ * contain an unbounded number of docs; this bounds the work a single request
+ * can queue up.
+ */
+const MAX_CHECKS_RUN_DOCS = 500;
+
+/** Number of checks to run in parallel within a `checks.run` request. */
+const CHECKS_RUN_CONCURRENCY = 5;
+
+/** Runs `fn` over `items` with at most `concurrency` in flight. */
+async function runPool<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  const queue = [...items];
+  const workers: Promise<void>[] = [];
+  const numWorkers = Math.max(1, Math.min(concurrency, queue.length));
+  for (let i = 0; i < numWorkers; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          const item = queue.shift()!;
+          await fn(item);
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
+}
 
 function testValidCollectionId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
@@ -1367,6 +1405,166 @@ export function api(server: Server, options: ApiOptions) {
       console.error(err.stack || err);
       res.status(500).json({success: false, error: err.message || 'UNKNOWN'});
     }
+  });
+
+  /**
+   * Runs the publishing checks configured on each doc's collection.
+   *
+   * Used to gate the publish and schedule flows in the CMS UI. Checks are
+   * opted into per collection via the `publishing.checks` schema config; docs
+   * in collections without any configured checks are skipped.
+   *
+   * ```
+   * POST /cms/api/checks.run
+   * {"docIds": ["Pages/index", "Pages/about"]}
+   * ```
+   */
+  server.use('/cms/api/checks.run', async (req: Request, res: Response) => {
+    if (
+      req.method !== 'POST' ||
+      !String(req.get('content-type')).startsWith('application/json')
+    ) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    if (!req.user?.email) {
+      res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      return;
+    }
+
+    const reqBody = req.body || {};
+    const docIds: string[] = Array.isArray(reqBody.docIds)
+      ? Array.from(
+          new Set(
+            reqBody.docIds
+              .map((docId: any) => String(docId || '').trim())
+              .filter(Boolean)
+          )
+        )
+      : [];
+    if (docIds.length === 0) {
+      res.status(400).json({success: false, error: 'MISSING_REQUIRED_FIELD'});
+      return;
+    }
+    if (docIds.length > MAX_CHECKS_RUN_DOCS) {
+      res.status(400).json({
+        success: false,
+        error: 'TOO_MANY_DOCS',
+        maxDocs: MAX_CHECKS_RUN_DOCS,
+      });
+      return;
+    }
+
+    const registeredChecks = options.checks || [];
+    const cmsClient = new RootCMSClient(req.rootConfig!);
+
+    // Collection schemas are shared by every doc in a collection, so resolve
+    // each one at most once per request.
+    const collectionSchemas = new Map<
+      string,
+      Promise<schema.Collection | null>
+    >();
+    function loadCollectionSchema(collectionId: string) {
+      let promise = collectionSchemas.get(collectionId);
+      if (!promise) {
+        promise = getCollectionSchema(req, collectionId).catch(() => null);
+        collectionSchemas.set(collectionId, promise);
+      }
+      return promise;
+    }
+
+    // Expand the requested docs into the individual check runs configured on
+    // each doc's collection.
+    const runs: Array<{
+      docId: string;
+      collectionId: string;
+      slug: string;
+      collectionSchema: schema.Collection | null;
+      check: CMSCheck;
+      level: PublishCheckLevel;
+    }> = [];
+    for (const docId of docIds) {
+      let collectionId: string;
+      let slug: string;
+      try {
+        ({collection: collectionId, slug} = parseDocId(docId));
+      } catch {
+        // Ignore malformed doc ids; there are no checks to run for them.
+        continue;
+      }
+      const collectionSchema = await loadCollectionSchema(collectionId);
+      const configuredChecks = normalizePublishChecks(
+        collectionSchema?.publishing?.checks
+      );
+      for (const configuredCheck of configuredChecks) {
+        const check = registeredChecks.find((c) => c.id === configuredCheck.id);
+        // Skip checks that aren't registered or that are restricted to other
+        // collections. A collection referencing an unknown check shouldn't
+        // block publishing, since that would make a config typo unrecoverable
+        // for non-admins.
+        if (!check) {
+          console.warn(
+            `check not registered: "${configuredCheck.id}" (configured on collection "${collectionId}")`
+          );
+          continue;
+        }
+        if (check.collections && !check.collections.includes(collectionId)) {
+          continue;
+        }
+        runs.push({
+          docId,
+          collectionId,
+          slug,
+          collectionSchema,
+          check,
+          level: configuredCheck.level,
+        });
+      }
+    }
+
+    const results: PublishCheckResult[] = [];
+    await runPool(runs, CHECKS_RUN_CONCURRENCY, async (run) => {
+      const base = {
+        docId: run.docId,
+        checkId: run.check.id,
+        label: run.check.label,
+        level: run.level,
+      };
+      try {
+        const result = await run.check.run({
+          rootConfig: req.rootConfig!,
+          cmsClient,
+          docId: run.docId,
+          collectionId: run.collectionId,
+          slug: run.slug,
+          collectionSchema: run.collectionSchema,
+        });
+        results.push({
+          ...base,
+          status: result.status,
+          message: result.message,
+          metadata: result.metadata,
+        });
+      } catch (err: any) {
+        // A check that throws is reported as an `error` result rather than
+        // failing the whole request, so one broken check doesn't hide the
+        // results of the others.
+        console.error(err.stack || err);
+        results.push({
+          ...base,
+          status: 'error',
+          message: `Check failed to run: ${err.message || 'UNKNOWN'}`,
+        });
+      }
+    });
+
+    // Sort for a stable presentation order in the UI, since results are
+    // pushed in completion order.
+    results.sort(
+      (a, b) =>
+        a.docId.localeCompare(b.docId) || a.checkId.localeCompare(b.checkId)
+    );
+    res.status(200).json({success: true, data: {results}});
   });
 
   /**

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -4,6 +4,11 @@ import {Server, Request, Response} from '@blinkk/root';
 import {multipartMiddleware} from '@blinkk/root/middleware';
 import {getAuth} from 'firebase-admin/auth';
 import {MAX_CSV_IMPORT_BYTES} from '../shared/csv.js';
+import {
+  normalizePublishChecks,
+  type PublishCheckLevel,
+  type PublishCheckResult,
+} from '../shared/publish-checks.js';
 import {toTranslationLanguages} from '../shared/translation-languages.js';
 import {
   buildChatSystemPrompt,
@@ -28,11 +33,44 @@ import {
   DependencyGraphService,
   DependencyGraphRebuildResult,
 } from './dependency-graph.js';
+import * as schema from './schema.js';
 import {SearchIndexService, RebuildResult} from './search-index.js';
 import {type CMSTranslationService} from './translations.js';
 import {assertPublicHttpUrl, UnsafeUrlError} from './url-safety.js';
 
 type AppModule = typeof import('./app.js');
+
+/**
+ * Maximum number of docs a single `checks.run` request may cover. Releases can
+ * contain an unbounded number of docs; this bounds the work a single request
+ * can queue up.
+ */
+const MAX_CHECKS_RUN_DOCS = 500;
+
+/** Number of checks to run in parallel within a `checks.run` request. */
+const CHECKS_RUN_CONCURRENCY = 5;
+
+/** Runs `fn` over `items` with at most `concurrency` in flight. */
+async function runPool<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  const queue = [...items];
+  const workers: Promise<void>[] = [];
+  const numWorkers = Math.max(1, Math.min(concurrency, queue.length));
+  for (let i = 0; i < numWorkers; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          const item = queue.shift()!;
+          await fn(item);
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
+}
 
 function testValidCollectionId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
@@ -1608,6 +1646,166 @@ export function api(server: Server, options: ApiOptions) {
       console.error(err.stack || err);
       res.status(500).json({success: false, error: err.message || 'UNKNOWN'});
     }
+  });
+
+  /**
+   * Runs the publishing checks configured on each doc's collection.
+   *
+   * Used to gate the publish and schedule flows in the CMS UI. Checks are
+   * opted into per collection via the `publishing.checks` schema config; docs
+   * in collections without any configured checks are skipped.
+   *
+   * ```
+   * POST /cms/api/checks.run
+   * {"docIds": ["Pages/index", "Pages/about"]}
+   * ```
+   */
+  server.use('/cms/api/checks.run', async (req: Request, res: Response) => {
+    if (
+      req.method !== 'POST' ||
+      !String(req.get('content-type')).startsWith('application/json')
+    ) {
+      res.status(400).json({success: false, error: 'BAD_REQUEST'});
+      return;
+    }
+    if (!req.user?.email) {
+      res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      return;
+    }
+
+    const reqBody = req.body || {};
+    const docIds: string[] = Array.isArray(reqBody.docIds)
+      ? Array.from(
+          new Set(
+            reqBody.docIds
+              .map((docId: any) => String(docId || '').trim())
+              .filter(Boolean)
+          )
+        )
+      : [];
+    if (docIds.length === 0) {
+      res.status(400).json({success: false, error: 'MISSING_REQUIRED_FIELD'});
+      return;
+    }
+    if (docIds.length > MAX_CHECKS_RUN_DOCS) {
+      res.status(400).json({
+        success: false,
+        error: 'TOO_MANY_DOCS',
+        maxDocs: MAX_CHECKS_RUN_DOCS,
+      });
+      return;
+    }
+
+    const registeredChecks = options.checks || [];
+    const cmsClient = new RootCMSClient(req.rootConfig!);
+
+    // Collection schemas are shared by every doc in a collection, so resolve
+    // each one at most once per request.
+    const collectionSchemas = new Map<
+      string,
+      Promise<schema.Collection | null>
+    >();
+    function loadCollectionSchema(collectionId: string) {
+      let promise = collectionSchemas.get(collectionId);
+      if (!promise) {
+        promise = getCollectionSchema(req, collectionId).catch(() => null);
+        collectionSchemas.set(collectionId, promise);
+      }
+      return promise;
+    }
+
+    // Expand the requested docs into the individual check runs configured on
+    // each doc's collection.
+    const runs: Array<{
+      docId: string;
+      collectionId: string;
+      slug: string;
+      collectionSchema: schema.Collection | null;
+      check: CMSCheck;
+      level: PublishCheckLevel;
+    }> = [];
+    for (const docId of docIds) {
+      let collectionId: string;
+      let slug: string;
+      try {
+        ({collection: collectionId, slug} = parseDocId(docId));
+      } catch {
+        // Ignore malformed doc ids; there are no checks to run for them.
+        continue;
+      }
+      const collectionSchema = await loadCollectionSchema(collectionId);
+      const configuredChecks = normalizePublishChecks(
+        collectionSchema?.publishing?.checks
+      );
+      for (const configuredCheck of configuredChecks) {
+        const check = registeredChecks.find((c) => c.id === configuredCheck.id);
+        // Skip checks that aren't registered or that are restricted to other
+        // collections. A collection referencing an unknown check shouldn't
+        // block publishing, since that would make a config typo unrecoverable
+        // for non-admins.
+        if (!check) {
+          console.warn(
+            `check not registered: "${configuredCheck.id}" (configured on collection "${collectionId}")`
+          );
+          continue;
+        }
+        if (check.collections && !check.collections.includes(collectionId)) {
+          continue;
+        }
+        runs.push({
+          docId,
+          collectionId,
+          slug,
+          collectionSchema,
+          check,
+          level: configuredCheck.level,
+        });
+      }
+    }
+
+    const results: PublishCheckResult[] = [];
+    await runPool(runs, CHECKS_RUN_CONCURRENCY, async (run) => {
+      const base = {
+        docId: run.docId,
+        checkId: run.check.id,
+        label: run.check.label,
+        level: run.level,
+      };
+      try {
+        const result = await run.check.run({
+          rootConfig: req.rootConfig!,
+          cmsClient,
+          docId: run.docId,
+          collectionId: run.collectionId,
+          slug: run.slug,
+          collectionSchema: run.collectionSchema,
+        });
+        results.push({
+          ...base,
+          status: result.status,
+          message: result.message,
+          metadata: result.metadata,
+        });
+      } catch (err: any) {
+        // A check that throws is reported as an `error` result rather than
+        // failing the whole request, so one broken check doesn't hide the
+        // results of the others.
+        console.error(err.stack || err);
+        results.push({
+          ...base,
+          status: 'error',
+          message: `Check failed to run: ${err.message || 'UNKNOWN'}`,
+        });
+      }
+    });
+
+    // Sort for a stable presentation order in the UI, since results are
+    // pushed in completion order.
+    results.sort(
+      (a, b) =>
+        a.docId.localeCompare(b.docId) || a.checkId.localeCompare(b.checkId)
+    );
+    res.status(200).json({success: true, data: {results}});
   });
 
   /**

--- a/packages/root-cms/core/app.tsx
+++ b/packages/root-cms/core/app.tsx
@@ -195,6 +195,7 @@ function serializeCollection(collection: Collection): Partial<Collection> {
     sortOptions: collection.sortOptions,
     customSorting: collection.customSorting,
     viewOptions: collection.viewOptions,
+    publishing: collection.publishing,
   };
 }
 

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -50,6 +50,13 @@ export type {
 } from './checks.js';
 export {translationsCheck} from './checks-translations.js';
 export type {TranslationsCheckOptions} from './checks-translations.js';
+export type {
+  CollectionPublishingOptions,
+  PublishCheckConfig,
+  PublishCheckLevel,
+  PublishCheckResult,
+  PublishCheckStatus,
+} from '../shared/publish-checks.js';
 export type {CMSService, CMSServiceContext} from './services.js';
 export type {
   CMSNotificationService,

--- a/packages/root-cms/core/plugin.ts
+++ b/packages/root-cms/core/plugin.ts
@@ -49,6 +49,13 @@ export type {
 } from './checks.js';
 export {translationsCheck} from './checks-translations.js';
 export type {TranslationsCheckOptions} from './checks-translations.js';
+export type {
+  CollectionPublishingOptions,
+  PublishCheckConfig,
+  PublishCheckLevel,
+  PublishCheckResult,
+  PublishCheckStatus,
+} from '../shared/publish-checks.js';
 export type {CMSService, CMSServiceContext} from './services.js';
 export type {
   CMSNotificationService,

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -1,3 +1,11 @@
+import {type CollectionPublishingOptions} from '../shared/publish-checks.js';
+
+export type {
+  CollectionPublishingOptions,
+  PublishCheckConfig,
+  PublishCheckLevel,
+} from '../shared/publish-checks.js';
+
 export interface CommonFieldProps {
   /** The type that defines the structure of the field and its UI component. */
   type: string;
@@ -663,6 +671,23 @@ export type Collection = SchemaWithTypes & {
      */
     compact?: boolean;
   };
+  /**
+   * Options that control how docs in this collection are published.
+   *
+   * Example:
+   * ```ts
+   * publishing: {
+   *   checks: [
+   *     {id: 'root-cms/translations', level: 'required'},
+   *     {id: 'seo-meta', level: 'warning'},
+   *   ],
+   * }
+   * ```
+   *
+   * NOTE: The checks feature is considered a "beta" feature, its interface
+   * may change from version to version as we add new features.
+   */
+  publishing?: CollectionPublishingOptions;
 };
 
 export function defineCollection(

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -1,4 +1,11 @@
+import {type CollectionPublishingOptions} from '../shared/publish-checks.js';
 import type {RichTextParagraphSizeOption} from '../shared/richtext.js';
+
+export type {
+  CollectionPublishingOptions,
+  PublishCheckConfig,
+  PublishCheckLevel,
+} from '../shared/publish-checks.js';
 
 export interface CommonFieldProps {
   /** The type that defines the structure of the field and its UI component. */
@@ -691,6 +698,23 @@ export type Collection = SchemaWithTypes & {
      */
     compact?: boolean;
   };
+  /**
+   * Options that control how docs in this collection are published.
+   *
+   * Example:
+   * ```ts
+   * publishing: {
+   *   checks: [
+   *     {id: 'root-cms/translations', level: 'required'},
+   *     {id: 'seo-meta', level: 'warning'},
+   *   ],
+   * }
+   * ```
+   *
+   * NOTE: The checks feature is considered a "beta" feature, its interface
+   * may change from version to version as we add new features.
+   */
+  publishing?: CollectionPublishingOptions;
 };
 
 export function defineCollection(

--- a/packages/root-cms/docs/publishing-checks.md
+++ b/packages/root-cms/docs/publishing-checks.md
@@ -1,0 +1,166 @@
+# Publishing Checks
+
+Status: implemented — see `shared/publish-checks.ts` for the shared types and
+helpers, `checks.run` in `core/api.ts` for the server-side runner,
+`ui/hooks/usePublishChecks.tsx` for the client-side gate, and
+`ui/components/PublishChecksModal/` for the UI.
+
+## Overview
+
+Publishing checks run a collection's registered CMS checks as a step in the
+publish flow. A check configured at the `required` level halts publishing when
+it fails; a check configured at the `warning` level lets publishing continue
+and reports its message once the content is live.
+
+Checks are registered globally via `cmsPlugin({checks: [...]})` and opted into
+per collection, so the same check can be required for one collection and a
+warning for another.
+
+## Configuration
+
+Register the check implementation in `root.config.ts`:
+
+```ts
+cmsPlugin({
+  checks: [
+    translationsCheck(),
+    {
+      id: 'seo-meta',
+      label: 'SEO Meta',
+      description: 'Verifies the doc has a meta title and description.',
+      run: async (ctx) => {
+        const doc = await ctx.cmsClient.getRawDoc(ctx.collectionId, ctx.slug, {
+          mode: 'draft',
+        });
+        if (!doc?.fields?.meta?.title) {
+          return {status: 'error', message: 'Missing `meta.title`.'};
+        }
+        return {status: 'success', message: 'All good!'};
+      },
+    },
+  ],
+});
+```
+
+Then opt a collection into the checks that gate its publish flow, in
+`collections/<id>.schema.ts`:
+
+```ts
+export default schema.defineCollection({
+  name: 'Pages',
+  publishing: {
+    checks: [
+      {id: 'seo-meta', level: 'required'},
+      {id: 'root-cms/translations', level: 'warning'},
+    ],
+  },
+  fields: [...],
+});
+```
+
+A bare string is shorthand for the `required` level, so
+`checks: ['seo-meta']` and `checks: [{id: 'seo-meta', level: 'required'}]` are
+equivalent.
+
+Collections without a `publishing.checks` config publish exactly as before —
+no checks run and no extra requests are made.
+
+## Behavior
+
+| Check level  | Result status | Outcome                                     |
+| ------------ | ------------- | ------------------------------------------- |
+| `required`   | `error`       | Publishing halts.                           |
+| `required`   | `warning`     | Publishes, warning shown afterwards.        |
+| `warning`    | `error`       | Publishes, downgraded to a warning.         |
+| `warning`    | `warning`     | Publishes, warning shown afterwards.        |
+| either       | `success`     | Publishes.                                  |
+
+An `error` from a `warning`-level check is deliberately downgraded rather than
+promoted, so the collection's configured level stays authoritative.
+
+A check that throws is reported as an `error` result for that check alone; the
+remaining checks still run and report.
+
+Checks that a collection references but that aren't registered (a config typo,
+or a check whose own `collections` allowlist excludes the collection) are
+skipped rather than treated as failures, so a bad reference can't make
+publishing unrecoverable for non-admins.
+
+## Where checks run
+
+Checks gate the interactive publish and schedule flows:
+
+- **Docs** — `PublishDocModal`, for both "Publish now" and "Scheduled". This
+  covers the doc editor and the collection list's publish action.
+- **Releases** — `ReleasePage` publish, and `ScheduleReleaseModal`. A release
+  runs the checks configured on each of its docs' collections, and a single
+  failed required check halts the whole release.
+
+Scheduled content is gated **at schedule time**, not when the cron fires. The
+scheduled publish itself runs unchanged, so content that drifts after being
+scheduled is not re-checked.
+
+## Admin overrides
+
+Admins (the `ADMIN` project role) get two escape hatches:
+
+- **Skip checks** — a "Skip publishing checks" toggle in the publish and
+  release UIs, which publishes without running any checks.
+- **Bypass failed checks** — a "Publish anyway" action in the modal shown when
+  required checks fail.
+
+Both are admin-only. The skip flag is re-validated against the user's role
+inside `usePublishChecks()`, so a stale toggle can't let a non-admin past the
+checks.
+
+## Audit trail
+
+Publishing writes go directly to Firestore from the browser, so this gate is a
+workflow guardrail rather than a security boundary. Every publish, schedule,
+and release action therefore records what the checks did in its action-log
+metadata under a `checks` key:
+
+```json
+{
+  "docId": "Pages/index",
+  "checks": {
+    "passed": 2,
+    "warnings": 1,
+    "failed": ["Pages/index::seo-meta"],
+    "bypassed": true
+  }
+}
+```
+
+When an admin skips checks, the metadata records `{"skipped": true}` instead.
+
+## API
+
+```
+POST /cms/api/checks.run
+{"docIds": ["Pages/index", "Pages/about"]}
+```
+
+Returns the results of every check configured on each doc's collection:
+
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "docId": "Pages/index",
+        "checkId": "seo-meta",
+        "label": "SEO Meta",
+        "level": "required",
+        "status": "error",
+        "message": "Missing `meta.title`."
+      }
+    ]
+  }
+}
+```
+
+Checks run with a concurrency of 5, and a single request covers at most 500
+docs (`TOO_MANY_DOCS` beyond that). Results are sorted by doc id and check id
+so the UI order is stable.

--- a/packages/root-cms/shared/publish-checks.test.ts
+++ b/packages/root-cms/shared/publish-checks.test.ts
@@ -1,0 +1,127 @@
+import {describe, expect, it} from 'vitest';
+import {
+  normalizePublishChecks,
+  summarizePublishChecks,
+  type PublishCheckResult,
+} from './publish-checks.js';
+
+describe('normalizePublishChecks', () => {
+  it('returns an empty list when nothing is configured', () => {
+    expect(normalizePublishChecks()).toEqual([]);
+    expect(normalizePublishChecks([])).toEqual([]);
+  });
+
+  it('defaults string shorthand to the required level', () => {
+    expect(normalizePublishChecks(['seo-meta'])).toEqual([
+      {id: 'seo-meta', level: 'required'},
+    ]);
+  });
+
+  it('defaults config objects without a level to required', () => {
+    expect(normalizePublishChecks([{id: 'seo-meta'}])).toEqual([
+      {id: 'seo-meta', level: 'required'},
+    ]);
+  });
+
+  it('preserves the warning level', () => {
+    expect(
+      normalizePublishChecks([{id: 'seo-meta', level: 'warning'}])
+    ).toEqual([{id: 'seo-meta', level: 'warning'}]);
+  });
+
+  it('coerces unknown levels to required', () => {
+    expect(
+      normalizePublishChecks([{id: 'seo-meta', level: 'bogus' as any}])
+    ).toEqual([{id: 'seo-meta', level: 'required'}]);
+  });
+
+  it('drops entries without an id', () => {
+    expect(
+      normalizePublishChecks(['', '  ', {id: ''}, null as any, {id: 'ok'}])
+    ).toEqual([{id: 'ok', level: 'required'}]);
+  });
+
+  it('trims ids', () => {
+    expect(normalizePublishChecks(['  seo-meta  '])).toEqual([
+      {id: 'seo-meta', level: 'required'},
+    ]);
+  });
+
+  it('keeps the first entry when an id is duplicated', () => {
+    expect(
+      normalizePublishChecks([
+        {id: 'seo-meta', level: 'warning'},
+        {id: 'seo-meta', level: 'required'},
+      ])
+    ).toEqual([{id: 'seo-meta', level: 'warning'}]);
+  });
+});
+
+function result(
+  overrides: Partial<PublishCheckResult> & Pick<PublishCheckResult, 'status'>
+): PublishCheckResult {
+  return {
+    docId: 'Pages/index',
+    checkId: 'seo-meta',
+    label: 'SEO Meta',
+    level: 'required',
+    message: 'message',
+    ...overrides,
+  };
+}
+
+describe('summarizePublishChecks', () => {
+  it('buckets a passing result as passed', () => {
+    const summary = summarizePublishChecks([result({status: 'success'})]);
+    expect(summary.passed).toHaveLength(1);
+    expect(summary.blocking).toHaveLength(0);
+    expect(summary.warnings).toHaveLength(0);
+  });
+
+  it('blocks on an error from a required check', () => {
+    const summary = summarizePublishChecks([
+      result({status: 'error', level: 'required'}),
+    ]);
+    expect(summary.blocking).toHaveLength(1);
+    expect(summary.warnings).toHaveLength(0);
+  });
+
+  it('downgrades an error from a warning-level check to a warning', () => {
+    const summary = summarizePublishChecks([
+      result({status: 'error', level: 'warning'}),
+    ]);
+    expect(summary.blocking).toHaveLength(0);
+    expect(summary.warnings).toHaveLength(1);
+  });
+
+  it('never blocks on a warning status, even for a required check', () => {
+    const summary = summarizePublishChecks([
+      result({status: 'warning', level: 'required'}),
+    ]);
+    expect(summary.blocking).toHaveLength(0);
+    expect(summary.warnings).toHaveLength(1);
+  });
+
+  it('buckets a mixed set of results across docs', () => {
+    const summary = summarizePublishChecks([
+      result({docId: 'Pages/a', status: 'success'}),
+      result({docId: 'Pages/b', status: 'error', level: 'required'}),
+      result({docId: 'Pages/c', status: 'warning', level: 'warning'}),
+      result({docId: 'Pages/d', status: 'error', level: 'warning'}),
+    ]);
+    expect(summary.passed.map((r) => r.docId)).toEqual(['Pages/a']);
+    expect(summary.blocking.map((r) => r.docId)).toEqual(['Pages/b']);
+    expect(summary.warnings.map((r) => r.docId)).toEqual([
+      'Pages/c',
+      'Pages/d',
+    ]);
+  });
+
+  it('handles an empty result set', () => {
+    expect(summarizePublishChecks([])).toEqual({
+      blocking: [],
+      warnings: [],
+      passed: [],
+    });
+  });
+});

--- a/packages/root-cms/shared/publish-checks.ts
+++ b/packages/root-cms/shared/publish-checks.ts
@@ -1,0 +1,145 @@
+/**
+ * Isomorphic helpers for the publishing checks feature.
+ *
+ * Checks are registered globally via `cmsPlugin({checks: [...]})` and opted
+ * into per collection via the `publishing.checks` config in a collection's
+ * `<id>.schema.ts`. Each collection decides which checks gate publishing and
+ * at what severity, so the same check can be `required` in one collection and
+ * a `warning` in another.
+ *
+ * ```ts
+ * export default schema.defineCollection({
+ *   name: 'Pages',
+ *   publishing: {
+ *     checks: [
+ *       {id: 'root-cms/translations', level: 'required'},
+ *       'seo-meta',
+ *     ],
+ *   },
+ *   fields: [...],
+ * });
+ * ```
+ *
+ * A `required` check halts publishing when it returns an `error` status. A
+ * `warning` check never halts publishing; its message is surfaced to the user
+ * after the content goes live.
+ */
+
+/**
+ * Severity level for a check configured on a collection.
+ *
+ * - `required`: an `error` result halts publishing.
+ * - `warning`: publishing continues, and the message is surfaced afterwards.
+ */
+export type PublishCheckLevel = 'required' | 'warning';
+
+/** A check configured to run as part of a collection's publishing flow. */
+export interface PublishCheckConfig {
+  /** ID of a check registered via `cmsPlugin({checks: [...]})`. */
+  id: string;
+  /** Severity level for the check. Defaults to `required`. */
+  level?: PublishCheckLevel;
+}
+
+/** Publishing options configured on a collection. */
+export interface CollectionPublishingOptions {
+  /**
+   * Checks to run before docs in this collection are published or scheduled.
+   * Accepts either a check ID (which defaults to the `required` level) or a
+   * `{id, level}` config object.
+   */
+  checks?: Array<string | PublishCheckConfig>;
+}
+
+/** The result status of a check. */
+export type PublishCheckStatus = 'success' | 'warning' | 'error';
+
+/** The result of running a single check against a single doc. */
+export interface PublishCheckResult {
+  /** The doc the check ran against, e.g. `Pages/index`. */
+  docId: string;
+  /** ID of the check that produced this result. */
+  checkId: string;
+  /** Human-readable label for the check. */
+  label: string;
+  /** The severity level the check was configured with. */
+  level: PublishCheckLevel;
+  /** Outcome of the check run. */
+  status: PublishCheckStatus;
+  /** A message describing the result. Supports markdown. */
+  message: string;
+  /** Optional metadata returned by the check. */
+  metadata?: Record<string, any>;
+}
+
+/** A summary of a set of check results. */
+export interface PublishCheckSummary {
+  /**
+   * Results that halt publishing, i.e. `error` results from checks configured
+   * at the `required` level.
+   */
+  blocking: PublishCheckResult[];
+  /**
+   * Results that don't halt publishing but should be surfaced to the user:
+   * `warning` results, plus `error` results from `warning`-level checks.
+   */
+  warnings: PublishCheckResult[];
+  /** Results where the check passed. */
+  passed: PublishCheckResult[];
+}
+
+/**
+ * Normalizes a collection's configured checks into a list of
+ * `{id, level}` objects. String entries default to the `required` level.
+ * Entries without an ID are dropped, and duplicate IDs keep the first entry.
+ */
+export function normalizePublishChecks(
+  checks?: Array<string | PublishCheckConfig>
+): Array<Required<PublishCheckConfig>> {
+  if (!checks || checks.length === 0) {
+    return [];
+  }
+  const normalized: Array<Required<PublishCheckConfig>> = [];
+  const seen = new Set<string>();
+  for (const check of checks) {
+    const config: PublishCheckConfig =
+      typeof check === 'string' ? {id: check} : check || {id: ''};
+    const id = String(config.id || '').trim();
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    normalized.push({
+      id: id,
+      level: config.level === 'warning' ? 'warning' : 'required',
+    });
+  }
+  return normalized;
+}
+
+/**
+ * Buckets check results into blocking failures, warnings, and passes.
+ *
+ * Only `error` results from `required` checks block publishing. An `error`
+ * from a `warning`-level check is downgraded to a warning so that publishing
+ * continues, which keeps the collection's configured level authoritative.
+ */
+export function summarizePublishChecks(
+  results: PublishCheckResult[]
+): PublishCheckSummary {
+  const summary: PublishCheckSummary = {
+    blocking: [],
+    warnings: [],
+    passed: [],
+  };
+  for (const result of results) {
+    if (result.status === 'success') {
+      summary.passed.push(result);
+    } else if (result.status === 'error' && result.level === 'required') {
+      summary.blocking.push(result);
+    } else {
+      summary.warnings.push(result);
+    }
+  }
+  return summary;
+}

--- a/packages/root-cms/ui/components/CheckStatusBadge/CheckStatusBadge.css
+++ b/packages/root-cms/ui/components/CheckStatusBadge/CheckStatusBadge.css
@@ -1,0 +1,3 @@
+.CheckStatusBadge {
+  vertical-align: middle;
+}

--- a/packages/root-cms/ui/components/CheckStatusBadge/CheckStatusBadge.tsx
+++ b/packages/root-cms/ui/components/CheckStatusBadge/CheckStatusBadge.tsx
@@ -1,0 +1,42 @@
+import './CheckStatusBadge.css';
+
+import {Badge} from '@mantine/core';
+import {IconAlertTriangle, IconCheck, IconX} from '@tabler/icons-preact';
+import {type PublishCheckStatus} from '../../../shared/publish-checks.js';
+import {joinClassNames} from '../../utils/classes.js';
+
+const STATUS_COLORS: Record<PublishCheckStatus, string> = {
+  success: 'green',
+  warning: 'yellow',
+  error: 'red',
+};
+
+const STATUS_ICONS: Record<PublishCheckStatus, any> = {
+  success: IconCheck,
+  warning: IconAlertTriangle,
+  error: IconX,
+};
+
+export interface CheckStatusBadgeProps {
+  /** The outcome of the check run. */
+  status: PublishCheckStatus;
+  className?: string;
+}
+
+/** Badge that displays the outcome of a CMS check run. */
+export function CheckStatusBadge(props: CheckStatusBadgeProps) {
+  const color = STATUS_COLORS[props.status];
+  const Icon = STATUS_ICONS[props.status];
+  const label = props.status.charAt(0).toUpperCase() + props.status.slice(1);
+  return (
+    <Badge
+      className={joinClassNames('CheckStatusBadge', props.className)}
+      color={color}
+      size="sm"
+      variant="filled"
+      leftSection={<Icon size={10} />}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/packages/root-cms/ui/components/ChecksPanel/ChecksPanel.tsx
+++ b/packages/root-cms/ui/components/ChecksPanel/ChecksPanel.tsx
@@ -1,14 +1,10 @@
 import './ChecksPanel.css';
 
-import {Badge, Button} from '@mantine/core';
-import {
-  IconAlertTriangle,
-  IconCheck,
-  IconPlayerPlay,
-  IconX,
-} from '@tabler/icons-preact';
+import {Button} from '@mantine/core';
+import {IconPlayerPlay} from '@tabler/icons-preact';
 import {useCallback, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
+import {CheckStatusBadge} from '../CheckStatusBadge/CheckStatusBadge.js';
 import {Markdown} from '../Markdown/Markdown.js';
 
 /** Status result from a check run. */
@@ -159,7 +155,12 @@ function CheckItem(props: CheckItemProps) {
       <div className="ChecksPanel__check__header">
         <div className="ChecksPanel__check__label">
           {check.label}
-          {state?.result && <StatusBadge status={state.result.status} />}
+          {state?.result && (
+            <CheckStatusBadge
+              className="ChecksPanel__statusBadge"
+              status={state.result.status}
+            />
+          )}
         </div>
         <Button
           className="ChecksPanel__check__runButton"
@@ -191,34 +192,5 @@ function CheckItem(props: CheckItemProps) {
         <div className="ChecksPanel__check__error">{state.error}</div>
       )}
     </div>
-  );
-}
-
-const STATUS_COLORS: Record<CheckStatus, string> = {
-  success: 'green',
-  warning: 'yellow',
-  error: 'red',
-};
-
-const STATUS_ICONS: Record<CheckStatus, any> = {
-  success: IconCheck,
-  warning: IconAlertTriangle,
-  error: IconX,
-};
-
-function StatusBadge(props: {status: CheckStatus}) {
-  const color = STATUS_COLORS[props.status];
-  const Icon = STATUS_ICONS[props.status];
-  const label = props.status.charAt(0).toUpperCase() + props.status.slice(1);
-  return (
-    <Badge
-      className="ChecksPanel__statusBadge"
-      color={color}
-      size="sm"
-      variant="filled"
-      leftSection={<Icon size={10} />}
-    >
-      {label}
-    </Badge>
   );
 }

--- a/packages/root-cms/ui/components/PublishChecksModal/PublishChecksModal.css
+++ b/packages/root-cms/ui/components/PublishChecksModal/PublishChecksModal.css
@@ -1,0 +1,33 @@
+.PublishChecksModal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.PublishChecksModal__intro {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.PublishChecksModal__intro__icon {
+  display: flex;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.PublishChecksModal__results {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.PublishChecksModal__buttons {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.PublishChecksModal__buttons__bypass {
+  margin-right: auto;
+}

--- a/packages/root-cms/ui/components/PublishChecksModal/PublishChecksModal.tsx
+++ b/packages/root-cms/ui/components/PublishChecksModal/PublishChecksModal.tsx
@@ -1,0 +1,106 @@
+import './PublishChecksModal.css';
+
+import {Button} from '@mantine/core';
+import {ContextModalProps} from '@mantine/modals';
+import {IconAlertTriangle, IconCircleX} from '@tabler/icons-preact';
+import {
+  summarizePublishChecks,
+  type PublishCheckResult,
+} from '../../../shared/publish-checks.js';
+import {PublishChecksResults} from '../PublishChecksResults/PublishChecksResults.js';
+import {Text} from '../Text/Text.js';
+
+const MODAL_ID = 'PublishChecksModal';
+
+/**
+ * Which outcome the modal is reporting.
+ *
+ * - `blocked`: required checks failed, so publishing was halted.
+ * - `warnings`: the content went live, and these warnings need attention.
+ */
+export type PublishChecksModalMode = 'blocked' | 'warnings';
+
+export interface PublishChecksModalProps {
+  [key: string]: unknown;
+  /** The results to display. */
+  results: PublishCheckResult[];
+  /** Which outcome the modal is reporting. */
+  mode: PublishChecksModalMode;
+  /** Verb for the halted action, e.g. "Publish" or "Schedule". */
+  actionLabel: string;
+  /**
+   * Whether the current user may proceed despite the failed checks. Only
+   * admins can bypass failed required checks.
+   */
+  canBypass?: boolean;
+  /**
+   * Called when the user chooses to proceed despite the failed checks. The
+   * modal closes itself afterwards, so this only needs to record the choice.
+   */
+  onBypass?: () => void;
+}
+
+export function PublishChecksModal(
+  modalProps: ContextModalProps<PublishChecksModalProps>
+) {
+  const {innerProps: props, context, id} = modalProps;
+  const summary = summarizePublishChecks(props.results);
+  const blocked = props.mode === 'blocked';
+  const shown = blocked
+    ? [...summary.blocking, ...summary.warnings]
+    : summary.warnings;
+
+  return (
+    <div className="PublishChecksModal">
+      <div className="PublishChecksModal__intro">
+        <div className="PublishChecksModal__intro__icon">
+          {blocked ? (
+            <IconCircleX size={20} stroke={1.5} color="#c92a2a" />
+          ) : (
+            <IconAlertTriangle size={20} stroke={1.5} color="#e67700" />
+          )}
+        </div>
+        <Text size="body-sm">
+          {blocked
+            ? `${summary.blocking.length} required check(s) failed, so nothing was published. Resolve the issues below and try again.`
+            : `The content went live, but ${summary.warnings.length} check(s) reported warnings.`}
+        </Text>
+      </div>
+
+      <div className="PublishChecksModal__results">
+        <PublishChecksResults results={shown} />
+      </div>
+
+      <div className="PublishChecksModal__buttons">
+        {blocked && props.canBypass && (
+          <Button
+            className="PublishChecksModal__buttons__bypass"
+            variant="outline"
+            size="xs"
+            color="red"
+            type="button"
+            onClick={() => {
+              // Record the choice before closing: the close fires the modal's
+              // `onClose`, which is what settles the caller's decision.
+              props.onBypass?.();
+              context.closeModal(id);
+            }}
+          >
+            {props.actionLabel} anyway
+          </Button>
+        )}
+        <Button
+          variant="filled"
+          onClick={() => context.closeModal(id)}
+          type="button"
+          size="xs"
+          color="dark"
+        >
+          {blocked ? 'Cancel' : 'Got it'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+PublishChecksModal.id = MODAL_ID;

--- a/packages/root-cms/ui/components/PublishChecksResults/PublishChecksResults.css
+++ b/packages/root-cms/ui/components/PublishChecksResults/PublishChecksResults.css
@@ -1,0 +1,97 @@
+.PublishChecksResults {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.PublishChecksResults__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.PublishChecksResults__group__docId {
+  display: flex;
+}
+
+.PublishChecksResults__group__results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.PublishChecksResults__result {
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.PublishChecksResults__result--success {
+  background-color: #d3f9d8;
+  border-color: #8ce99a;
+}
+
+.PublishChecksResults__result--warning {
+  background-color: #fff3bf;
+  border-color: #ffe066;
+}
+
+.PublishChecksResults__result--error {
+  background-color: #ffe3e3;
+  border-color: #ffa8a8;
+}
+
+.PublishChecksResults__result__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.PublishChecksResults__result__label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.PublishChecksResults__result__badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.PublishChecksResults__result__message {
+  margin-top: 6px;
+}
+
+.PublishChecksResults__result__message .Markdown {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.PublishChecksResults__result__message .Markdown p {
+  margin: 0 0 6px;
+}
+
+.PublishChecksResults__result__message .Markdown p:last-child {
+  margin-bottom: 0;
+}
+
+.PublishChecksResults__result__message .Markdown code {
+  background-color: rgba(0, 0, 0, 0.06);
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.PublishChecksResults__result__message .Markdown ul,
+.PublishChecksResults__result__message .Markdown ol {
+  margin: 0 0 6px;
+  padding-left: 18px;
+}
+
+.PublishChecksResults__result__message .Markdown ul:last-child,
+.PublishChecksResults__result__message .Markdown ol:last-child {
+  margin-bottom: 0;
+}

--- a/packages/root-cms/ui/components/PublishChecksResults/PublishChecksResults.tsx
+++ b/packages/root-cms/ui/components/PublishChecksResults/PublishChecksResults.tsx
@@ -1,0 +1,94 @@
+import './PublishChecksResults.css';
+
+import {Badge} from '@mantine/core';
+import {type PublishCheckResult} from '../../../shared/publish-checks.js';
+import {joinClassNames} from '../../utils/classes.js';
+import {CheckStatusBadge} from '../CheckStatusBadge/CheckStatusBadge.js';
+import {DocIdBadge} from '../DocIdBadge/DocIdBadge.js';
+import {Markdown} from '../Markdown/Markdown.js';
+
+export interface PublishChecksResultsProps {
+  /** The check results to display. */
+  results: PublishCheckResult[];
+  /**
+   * Whether to show the doc id above each group of results. Defaults to
+   * showing it only when the results span more than one doc.
+   */
+  showDocIds?: boolean;
+  className?: string;
+}
+
+/** Groups results by doc id, preserving the order the results arrived in. */
+function groupResultsByDoc(
+  results: PublishCheckResult[]
+): Array<{docId: string; results: PublishCheckResult[]}> {
+  const groups: Array<{docId: string; results: PublishCheckResult[]}> = [];
+  const byDocId = new Map<string, PublishCheckResult[]>();
+  for (const result of results) {
+    let group = byDocId.get(result.docId);
+    if (!group) {
+      group = [];
+      byDocId.set(result.docId, group);
+      groups.push({docId: result.docId, results: group});
+    }
+    group.push(result);
+  }
+  return groups;
+}
+
+/**
+ * Renders the results of a publishing check run, grouped by doc.
+ *
+ * Used by the publish flows to show why publishing was halted, and to surface
+ * warnings after content goes live.
+ */
+export function PublishChecksResults(props: PublishChecksResultsProps) {
+  const groups = groupResultsByDoc(props.results);
+  const showDocIds = props.showDocIds ?? groups.length > 1;
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={joinClassNames('PublishChecksResults', props.className)}>
+      {groups.map((group) => (
+        <div className="PublishChecksResults__group" key={group.docId}>
+          {showDocIds && (
+            <div className="PublishChecksResults__group__docId">
+              <DocIdBadge docId={group.docId} />
+            </div>
+          )}
+          <div className="PublishChecksResults__group__results">
+            {group.results.map((result) => (
+              <div
+                className={joinClassNames(
+                  'PublishChecksResults__result',
+                  `PublishChecksResults__result--${result.status}`
+                )}
+                key={`${result.docId}::${result.checkId}`}
+              >
+                <div className="PublishChecksResults__result__header">
+                  <div className="PublishChecksResults__result__label">
+                    {result.label}
+                  </div>
+                  <div className="PublishChecksResults__result__badges">
+                    {result.level === 'required' && (
+                      <Badge size="sm" variant="outline" color="gray">
+                        Required
+                      </Badge>
+                    )}
+                    <CheckStatusBadge status={result.status} />
+                  </div>
+                </div>
+                <div className="PublishChecksResults__result__message">
+                  <Markdown code={result.message} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.css
@@ -77,6 +77,27 @@
   text-align: right;
 }
 
+.PublishDocModal__form__checks {
+  margin-top: 16px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.PublishDocModal__form__checks__note {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.PublishDocModal__form__checks__note svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
 .PublishDocModal__form__publishMessage {
   margin-top: 16px;
 }

--- a/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
+++ b/packages/root-cms/ui/components/PublishDocModal/PublishDocModal.tsx
@@ -1,18 +1,29 @@
 import './PublishDocModal.css';
 
-import {Accordion, Button, Loader, Tooltip} from '@mantine/core';
+import {Accordion, Button, Checkbox, Loader, Tooltip} from '@mantine/core';
 import {ContextModalProps, useModals} from '@mantine/modals';
 import {showNotification} from '@mantine/notifications';
-import {IconGitCompare, IconPackage, IconSparkles} from '@tabler/icons-preact';
+import {
+  IconChecklist,
+  IconGitCompare,
+  IconPackage,
+  IconSparkles,
+} from '@tabler/icons-preact';
+import {ChangeEvent} from 'preact/compat';
 import {useState, useRef, useEffect} from 'preact/hooks';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
+import {
+  usePublishChecks,
+  type PublishChecksDecision,
+} from '../../hooks/usePublishChecks.js';
 import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocFromCacheOrFetch} from '../../utils/doc-cache.js';
 import {cmsPublishDoc, cmsScheduleDoc} from '../../utils/doc.js';
 import {errorMessage} from '../../utils/notifications.js';
 import {testCanPublish} from '../../utils/permissions.js';
+import {getCollectionPublishChecks} from '../../utils/publish-checks.js';
 import {extractReferenceDocIds} from '../../utils/references.js';
 import {getLocalISOString} from '../../utils/time.js';
 import {testV2TranslationsEnabled} from '../../utils/translations-manager.js';
@@ -58,6 +69,8 @@ export function PublishDocModal(
   const [loading, setLoading] = useState(false);
   const [publishMessage, setPublishMessage] = useState('');
   const [generatingMessage, setGeneratingMessage] = useState(false);
+  const [skipChecks, setSkipChecks] = useState(false);
+  const [checksRunning, setChecksRunning] = useState(false);
   const dateTimeRef = useRef<HTMLInputElement>(null);
   const modals = useModals();
   const modalTheme = useModalTheme();
@@ -67,13 +80,19 @@ export function PublishDocModal(
   const currentUserEmail = window.firebase.user.email || '';
   const canPublish = testCanPublish(roles, currentUserEmail);
 
+  const publishChecks = usePublishChecks();
+  const collectionId = props.docId.split('/')[0];
+  const configuredChecks = getCollectionPublishChecks(collectionId);
+  const hasChecks = configuredChecks.length > 0;
+
   const buttonLabel = publishType === 'scheduled' ? 'Schedule' : 'Publish';
 
-  async function publish() {
+  async function publish(decision: PublishChecksDecision) {
     try {
       setLoading(true);
       await cmsPublishDoc(props.docId, {
         publishMessage: publishMessage.trim() || undefined,
+        checksAudit: decision.audit || undefined,
       });
       showNotification({
         title: 'Published!',
@@ -82,6 +101,9 @@ export function PublishDocModal(
       });
       props.onSuccess?.({publishType: 'now'});
       modals.closeAll();
+      // Opened after `closeAll()` so the warnings aren't closed along with the
+      // publish modal.
+      publishChecks.showWarnings(decision.results, {actionLabel: 'Publish'});
     } catch (err) {
       console.error(err);
       const detail = errorMessage(err);
@@ -96,12 +118,13 @@ export function PublishDocModal(
     }
   }
 
-  async function schedule() {
+  async function schedule(decision: PublishChecksDecision) {
     try {
       setLoading(true);
       const millis = Math.floor(new Date(scheduledDate).getTime());
       await cmsScheduleDoc(props.docId, millis, {
         publishMessage: publishMessage.trim() || undefined,
+        checksAudit: decision.audit || undefined,
       });
       showNotification({
         title: 'Scheduled!',
@@ -110,6 +133,9 @@ export function PublishDocModal(
       });
       props.onSuccess?.({publishType: 'scheduled'});
       modals.closeAll();
+      // Opened after `closeAll()` so the warnings aren't closed along with the
+      // publish modal.
+      publishChecks.showWarnings(decision.results, {actionLabel: 'Schedule'});
     } catch (err) {
       console.error(err);
       const detail = errorMessage(err);
@@ -156,7 +182,39 @@ export function PublishDocModal(
     }
   }
 
-  function onSubmit() {
+  /**
+   * Runs the collection's publishing checks and, if publishing isn't halted,
+   * asks the user to confirm.
+   */
+  async function onSubmit() {
+    let decision: PublishChecksDecision;
+    try {
+      setChecksRunning(true);
+      decision = await publishChecks.run({
+        docIds: [props.docId],
+        actionLabel: buttonLabel,
+        skip: skipChecks,
+      });
+    } catch (err) {
+      console.error(err);
+      showNotification({
+        title: 'Checks failed',
+        message: `Failed to run publishing checks: ${errorMessage(err)}`,
+        color: 'red',
+        autoClose: false,
+      });
+      return;
+    } finally {
+      setChecksRunning(false);
+    }
+    // Publishing was halted by a failed required check.
+    if (!decision.proceed) {
+      return;
+    }
+    openConfirmModal(decision);
+  }
+
+  function openConfirmModal(decision: PublishChecksDecision) {
     modals.openConfirmModal({
       ...modalTheme,
       title: `${buttonLabel} ${props.docId}`,
@@ -171,6 +229,17 @@ export function PublishDocModal(
             live {publishType === 'now' ? 'now' : `at ${scheduledDate}`}.
           </Text>
           <DocIdBadge docId={props.docId} />
+          {(decision.skipped || decision.bypassed) && (
+            <Text
+              size="body-sm"
+              color="red"
+              className="PublishDocModal__confirmText"
+            >
+              {decision.skipped
+                ? 'Publishing checks will be skipped.'
+                : 'Failed required checks will be bypassed.'}
+            </Text>
+          )}
         </>
       ),
       labels: {confirm: buttonLabel, cancel: 'Cancel'},
@@ -180,9 +249,9 @@ export function PublishDocModal(
       closeOnConfirm: true,
       onConfirm: () => {
         if (publishType === 'now') {
-          publish();
+          publish(decision);
         } else if (publishType === 'scheduled') {
-          schedule();
+          schedule(decision);
         }
       },
     });
@@ -287,6 +356,29 @@ export function PublishDocModal(
             </div>
           )}
 
+          {hasChecks && (
+            <div className="PublishDocModal__form__checks">
+              <div className="PublishDocModal__form__checks__note">
+                <IconChecklist size={16} stroke={1.5} />
+                <Text size="body-sm" color="gray">
+                  {configuredChecks.length} publishing check
+                  {configuredChecks.length === 1 ? '' : 's'} will run first:{' '}
+                  {configuredChecks.map((check) => check.label).join(', ')}.
+                </Text>
+              </div>
+              {publishChecks.isAdmin && (
+                <Checkbox
+                  label="Skip publishing checks (admins only)"
+                  size="xs"
+                  checked={skipChecks}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setSkipChecks(e.currentTarget.checked);
+                  }}
+                />
+              )}
+            </div>
+          )}
+
           <div className="PublishDocModal__form__publishMessage">
             <div className="PublishDocModal__form__publishMessage__wrapper">
               <textarea
@@ -339,10 +431,10 @@ export function PublishDocModal(
               size="xs"
               color="dark"
               disabled={disabled}
-              loading={loading}
+              loading={loading || checksRunning}
               type="submit"
             >
-              {buttonLabel}
+              {checksRunning ? 'Running checks' : buttonLabel}
             </Button>
           </div>
         </form>

--- a/packages/root-cms/ui/components/ScheduleReleaseModal/ScheduleReleaseModal.tsx
+++ b/packages/root-cms/ui/components/ScheduleReleaseModal/ScheduleReleaseModal.tsx
@@ -4,6 +4,7 @@ import {showNotification} from '@mantine/notifications';
 import {Timestamp} from 'firebase/firestore';
 import {useState, useRef} from 'preact/hooks';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {usePublishChecks} from '../../hooks/usePublishChecks.js';
 import {notifyErrors} from '../../utils/notifications.js';
 import {scheduleRelease} from '../../utils/release.js';
 import {getLocalISOString} from '../../utils/time.js';
@@ -17,6 +18,13 @@ export type PublishType = 'now' | 'scheduled' | '';
 export interface ScheduleReleaseModalProps {
   [key: string]: unknown;
   releaseId: string;
+  /**
+   * Docs in the release. Used to run the publishing checks configured on each
+   * doc's collection before the release is scheduled.
+   */
+  docIds?: string[];
+  /** Whether an admin opted to skip the publishing checks. */
+  skipChecks?: boolean;
   onScheduled?: (scheduledAt: Timestamp) => void;
 }
 
@@ -42,6 +50,7 @@ export function ScheduleReleaseModal(
   const [loading, setLoading] = useState(false);
   const dateTimeRef = useRef<HTMLInputElement>(null);
   const modals = useModals();
+  const publishChecks = usePublishChecks();
 
   async function schedule() {
     setLoading(true);
@@ -51,8 +60,19 @@ export function ScheduleReleaseModal(
       if (now >= millis) {
         throw new Error('bad datetime, please choose a date in the future');
       }
+      // Checks run when the release is scheduled, not when it goes live.
+      const decision = await publishChecks.run({
+        docIds: props.docIds || [],
+        actionLabel: 'Schedule',
+        skip: props.skipChecks,
+      });
+      if (!decision.proceed) {
+        return;
+      }
       const timestamp = Timestamp.fromMillis(millis);
-      await scheduleRelease(props.releaseId, millis);
+      await scheduleRelease(props.releaseId, millis, {
+        checksAudit: decision.audit || undefined,
+      });
       showNotification({
         title: 'Scheduled!',
         message: `Release ${props.releaseId} will go live ${scheduledDate}.`,
@@ -62,6 +82,9 @@ export function ScheduleReleaseModal(
       if (props.onScheduled) {
         props.onScheduled(timestamp);
       }
+      // Opened after `closeAll()` so the warnings aren't closed along with the
+      // schedule modal.
+      publishChecks.showWarnings(decision.results, {actionLabel: 'Schedule'});
     });
     setLoading(false);
   }

--- a/packages/root-cms/ui/hooks/usePublishChecks.tsx
+++ b/packages/root-cms/ui/hooks/usePublishChecks.tsx
@@ -1,0 +1,178 @@
+import {useModals} from '@mantine/modals';
+import {useCallback} from 'preact/hooks';
+import {
+  summarizePublishChecks,
+  type PublishCheckResult,
+} from '../../shared/publish-checks.js';
+import {PublishChecksModal} from '../components/PublishChecksModal/PublishChecksModal.js';
+import {testIsAdmin} from '../utils/permissions.js';
+import {
+  buildPublishChecksAudit,
+  runPublishChecks,
+  testHasPublishChecks,
+  type PublishChecksAuditMetadata,
+} from '../utils/publish-checks.js';
+import {useModalTheme} from './useModalTheme.js';
+import {useProjectRoles} from './useProjectRoles.js';
+
+/** The outcome of gating a publish action on the configured checks. */
+export interface PublishChecksDecision {
+  /** Whether the caller should go ahead with publishing. */
+  proceed: boolean;
+  /** The results of the check run. Empty when checks were skipped. */
+  results: PublishCheckResult[];
+  /** Whether an admin skipped running checks entirely. */
+  skipped: boolean;
+  /** Whether an admin chose to publish over failed required checks. */
+  bypassed: boolean;
+  /**
+   * Audit metadata to record on the publish action, or `null` when there is
+   * nothing to record.
+   */
+  audit: PublishChecksAuditMetadata | null;
+}
+
+export interface RunPublishChecksOptions {
+  /** The docs about to be published or scheduled. */
+  docIds: string[];
+  /** Verb for the action being gated, e.g. "Publish" or "Schedule". */
+  actionLabel: string;
+  /**
+   * Whether to skip running checks entirely. Only honored for admins, so a
+   * stale UI toggle can't let a non-admin past the checks.
+   */
+  skip?: boolean;
+}
+
+/**
+ * Gates a publish or schedule action on the checks configured on each doc's
+ * collection.
+ *
+ * ```tsx
+ * const publishChecks = usePublishChecks();
+ *
+ * const decision = await publishChecks.run({
+ *   docIds: [docId],
+ *   actionLabel: 'Publish',
+ *   skip: skipChecks,
+ * });
+ * if (!decision.proceed) {
+ *   return;
+ * }
+ * await cmsPublishDoc(docId, {checksAudit: decision.audit});
+ * publishChecks.showWarnings(decision.results);
+ * ```
+ *
+ * When required checks fail, `run()` opens a modal describing the failures and
+ * resolves with `proceed: false`, unless an admin chooses to publish anyway.
+ * Warnings never halt publishing; the caller surfaces them via
+ * `showWarnings()` once the content is live.
+ */
+export function usePublishChecks() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  const {roles, loading: rolesLoading} = useProjectRoles();
+  const currentUserEmail = window.firebase.user.email || '';
+  // Treat an unresolved roles fetch as "not an admin" so checks can't be
+  // skipped or bypassed before permissions are known.
+  const isAdmin = !rolesLoading && testIsAdmin(roles, currentUserEmail);
+
+  const run = useCallback(
+    async (
+      options: RunPublishChecksOptions
+    ): Promise<PublishChecksDecision> => {
+      const docIds = options.docIds || [];
+      if (options.skip && isAdmin) {
+        return {
+          proceed: true,
+          results: [],
+          skipped: true,
+          bypassed: false,
+          audit: buildPublishChecksAudit([], {skipped: true}),
+        };
+      }
+      if (docIds.length === 0 || !testHasPublishChecks(docIds)) {
+        return {
+          proceed: true,
+          results: [],
+          skipped: false,
+          bypassed: false,
+          audit: null,
+        };
+      }
+
+      const results = await runPublishChecks(docIds);
+      const summary = summarizePublishChecks(results);
+      if (summary.blocking.length === 0) {
+        return {
+          proceed: true,
+          results: results,
+          skipped: false,
+          bypassed: false,
+          audit: buildPublishChecksAudit(results),
+        };
+      }
+
+      // Required checks failed. Show what failed and let admins override.
+      return await new Promise<PublishChecksDecision>((resolve) => {
+        let bypassed = false;
+        modals.openContextModal(PublishChecksModal.id, {
+          ...modalTheme,
+          title: `${options.actionLabel} blocked by checks`,
+          size: '700px',
+          innerProps: {
+            results: results,
+            mode: 'blocked',
+            actionLabel: options.actionLabel,
+            canBypass: isAdmin,
+            // The modal closes itself, which settles the promise below.
+            onBypass: () => {
+              bypassed = true;
+            },
+          },
+          // Fires on every close path, including the bypass above, so the
+          // promise always settles exactly once.
+          onClose: () => {
+            resolve({
+              proceed: bypassed,
+              results: results,
+              skipped: false,
+              bypassed: bypassed,
+              audit: buildPublishChecksAudit(results, {bypassed}),
+            });
+          },
+        });
+      });
+    },
+    [modals, modalTheme, isAdmin]
+  );
+
+  const showWarnings = useCallback(
+    (results: PublishCheckResult[], options?: {actionLabel?: string}) => {
+      const summary = summarizePublishChecks(results);
+      if (summary.warnings.length === 0) {
+        return;
+      }
+      modals.openContextModal(PublishChecksModal.id, {
+        ...modalTheme,
+        title: 'Published with warnings',
+        size: '700px',
+        innerProps: {
+          results: results,
+          mode: 'warnings',
+          actionLabel: options?.actionLabel || 'Publish',
+        },
+      });
+    },
+    [modals, modalTheme]
+  );
+
+  return {
+    /** Whether the current user can skip or bypass checks. */
+    isAdmin,
+    /** Runs the configured checks and decides whether publishing proceeds. */
+    run,
+    /** Surfaces any warnings from a check run after the content is live. */
+    showWarnings,
+  };
+}

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.css
@@ -67,6 +67,10 @@
   gap: 8px;
 }
 
+.ReleasePage__PublishStatus__skipChecks {
+  margin-top: 8px;
+}
+
 .ReleasePage__PublishStatus__table {
   border: none;
 }

--- a/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
+++ b/packages/root-cms/ui/pages/ReleasePage/ReleasePage.tsx
@@ -4,6 +4,7 @@ import {
   ActionIcon,
   Breadcrumbs,
   Button,
+  Checkbox,
   Loader,
   Table,
   Tooltip,
@@ -11,6 +12,7 @@ import {
 import {useModals} from '@mantine/modals';
 import {showNotification, updateNotification} from '@mantine/notifications';
 import {IconSettings} from '@tabler/icons-preact';
+import {ChangeEvent} from 'preact/compat';
 import {useEffect, useState} from 'preact/hooks';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {DataSourceIcon} from '../../components/DataSourceIcon/DataSourceIcon.js';
@@ -24,10 +26,15 @@ import {Text} from '../../components/Text/Text.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
+import {
+  usePublishChecks,
+  type PublishChecksDecision,
+} from '../../hooks/usePublishChecks.js';
 import {Layout} from '../../layout/Layout.js';
 import {DataSource, getDataSource} from '../../utils/data-source.js';
-import {notifyErrors} from '../../utils/notifications.js';
+import {errorMessage, notifyErrors} from '../../utils/notifications.js';
 import {testCanPublish} from '../../utils/permissions.js';
+import {testHasPublishChecks} from '../../utils/publish-checks.js';
 import {
   Release,
   cancelScheduledRelease,
@@ -137,17 +144,27 @@ ReleasePage.PublishStatus = (props: {
 
   const release = props.release;
   const [publishLoading, setPublishLoading] = useState(false);
+  const [checksRunning, setChecksRunning] = useState(false);
+  const [skipChecks, setSkipChecks] = useState(false);
 
   const modals = useModals();
   const modalTheme = useModalTheme();
+  const publishChecks = usePublishChecks();
+  const releaseHasChecks = testHasPublishChecks(release.docIds || []);
   const scheduleReleaseModal = useScheduleReleaseModal({
     releaseId: release.id,
+    docIds: release.docIds || [],
+    skipChecks: skipChecks,
     onScheduled: () => {
       props.onAction('scheduled');
     },
   });
 
-  function onPublishClicked() {
+  /**
+   * Runs the publishing checks for every doc in the release and, if publishing
+   * isn't halted, asks the user to confirm.
+   */
+  async function onPublishClicked() {
     const docIds = release.docIds || [];
     const dataSourceIds = release.dataSourceIds || [];
     const total = docIds.length + dataSourceIds.length;
@@ -161,14 +178,48 @@ ReleasePage.PublishStatus = (props: {
       return;
     }
 
+    let decision: PublishChecksDecision;
+    try {
+      setChecksRunning(true);
+      decision = await publishChecks.run({
+        docIds: docIds,
+        actionLabel: 'Publish',
+        skip: skipChecks,
+      });
+    } catch (err) {
+      console.error(err);
+      showNotification({
+        title: 'Checks failed',
+        message: `Failed to run publishing checks: ${errorMessage(err)}`,
+        color: 'red',
+        autoClose: false,
+      });
+      return;
+    } finally {
+      setChecksRunning(false);
+    }
+    // Publishing was halted by a failed required check.
+    if (!decision.proceed) {
+      return;
+    }
+
     modals.openConfirmModal({
       ...modalTheme,
       title: `Publish release: ${release.id}`,
       children: (
-        <Text size="body-sm" weight="semi-bold">
-          Are you sure you want to publish this release? The {total} items in
-          the release will go live immediately.
-        </Text>
+        <>
+          <Text size="body-sm" weight="semi-bold">
+            Are you sure you want to publish this release? The {total} items in
+            the release will go live immediately.
+          </Text>
+          {(decision.skipped || decision.bypassed) && (
+            <Text size="body-sm" color="red">
+              {decision.skipped
+                ? 'Publishing checks will be skipped.'
+                : 'Failed required checks will be bypassed.'}
+            </Text>
+          )}
+        </>
       ),
       labels: {confirm: 'Publish', cancel: 'Cancel'},
       cancelProps: {size: 'xs'},
@@ -176,12 +227,12 @@ ReleasePage.PublishStatus = (props: {
       onCancel: () => console.log('Cancel'),
       closeOnConfirm: true,
       onConfirm: () => {
-        publish();
+        publish(decision);
       },
     });
   }
 
-  async function publish() {
+  async function publish(decision: PublishChecksDecision) {
     setPublishLoading(true);
     await notifyErrors(async () => {
       const notificationId = `publish-release-${release.id}`;
@@ -195,8 +246,9 @@ ReleasePage.PublishStatus = (props: {
         loading: true,
         autoClose: false,
       });
-      // await cmsPublishDocs(release.docIds || []);
-      await publishRelease(release.id);
+      await publishRelease(release.id, {
+        checksAudit: decision.audit || undefined,
+      });
       updateNotification({
         id: notificationId,
         title: 'Published release!',
@@ -207,6 +259,7 @@ ReleasePage.PublishStatus = (props: {
       if (props.onAction) {
         props.onAction('publish');
       }
+      publishChecks.showWarnings(decision.results, {actionLabel: 'Publish'});
     });
     setPublishLoading(false);
   }
@@ -259,10 +312,14 @@ ReleasePage.PublishStatus = (props: {
                           size="xs"
                           compact
                           onClick={() => onPublishClicked()}
-                          loading={publishLoading}
+                          loading={publishLoading || checksRunning}
                           disabled={!canPublish}
                         >
-                          {release.publishedAt ? 'Re-publish' : 'Publish'}
+                          {checksRunning
+                            ? 'Running checks'
+                            : release.publishedAt
+                              ? 'Re-publish'
+                              : 'Publish'}
                         </Button>
                       </Tooltip>
                     </ConditionalTooltip>
@@ -316,6 +373,19 @@ ReleasePage.PublishStatus = (props: {
                       </ConditionalTooltip>
                     ))}
                 </div>
+                {!release.archivedAt &&
+                  releaseHasChecks &&
+                  publishChecks.isAdmin && (
+                    <Checkbox
+                      className="ReleasePage__PublishStatus__skipChecks"
+                      label="Skip publishing checks (admins only)"
+                      size="xs"
+                      checked={skipChecks}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                        setSkipChecks(e.currentTarget.checked);
+                      }}
+                    />
+                  )}
               </td>
             </tr>
           </tbody>

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -35,6 +35,7 @@ import {GlobalSearch} from './components/GlobalSearch/GlobalSearch.js';
 import {LocalizationModal} from './components/LocalizationModal/LocalizationModal.js';
 import {LockPublishingModal} from './components/LockPublishingModal/LockPublishingModal.js';
 import {PruneTranslationsModal} from './components/PruneTranslationsModal/PruneTranslationsModal.js';
+import {PublishChecksModal} from './components/PublishChecksModal/PublishChecksModal.js';
 import {PublishDocModal} from './components/PublishDocModal/PublishDocModal.js';
 import {ReferenceFieldEditorModal} from './components/ReferenceFieldEditorModal/ReferenceFieldEditorModal.js';
 import {ScheduleReleaseModal} from './components/ScheduleReleaseModal/ScheduleReleaseModal.js';
@@ -367,6 +368,7 @@ function App() {
                         [LocalizationModal.id]: LocalizationModal,
                         [LockPublishingModal.id]: LockPublishingModal,
                         [PruneTranslationsModal.id]: PruneTranslationsModal,
+                        [PublishChecksModal.id]: PublishChecksModal,
                         [PublishDocModal.id]: PublishDocModal,
                         [ReferenceFieldEditorModal.id]:
                           ReferenceFieldEditorModal,

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -36,6 +36,7 @@ import {
   normalizeString,
   sourceHash,
 } from './l10n.js';
+import {type PublishChecksAuditMetadata} from './publish-checks.js';
 import {
   TranslationsLocaleDocWithRef,
   addDeleteTranslationsOpsToBatch,
@@ -157,7 +158,7 @@ export async function cmsDeleteDoc(docId: string) {
 
 export async function cmsPublishDoc(
   docId: string,
-  options?: {publishMessage?: string}
+  options?: {publishMessage?: string; checksAudit?: PublishChecksAuditMetadata}
 ) {
   await cmsPublishDocs([docId], options);
 }
@@ -178,6 +179,8 @@ export async function cmsPublishDocs(
     commitBatch?: boolean;
     releaseId?: string;
     publishMessage?: string;
+    /** Outcome of the publishing checks, recorded in the action log. */
+    checksAudit?: PublishChecksAuditMetadata;
   }
 ) {
   if (docIds.length === 0) {
@@ -237,6 +240,9 @@ export async function cmsPublishDocs(
     const metadata: Record<string, unknown> = {docId};
     if (options?.publishMessage) {
       metadata.publishMessage = options.publishMessage;
+    }
+    if (options?.checksAudit) {
+      metadata.checks = options.checksAudit;
     }
     logAction('doc.publish', {metadata});
   }
@@ -393,7 +399,7 @@ export async function cmsSyncDependencyGraph(docIds: string[]) {
 export async function cmsScheduleDoc(
   docId: string,
   millis: number,
-  options?: {publishMessage?: string}
+  options?: {publishMessage?: string; checksAudit?: PublishChecksAuditMetadata}
 ) {
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   const db = window.firebase.db;
@@ -443,6 +449,9 @@ export async function cmsScheduleDoc(
   const metadata: Record<string, unknown> = {docId, scheduledAt: millis};
   if (options?.publishMessage) {
     metadata.publishMessage = options.publishMessage;
+  }
+  if (options?.checksAudit) {
+    metadata.checks = options.checksAudit;
   }
   logAction('doc.schedule', {metadata});
 }

--- a/packages/root-cms/ui/utils/permissions.ts
+++ b/packages/root-cms/ui/utils/permissions.ts
@@ -36,6 +36,19 @@ export function testCanPublish(
 }
 
 /**
+ * Returns true if the user is a project admin.
+ *
+ * Admins can skip publishing checks entirely and publish over failed
+ * required checks.
+ */
+export function testIsAdmin(
+  roles: Record<string, UserRole>,
+  email: string
+): boolean {
+  return getRole(roles, email) === 'ADMIN';
+}
+
+/**
  * Returns true if the user has permission to edit content (save drafts).
  *
  * Users with ADMIN, EDITOR, or CONTRIBUTOR roles can edit.

--- a/packages/root-cms/ui/utils/publish-checks.test.ts
+++ b/packages/root-cms/ui/utils/publish-checks.test.ts
@@ -1,0 +1,234 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  buildPublishChecksAudit,
+  getCollectionPublishChecks,
+  runPublishChecks,
+  testHasPublishChecks,
+} from './publish-checks.js';
+
+/** Sets up `window.__ROOT_CTX` with the given collections and check registry. */
+function setCtx(options: {collections?: any; checks?: any[]}) {
+  window.__ROOT_CTX = {
+    rootConfig: {projectId: 'test-project'},
+    collections: options.collections || {},
+    checks: options.checks || [],
+  } as any;
+}
+
+const SEO_CHECK = {id: 'seo-meta', label: 'SEO Meta', description: 'Checks.'};
+const A11Y_CHECK = {id: 'a11y', label: 'Accessibility'};
+
+describe('getCollectionPublishChecks', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty list when the collection has no checks configured', () => {
+    setCtx({collections: {Pages: {id: 'Pages'}}, checks: [SEO_CHECK]});
+    expect(getCollectionPublishChecks('Pages')).toEqual([]);
+  });
+
+  it('returns an empty list for an unknown collection', () => {
+    setCtx({collections: {}, checks: [SEO_CHECK]});
+    expect(getCollectionPublishChecks('Nope')).toEqual([]);
+  });
+
+  it('resolves configured checks against the registry', () => {
+    setCtx({
+      collections: {
+        Pages: {publishing: {checks: [{id: 'seo-meta', level: 'warning'}]}},
+      },
+      checks: [SEO_CHECK],
+    });
+    expect(getCollectionPublishChecks('Pages')).toEqual([
+      {
+        id: 'seo-meta',
+        level: 'warning',
+        label: 'SEO Meta',
+        description: 'Checks.',
+      },
+    ]);
+  });
+
+  it('omits checks that are not registered', () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['seo-meta', 'ghost']}}},
+      checks: [SEO_CHECK],
+    });
+    expect(getCollectionPublishChecks('Pages').map((c) => c.id)).toEqual([
+      'seo-meta',
+    ]);
+  });
+
+  it("omits checks restricted to another collection by the check's allowlist", () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['a11y']}}},
+      checks: [{...A11Y_CHECK, collections: ['Posts']}],
+    });
+    expect(getCollectionPublishChecks('Pages')).toEqual([]);
+  });
+
+  it('keeps checks whose allowlist includes the collection', () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['a11y']}}},
+      checks: [{...A11Y_CHECK, collections: ['Pages']}],
+    });
+    expect(getCollectionPublishChecks('Pages').map((c) => c.id)).toEqual([
+      'a11y',
+    ]);
+  });
+});
+
+describe('testHasPublishChecks', () => {
+  it('returns false when no doc belongs to a collection with checks', () => {
+    setCtx({
+      collections: {Pages: {}, Posts: {}},
+      checks: [SEO_CHECK],
+    });
+    expect(testHasPublishChecks(['Pages/index', 'Posts/hello'])).toBe(false);
+  });
+
+  it('returns true when at least one doc has checks configured', () => {
+    setCtx({
+      collections: {
+        Pages: {},
+        Posts: {publishing: {checks: ['seo-meta']}},
+      },
+      checks: [SEO_CHECK],
+    });
+    expect(testHasPublishChecks(['Pages/index', 'Posts/hello'])).toBe(true);
+  });
+
+  it('returns false for an empty doc list', () => {
+    setCtx({collections: {}, checks: []});
+    expect(testHasPublishChecks([])).toBe(false);
+  });
+});
+
+describe('runPublishChecks', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips the request entirely when no docs have checks', async () => {
+    setCtx({collections: {Pages: {}}, checks: [SEO_CHECK]});
+    const fetchSpy = vi.fn();
+    window.fetch = fetchSpy as any;
+    await expect(runPublishChecks(['Pages/index'])).resolves.toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts the doc ids and returns the results', async () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['seo-meta']}}},
+      checks: [SEO_CHECK],
+    });
+    const results = [
+      {
+        docId: 'Pages/index',
+        checkId: 'seo-meta',
+        label: 'SEO Meta',
+        level: 'required',
+        status: 'error',
+        message: 'Missing title.',
+      },
+    ];
+    const fetchSpy = vi.fn().mockResolvedValue({
+      json: async () => ({success: true, data: {results}}),
+    });
+    window.fetch = fetchSpy as any;
+
+    await expect(runPublishChecks(['Pages/index'])).resolves.toEqual(results);
+    expect(fetchSpy).toHaveBeenCalledWith('/cms/api/checks.run', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({docIds: ['Pages/index']}),
+    });
+  });
+
+  it('throws a helpful error when too many docs are requested', async () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['seo-meta']}}},
+      checks: [SEO_CHECK],
+    });
+    window.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        success: false,
+        error: 'TOO_MANY_DOCS',
+        maxDocs: 500,
+      }),
+    }) as any;
+    await expect(runPublishChecks(['Pages/index'])).rejects.toThrow(
+      /500 docs at a time/
+    );
+  });
+
+  it('throws when the request fails', async () => {
+    setCtx({
+      collections: {Pages: {publishing: {checks: ['seo-meta']}}},
+      checks: [SEO_CHECK],
+    });
+    window.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({success: false, error: 'UNAUTHORIZED'}),
+    }) as any;
+    await expect(runPublishChecks(['Pages/index'])).rejects.toThrow(
+      'UNAUTHORIZED'
+    );
+  });
+});
+
+describe('buildPublishChecksAudit', () => {
+  it('records only the skip when checks were skipped', () => {
+    expect(buildPublishChecksAudit([], {skipped: true})).toEqual({
+      skipped: true,
+    });
+  });
+
+  it('returns null when no checks ran', () => {
+    expect(buildPublishChecksAudit([])).toBeNull();
+  });
+
+  it('counts passes and warnings', () => {
+    const audit = buildPublishChecksAudit([
+      {
+        docId: 'Pages/a',
+        checkId: 'seo-meta',
+        label: 'SEO Meta',
+        level: 'required',
+        status: 'success',
+        message: '',
+      },
+      {
+        docId: 'Pages/b',
+        checkId: 'seo-meta',
+        label: 'SEO Meta',
+        level: 'warning',
+        status: 'warning',
+        message: '',
+      },
+    ]);
+    expect(audit).toEqual({passed: 1, warnings: 1});
+  });
+
+  it('records the failed checks and the bypass', () => {
+    const audit = buildPublishChecksAudit(
+      [
+        {
+          docId: 'Pages/a',
+          checkId: 'seo-meta',
+          label: 'SEO Meta',
+          level: 'required',
+          status: 'error',
+          message: '',
+        },
+      ],
+      {bypassed: true}
+    );
+    expect(audit).toEqual({
+      passed: 0,
+      warnings: 0,
+      failed: ['Pages/a::seo-meta'],
+      bypassed: true,
+    });
+  });
+});

--- a/packages/root-cms/ui/utils/publish-checks.ts
+++ b/packages/root-cms/ui/utils/publish-checks.ts
@@ -1,0 +1,151 @@
+import {
+  normalizePublishChecks,
+  summarizePublishChecks,
+  type PublishCheckConfig,
+  type PublishCheckResult,
+  type PublishCheckSummary,
+} from '../../shared/publish-checks.js';
+
+export type {
+  PublishCheckLevel,
+  PublishCheckResult,
+  PublishCheckStatus,
+  PublishCheckSummary,
+} from '../../shared/publish-checks.js';
+export {summarizePublishChecks} from '../../shared/publish-checks.js';
+
+/** A check configured on a collection, resolved against the check registry. */
+export interface ResolvedPublishCheck extends Required<PublishCheckConfig> {
+  /** Human-readable label from the check registry. */
+  label: string;
+  /** Optional description from the check registry. */
+  description?: string;
+}
+
+/**
+ * Returns the publishing checks configured on a collection, resolved against
+ * the checks registered via `cmsPlugin({checks: [...]})`.
+ *
+ * Checks that aren't registered, or that are restricted to other collections
+ * via the check's own `collections` allowlist, are omitted. This mirrors the
+ * server-side behavior in `POST /cms/api/checks.run`.
+ */
+export function getCollectionPublishChecks(
+  collectionId: string
+): ResolvedPublishCheck[] {
+  const collection = window.__ROOT_CTX.collections?.[collectionId];
+  const configuredChecks = normalizePublishChecks(
+    collection?.publishing?.checks
+  );
+  if (configuredChecks.length === 0) {
+    return [];
+  }
+  const registry = window.__ROOT_CTX.checks || [];
+  const resolved: ResolvedPublishCheck[] = [];
+  for (const configuredCheck of configuredChecks) {
+    const registered = registry.find((c) => c.id === configuredCheck.id);
+    if (!registered) {
+      continue;
+    }
+    if (
+      registered.collections &&
+      !registered.collections.includes(collectionId)
+    ) {
+      continue;
+    }
+    resolved.push({
+      ...configuredCheck,
+      label: registered.label,
+      description: registered.description,
+    });
+  }
+  return resolved;
+}
+
+/**
+ * Returns true if any of the given docs belong to a collection with
+ * publishing checks configured. Used to skip the server round trip entirely
+ * when nothing would run.
+ */
+export function testHasPublishChecks(docIds: string[]): boolean {
+  const collectionIds = new Set(docIds.map((docId) => docId.split('/')[0]));
+  for (const collectionId of collectionIds) {
+    if (getCollectionPublishChecks(collectionId).length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Runs the publishing checks configured on each doc's collection.
+ *
+ * Returns an empty result set when none of the docs have checks configured.
+ */
+export async function runPublishChecks(
+  docIds: string[]
+): Promise<PublishCheckResult[]> {
+  if (docIds.length === 0 || !testHasPublishChecks(docIds)) {
+    return [];
+  }
+  const res = await window.fetch('/cms/api/checks.run', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({docIds}),
+  });
+  const data = await res.json();
+  if (!data.success) {
+    if (data.error === 'TOO_MANY_DOCS') {
+      throw new Error(
+        `Publishing checks can only run on ${data.maxDocs} docs at a time. Publish this content in smaller batches, or ask an admin to skip checks.`
+      );
+    }
+    throw new Error(data.error || 'Failed to run publishing checks.');
+  }
+  return (data.data?.results || []) as PublishCheckResult[];
+}
+
+/** Summary metadata about a check run, recorded in the action log. */
+export interface PublishChecksAuditMetadata {
+  /** Whether an admin chose to skip running checks entirely. */
+  skipped?: boolean;
+  /** Whether an admin published over failed required checks. */
+  bypassed?: boolean;
+  /** Number of checks that passed. */
+  passed?: number;
+  /** Number of results surfaced as warnings. */
+  warnings?: number;
+  /** IDs of the checks that failed, as `docId::checkId`. */
+  failed?: string[];
+}
+
+/**
+ * Builds the audit metadata recorded alongside a publish action so the action
+ * log shows which checks ran and whether they were skipped or bypassed.
+ */
+export function buildPublishChecksAudit(
+  results: PublishCheckResult[],
+  options?: {skipped?: boolean; bypassed?: boolean}
+): PublishChecksAuditMetadata | null {
+  const skipped = options?.skipped || false;
+  if (skipped) {
+    return {skipped: true};
+  }
+  if (results.length === 0) {
+    return null;
+  }
+  const summary: PublishCheckSummary = summarizePublishChecks(results);
+  const audit: PublishChecksAuditMetadata = {
+    passed: summary.passed.length,
+    warnings: summary.warnings.length,
+  };
+  if (summary.blocking.length > 0) {
+    audit.failed = summary.blocking.map(
+      (result) => `${result.docId}::${result.checkId}`
+    );
+  }
+  if (options?.bypassed) {
+    audit.bypassed = true;
+  }
+  return audit;
+}

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -17,6 +17,7 @@ import {logAction} from './actions.js';
 import {MultiBatch} from './batch.js';
 import {cmsPublishDataSources} from './data-source.js';
 import {cmsPublishDocs, cmsSyncDependencyGraph} from './doc.js';
+import {type PublishChecksAuditMetadata} from './publish-checks.js';
 
 export interface Release {
   id: string;
@@ -120,7 +121,10 @@ export async function unarchiveRelease(id: string) {
   logAction('release.unarchive', {metadata: {releaseId: id}});
 }
 
-export async function publishRelease(id: string) {
+export async function publishRelease(
+  id: string,
+  options?: {checksAudit?: PublishChecksAuditMetadata}
+) {
   const release = await getRelease(id);
   if (!release) {
     throw new Error(`release not found: ${id}`);
@@ -151,6 +155,7 @@ export async function publishRelease(id: string) {
     batch,
     releaseId: id,
     publishMessage: release.description,
+    checksAudit: options?.checksAudit,
   });
   // Update the release's publishedAt. This write is intentionally added last
   // so that if any of the previous batches fails to commit, the release is
@@ -174,6 +179,9 @@ export async function publishRelease(id: string) {
   if (release.description) {
     metadata.publishMessage = release.description;
   }
+  if (options?.checksAudit) {
+    metadata.checks = options.checksAudit;
+  }
   logAction('release.publish', {
     metadata,
   });
@@ -181,7 +189,8 @@ export async function publishRelease(id: string) {
 
 export async function scheduleRelease(
   id: string,
-  timestamp: Timestamp | number
+  timestamp: Timestamp | number,
+  options?: {checksAudit?: PublishChecksAuditMetadata}
 ) {
   const release = await getRelease(id);
   if (!release) {
@@ -204,9 +213,14 @@ export async function scheduleRelease(
     scheduledAt: timestamp,
     scheduledBy: window.firebase.user.email,
   });
-  logAction('release.publish', {
-    metadata: {releaseId: id, scheduledAt: timestamp.toMillis()},
-  });
+  const metadata: Record<string, unknown> = {
+    releaseId: id,
+    scheduledAt: timestamp.toMillis(),
+  };
+  if (options?.checksAudit) {
+    metadata.checks = options.checksAudit;
+  }
+  logAction('release.publish', {metadata});
 }
 
 /** Generates a release ID like `20260318-golden-meadow`. */


### PR DESCRIPTION
Implements a publishing checks feature that gates the publish and schedule flows on configurable per-collection checks. Checks are registered globally via `cmsPlugin({checks: [...]})` and opted into per collection via the `publishing.checks` schema config.

## Key Changes

- **Shared types and helpers** (`shared/publish-checks.ts`): Isomorphic utilities for normalizing check configs and summarizing results. Supports `required` and `warning` severity levels, where required checks halt publishing on error and warning checks never halt.

- **Server-side check runner** (`core/api.ts`): New `POST /cms/api/checks.run` endpoint that runs checks configured on each doc's collection. Validates request size (max 500 docs), runs checks with concurrency pooling, and returns structured results.

- **Client-side gate** (`ui/hooks/usePublishChecks.tsx`): `usePublishChecks()` hook that orchestrates the check flow, showing a modal when required checks fail and allowing admins to skip or bypass checks.

- **UI components**:
  - `PublishChecksModal`: Modal for displaying blocked/warning results with admin bypass option
  - `PublishChecksResults`: Reusable component for rendering grouped check results
  - `CheckStatusBadge`: Badge component for displaying check outcome status

- **Integration points**:
  - `PublishDocModal`: Added skip checks toggle and check gating for publish/schedule actions
  - `ReleasePage`: Added check gating for release publishing with per-doc check aggregation
  - `ScheduleReleaseModal`: Integrated check gating for scheduled releases
  - `core/schema.ts`: Exported `CollectionPublishingOptions` type for schema definitions

- **Utilities**:
  - `ui/utils/publish-checks.ts`: Client-side helpers for resolving configured checks against the registry and running checks
  - `ui/utils/permissions.ts`: Added `testIsAdmin()` helper for permission checks
  - `ui/utils/release.ts`: Added audit metadata support for check results

- **Tests**: Comprehensive test coverage for shared helpers, client utilities, and server endpoint behavior.

- **Documentation**: `docs/publishing-checks.md` with configuration examples, behavior matrix, and admin override details.

## Implementation Details

- Checks are skipped entirely when no docs have checks configured, avoiding unnecessary requests
- Admin users can skip checks or publish over failed required checks; non-admins cannot
- Check results are grouped by doc in the UI for clarity
- Errors from warning-level checks are deliberately downgraded to warnings, keeping the collection's configured level authoritative
- Unregistered checks or checks restricted to other collections are silently skipped rather than treated as failures

https://claude.ai/code/session_01GaQ67SQW3SdrdngVKToTu5