### PR TITLE
feat: add inert to the jsx html attribute types

### DIFF
--- a/.changeset/wild-pugs-shake.md
+++ b/.changeset/wild-pugs-shake.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root': patch
+---
+
+feat: add inert to the jsx html attribute types

--- a/packages/root/src/jsx/jsx-render.test.tsx
+++ b/packages/root/src/jsx/jsx-render.test.tsx
@@ -52,6 +52,17 @@ test('renders disablePictureInPicture as a boolean attribute', () => {
   expect(output).toBe('<video disablepictureinpicture></video>');
 });
 
+test('renders inert as a boolean attribute', () => {
+  // `<div inert />` minimizes to a bare `inert` attribute.
+  expect(renderJsxToString(<div inert />, {mode: 'minimal'})).toBe(
+    '<div inert></div>'
+  );
+  // `inert={false}` removes the attribute.
+  expect(renderJsxToString(<div inert={false} />, {mode: 'minimal'})).toBe(
+    '<div></div>'
+  );
+});
+
 test('renders popover as a boolean attribute', () => {
   // `<div popover />` should minimize to `popover` (treated as "auto" by the
   // browser) rather than rendering an invalid `popover="true"` value.

--- a/packages/root/src/jsx/types.ts
+++ b/packages/root/src/jsx/types.ts
@@ -253,6 +253,7 @@ export interface HTMLAttributes<T = HTMLElement>
   icon?: string;
   id?: string;
   importance?: 'auto' | 'high' | 'low';
+  inert?: boolean;
   inputMode?: string;
   integrity?: string;
   is?: string;


### PR DESCRIPTION
Adds support for the `inert` boolean attribute in JSX HTML attributes.

## Changes

- Added `inert?: boolean` to the `HTMLAttributes` interface in `packages/root/src/jsx/types.ts`
- Added test coverage in `packages/root/src/jsx/jsx-render.test.tsx` to verify:
  - `<div inert />` renders as `<div inert></div>` in minimal mode
  - `<div inert={false} />` removes the attribute entirely
- Added changeset entry for patch version bump

The `inert` attribute is a standard HTML boolean attribute that makes an element and its descendants non-interactive, which is useful for temporarily disabling UI sections.

https://claude.ai/code/session_01UstmWUKULaBoifTq2uhWNT