### PR TITLE
feat: add docker setup for root cms projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@
   and the local playground for testing framework/CMS changes.
 - `examples/` — example projects. `apps/` — internal, unpublished.
 - `docker/` — an Ubuntu image (Node + pnpm + gcloud) for running a Root CMS
-  project against Firestore with persisted gcloud credentials.
+  project against Firestore with persisted gcloud credentials, plus a child
+  image (`Dockerfile.claude`) that adds the Claude Code CLI.
 
 ## Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@
 - `docs/` — powers `rootjs.dev`. It's a real Root.js project (`@private/docs`)
   and the local playground for testing framework/CMS changes.
 - `examples/` — example projects. `apps/` — internal, unpublished.
+- `docker/` — an Ubuntu image (Node + pnpm + gcloud) for running a Root CMS
+  project against Firestore with persisted gcloud credentials.
 
 ## Development
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,21 @@ RUN set -eux; \
              /workspace; \
     chown -R "${UID}:${GID}" "/home/${USERNAME}" /workspace
 
+# Group-own $HOME and the workspace by root (gid 0) with the same permissions
+# the owner has, so the image also works when the host user isn't ${UID}:
+# `docker run --user "$(id -u):0"` can still write the gcloud, pnpm and Claude
+# Code config under $HOME.
+RUN set -eux; \
+    chgrp -R 0 "/home/${USERNAME}" /workspace; \
+    chmod -R g=u "/home/${USERNAME}" /workspace
+
+# A bind-mounted repo is owned by the host user, which git rejects as "dubious
+# ownership" whenever that uid differs from the one running in the container —
+# refusing every command, not just writes. The container is single-tenant and
+# the mount is the caller's own checkout, so the check has nothing to protect
+# here.
+RUN git config --system --add safe.directory '*'
+
 COPY --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENV HOME=/home/${USERNAME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,108 @@
+# Ubuntu-based image for running a Root.js CMS project with Node, pnpm, and the
+# Google Cloud CLI pre-installed.
+#
+# The project itself is not baked into the image — mount it at /workspace and
+# mount a volume at $HOME/.config/gcloud to persist `gcloud` credentials across
+# runs. See ./README.md for the full workflow.
+
+FROM ubuntu:24.04
+
+# Keep NODE_VERSION in sync with /.node-version and PNPM_VERSION with the
+# `packageManager` field of the project's package.json.
+ARG NODE_VERSION=24.16.0
+ARG PNPM_VERSION=11.17.0
+ARG USERNAME=rootjs
+ARG UID=1000
+ARG GID=1000
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+# Base packages. `xz-utils` unpacks the Node tarball, `git` is used by pnpm when
+# a dependency resolves to a git ref, and `gnupg`/`python3` are required by the
+# Google Cloud CLI.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      gnupg \
+      less \
+      openssh-client \
+      python3 \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js, from the official tarball, verified against the published checksums.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch}" in \
+      amd64) node_arch='x64' ;; \
+      arm64) node_arch='arm64' ;; \
+      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    tarball="node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"; \
+    cd /tmp; \
+    curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/${tarball}"; \
+    curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
+    grep " ${tarball}\$" SHASUMS256.txt | sha256sum -c -; \
+    tar -xJf "${tarball}" -C /usr/local --strip-components=1 --no-same-owner \
+      --exclude=CHANGELOG.md --exclude=LICENSE --exclude=README.md; \
+    rm -f "${tarball}" SHASUMS256.txt; \
+    node --version
+
+# pnpm, pinned via corepack. A project whose `packageManager` field requests a
+# different version still works — corepack fetches it on demand.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN set -eux; \
+    if command -v corepack >/dev/null 2>&1; then \
+      corepack enable; \
+      corepack prepare "pnpm@${PNPM_VERSION}" --activate; \
+    else \
+      npm install -g "pnpm@${PNPM_VERSION}"; \
+    fi; \
+    pnpm --version
+
+# Google Cloud CLI, from the official apt repo.
+RUN set -eux; \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+      > /etc/apt/sources.list.d/google-cloud-sdk.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends google-cloud-cli; \
+    rm -rf /var/lib/apt/lists/*; \
+    gcloud --version
+
+# Run as a non-root user so files written to the mounted project keep the host
+# user's ownership. Ubuntu 24.04 ships a default `ubuntu` account at uid 1000,
+# which is removed here so the requested uid/gid is available.
+RUN set -eux; \
+    if id -u ubuntu >/dev/null 2>&1; then userdel -r ubuntu 2>/dev/null || userdel ubuntu; fi; \
+    if ! getent group "${GID}" >/dev/null; then groupadd --gid "${GID}" "${USERNAME}"; fi; \
+    useradd --uid "${UID}" --gid "${GID}" --create-home --shell /bin/bash "${USERNAME}"; \
+    mkdir -p "/home/${USERNAME}/.config/gcloud" \
+             "/home/${USERNAME}/.local/share/pnpm" \
+             "/home/${USERNAME}/.pnpm-store" \
+             /workspace; \
+    chown -R "${UID}:${GID}" "/home/${USERNAME}" /workspace
+
+COPY --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENV HOME=/home/${USERNAME}
+# Global pnpm binaries and the content-addressable store both live under $HOME
+# so they can be persisted with a volume.
+ENV PNPM_HOME=/home/${USERNAME}/.local/share/pnpm
+ENV npm_config_store_dir=/home/${USERNAME}/.pnpm-store
+ENV PATH=${PNPM_HOME}:${PATH}
+# Consumed by `root dev`, see packages/root/src/cli/dev.ts.
+ENV PORT=4007
+
+USER ${UID}:${GID}
+WORKDIR /workspace
+EXPOSE 4007
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# `root dev` binds to localhost by default, which is unreachable from outside
+# the container.
+CMD ["pnpm", "exec", "root", "dev", "--host", "0.0.0.0"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,6 +90,11 @@ RUN set -eux; \
 COPY --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENV HOME=/home/${USERNAME}
+# Re-exported so images built `FROM` this one can refer to the runtime user
+# without hardcoding the values the base was built with.
+ENV ROOTJS_USER=${USERNAME}
+ENV ROOTJS_UID=${UID}
+ENV ROOTJS_GID=${GID}
 # Global pnpm binaries and the content-addressable store both live under $HOME
 # so they can be persisted with a volume.
 ENV PNPM_HOME=/home/${USERNAME}/.local/share/pnpm

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -1,15 +1,15 @@
-# Adds the Claude Code CLI to the Root CMS image so an agent session can run
+# Adds the Claude Code CLI to the `root` image so an agent session can run
 # against the project — including Remote Control, which drives a session running
 # in this container from claude.ai or the Claude mobile app.
 #
 # Build the base image first:
-#   docker build -t root-cms docker/
-#   docker build -t root-cms-claude -f docker/Dockerfile.claude docker/
+#   docker build -t root docker/
+#   docker build -t root-ai-claude -f docker/Dockerfile.claude docker/
 #
 # See ./README.md for the sign-in steps and the security tradeoffs of giving an
 # agent container the project's Google Cloud credentials.
 
-ARG BASE_IMAGE=root-cms
+ARG BASE_IMAGE=root
 FROM ${BASE_IMAGE}
 
 ARG CLAUDE_CODE_VERSION=latest

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -43,7 +43,7 @@ ENV NPM_CONFIG_PREFIX=${HOME}/.npm-global
 ENV PATH=${HOME}/.npm-global/bin:${PATH}
 
 RUN set -eux; \
-    mkdir -p "${NPM_CONFIG_PREFIX}" "${CLAUDE_CONFIG_DIR}"; \
+    mkdir -p "${NPM_CONFIG_PREFIX}" "${CLAUDE_CONFIG_DIR}" "${HOME}/.config/gh"; \
     npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"; \
     claude --version; \
     chown -R "${ROOTJS_UID}:0" "${HOME}"; \

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -14,6 +14,21 @@ FROM ${BASE_IMAGE}
 
 ARG CLAUDE_CODE_VERSION=latest
 
+# The GitHub CLI, from the official apt repo. Claude reaches for `gh` to open
+# pull requests and read CI results, and `gh auth setup-git` is one way to give
+# the container push credentials.
+USER root
+RUN set -eux; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gh; \
+    rm -rf /var/lib/apt/lists/*; \
+    gh --version
+
 # Claude Code stores its auth token, settings and history under ~/.claude, but
 # keeps the OAuth account, MCP servers and per-project trust in ~/.claude.json,
 # outside that directory. CLAUDE_CONFIG_DIR moves that file inside it so a
@@ -27,12 +42,14 @@ ENV CLAUDE_CONFIG_DIR=${HOME}/.claude
 ENV NPM_CONFIG_PREFIX=${HOME}/.npm-global
 ENV PATH=${HOME}/.npm-global/bin:${PATH}
 
-USER ${ROOTJS_UID}:${ROOTJS_GID}
 RUN set -eux; \
     mkdir -p "${NPM_CONFIG_PREFIX}" "${CLAUDE_CONFIG_DIR}"; \
     npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"; \
-    claude --version
+    claude --version; \
+    chown -R "${ROOTJS_UID}:0" "${HOME}"; \
+    chmod -R g=u "${HOME}"
 
+USER ${ROOTJS_UID}:${ROOTJS_GID}
 WORKDIR /workspace
 
 # Server mode: stays running, prints a session URL, and accepts connections from

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -1,0 +1,41 @@
+# Adds the Claude Code CLI to the Root CMS image so an agent session can run
+# against the project — including Remote Control, which drives a session running
+# in this container from claude.ai or the Claude mobile app.
+#
+# Build the base image first:
+#   docker build -t root-cms docker/
+#   docker build -t root-cms-claude -f docker/Dockerfile.claude docker/
+#
+# See ./README.md for the sign-in steps and the security tradeoffs of giving an
+# agent container the project's Google Cloud credentials.
+
+ARG BASE_IMAGE=root-cms
+FROM ${BASE_IMAGE}
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# Claude Code stores its auth token, settings and history under ~/.claude, but
+# keeps the OAuth account, MCP servers and per-project trust in ~/.claude.json,
+# outside that directory. CLAUDE_CONFIG_DIR moves that file inside it so a
+# single volume mounted at ~/.claude persists the whole login.
+ENV CLAUDE_CONFIG_DIR=${HOME}/.claude
+
+# Installed into a user-owned npm prefix (rather than /usr/local as root) so
+# Claude Code's self-updater can write to it. Updates land in the container's
+# writable layer, so rebuild this image now and then to bake them in — or set
+# DISABLE_AUTOUPDATER=1 to pin CLAUDE_CODE_VERSION.
+ENV NPM_CONFIG_PREFIX=${HOME}/.npm-global
+ENV PATH=${HOME}/.npm-global/bin:${PATH}
+
+USER ${ROOTJS_UID}:${ROOTJS_GID}
+RUN set -eux; \
+    mkdir -p "${NPM_CONFIG_PREFIX}" "${CLAUDE_CONFIG_DIR}"; \
+    npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"; \
+    claude --version
+
+WORKDIR /workspace
+
+# Server mode: stays running, prints a session URL, and accepts connections from
+# claude.ai or the Claude app. Override with `claude` for a local interactive
+# session, or `claude --remote-control` for both at once.
+CMD ["claude", "remote-control"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,6 +13,9 @@ The project is **not** baked into the image — you mount it at `/workspace`. Th
 container runs as a non-root user (uid/gid `1000` by default) so files it
 writes into the mounted project stay owned by you.
 
+`Dockerfile.claude` builds on top of it to add the Claude Code CLI — see
+[Running Claude Code against the project](#running-claude-code-against-the-project).
+
 ## How auth works
 
 Root CMS connects to Firestore with the Firebase Admin SDK, which uses
@@ -153,6 +156,88 @@ that `root.config.ts` reads from the environment (`GAPI_API_KEY`,
 `GAPI_CLIENT_ID`, `COOKIE_SECRET`, and any translation/AI provider keys). Pass
 them with `--env-file .env` or compose's `env_file`.
 
+## Running Claude Code against the project
+
+`Dockerfile.claude` builds a child image (`FROM root-cms`) that adds the Claude
+Code CLI, so an agent session runs with the same Node, pnpm, gcloud and project
+files as the dev server. Its default command is `claude remote-control`, which
+[drives the session from claude.ai or the Claude app][remote-control] while
+execution stays in the container.
+
+It's deliberately a separate image rather than a flag on the base one: the base
+image is also the base for deployable images (see below), and the agent image
+carries a second credential surface — a claude.ai token — on top of the
+project's Google Cloud credentials.
+
+```bash
+# 1. Build the base image first, then the child.
+docker build -t root-cms docker/
+docker build -t root-cms-claude -f docker/Dockerfile.claude docker/
+
+docker volume create root-cms-claude-config
+
+# 2. Sign in and accept the workspace trust prompt. Remote Control needs a
+#    claude.ai login (Pro, Max, Team or Enterprise) — API keys don't work.
+#    If the browser callback can't reach the container, paste the code shown in
+#    the browser at the "Paste code here if prompted" prompt.
+docker run --rm -it \
+  -v "$PWD:/workspace" \
+  -v root-cms-claude-config:/home/rootjs/.claude \
+  root-cms-claude claude
+
+# 3. Start Remote Control. It prints a session URL; press space for a QR code.
+docker run --rm -it --init \
+  -p 4008:4007 \
+  -v "$PWD:/workspace" \
+  -v root-cms-claude-config:/home/rootjs/.claude \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  -v root-cms-pnpm-store:/home/rootjs/.pnpm-store \
+  --env-file .env \
+  root-cms-claude
+```
+
+Or with compose, where the service sits behind a `claude` profile so
+`docker compose up` never starts an agent by surprise:
+
+```bash
+docker compose -f docker/docker-compose.yml build root-cms
+docker compose -f docker/docker-compose.yml build claude
+docker compose -f docker/docker-compose.yml run --rm claude
+```
+
+Port 4008 maps to the container's 4007, so a dev server Claude starts inside the
+container is at <http://localhost:4008/cms/> — on a different host port than the
+`root-cms` service, so both can run at once.
+
+Other useful commands: `claude` for a plain local session, `claude
+--remote-control` for one that is both local and remote, and `claude
+remote-control --spawn worktree` to give each remote session its own git
+worktree.
+
+### Notes
+
+- **Credentials the agent inherits.** Mounting the gcloud volume gives Claude
+  write access to your CMS's Firestore data. For anything beyond a scratch
+  project, point the agent container at a volume signed in to a non-production
+  project, or leave the gcloud mount off entirely and let it work on code only.
+  This is also why `--dangerously-skip-permissions` deserves care here, even
+  though the container runs as a non-root user (the CLI rejects that flag as
+  root).
+- **Don't disable non-essential traffic.** `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`,
+  `DISABLE_TELEMETRY`, `DO_NOT_TRACK` and `DISABLE_GROWTHBOOK` each turn off the
+  feature-flag lookup Remote Control depends on. Likewise, Remote Control is
+  disabled when `ANTHROPIC_BASE_URL` points anywhere other than
+  `api.anthropic.com` — worth knowing if your project's `.env` sets it.
+- **The session lives as long as the container.** Remote Control is a local
+  process; stopping the container takes the session offline. Re-running
+  `claude remote-control` in the same directory brings its sessions back for
+  about four hours.
+- **Updates.** Claude Code self-updates into the container's writable layer, so
+  a `--rm` run starts from the version baked into the image. Rebuild
+  periodically (`docker build --no-cache -f docker/Dockerfile.claude ...`), or
+  pin with `--build-arg CLAUDE_CODE_VERSION=X.Y.Z` plus
+  `-e DISABLE_AUTOUPDATER=1`.
+
 ## Baking a project into an image
 
 For a deployable image, use this one as a base:
@@ -186,4 +271,9 @@ above.
 - **Port already in use** — `root dev` reads `PORT` (default `4007`), so
   `-e PORT=5000 -p 5000:5000` moves it.
 
+- **`claude remote-control` exits immediately** — it checks eligibility before
+  anything else. Run `claude` in the container and use `/login`; the volume at
+  `/home/rootjs/.claude` has to be mounted for that login to stick.
+
 [adc]: https://cloud.google.com/docs/authentication/application-default-credentials
+[remote-control]: https://code.claude.com/docs/en/remote-control

--- a/docker/README.md
+++ b/docker/README.md
@@ -121,15 +121,22 @@ default — install only when `node_modules` is missing), `always`, or `never`.
 
 **Reuse the host's gcloud config.** If you're already signed in on the host,
 bind-mount the config directory instead of using a named volume. Ownership has
-to line up, so build with your own uid/gid if it isn't `1000`:
+to line up, so run as your own uid if it isn't `1000`:
 
 ```bash
-docker build -t root --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" docker/
 docker run --rm -it -p 4007:4007 \
+  --user "$(id -u):0" \
   -v "$PWD:/workspace" \
   -v "$HOME/.config/gcloud:/home/rootjs/.config/gcloud" \
   root
 ```
+
+`$HOME` inside the image is group-owned by root (gid `0`) with the owner's
+permissions, so any uid that runs with group `0` can still write the gcloud,
+pnpm and Claude Code config. Building with
+`--build-arg UID="$(id -u)" --build-arg GID="$(id -g)"` also works and is
+tidier if you're building locally anyway, but `--user` is the option that works
+against a pulled image.
 
 **Service account key**, for CI or a shared server:
 
@@ -183,13 +190,14 @@ docker run --rm -it \
 
 # 3. Start Remote Control. It prints a session URL; press space for a QR code.
 docker run --rm -it --init \
-  -p 4008:4007 \
+  -p 4008-4013:4007-4012 \
   -v "$PWD:/workspace" \
   -v root-ai-claude-config:/home/rootjs/.claude \
   -v root-gcloud:/home/rootjs/.config/gcloud \
   -v root-pnpm-store:/home/rootjs/.pnpm-store \
+  -e GIT_AUTHOR_NAME -e GIT_AUTHOR_EMAIL \
   --env-file .env \
-  root-ai-claude
+  root-ai-claude claude remote-control --spawn worktree
 ```
 
 Or with compose, where the service sits behind a `claude` profile so
@@ -201,14 +209,76 @@ docker compose -f docker/docker-compose.yml build claude
 docker compose -f docker/docker-compose.yml run --rm claude
 ```
 
-Port 4008 maps to the container's 4007, so a dev server Claude starts inside the
-container is at <http://localhost:4008/cms/> — on a different host port than the
-`root` service, so both can run at once.
+Other useful commands: `claude` for a plain local session and
+`claude --remote-control` for one that is both local and remote.
 
-Other useful commands: `claude` for a plain local session, `claude
---remote-control` for one that is both local and remote, and `claude
-remote-control --spawn worktree` to give each remote session its own git
-worktree.
+### Parallel sessions
+
+Server mode (`claude remote-control`, the image's default) serves multiple
+concurrent sessions from one process — up to `--capacity`, which defaults to 32.
+`claude --remote-control` does not; it's one remote session per process.
+
+Two things make that work in a container:
+
+- **`--spawn worktree`.** The default spawn mode is `same-dir`, where every
+  session edits the same files in `/workspace` and they collide. With
+  `--spawn worktree`, each on-demand session gets its own git worktree. Press
+  `w` at runtime to toggle. The compose service passes this flag already.
+- **A port range, not a single port.** `root dev` scans upward from 4007 for a
+  free port, so a second session's dev server binds 4008 *inside* the container.
+  Publishing `4008-4013:4007-4012` keeps them reachable — the first session's
+  server is at <http://localhost:4008/cms/>, the second at `:4009`, and so on.
+
+What every session shares: one CPU/memory budget, one pnpm store, and one set of
+Google Cloud credentials — so N parallel agents write to the same Firestore
+project as the same identity.
+
+### Git access
+
+`git` is in the base image and `gh` is in the Claude image, and `/workspace` is a
+bind mount that includes `.git`, so branches and commits land in your real
+repository on the host.
+
+Worktrees work well here because Claude Code creates them under
+`.claude/worktrees/<name>/` **at the repository root** — inside the bind mount,
+so they survive `docker rm` and are visible on the host. (This repo's
+`.gitignore` already covers `.claude/`; add `.claude/worktrees/` to your own
+project's if it doesn't.) Two consequences worth planning for:
+
+- A worktree is a fresh checkout with **no `node_modules`**. The entrypoint only
+  auto-installs for the directory the container started in, so each worktree
+  needs its own `pnpm install`. The shared pnpm store makes that cheap.
+- A worktree has none of your gitignored files either, including `.env`. Add a
+  [`.worktreeinclude`][worktreeinclude] to the project root to copy them in
+  automatically:
+
+  ```text
+  .env
+  .env.local
+  ```
+
+**Committing** needs an identity. Pass one through, and the entrypoint mirrors it
+to the committer fields:
+
+```bash
+-e GIT_AUTHOR_NAME="Your Name" -e GIT_AUTHOR_EMAIL="you@example.com"
+```
+
+Compose forwards `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL` and the `GIT_COMMITTER_*`
+pair from your shell when they're set. Mounting a gitconfig
+(`-v "$HOME/.gitconfig:/home/rootjs/.gitconfig:ro"`) also works, though a host
+config that references signing keys or credential helpers the container lacks
+will fail in confusing ways. Without either, the entrypoint warns at startup that
+commits will fail.
+
+**Pushing is not set up yet.** There are no SSH keys, no token and no credential
+helper in the image, so `git push` fails on authentication and Claude can create
+branches locally but not publish them. A fine-grained token scoped to the one
+repository, passed as `GH_TOKEN` with `gh auth setup-git`, is the approach I'd
+suggest — mounting `~/.ssh` gives an agent container push access to every
+repository you can reach. This also affects worktrees indirectly: their default
+base is the remote's default branch, and when that fetch fails they silently fall
+back to your local `HEAD`.
 
 ### Notes
 
@@ -259,8 +329,14 @@ above.
   `USERNAME` build arg).
 - **`reauthentication is needed`** — user ADC expires. Re-run
   `gcloud auth application-default login` with the volume mounted.
-- **Permission errors on files in the mounted project** — rebuild with
-  `--build-arg UID="$(id -u)" --build-arg GID="$(id -g)"`.
+- **Permission errors on files in the mounted project**, or git failing with
+  `detected dubious ownership` — run with `--user "$(id -u):0"`, or rebuild with
+  `--build-arg UID="$(id -u)" --build-arg GID="$(id -g)"`. (The image sets
+  `safe.directory=*` system-wide, so the ownership check itself is off; what's
+  left is real filesystem permissions.)
+- **`git commit` fails with `empty ident name`** — an identity variable was
+  passed through empty. The entrypoint drops empty `GIT_*` values, so this means
+  something set them after startup.
 - **Port already in use** — `root dev` reads `PORT` (default `4007`), so
   `-e PORT=5000 -p 5000:5000` moves it.
 - **`claude remote-control` exits immediately** — it checks eligibility before
@@ -269,3 +345,4 @@ above.
 
 [adc]: https://cloud.google.com/docs/authentication/application-default-credentials
 [remote-control]: https://code.claude.com/docs/en/remote-control
+[worktreeinclude]: https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,16 +35,16 @@ Both are written to `$HOME/.config/gcloud` inside the container
 
 ```bash
 # 1. Build the image.
-docker build -t root-cms docker/
+docker build -t root docker/
 
 # 2. Create the volume that will hold your gcloud credentials.
-docker volume create root-cms-gcloud
+docker volume create root-gcloud
 
 # 3. Sign in — once. Follow the printed URL, paste the code back in.
 #    Replace MY_GCP_PROJECT with your Firebase/GCP project id.
 docker run --rm -it \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  root-cms bash -lc '
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  root bash -lc '
     gcloud auth login --no-launch-browser &&
     gcloud auth application-default login --no-launch-browser &&
     gcloud config set project MY_GCP_PROJECT &&
@@ -54,10 +54,10 @@ docker run --rm -it \
 docker run --rm -it --init \
   -p 4007:4007 \
   -v "$PWD:/workspace" \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  -v root-cms-pnpm-store:/home/rootjs/.pnpm-store \
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  -v root-pnpm-store:/home/rootjs/.pnpm-store \
   --env-file .env \
-  root-cms
+  root
 ```
 
 The CMS is then at <http://localhost:4007/cms/>.
@@ -67,8 +67,8 @@ is deleted. To verify a volume already holds credentials:
 
 ```bash
 docker run --rm -it \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  root-cms gcloud auth list
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  root gcloud auth list
 ```
 
 ### Using docker compose instead
@@ -79,7 +79,7 @@ docker run --rm -it \
 export ROOT_PROJECT_DIR=/path/to/my-project
 export GOOGLE_CLOUD_PROJECT=my-gcp-project
 
-docker compose -f docker/docker-compose.yml run --rm root-cms bash -lc '
+docker compose -f docker/docker-compose.yml run --rm root bash -lc '
   gcloud auth login --no-launch-browser &&
   gcloud auth application-default login --no-launch-browser &&
   gcloud auth application-default set-quota-project $CLOUDSDK_CORE_PROJECT'
@@ -105,17 +105,17 @@ as the `docker run` command:
 ```bash
 # A shell.
 docker run --rm -it -v "$PWD:/workspace" \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud root-cms bash
+  -v root-gcloud:/home/rootjs/.config/gcloud root bash
 
 # The Root CMS CLI.
 docker run --rm -it -v "$PWD:/workspace" \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  root-cms pnpm exec root-cms client.methods --json
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  root pnpm exec root-cms client.methods --json
 
 # A production build + server.
 docker run --rm -it -p 4007:4007 -v "$PWD:/workspace" \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  root-cms bash -lc 'pnpm exec root build && pnpm exec root start --host 0.0.0.0'
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  root bash -lc 'pnpm exec root build && pnpm exec root start --host 0.0.0.0'
 ```
 
 Dependency installation is controlled by `ROOT_DOCKER_INSTALL`: `auto` (the
@@ -128,11 +128,11 @@ bind-mount the config directory instead of using a named volume. Ownership has
 to line up, so build with your own uid/gid if it isn't `1000`:
 
 ```bash
-docker build -t root-cms --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" docker/
+docker build -t root --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" docker/
 docker run --rm -it -p 4007:4007 \
   -v "$PWD:/workspace" \
   -v "$HOME/.config/gcloud:/home/rootjs/.config/gcloud" \
-  root-cms
+  root
 ```
 
 **Service account key**, for CI or a shared server:
@@ -142,7 +142,7 @@ docker run --rm -it -p 4007:4007 \
   -v "$PWD:/workspace" \
   -v /path/to/key.json:/secrets/key.json:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS=/secrets/key.json \
-  root-cms
+  root
 ```
 
 **Workload identity / metadata server.** On GCE, Cloud Run, or GKE, ADC is
@@ -158,7 +158,7 @@ them with `--env-file .env` or compose's `env_file`.
 
 ## Running Claude Code against the project
 
-`Dockerfile.claude` builds a child image (`FROM root-cms`) that adds the Claude
+`Dockerfile.claude` builds a child image (`FROM root`) that adds the Claude
 Code CLI, so an agent session runs with the same Node, pnpm, gcloud and project
 files as the dev server. Its default command is `claude remote-control`, which
 [drives the session from claude.ai or the Claude app][remote-control] while
@@ -171,10 +171,10 @@ project's Google Cloud credentials.
 
 ```bash
 # 1. Build the base image first, then the child.
-docker build -t root-cms docker/
-docker build -t root-cms-claude -f docker/Dockerfile.claude docker/
+docker build -t root docker/
+docker build -t root-ai-claude -f docker/Dockerfile.claude docker/
 
-docker volume create root-cms-claude-config
+docker volume create root-ai-claude-config
 
 # 2. Sign in and accept the workspace trust prompt. Remote Control needs a
 #    claude.ai login (Pro, Max, Team or Enterprise) — API keys don't work.
@@ -182,32 +182,32 @@ docker volume create root-cms-claude-config
 #    the browser at the "Paste code here if prompted" prompt.
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  -v root-cms-claude-config:/home/rootjs/.claude \
-  root-cms-claude claude
+  -v root-ai-claude-config:/home/rootjs/.claude \
+  root-ai-claude claude
 
 # 3. Start Remote Control. It prints a session URL; press space for a QR code.
 docker run --rm -it --init \
   -p 4008:4007 \
   -v "$PWD:/workspace" \
-  -v root-cms-claude-config:/home/rootjs/.claude \
-  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
-  -v root-cms-pnpm-store:/home/rootjs/.pnpm-store \
+  -v root-ai-claude-config:/home/rootjs/.claude \
+  -v root-gcloud:/home/rootjs/.config/gcloud \
+  -v root-pnpm-store:/home/rootjs/.pnpm-store \
   --env-file .env \
-  root-cms-claude
+  root-ai-claude
 ```
 
 Or with compose, where the service sits behind a `claude` profile so
 `docker compose up` never starts an agent by surprise:
 
 ```bash
-docker compose -f docker/docker-compose.yml build root-cms
+docker compose -f docker/docker-compose.yml build root
 docker compose -f docker/docker-compose.yml build claude
 docker compose -f docker/docker-compose.yml run --rm claude
 ```
 
 Port 4008 maps to the container's 4007, so a dev server Claude starts inside the
 container is at <http://localhost:4008/cms/> — on a different host port than the
-`root-cms` service, so both can run at once.
+`root` service, so both can run at once.
 
 Other useful commands: `claude` for a plain local session, `claude
 --remote-control` for one that is both local and remote, and `claude
@@ -243,7 +243,7 @@ worktree.
 For a deployable image, use this one as a base:
 
 ```dockerfile
-FROM root-cms
+FROM root
 
 COPY --chown=1000:1000 . /workspace
 RUN pnpm install --frozen-lockfile && pnpm exec root build

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,189 @@
+# Docker image for Root.js CMS projects
+
+An Ubuntu 24.04 image with everything needed to run a Root.js CMS project
+against a real Firebase/Firestore project:
+
+| Tool             | Version                                            |
+| ---------------- | -------------------------------------------------- |
+| Node.js          | `24.16.0` (`NODE_VERSION` build arg)               |
+| pnpm             | `11.17.0` via corepack (`PNPM_VERSION` build arg)  |
+| Google Cloud CLI | latest from the `cloud-sdk` apt repo               |
+
+The project is **not** baked into the image — you mount it at `/workspace`. The
+container runs as a non-root user (uid/gid `1000` by default) so files it
+writes into the mounted project stay owned by you.
+
+## How auth works
+
+Root CMS connects to Firestore with the Firebase Admin SDK, which uses
+[Application Default Credentials][adc] (see
+`packages/root-cms/core/plugin.ts`). Some CLI features (`root secrets`) also
+shell out to `gcloud` directly, so the container needs both:
+
+- `gcloud auth login` — credentials for the `gcloud` CLI itself.
+- `gcloud auth application-default login` — the ADC file that
+  `firebase-admin` reads.
+
+Both are written to `$HOME/.config/gcloud` inside the container
+(`/home/rootjs/.config/gcloud`). Mount a named volume there and you sign in
+**once**; every later `docker run` reuses it.
+
+## Quick start
+
+```bash
+# 1. Build the image.
+docker build -t root-cms docker/
+
+# 2. Create the volume that will hold your gcloud credentials.
+docker volume create root-cms-gcloud
+
+# 3. Sign in — once. Follow the printed URL, paste the code back in.
+#    Replace MY_GCP_PROJECT with your Firebase/GCP project id.
+docker run --rm -it \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  root-cms bash -lc '
+    gcloud auth login --no-launch-browser &&
+    gcloud auth application-default login --no-launch-browser &&
+    gcloud config set project MY_GCP_PROJECT &&
+    gcloud auth application-default set-quota-project MY_GCP_PROJECT'
+
+# 4. Run the project. Dependencies install automatically on first start.
+docker run --rm -it --init \
+  -p 4007:4007 \
+  -v "$PWD:/workspace" \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  -v root-cms-pnpm-store:/home/rootjs/.pnpm-store \
+  --env-file .env \
+  root-cms
+```
+
+The CMS is then at <http://localhost:4007/cms/>.
+
+Step 3 only has to be repeated when the credentials are revoked or the volume
+is deleted. To verify a volume already holds credentials:
+
+```bash
+docker run --rm -it \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  root-cms gcloud auth list
+```
+
+### Using docker compose instead
+
+`docker-compose.yml` wires up the same volumes declaratively:
+
+```bash
+export ROOT_PROJECT_DIR=/path/to/my-project
+export GOOGLE_CLOUD_PROJECT=my-gcp-project
+
+docker compose -f docker/docker-compose.yml run --rm root-cms bash -lc '
+  gcloud auth login --no-launch-browser &&
+  gcloud auth application-default login --no-launch-browser &&
+  gcloud auth application-default set-quota-project $CLOUDSDK_CORE_PROJECT'
+
+docker compose -f docker/docker-compose.yml up
+```
+
+`ROOT_PROJECT_DIR` defaults to this repo's root, and `ROOT_PROJECT_SUBDIR`
+picks a project inside it — e.g. `ROOT_PROJECT_SUBDIR=docs` to run the docs
+site from a checkout of this monorepo. `${ROOT_PROJECT_DIR}/.env` is loaded
+automatically when present. The shell doesn't export `UID`/`GID`, so pass them
+explicitly if your host user isn't `1000`:
+
+```bash
+UID=$(id -u) GID=$(id -g) docker compose -f docker/docker-compose.yml build
+```
+
+## Running commands other than the dev server
+
+The default command is `root dev --host 0.0.0.0`. Anything else can be passed
+as the `docker run` command:
+
+```bash
+# A shell.
+docker run --rm -it -v "$PWD:/workspace" \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud root-cms bash
+
+# The Root CMS CLI.
+docker run --rm -it -v "$PWD:/workspace" \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  root-cms pnpm exec root-cms client.methods --json
+
+# A production build + server.
+docker run --rm -it -p 4007:4007 -v "$PWD:/workspace" \
+  -v root-cms-gcloud:/home/rootjs/.config/gcloud \
+  root-cms bash -lc 'pnpm exec root build && pnpm exec root start --host 0.0.0.0'
+```
+
+Dependency installation is controlled by `ROOT_DOCKER_INSTALL`: `auto` (the
+default — install only when `node_modules` is missing), `always`, or `never`.
+
+## Other ways to supply credentials
+
+**Reuse the host's gcloud config.** If you're already signed in on the host,
+bind-mount the config directory instead of using a named volume. Ownership has
+to line up, so build with your own uid/gid if it isn't `1000`:
+
+```bash
+docker build -t root-cms --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" docker/
+docker run --rm -it -p 4007:4007 \
+  -v "$PWD:/workspace" \
+  -v "$HOME/.config/gcloud:/home/rootjs/.config/gcloud" \
+  root-cms
+```
+
+**Service account key**, for CI or a shared server:
+
+```bash
+docker run --rm -it -p 4007:4007 \
+  -v "$PWD:/workspace" \
+  -v /path/to/key.json:/secrets/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/secrets/key.json \
+  root-cms
+```
+
+**Workload identity / metadata server.** On GCE, Cloud Run, or GKE, ADC is
+picked up from the metadata server automatically — no volume needed.
+
+## Project env vars
+
+Google Cloud credentials only cover the server side. The CMS sign-in page uses
+Firebase Auth in the browser, which needs the `firebaseConfig` and `gapi` keys
+that `root.config.ts` reads from the environment (`GAPI_API_KEY`,
+`GAPI_CLIENT_ID`, `COOKIE_SECRET`, and any translation/AI provider keys). Pass
+them with `--env-file .env` or compose's `env_file`.
+
+## Baking a project into an image
+
+For a deployable image, use this one as a base:
+
+```dockerfile
+FROM root-cms
+
+COPY --chown=1000:1000 . /workspace
+RUN pnpm install --frozen-lockfile && pnpm exec root build
+
+ENV ROOT_DOCKER_INSTALL=never
+CMD ["pnpm", "exec", "root", "start", "--host", "0.0.0.0"]
+```
+
+Don't bake credentials in — supply them at runtime with one of the options
+above.
+
+## Troubleshooting
+
+- **`Could not load the default credentials`** — the gcloud volume isn't
+  mounted, or is mounted at the wrong path. It must be
+  `/home/rootjs/.config/gcloud` (or `/home/<USERNAME>/...` if you overrode the
+  `USERNAME` build arg).
+- **`Your application is authenticating by using local Application Default
+  Credentials... quota project`** — run `gcloud auth application-default
+  set-quota-project MY_GCP_PROJECT`.
+- **`reauthentication is needed`** — user ADC expires. Re-run
+  `gcloud auth application-default login` with the volume mounted.
+- **Permission errors on files in the mounted project** — rebuild with
+  `--build-arg UID="$(id -u)" --build-arg GID="$(id -g)"`.
+- **Port already in use** — `root dev` reads `PORT` (default `4007`), so
+  `-e PORT=5000 -p 5000:5000` moves it.
+
+[adc]: https://cloud.google.com/docs/authentication/application-default-credentials

--- a/docker/README.md
+++ b/docker/README.md
@@ -195,7 +195,7 @@ docker run --rm -it --init \
   -v root-ai-claude-config:/home/rootjs/.claude \
   -v root-gcloud:/home/rootjs/.config/gcloud \
   -v root-pnpm-store:/home/rootjs/.pnpm-store \
-  -e GIT_AUTHOR_NAME -e GIT_AUTHOR_EMAIL \
+  -e GIT_AUTHOR_NAME -e GIT_AUTHOR_EMAIL -e GH_TOKEN \
   --env-file .env \
   root-ai-claude claude remote-control --spawn worktree
 ```
@@ -271,21 +271,47 @@ config that references signing keys or credential helpers the container lacks
 will fail in confusing ways. Without either, the entrypoint warns at startup that
 commits will fail.
 
-**Pushing is not set up yet.** There are no SSH keys, no token and no credential
-helper in the image, so `git push` fails on authentication and Claude can create
-branches locally but not publish them. A fine-grained token scoped to the one
-repository, passed as `GH_TOKEN` with `gh auth setup-git`, is the approach I'd
-suggest — mounting `~/.ssh` gives an agent container push access to every
-repository you can reach. This also affects worktrees indirectly: their default
-base is the remote's default branch, and when that fetch fails they silently fall
-back to your local `HEAD`.
+**Pushing** uses `gh` as git's credential helper. The entrypoint runs
+`gh auth setup-git` when it finds a credential, so `git push`, `git fetch` and
+`gh pr create` all work. There are two ways to supply one:
+
+```bash
+# A token in the environment. Compose forwards GH_TOKEN and GH_HOST when set.
+docker run --rm -it -e GH_TOKEN ... root-ai-claude
+
+# Or sign in once and keep it in a volume, like the gcloud login.
+docker run --rm -it -v root-ai-gh-config:/home/rootjs/.config/gh \
+  root-ai-claude gh auth login
+```
+
+Use a **fine-grained token scoped to this repository only** — `Contents:
+read and write` to push, plus `Pull requests: read and write` if Claude should
+open PRs. Mounting `~/.ssh` instead would give the agent container push access to
+every repository you can reach, which is the thing worth avoiding. Note that
+compose forwards whatever `GH_TOKEN` is already exported in your shell, so check
+it isn't a broad-scope one you set for something else.
+
+Two details the wiring handles for you:
+
+- Token auth only applies to **https remotes**, so when a token is present the
+  entrypoint adds an `insteadOf` rewrite for `git@<host>:`. A checkout cloned
+  over ssh would otherwise still fail to push, with no key in the container.
+- The credential config is written to the container's own `~/.gitconfig`, in the
+  writable layer — not to a volume and not to your host — so no token outlives
+  the container.
+
+Without a credential, worktrees are affected too: their default base is the
+remote's default branch, and when that fetch fails they fall back silently to
+your local `HEAD`.
 
 ### Notes
 
 - **Credentials the agent inherits.** Mounting the gcloud volume gives Claude
-  write access to your CMS's Firestore data. For anything beyond a scratch
-  project, point the agent container at a volume signed in to a non-production
-  project, or leave the gcloud mount off entirely and let it work on code only.
+  write access to your CMS's Firestore data, and `GH_TOKEN` gives it whatever
+  the token grants. For anything beyond a scratch project, point the agent
+  container at a volume signed in to a non-production project and scope the
+  token to a single repository, or leave the gcloud mount off entirely and let
+  it work on code only.
   This is also why `--dangerously-skip-permissions` deserves care here, even
   though the container runs as a non-root user (the CLI rejects that flag as
   root).

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,15 +40,13 @@ docker build -t root docker/
 # 2. Create the volume that will hold your gcloud credentials.
 docker volume create root-gcloud
 
-# 3. Sign in — once. Follow the printed URL, paste the code back in.
-#    Replace MY_GCP_PROJECT with your Firebase/GCP project id.
+# 3. Sign in — once. Follow the printed URL, paste the code back in. You will be
+# asked to sign in twice.
 docker run --rm -it \
   -v root-gcloud:/home/rootjs/.config/gcloud \
   root bash -lc '
     gcloud auth login --no-launch-browser &&
-    gcloud auth application-default login --no-launch-browser &&
-    gcloud config set project MY_GCP_PROJECT &&
-    gcloud auth application-default set-quota-project MY_GCP_PROJECT'
+    gcloud auth application-default login --no-launch-browser'
 
 # 4. Run the project. Dependencies install automatically on first start.
 docker run --rm -it --init \
@@ -77,12 +75,10 @@ docker run --rm -it \
 
 ```bash
 export ROOT_PROJECT_DIR=/path/to/my-project
-export GOOGLE_CLOUD_PROJECT=my-gcp-project
 
 docker compose -f docker/docker-compose.yml run --rm root bash -lc '
   gcloud auth login --no-launch-browser &&
-  gcloud auth application-default login --no-launch-browser &&
-  gcloud auth application-default set-quota-project $CLOUDSDK_CORE_PROJECT'
+  gcloud auth application-default login --no-launch-browser'
 
 docker compose -f docker/docker-compose.yml up
 ```
@@ -261,16 +257,12 @@ above.
   mounted, or is mounted at the wrong path. It must be
   `/home/rootjs/.config/gcloud` (or `/home/<USERNAME>/...` if you overrode the
   `USERNAME` build arg).
-- **`Your application is authenticating by using local Application Default
-  Credentials... quota project`** — run `gcloud auth application-default
-  set-quota-project MY_GCP_PROJECT`.
 - **`reauthentication is needed`** — user ADC expires. Re-run
   `gcloud auth application-default login` with the volume mounted.
 - **Permission errors on files in the mounted project** — rebuild with
   `--build-arg UID="$(id -u)" --build-arg GID="$(id -g)"`.
 - **Port already in use** — `root dev` reads `PORT` (default `4007`), so
   `-e PORT=5000 -p 5000:5000` moves it.
-
 - **`claude remote-control` exits immediately** — it checks eligibility before
   anything else. Run `claude` in the container and use `/login`; the volume at
   `/home/rootjs/.claude` has to be mounted for that login to stick.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+# Convenience wrapper around ./Dockerfile. Set ROOT_PROJECT_DIR to the Root.js
+# project you want to run (defaults to this repo). See ./README.md.
+#
+# `UID`/`GID` are not exported by the shell, so pass them explicitly if your
+# host user isn't 1000: `UID=$(id -u) GID=$(id -g) docker compose ... build`.
+#
+#   docker compose -f docker/docker-compose.yml run --rm root-cms \
+#     gcloud auth application-default login --no-launch-browser
+#   docker compose -f docker/docker-compose.yml up
+
+name: root-cms
+
+services:
+  root-cms:
+    build:
+      context: .
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    image: root-cms
+    init: true
+    stdin_open: true
+    tty: true
+    working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
+    ports:
+      - '${PORT:-4007}:4007'
+    environment:
+      # Picked up by gcloud as the active project.
+      CLOUDSDK_CORE_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
+    env_file:
+      - path: ${ROOT_PROJECT_DIR:-..}/.env
+        required: false
+    volumes:
+      - ${ROOT_PROJECT_DIR:-..}:/workspace
+      # Persists `gcloud auth login` and `gcloud auth application-default
+      # login` between runs.
+      - gcloud-config:/home/rootjs/.config/gcloud
+      # Persists the pnpm content-addressable store between runs.
+      - pnpm-store:/home/rootjs/.pnpm-store
+
+volumes:
+  gcloud-config:
+  pnpm-store:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,13 @@
 #   docker compose -f docker/docker-compose.yml run --rm root-cms \
 #     gcloud auth application-default login --no-launch-browser
 #   docker compose -f docker/docker-compose.yml up
+#
+# The `claude` service builds FROM the `root-cms` image, so build that one
+# first. It sits behind a profile, so `up` never starts an agent by surprise:
+#
+#   docker compose -f docker/docker-compose.yml build root-cms
+#   docker compose -f docker/docker-compose.yml build claude
+#   docker compose -f docker/docker-compose.yml run --rm claude
 
 name: root-cms
 
@@ -38,6 +45,38 @@ services:
       # Persists the pnpm content-addressable store between runs.
       - pnpm-store:/home/rootjs/.pnpm-store
 
+  # Claude Code with Remote Control, running against the same project. Started
+  # explicitly (`run --rm claude`), never by `docker compose up`.
+  claude:
+    profiles: ['claude']
+    build:
+      context: .
+      dockerfile: Dockerfile.claude
+      args:
+        BASE_IMAGE: root-cms
+    image: root-cms-claude
+    init: true
+    stdin_open: true
+    tty: true
+    working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
+    ports:
+      # A dev server started by Claude inside the container, on a different
+      # host port so it can run alongside the `root-cms` service.
+      - '${CLAUDE_PORT:-4008}:4007'
+    environment:
+      CLOUDSDK_CORE_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
+    env_file:
+      - path: ${ROOT_PROJECT_DIR:-..}/.env
+        required: false
+    volumes:
+      - ${ROOT_PROJECT_DIR:-..}:/workspace
+      # Persists the claude.ai login, settings and history. Separate from the
+      # gcloud volume so each can be granted independently.
+      - claude-config:/home/rootjs/.claude
+      - gcloud-config:/home/rootjs/.config/gcloud
+      - pnpm-store:/home/rootjs/.pnpm-store
+
 volumes:
+  claude-config:
   gcloud-config:
   pnpm-store:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,6 +78,10 @@ services:
       - GIT_AUTHOR_EMAIL
       - GIT_COMMITTER_NAME
       - GIT_COMMITTER_EMAIL
+      # Lets the container push and open pull requests. Prefer a fine-grained
+      # token scoped to this repository; see README.md.
+      - GH_TOKEN
+      - GH_HOST
     env_file:
       - path: ${ROOT_PROJECT_DIR:-..}/.env
         required: false
@@ -86,10 +90,13 @@ services:
       # Persists the claude.ai login, settings and history. Separate from the
       # gcloud volume so each can be granted independently.
       - claude-config:/home/rootjs/.claude
+      # Persists an interactive `gh auth login`, as an alternative to GH_TOKEN.
+      - gh-config:/home/rootjs/.config/gh
       - gcloud-config:/home/rootjs/.config/gcloud
       - pnpm-store:/home/rootjs/.pnpm-store
 
 volumes:
   claude-config:
   gcloud-config:
+  gh-config:
   pnpm-store:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,9 +31,6 @@ services:
     working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
     ports:
       - '${PORT:-4007}:4007'
-    environment:
-      # Picked up by gcloud as the active project.
-      CLOUDSDK_CORE_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
     env_file:
       - path: ${ROOT_PROJECT_DIR:-..}/.env
         required: false
@@ -63,8 +60,6 @@ services:
       # A dev server started by Claude inside the container, on a different
       # host port so it can run alongside the `root` service.
       - '${CLAUDE_PORT:-4008}:4007'
-    environment:
-      CLOUDSDK_CORE_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
     env_file:
       - path: ${ROOT_PROJECT_DIR:-..}/.env
         required: false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,27 +4,27 @@
 # `UID`/`GID` are not exported by the shell, so pass them explicitly if your
 # host user isn't 1000: `UID=$(id -u) GID=$(id -g) docker compose ... build`.
 #
-#   docker compose -f docker/docker-compose.yml run --rm root-cms \
+#   docker compose -f docker/docker-compose.yml run --rm root \
 #     gcloud auth application-default login --no-launch-browser
 #   docker compose -f docker/docker-compose.yml up
 #
-# The `claude` service builds FROM the `root-cms` image, so build that one
-# first. It sits behind a profile, so `up` never starts an agent by surprise:
+# The `claude` service builds FROM the `root` image, so build that one first. It
+# sits behind a profile, so `up` never starts an agent by surprise:
 #
-#   docker compose -f docker/docker-compose.yml build root-cms
+#   docker compose -f docker/docker-compose.yml build root
 #   docker compose -f docker/docker-compose.yml build claude
 #   docker compose -f docker/docker-compose.yml run --rm claude
 
-name: root-cms
+name: root
 
 services:
-  root-cms:
+  root:
     build:
       context: .
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
-    image: root-cms
+    image: root
     init: true
     stdin_open: true
     tty: true
@@ -53,15 +53,15 @@ services:
       context: .
       dockerfile: Dockerfile.claude
       args:
-        BASE_IMAGE: root-cms
-    image: root-cms-claude
+        BASE_IMAGE: root
+    image: root-ai-claude
     init: true
     stdin_open: true
     tty: true
     working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
     ports:
       # A dev server started by Claude inside the container, on a different
-      # host port so it can run alongside the `root-cms` service.
+      # host port so it can run alongside the `root` service.
       - '${CLAUDE_PORT:-4008}:4007'
     environment:
       CLOUDSDK_CORE_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,13 @@ services:
     working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
     ports:
       - '${PORT:-4007}:4007'
+    environment:
+      # Passed through only when set on the host, so git never sees an empty
+      # identity (which it rejects more loudly than a missing one).
+      - GIT_AUTHOR_NAME
+      - GIT_AUTHOR_EMAIL
+      - GIT_COMMITTER_NAME
+      - GIT_COMMITTER_EMAIL
     env_file:
       - path: ${ROOT_PROJECT_DIR:-..}/.env
         required: false
@@ -56,10 +63,21 @@ services:
     stdin_open: true
     tty: true
     working_dir: /workspace${ROOT_PROJECT_SUBDIR:+/}${ROOT_PROJECT_SUBDIR:-}
+    # Each session gets its own git worktree under .claude/worktrees/, which is
+    # inside the bind mount, so the work survives the container. Without this,
+    # every session edits the same files in /workspace.
+    command: ['claude', 'remote-control', '--spawn', 'worktree']
     ports:
-      # A dev server started by Claude inside the container, on a different
-      # host port so it can run alongside the `root` service.
-      - '${CLAUDE_PORT:-4008}:4007'
+      # A range, not a single port: `root dev` scans upward from 4007 for a free
+      # port, so a second concurrent session's dev server lands on 4008 inside
+      # the container and would otherwise be unreachable. Host ports are offset
+      # by one so they don't collide with the `root` service.
+      - '4008-4013:4007-4012'
+    environment:
+      - GIT_AUTHOR_NAME
+      - GIT_AUTHOR_EMAIL
+      - GIT_COMMITTER_NAME
+      - GIT_COMMITTER_EMAIL
     env_file:
       - path: ${ROOT_PROJECT_DIR:-..}/.env
         required: false

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
-# Container entrypoint. Sets up the git committer identity, installs the mounted
-# project's dependencies when they are missing, reports whether Google Cloud
-# credentials are available, then execs the requested command.
+# Container entrypoint. Sets up the git committer identity and push credentials,
+# installs the mounted project's dependencies when they are missing, reports
+# whether Google Cloud credentials are available, then execs the requested
+# command.
 
 set -euo pipefail
 
@@ -84,6 +85,51 @@ warn_missing_git_identity() {
     "${HOME}/.gitconfig." >&2
 }
 
+# Points git at `gh` for credentials, so `git push` and `gh pr create` work with
+# a token from the environment (GH_TOKEN / GITHUB_TOKEN) or with a `gh auth
+# login` persisted in a volume at ~/.config/gh. A no-op when gh isn't installed
+# (the base image) or when there is nothing to authenticate with.
+#
+# The config is written to the container's own ~/.gitconfig, which lives in the
+# writable layer, so nothing is left behind on the host and no token is
+# persisted to a volume.
+configure_git_credentials() {
+  local name
+  for name in GH_TOKEN GITHUB_TOKEN GH_HOST; do
+    if [[ -z "${!name:-}" ]]; then
+      unset "${name}"
+    fi
+  done
+
+  command -v gh >/dev/null 2>&1 || return 0
+
+  local host="${GH_HOST:-github.com}"
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  # Checking the config file rather than `gh auth status` keeps startup offline
+  # and fast — `gh auth status` validates the token over the network.
+  local gh_hosts="${GH_CONFIG_DIR:-${HOME}/.config/gh}/hosts.yml"
+  if [[ -z "${token}" ]] && [[ ! -s "${gh_hosts}" ]]; then
+    return 0
+  fi
+
+  # `gh auth setup-git` is the supported path, but some versions refuse when the
+  # only credential is an environment token. The helper it would have written
+  # works either way, so fall back to writing it directly.
+  if ! gh auth setup-git --hostname "${host}" >/dev/null 2>&1; then
+    if ! git config --global "credential.https://${host}.helper" '!gh auth git-credential'; then
+      echo "[root docker] Could not configure the git credential helper —" \
+        "${HOME}/.gitconfig is not writable. Pushing will fail." >&2
+      return 0
+    fi
+  fi
+
+  # A token only authenticates https remotes, so rewrite ssh remotes. Without
+  # this, a repository cloned over ssh still fails to push with no key present.
+  if [[ -n "${token}" ]]; then
+    git config --global "url.https://${host}/.insteadOf" "git@${host}:" || true
+  fi
+}
+
 # Installs dependencies when /workspace looks like an uninstalled npm project.
 # Set ROOT_DOCKER_INSTALL=always to reinstall on every start, or =never to skip.
 maybe_install_deps() {
@@ -99,6 +145,7 @@ maybe_install_deps() {
 }
 
 export_git_identity
+configure_git_credentials
 
 if ! is_setup_command "${1:-}"; then
   check_credentials

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,7 @@ is_setup_command() {
 check_credentials() {
   if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
     if [[ ! -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-      echo "[root-cms docker] GOOGLE_APPLICATION_CREDENTIALS is set to" \
+      echo "[root docker] GOOGLE_APPLICATION_CREDENTIALS is set to" \
         "'${GOOGLE_APPLICATION_CREDENTIALS}' but no file exists there." >&2
     fi
     return 0
@@ -35,15 +35,15 @@ check_credentials() {
   fi
 
   cat >&2 <<EOF
-[root-cms docker] No application default credentials (ADC) found at
+[root docker] No application default credentials (ADC) found at
 ${ADC_FILE}
 
 Root CMS reads and writes Firestore using ADC, so those requests will fail
 until you sign in. Run this once, with the same gcloud volume mounted:
 
   docker run --rm -it \\
-    -v root-cms-gcloud:${HOME}/.config/gcloud \\
-    root-cms gcloud auth application-default login --no-launch-browser
+    -v root-gcloud:${HOME}/.config/gcloud \\
+    root gcloud auth application-default login --no-launch-browser
 
 EOF
 }
@@ -58,7 +58,7 @@ maybe_install_deps() {
   if [[ "${mode}" == 'auto' ]] && [[ -d node_modules ]]; then
     return 0
   fi
-  echo '[root-cms docker] Installing dependencies with pnpm...' >&2
+  echo '[root docker] Installing dependencies with pnpm...' >&2
   pnpm install
 }
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Container entrypoint. Installs the mounted project's dependencies when they
+# are missing, reports whether Google Cloud credentials are available, then
+# execs the requested command.
+
+set -euo pipefail
+
+readonly ADC_FILE="${HOME}/.config/gcloud/application_default_credentials.json"
+
+# Returns 0 for commands that exist to create credentials or poke at the
+# container (`gcloud auth login`, an interactive shell), which shouldn't be
+# gated on credentials already existing.
+is_setup_command() {
+  case "${1:-}" in
+    gcloud | bash | sh | zsh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Warns when Root CMS won't be able to reach Firestore. This never fails the
+# container: some commands (`root build --ssr-only`, `pnpm lint`) don't need
+# credentials at all.
+check_credentials() {
+  if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    if [[ ! -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+      echo "[root-cms docker] GOOGLE_APPLICATION_CREDENTIALS is set to" \
+        "'${GOOGLE_APPLICATION_CREDENTIALS}' but no file exists there." >&2
+    fi
+    return 0
+  fi
+
+  if [[ -f "${ADC_FILE}" ]]; then
+    return 0
+  fi
+
+  cat >&2 <<EOF
+[root-cms docker] No application default credentials (ADC) found at
+${ADC_FILE}
+
+Root CMS reads and writes Firestore using ADC, so those requests will fail
+until you sign in. Run this once, with the same gcloud volume mounted:
+
+  docker run --rm -it \\
+    -v root-cms-gcloud:${HOME}/.config/gcloud \\
+    root-cms gcloud auth application-default login --no-launch-browser
+
+EOF
+}
+
+# Installs dependencies when /workspace looks like an uninstalled npm project.
+# Set ROOT_DOCKER_INSTALL=always to reinstall on every start, or =never to skip.
+maybe_install_deps() {
+  local mode="${ROOT_DOCKER_INSTALL:-auto}"
+  if [[ "${mode}" == 'never' ]] || [[ ! -f package.json ]]; then
+    return 0
+  fi
+  if [[ "${mode}" == 'auto' ]] && [[ -d node_modules ]]; then
+    return 0
+  fi
+  echo '[root-cms docker] Installing dependencies with pnpm...' >&2
+  pnpm install
+}
+
+if ! is_setup_command "${1:-}"; then
+  check_credentials
+  maybe_install_deps
+fi
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Container entrypoint. Installs the mounted project's dependencies when they
-# are missing, reports whether Google Cloud credentials are available, then
-# execs the requested command.
+# Container entrypoint. Sets up the git committer identity, installs the mounted
+# project's dependencies when they are missing, reports whether Google Cloud
+# credentials are available, then execs the requested command.
 
 set -euo pipefail
 
@@ -48,6 +48,42 @@ until you sign in. Run this once, with the same gcloud volume mounted:
 EOF
 }
 
+# Git refuses to commit without a committer identity, and an exported-but-empty
+# GIT_* variable fails harder than an unset one ("empty ident name not allowed"),
+# so drop the empties. GIT_AUTHOR_* is mirrored to GIT_COMMITTER_* so callers
+# only have to pass one pair.
+export_git_identity() {
+  local name
+  for name in GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL; do
+    if [[ -z "${!name:-}" ]]; then
+      unset "${name}"
+    fi
+  done
+  if [[ -n "${GIT_AUTHOR_NAME:-}" ]] && [[ -z "${GIT_COMMITTER_NAME:-}" ]]; then
+    export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
+  fi
+  if [[ -n "${GIT_AUTHOR_EMAIL:-}" ]] && [[ -z "${GIT_COMMITTER_EMAIL:-}" ]]; then
+    export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+  fi
+}
+
+# Warns when a commit would fail for lack of an identity. Only meaningful inside
+# a repository, so non-git workspaces stay quiet.
+warn_missing_git_identity() {
+  if [[ -n "${GIT_AUTHOR_EMAIL:-}" ]]; then
+    return 0
+  fi
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ -n "$(git config --get user.email 2>/dev/null || true)" ]]; then
+    return 0
+  fi
+  echo "[root docker] No git identity configured — commits will fail. Pass" \
+    "-e GIT_AUTHOR_NAME -e GIT_AUTHOR_EMAIL, or mount a gitconfig at" \
+    "${HOME}/.gitconfig." >&2
+}
+
 # Installs dependencies when /workspace looks like an uninstalled npm project.
 # Set ROOT_DOCKER_INSTALL=always to reinstall on every start, or =never to skip.
 maybe_install_deps() {
@@ -62,8 +98,11 @@ maybe_install_deps() {
   pnpm install
 }
 
+export_git_identity
+
 if ! is_setup_command "${1:-}"; then
   check_credentials
+  warn_missing_git_identity
   maybe_install_deps
 fi
 


### PR DESCRIPTION
Adds a complete Docker-based development environment for Root.js CMS projects, enabling local development against real Firebase/Firestore backends without manual toolchain setup.

## Changes

- **`docker/Dockerfile`** — Ubuntu 24.04 base image with Node.js 24.16.0, pnpm 11.17.0, and Google Cloud CLI pre-installed. Runs as a non-root user (uid/gid 1000 by default) so mounted project files retain host ownership. Includes an entrypoint script that auto-installs dependencies and validates credentials.

- **`docker/entrypoint.sh`** — Container startup script that:
  - Automatically installs project dependencies via pnpm when `node_modules` is missing (controlled by `ROOT_DOCKER_INSTALL` env var)
  - Validates Google Cloud credentials are available (either via ADC file or `GOOGLE_APPLICATION_CREDENTIALS`)
  - Allows setup commands (gcloud auth, interactive shells) to run without pre-existing credentials

- **`docker/Dockerfile.claude`** — Child image that adds Claude Code CLI on top of the base image, enabling AI agent sessions (via Remote Control) to run against the project with the same Node/pnpm/gcloud environment.

- **`docker/docker-compose.yml`** — Declarative compose configuration that:
  - Wires up volumes for gcloud credentials, pnpm store, and Claude config
  - Supports `ROOT_PROJECT_DIR` and `ROOT_PROJECT_SUBDIR` for flexible project mounting
  - Includes a `claude` service behind a profile so agent sessions don't start unexpectedly
  - Loads `.env` from the project automatically

- **`docker/README.md`** — Comprehensive documentation covering:
  - Quick start workflow (build, create volumes, sign in, run)
  - Authentication options (gcloud volume, host config bind-mount, service account key, workload identity)
  - Running commands other than the dev server
  - Claude Code Remote Control setup and security considerations
  - Baking projects into deployable images
  - Troubleshooting guide

- **`AGENTS.md`** — Updated to reference the new Docker setup in the project structure section.

## Implementation Details

- Credentials are persisted in named volumes (`root-gcloud`, `root-ai-claude-config`) so users sign in once and reuse credentials across container runs.
- The base image is deliberately separate from the Claude image to keep the base suitable for deployable images without carrying the agent credential surface.
- Build args (`UID`, `GID`, `USERNAME`) allow the container to match the host user's ownership, preventing permission issues on mounted files.
- The entrypoint distinguishes between setup commands (that create credentials) and regular commands (that require credentials), avoiding false failures during initial auth.

https://claude.ai/code/session_01Q3fsygkHJZtnYPN64syuvy