### PR TITLE
fix: let admins reset a user's stale Google sign-in link

### DIFF
--- a/.changeset/lucky-pears-fetch.md
+++ b/.changeset/lucky-pears-fetch.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: let admins reset a user's stale Google sign-in link

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -2,6 +2,7 @@ import {promises as fs} from 'node:fs';
 import path from 'node:path';
 import {Server, Request, Response} from '@blinkk/root';
 import {multipartMiddleware} from '@blinkk/root/middleware';
+import {getAuth} from 'firebase-admin/auth';
 import {toTranslationLanguages} from '../shared/translation-languages.js';
 import {
   buildChatSystemPrompt,
@@ -51,6 +52,9 @@ const SYNC_PROXY_ALLOWED_HOSTS: RegExp[] = [
 
 /** Max response size the asset sync relay will forward (100MB). */
 const SYNC_PROXY_MAX_BYTES = 100 * 1024 * 1024;
+
+/** The only sign-in provider the CMS uses. */
+const GOOGLE_PROVIDER_ID = 'google.com';
 
 type DocVersion = 'draft' | 'published';
 
@@ -798,6 +802,96 @@ export function api(server: Server, options: ApiOptions) {
       res.status(500).json({success: false, error: 'UNKNOWN'});
     }
   });
+
+  /**
+   * Unlinks the Google provider from a user's Firebase Auth record so their
+   * next sign-in re-links it. ADMIN-only.
+   *
+   * Identity Platform attaches a federated identity to the account that
+   * already exists for an email address, and rejects the attach with
+   * `auth/provider-already-linked` when that account carries a `google.com`
+   * provider with a different federated id. The address alone still resolves
+   * to the same person — the CMS keys access off the email, not the Firebase
+   * uid — so dropping the stale provider lets the user back in without
+   * touching their role or any of their content. Nothing else on the account
+   * record is modified, and the account is left untouched when it has no
+   * Google provider to drop.
+   *
+   * Sample request:
+   *
+   * ```
+   * POST /cms/api/users.reset_sign_in
+   * {"email": "grogu@example.com"}
+   * ```
+   */
+  server.use(
+    '/cms/api/users.reset_sign_in',
+    async (req: Request, res: Response) => {
+      if (
+        req.method !== 'POST' ||
+        !String(req.get('content-type')).startsWith('application/json')
+      ) {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      if (!req.user?.email) {
+        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+        return;
+      }
+      const email = String(req.body?.email || '')
+        .trim()
+        .toLowerCase();
+      if (!email || !email.includes('@') || email.startsWith('*@')) {
+        res.status(400).json({
+          success: false,
+          error: 'INVALID_EMAIL',
+        });
+        return;
+      }
+
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      try {
+        const role = await cmsClient.getUserRole(req.user.email);
+        if (role !== 'ADMIN') {
+          res.status(403).json({success: false, error: 'FORBIDDEN'});
+          return;
+        }
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+        return;
+      }
+
+      try {
+        const auth = getAuth(cmsClient.app);
+        const user = await auth.getUserByEmail(email).catch((err) => {
+          if (err?.code === 'auth/user-not-found') {
+            return null;
+          }
+          throw err;
+        });
+        const hasGoogleProvider = !!user?.providerData?.some(
+          (provider) => provider.providerId === GOOGLE_PROVIDER_ID
+        );
+        if (!user || !hasGoogleProvider) {
+          // Nothing to reset. The next sign-in creates or links the record.
+          res.status(200).json({success: true, reset: false});
+          return;
+        }
+        await auth.updateUser(user.uid, {
+          providersToUnlink: [GOOGLE_PROVIDER_ID],
+        });
+        await cmsClient.logAction('user.reset_sign_in', {
+          by: req.user.email,
+          metadata: {email: email},
+        });
+        res.status(200).json({success: true, reset: true});
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
 
   // ===========================================================================
   // One-shot AI tasks. These wrap the Vercel AI SDK helpers in `ai.ts`

--- a/packages/root-cms/core/api.ts
+++ b/packages/root-cms/core/api.ts
@@ -56,6 +56,64 @@ const SYNC_PROXY_MAX_BYTES = 100 * 1024 * 1024;
 /** The only sign-in provider the CMS uses. */
 const GOOGLE_PROVIDER_ID = 'google.com';
 
+/** Max identifiers accepted by a single `auth.getUsers()` call. */
+const GET_USERS_BATCH_SIZE = 100;
+
+/** Max emails `users.sign_in_status` will look up in one request. */
+const MAX_SIGN_IN_STATUS_EMAILS = 500;
+
+/** Whether an email has a Google sign-in link that could be reset. */
+interface SignInStatus {
+  /** True if a Firebase Auth account exists for the email. */
+  exists: boolean;
+  /** True if that account has a Google provider linked to it. */
+  hasGoogleLink: boolean;
+}
+
+/**
+ * Normalizes an email from a request body. Returns null when the value isn't a
+ * usable address, including the `*@example.com` wildcards used to share a
+ * project with a whole domain -- those map to no account at all.
+ */
+function normalizeUserEmail(value: unknown): string | null {
+  const email = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (!email || !email.includes('@') || email.startsWith('*@')) {
+    return null;
+  }
+  return email;
+}
+
+/**
+ * Verifies that the request comes from a signed-in project ADMIN, responding
+ * with the appropriate status when it doesn't. Returns the admin's email when
+ * the caller may proceed, or null when a response has already been sent.
+ */
+async function verifyAdminRequest(
+  req: Request,
+  res: Response,
+  cmsClient: RootCMSClient
+): Promise<string | null> {
+  const email = req.user?.email;
+  if (!email) {
+    res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+    return null;
+  }
+  try {
+    const role = await cmsClient.getUserRole(email);
+    if (role !== 'ADMIN') {
+      res.status(403).json({success: false, error: 'FORBIDDEN'});
+      return null;
+    }
+  } catch (err) {
+    console.error(err.stack || err);
+    res.status(500).json({success: false, error: 'UNKNOWN'});
+    return null;
+  }
+  return email;
+}
+
 type DocVersion = 'draft' | 'published';
 
 interface BuildDocDiffOptions {
@@ -834,31 +892,17 @@ export function api(server: Server, options: ApiOptions) {
         res.status(400).json({success: false, error: 'BAD_REQUEST'});
         return;
       }
-      if (!req.user?.email) {
-        res.status(401).json({success: false, error: 'UNAUTHORIZED'});
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      const adminEmail = await verifyAdminRequest(req, res, cmsClient);
+      if (!adminEmail) {
         return;
       }
-      const email = String(req.body?.email || '')
-        .trim()
-        .toLowerCase();
-      if (!email || !email.includes('@') || email.startsWith('*@')) {
+      const email = normalizeUserEmail(req.body?.email);
+      if (!email) {
         res.status(400).json({
           success: false,
           error: 'INVALID_EMAIL',
         });
-        return;
-      }
-
-      const cmsClient = new RootCMSClient(req.rootConfig!);
-      try {
-        const role = await cmsClient.getUserRole(req.user.email);
-        if (role !== 'ADMIN') {
-          res.status(403).json({success: false, error: 'FORBIDDEN'});
-          return;
-        }
-      } catch (err) {
-        console.error(err.stack || err);
-        res.status(500).json({success: false, error: 'UNKNOWN'});
         return;
       }
 
@@ -882,10 +926,97 @@ export function api(server: Server, options: ApiOptions) {
           providersToUnlink: [GOOGLE_PROVIDER_ID],
         });
         await cmsClient.logAction('user.reset_sign_in', {
-          by: req.user.email,
+          by: adminEmail,
           metadata: {email: email},
         });
         res.status(200).json({success: true, reset: true});
+      } catch (err) {
+        console.error(err.stack || err);
+        res.status(500).json({success: false, error: 'UNKNOWN'});
+      }
+    }
+  );
+
+  /**
+   * Reports whether the given emails have a Google sign-in link that could be
+   * reset by `users.reset_sign_in`. ADMIN-only.
+   *
+   * Used to keep the "reset sign-in" action out of the way for users it can't
+   * do anything for, e.g. someone who was granted access but has never signed
+   * in. Whether an existing link is stale can't be known here -- that only
+   * surfaces when the user tries to sign in.
+   *
+   * Sample request:
+   *
+   * ```
+   * POST /cms/api/users.sign_in_status
+   * {"emails": ["grogu@example.com"]}
+   * ```
+   *
+   * =>
+   *
+   * ```
+   * {
+   *   "success": true,
+   *   "users": {"grogu@example.com": {"exists": true, "hasGoogleLink": true}}
+   * }
+   * ```
+   */
+  server.use(
+    '/cms/api/users.sign_in_status',
+    async (req: Request, res: Response) => {
+      if (
+        req.method !== 'POST' ||
+        !String(req.get('content-type')).startsWith('application/json')
+      ) {
+        res.status(400).json({success: false, error: 'BAD_REQUEST'});
+        return;
+      }
+      const cmsClient = new RootCMSClient(req.rootConfig!);
+      if (!(await verifyAdminRequest(req, res, cmsClient))) {
+        return;
+      }
+      const requested: string[] = Array.isArray(req.body?.emails)
+        ? req.body.emails
+        : [];
+      const emails = Array.from(
+        new Set(
+          requested
+            .map((email) => normalizeUserEmail(email))
+            .filter((email): email is string => !!email)
+        )
+      ).slice(0, MAX_SIGN_IN_STATUS_EMAILS);
+      if (emails.length === 0) {
+        res.status(200).json({success: true, users: {}});
+        return;
+      }
+
+      try {
+        const auth = getAuth(cmsClient.app);
+        const users: Record<string, SignInStatus> = {};
+        emails.forEach((email) => {
+          users[email] = {exists: false, hasGoogleLink: false};
+        });
+        // `getUsers()` accepts at most 100 identifiers per call.
+        for (let i = 0; i < emails.length; i += GET_USERS_BATCH_SIZE) {
+          const batch = emails.slice(i, i + GET_USERS_BATCH_SIZE);
+          const result = await auth.getUsers(
+            batch.map((email) => ({email: email}))
+          );
+          result.users.forEach((user) => {
+            const email = String(user.email || '').toLowerCase();
+            if (!(email in users)) {
+              return;
+            }
+            users[email] = {
+              exists: true,
+              hasGoogleLink: user.providerData.some(
+                (provider) => provider.providerId === GOOGLE_PROVIDER_ID
+              ),
+            };
+          });
+        }
+        res.status(200).json({success: true, users: users});
       } catch (err) {
         console.error(err.stack || err);
         res.status(500).json({success: false, error: 'UNKNOWN'});

--- a/packages/root-cms/shared/sign-in-errors.test.ts
+++ b/packages/root-cms/shared/sign-in-errors.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, it} from 'vitest';
+import {
+  STALE_PROVIDER_LINK_ERROR_CODE,
+  getSignInErrorMessage,
+  isStaleProviderLinkError,
+} from './sign-in-errors.js';
+
+function authError(code: string, message = 'firebase error') {
+  return Object.assign(new Error(message), {code});
+}
+
+describe('isStaleProviderLinkError', () => {
+  it('matches the stale provider link code', () => {
+    expect(isStaleProviderLinkError(STALE_PROVIDER_LINK_ERROR_CODE)).toBe(true);
+  });
+
+  it('ignores other codes', () => {
+    expect(isStaleProviderLinkError('auth/credential-already-in-use')).toBe(
+      false
+    );
+    expect(isStaleProviderLinkError('')).toBe(false);
+  });
+});
+
+describe('getSignInErrorMessage', () => {
+  it('explains how to recover from a stale provider link', () => {
+    const msg = getSignInErrorMessage(
+      authError(STALE_PROVIDER_LINK_ERROR_CODE)
+    );
+    expect(msg).toContain('no longer linked');
+    expect(msg).toContain('reset your sign-in');
+    expect(msg).not.toContain('firebase error');
+  });
+
+  it('returns a message for other known codes', () => {
+    expect(
+      getSignInErrorMessage(authError('auth/network-request-failed'))
+    ).toBe('Network error. Please check your connection and try again.');
+    expect(getSignInErrorMessage(authError('auth/popup-blocked'))).toContain(
+      'blocked the sign-in popup'
+    );
+    expect(getSignInErrorMessage(authError('auth/user-disabled'))).toContain(
+      'disabled'
+    );
+  });
+
+  it('falls back to the error message', () => {
+    expect(
+      getSignInErrorMessage(authError('auth/internal-error', 'boom'))
+    ).toBe('Sign in failed: boom');
+    expect(getSignInErrorMessage(new Error('boom'))).toBe(
+      'Sign in failed: boom'
+    );
+  });
+
+  it('handles errors without a usable message', () => {
+    expect(getSignInErrorMessage({code: 'auth/internal-error'})).toBe(
+      'Sign in failed: unknown error'
+    );
+    expect(getSignInErrorMessage(null)).toBe('Sign in failed: unknown error');
+    expect(getSignInErrorMessage(undefined)).toBe(
+      'Sign in failed: unknown error'
+    );
+  });
+});

--- a/packages/root-cms/shared/sign-in-errors.ts
+++ b/packages/root-cms/shared/sign-in-errors.ts
@@ -1,0 +1,64 @@
+/**
+ * User-facing messages for the Firebase Auth errors the CMS sign-in page can
+ * run into. Kept out of `signin/` so the strings can be unit tested and reused
+ * by anything else that surfaces a sign-in failure.
+ */
+
+/**
+ * Returned by Identity Platform when the Google identity signing in can't be
+ * attached to the account that already exists for that email address.
+ *
+ * Projects that keep the default "one account per email address" setting link
+ * a federated identity to the existing account implicitly at sign-in. That
+ * link is rejected when the account already carries a `google.com` provider
+ * whose federated id differs from the one signing in, which is what happens
+ * after the underlying Google account is deleted and recreated: the address
+ * stays the same but Google mints a new subject id for it.
+ *
+ * The user can't recover from this on their own — the stale provider has to be
+ * unlinked from the account record with admin credentials (see
+ * `POST /cms/api/users.reset_sign_in`).
+ */
+export const STALE_PROVIDER_LINK_ERROR_CODE = 'auth/provider-already-linked';
+
+/** True if the error means the account's sign-in link needs to be reset. */
+export function isStaleProviderLinkError(code: string): boolean {
+  return code === STALE_PROVIDER_LINK_ERROR_CODE;
+}
+
+/**
+ * Maps a Firebase Auth error to a message that tells the user what to do
+ * about it. Unrecognized errors fall back to the error's own message, which is
+ * usually only meaningful to a developer but is better than nothing.
+ */
+export function getSignInErrorMessage(err: unknown): string {
+  const code = (err as {code?: unknown} | null)?.code;
+  switch (code) {
+    case STALE_PROVIDER_LINK_ERROR_CODE:
+      return (
+        'Your Google account is no longer linked to the sign-in record for ' +
+        'this project. Ask a CMS admin to reset your sign-in from Settings, ' +
+        'then try again.'
+      );
+    case 'auth/network-request-failed':
+      return 'Network error. Please check your connection and try again.';
+    case 'auth/popup-blocked':
+      return (
+        'Your browser blocked the sign-in popup. Allow popups for this site ' +
+        'and try again.'
+      );
+    case 'auth/unauthorized-domain':
+      return (
+        'This domain is not authorized for sign-in. A developer needs to add ' +
+        'it to the authorized domains of the Firebase project.'
+      );
+    case 'auth/user-disabled':
+      return 'This account has been disabled. Please contact a CMS admin.';
+    default:
+      break;
+  }
+  const message = (err as {message?: unknown} | null)?.message;
+  return `Sign in failed: ${
+    typeof message === 'string' && message ? message : 'unknown error'
+  }`;
+}

--- a/packages/root-cms/signin/signin.tsx
+++ b/packages/root-cms/signin/signin.tsx
@@ -16,6 +16,7 @@ import {
   markAutoSignInAttempt,
   setLastSignIn,
 } from '../shared/auth-hints.js';
+import {getSignInErrorMessage} from '../shared/sign-in-errors.js';
 import './styles/global.css';
 import './styles/signin.css';
 
@@ -289,11 +290,7 @@ SignIn.Button = (props: ButtonProps) => {
         return;
       }
       console.error(err);
-      updateError(
-        code === 'auth/network-request-failed'
-          ? 'Network error. Please check your connection and try again.'
-          : `Sign in failed: ${err?.message || 'unknown error'}`
-      );
+      updateError(getSignInErrorMessage(err));
       updateStatus('idle');
       return;
     }

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -26,6 +26,19 @@
   justify-content: flex-end;
 }
 
+/* Kept out of the way until the row is hovered or the button is tabbed to.
+ * The grid column is reserved either way so rows don't shift. */
+.ShareBox__user__resetSignIn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ShareBox__user:hover .ShareBox__user__resetSignIn,
+.ShareBox__user:focus-within .ShareBox__user__resetSignIn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .ShareBox__user:hover {
   background-color: rgb(248, 249, 250);
 }

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -16,8 +16,14 @@
 }
 
 .ShareBox__user {
-  grid-template-columns: 24px minmax(0, 1fr) 120px;
+  grid-template-columns: 24px minmax(0, 1fr) 24px 120px;
   padding: 6px 16px;
+}
+
+.ShareBox__user__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .ShareBox__user:hover {

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -2,6 +2,7 @@ import {ActionIcon, Button, Select, TextInput, Tooltip} from '@mantine/core';
 import {IconKeyOff} from '@tabler/icons-preact';
 import {useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
+import {useSignInStatuses} from '../../hooks/useSignInStatus.js';
 import {useUserProfiles} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {sortByKey} from '../../utils/objects.js';
@@ -28,6 +29,11 @@ export function ShareBox(props: ShareBoxProps) {
     (email) => !isOrgEmail(email)
   );
   const {profiles} = useUserProfiles(profileEmails);
+  // Only admins can reset a sign-in, and only accounts that actually have a
+  // Google link have anything to reset.
+  const {statuses} = useSignInStatuses(profileEmails, {
+    enabled: currentUserIsAdmin && !!onResetSignIn,
+  });
 
   function setRole(email: string, role: UserRole) {
     onChange({...roles, [email]: role});
@@ -54,6 +60,7 @@ export function ShareBox(props: ShareBoxProps) {
         email,
         role: roles[email],
         profile: profiles.get(email.toLowerCase()) || null,
+        hasGoogleLink: !!statuses.get(email.toLowerCase())?.hasGoogleLink,
       };
     }),
     'email'
@@ -110,6 +117,8 @@ export interface ShareBoxUserProps {
   role: UserRole;
   profile?: UserProfile | null;
   currentUserIsAdmin: boolean;
+  /** True if the user has a Google sign-in link that could be reset. */
+  hasGoogleLink?: boolean;
   onRoleChange: (email: string, newRole: UserRole) => void;
   onRemove: (email: string) => void;
   onResetSignIn?: (email: string) => void;
@@ -117,12 +126,13 @@ export interface ShareBoxUserProps {
 
 ShareBox.User = (props: ShareBoxUserProps) => {
   const isCurrentUser = props.email === window.firebase.user.email;
-  // Domain-wide entries (`*@example.com`) don't map to an account, so there's
-  // nothing to reset for them.
+  // Hidden unless there's a Google link to unlink. Domain-wide entries
+  // (`*@example.com`) and users who have never signed in don't have one.
   const canResetSignIn =
     !!props.onResetSignIn &&
     props.currentUserIsAdmin &&
-    !isOrgEmail(props.email);
+    !isOrgEmail(props.email) &&
+    !!props.hasGoogleLink;
   return (
     <div className="ShareBox__user">
       <EmailAvatar

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -1,4 +1,5 @@
-import {Button, Select, TextInput} from '@mantine/core';
+import {ActionIcon, Button, Select, TextInput, Tooltip} from '@mantine/core';
+import {IconKeyOff} from '@tabler/icons-preact';
 import {useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
 import {useUserProfiles} from '../../hooks/useUserProfile.js';
@@ -14,10 +15,14 @@ export interface ShareBoxProps {
   roles: Record<string, UserRole>;
   onChange: (roles: Record<string, UserRole>) => void;
   currentUserIsAdmin: boolean;
+  /**
+   * Called when an admin resets a user's sign-in. Omit to hide the action.
+   */
+  onResetSignIn?: (email: string) => void;
 }
 
 export function ShareBox(props: ShareBoxProps) {
-  const {roles, onChange, currentUserIsAdmin} = props;
+  const {roles, onChange, currentUserIsAdmin, onResetSignIn} = props;
   const [emailInput, setEmailInput] = useState('');
   const profileEmails = Object.keys(roles).filter(
     (email) => !isOrgEmail(email)
@@ -92,6 +97,7 @@ export function ShareBox(props: ShareBoxProps) {
             currentUserIsAdmin={currentUserIsAdmin}
             onRoleChange={setRole}
             onRemove={removeUser}
+            onResetSignIn={onResetSignIn}
           />
         ))}
       </div>
@@ -106,10 +112,17 @@ export interface ShareBoxUserProps {
   currentUserIsAdmin: boolean;
   onRoleChange: (email: string, newRole: UserRole) => void;
   onRemove: (email: string) => void;
+  onResetSignIn?: (email: string) => void;
 }
 
 ShareBox.User = (props: ShareBoxUserProps) => {
   const isCurrentUser = props.email === window.firebase.user.email;
+  // Domain-wide entries (`*@example.com`) don't map to an account, so there's
+  // nothing to reset for them.
+  const canResetSignIn =
+    !!props.onResetSignIn &&
+    props.currentUserIsAdmin &&
+    !isOrgEmail(props.email);
   return (
     <div className="ShareBox__user">
       <EmailAvatar
@@ -127,6 +140,28 @@ ShareBox.User = (props: ShareBoxUserProps) => {
         {props.email}
         {isCurrentUser && ' (you)'}
       </Text>
+      <div className="ShareBox__user__actions">
+        {canResetSignIn && (
+          <Tooltip
+            label="Reset sign-in"
+            withArrow
+            transition="pop"
+            position="left"
+          >
+            <ActionIcon
+              className="ShareBox__user__resetSignIn"
+              size="sm"
+              radius={0}
+              variant="subtle"
+              color="dark"
+              aria-label={`Reset sign-in for ${props.email}`}
+              onClick={() => props.onResetSignIn!(props.email)}
+            >
+              <IconKeyOff size={16} strokeWidth={1.75} />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </div>
       <div className="ShareBox__user__roleSelect">
         <Select
           data={[

--- a/packages/root-cms/ui/hooks/useSignInStatus.ts
+++ b/packages/root-cms/ui/hooks/useSignInStatus.ts
@@ -1,0 +1,56 @@
+import {useEffect, useState} from 'preact/hooks';
+import {SignInStatus, getSignInStatuses} from '../utils/users.js';
+
+export interface UseSignInStatusesResult {
+  /** Sign-in statuses keyed by lower-cased email. */
+  statuses: Map<string, SignInStatus>;
+  loading: boolean;
+}
+
+/**
+ * Looks up whether a set of users have a Google sign-in link that an admin
+ * could reset. Requires the ADMIN role, so callers should pass `enabled:
+ * false` for everyone else. Errors are logged and leave the map empty, which
+ * keeps the action hidden rather than offering something that would fail.
+ */
+export function useSignInStatuses(
+  emails: string[],
+  options?: {enabled?: boolean}
+): UseSignInStatusesResult {
+  const enabled = options?.enabled !== false;
+  // Joined as a stable dependency string so the effect re-runs when the set of
+  // emails changes, regardless of array identity.
+  const key = emails.slice().sort().join(',');
+  const [statuses, setStatuses] = useState<Map<string, SignInStatus>>(
+    () => new Map()
+  );
+  const [loading, setLoading] = useState(enabled && emails.length > 0);
+
+  useEffect(() => {
+    if (!enabled || emails.length === 0) {
+      setStatuses(new Map());
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    getSignInStatuses(emails)
+      .then((result) => {
+        if (!cancelled) {
+          setStatuses(result);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        console.error('failed to fetch sign-in statuses:', err);
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [key, enabled]);
+
+  return {statuses, loading};
+}

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import './SettingsPage.css';
 import {Button, LoadingOverlay, Switch, Textarea} from '@mantine/core';
+import {useModals} from '@mantine/modals';
 import {showNotification} from '@mantine/notifications';
 import {IconCheck} from '@tabler/icons-preact';
 import {doc, getDoc, setDoc, updateDoc} from 'firebase/firestore';
@@ -11,6 +12,7 @@ import {ShareBox} from '../../components/ShareBox/ShareBox.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
 import {useSearchIndexStatus} from '../../hooks/useGlobalSearch.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {SITE_SETTINGS, useSiteSettings} from '../../hooks/useSiteSettings.js';
@@ -23,6 +25,7 @@ import {
   PermissionGroup,
   derivedRolesFromGroups,
 } from '../../utils/permissionGroups.js';
+import {resetUserSignIn} from '../../utils/users.js';
 import {withTimeout} from '../../utils/with-timeout.js';
 
 function formatRelative(ts: number | null): string {
@@ -242,6 +245,8 @@ function ShareSection() {
   );
   const db = window.firebase.db;
   const docRef = doc(db, 'Projects', projectId);
+  const modals = useModals();
+  const modalTheme = useModalTheme();
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -303,6 +308,49 @@ function ShareSection() {
 
   function setGroups(permissionGroups: PermissionGroup[]) {
     setDraft((prev) => ({...prev, permissionGroups}));
+  }
+
+  /**
+   * Clears the stale Google link on a user's account so that they can sign in
+   * again. Their role and content are untouched; the account re-links itself
+   * on their next sign-in.
+   */
+  function resetSignIn(email: string) {
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: 'Reset sign-in',
+      children: (
+        <Text size="body-sm" weight="semi-bold">
+          <p>
+            Use this when {email} can't sign in and sees an error about their
+            Google account no longer being linked. It unlinks the Google account
+            from their sign-in record so the next sign-in links it again.
+          </p>
+          <p>
+            Their role and content are not affected, and they stay signed in
+            wherever they already are.
+          </p>
+        </Text>
+      ),
+      labels: {confirm: 'Reset sign-in', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      closeOnConfirm: false,
+      onConfirm: async () => {
+        await notifyErrors(async () => {
+          const reset = await resetUserSignIn(email);
+          showNotification({
+            title: reset ? 'Sign-in reset' : 'Nothing to reset',
+            message: reset
+              ? `${email} can sign in again.`
+              : `${email} has no Google sign-in link to reset. They may be signing in with a different address.`,
+            color: reset ? 'green' : 'yellow',
+            autoClose: 5000,
+          });
+        });
+        modals.closeModal(modalId);
+      },
+    });
   }
 
   function discard() {
@@ -405,6 +453,11 @@ function ShareSection() {
             Use <strong>groups</strong> to manage many users at once and
             optionally scope a role to specific collections.
           </p>
+          <p>
+            If a user is blocked at sign-in because their Google account is no
+            longer linked, use <strong>Reset sign-in</strong> next to their
+            name.
+          </p>
         </Text>
       </div>
       <Surface className="SettingsPage__section__right">
@@ -422,6 +475,7 @@ function ShareSection() {
               roles={draft.globalRoles}
               onChange={setRoles}
               currentUserIsAdmin={currentUserIsAdmin}
+              onResetSignIn={resetSignIn}
             />
           </div>
           <div className="SettingsPage__share__subsection">

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -455,8 +455,8 @@ function ShareSection() {
           </p>
           <p>
             If a user is blocked at sign-in because their Google account is no
-            longer linked, use <strong>Reset sign-in</strong> next to their
-            name.
+            longer linked, hover their row and use{' '}
+            <strong>Reset sign-in</strong>.
           </p>
         </Text>
       </div>

--- a/packages/root-cms/ui/utils/users.ts
+++ b/packages/root-cms/ui/utils/users.ts
@@ -21,3 +21,35 @@ export async function getAllEditors(): Promise<string[]> {
   });
   return editors;
 }
+
+/**
+ * Resets a user's Google sign-in link.
+ *
+ * Unlinks the Google provider from the user's Firebase Auth record so that
+ * their next sign-in attaches the identity they're signing in with. Used to
+ * recover accounts that fail sign-in with `auth/provider-already-linked`,
+ * which happens when the Google account behind an email address is recreated
+ * and Identity Platform refuses to attach the new federated id to the record
+ * that already holds the address.
+ *
+ * Requires the ADMIN role. Resolves to `true` if a stale link was removed, or
+ * `false` if the account had no Google provider to remove (in which case
+ * sign-in is failing for some other reason).
+ */
+export async function resetUserSignIn(email: string): Promise<boolean> {
+  const res = await fetch('/cms/api/users.reset_sign_in', {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify({email: email}),
+  });
+  let data: any = {};
+  try {
+    data = await res.json();
+  } catch (err) {
+    console.error(err);
+  }
+  if (res.status !== 200 || !data.success) {
+    throw new Error(data.error || `failed to reset sign-in for ${email}`);
+  }
+  return !!data.reset;
+}

--- a/packages/root-cms/ui/utils/users.ts
+++ b/packages/root-cms/ui/utils/users.ts
@@ -22,6 +22,41 @@ export async function getAllEditors(): Promise<string[]> {
   return editors;
 }
 
+/** Whether an email has a Google sign-in link that could be reset. */
+export interface SignInStatus {
+  /** True if a Firebase Auth account exists for the email. */
+  exists: boolean;
+  /** True if that account has a Google provider linked to it. */
+  hasGoogleLink: boolean;
+}
+
+/**
+ * Looks up which of the given emails have a Google sign-in link, so that the
+ * "reset sign-in" action can be hidden for the users it can't help. Requires
+ * the ADMIN role. Results are keyed by lower-cased email.
+ */
+export async function getSignInStatuses(
+  emails: string[]
+): Promise<Map<string, SignInStatus>> {
+  const statuses = new Map<string, SignInStatus>();
+  if (emails.length === 0) {
+    return statuses;
+  }
+  const res = await fetch('/cms/api/users.sign_in_status', {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify({emails: emails}),
+  });
+  if (res.status !== 200) {
+    throw new Error(`failed to fetch sign-in statuses (${res.status})`);
+  }
+  const data = await res.json();
+  Object.entries(data.users || {}).forEach(([email, status]) => {
+    statuses.set(email.toLowerCase(), status as SignInStatus);
+  });
+  return statuses;
+}
+
 /**
  * Resets a user's Google sign-in link.
  *


### PR DESCRIPTION
## Problem

A user whose Google account is deleted and recreated keeps the same email address but gets a new federated id (`sub`). Projects on the default "one account per email address" setting have Identity Platform attach a federated identity to the account that already exists for that address — and it rejects the attach when that account already carries a `google.com` provider with a *different* federated id.

The result is that `signInWithPopup()` on the CMS sign-in page fails with:

```
Sign in failed: Firebase: Error (auth/provider-already-linked).
```

Two problems with that today:

1. The message is meaningless to the person reading it, and the code is misleading — the CMS never links providers, so the error looks like a CMS bug.
2. Nothing in the CMS can clear it. Recovering the account means someone with Firebase admin credentials unlinking the stale provider by hand (Firebase console or the Identity Toolkit API) every time it happens.

## Change

**`POST /cms/api/users.reset_sign_in` (ADMIN-only)** — unlinks the `google.com` provider from the account with the given email so that the next sign-in attaches the identity the user is actually signing in with. The Firebase uid, the user's role, and their content are untouched: CMS access is keyed off the email address (`getUserAcl()`), not the uid. The endpoint is a no-op (`{success: true, reset: false}`) when no account or no Google provider exists, and the action is written to the project's action log.

Requiring ADMIN keeps the capability strictly below what an admin already has — an admin can grant and revoke CMS access outright from the same page.

**"Reset sign-in" in Settings** — an action next to each user in the Share box, behind a confirm modal that explains what it does. This is the piece that removes the "file a ticket for someone with Firebase credentials" step. It stays out of the way: it renders only for admins, only on row hover or keyboard focus, and only for users who actually have a Google link to unlink.

**`POST /cms/api/users.sign_in_status` (ADMIN-only)** — batched `getUsers()` lookup (100 identifiers per call) backing that last filter. It reports `{exists, hasGoogleLink}` per email, which hides the action for `*@domain` wildcards and for users who were granted access but have never signed in. Whether an *existing* link is stale can't be answered server-side — that only surfaces when the user tries to sign in — so the action remains available for accounts that do have one.

**Plain-language sign-in errors** — new `shared/sign-in-errors.ts` maps the errors a user can act on (`auth/provider-already-linked`, `auth/network-request-failed`, `auth/popup-blocked`, `auth/unauthorized-domain`, `auth/user-disabled`) to messages that say what to do, and falls back to the raw message otherwise. The stale-link message points at the Settings action, so the user knows what to ask for.

## Alternatives considered

- **Automatic self-service repair from the sign-in page.** Attractive, but a user who can't sign in has no credential to prove ownership of the address: on this failure the Firebase SDK throws without a `_tokenResponse`, so there's no OAuth credential to hand to the server. That leaves an unauthenticated endpoint that mutates auth records on request, which isn't a trade worth making for a rare failure. A variant that re-obtains a Google ID token through GIS and verifies it server-side would work, but it needs an OAuth client id configured per project, so it can't be the general path.
- **Flagging the specific user who failed.** The sign-in page could report the failure so the action only appears for that user, but the error carries no identity: on this code the SDK throws through `_fail()` with no `_tokenResponse`, so the email is only known when the browser happens to have a last-sign-in hint. Left out rather than shipping a best-effort flag behind a public write endpoint.
- **Deleting the Firebase Auth user instead of unlinking.** Same end state for the CMS, but it throws away the uid, which projects sharing the Firebase project may key data off.

## Testing

- `packages/root-cms/shared/sign-in-errors.test.ts` (new, 6 cases) — `pnpm vitest run shared/` passes (13 files, 156 tests).
- `pnpm build` in `packages/root-cms` passes; `tsc --noEmit` reports no errors in the touched files.
- Verified the underlying fix out-of-band against a real locked-out account: unlinking `google.com` from the record restored sign-in, with no change to the user's role or content.
- The Firestore-emulator suite wasn't run locally (no JDK on this machine).
