### PR TITLE
feat: bring the task manager closer to Asana-style tracker parity

### DIFF
--- a/.changeset/thick-donkeys-smile.md
+++ b/.changeset/thick-donkeys-smile.md
@@ -1,0 +1,19 @@
+---
+'@blinkk/root-cms': minor
+---
+
+feat: bring the task manager closer to Asana-style tracker parity
+
+Tasks now support project-defined custom fields (text, number, date,
+select, multi-select, checkbox) that can be surfaced as list columns,
+subtasks, followers, tags, dependencies ("blocked by"), start and due
+dates, a rich-text description, and comment attachments. The task list
+gains search, sortable columns, and a one-click completion toggle.
+
+`createTask()` and `addTaskComment()` also accept an optional `imported`
+block so a thread migrated from another tracker keeps its original author
+name and timestamps; `createdBy` still records the authenticated account
+that performed the import.
+
+`targetLaunchDate` is superseded by `dueDate` but is kept in sync, so
+existing tasks and callers keep working with no migration.

--- a/packages/root-cms/docs/tasks-parity-design.md
+++ b/packages/root-cms/docs/tasks-parity-design.md
@@ -1,0 +1,212 @@
+# Design: Task Manager Parity with Asana-style Trackers
+
+Status: in progress — v1 covers §5.1–§5.7. See `ui/utils/tasks.ts` for the
+data layer, `ui/components/TaskManager/` for the list/board, and
+`ui/pages/TaskPage/` for the detail view.
+Author: root-cms team
+
+## 1. Overview
+
+The CMS ships a lightweight task manager at `/cms/tasks`. It is good enough
+for "leave a note for a teammate", but teams that run their content intake
+in a dedicated tracker (Asana, Jira, Linear, Trello) cannot move that
+workflow into the CMS without losing structure. In practice the missing
+pieces force people to flatten a structured request — its request type,
+target surface, device scope, blocked state — into free text at the top of
+the description, which then cannot be filtered, sorted, or reported on.
+
+This document inventories the gap against an Asana-style tracker, decides
+what belongs in a CMS task manager and what does not, and specifies the
+data model and UI for closing it.
+
+### Goals
+
+- Represent a structured intake request without stuffing metadata into the
+  description: project-defined **custom fields** with typed values.
+- Support the hierarchy and relationships real work has: **subtasks** and
+  **dependencies**.
+- Let more than one person be attached to a task: **followers** in addition
+  to the single assignee.
+- Make the list usable at scale: **search**, **sorting**, and **custom
+  field columns**.
+- Preserve provenance for tasks migrated in from another tracker: an
+  **external source** link and importable author/timestamp.
+
+### Non-goals
+
+Some Asana surface area is deliberately out of scope — it belongs to a
+project-management product, not to a CMS:
+
+- Timeline/Gantt views, portfolios, workload and capacity planning.
+- Rules/automation builders, intake forms, approval workflows.
+- Recurring tasks, goals/OKRs, time tracking, invoicing.
+- Cross-project task multi-homing (a task living in several projects).
+
+A CMS task is scoped to one CMS project; that is the intended boundary.
+
+## 2. What exists today
+
+| Capability | Where |
+| --- | --- |
+| Task doc (`title`, `description`, `assignee`, `priority`, `status`, `targetLaunchDate`, `attachments`) | `Projects/<pid>/Tasks/<id>` |
+| Auto-incrementing numeric task ids | `Counters/tasks` + `runTransaction` in `createTask` |
+| Rich-text comments, one level of replies, `@email` mentions, edit/delete with history | `Tasks/<id>/Comments/*` |
+| Metadata change log (title, assignee, priority, status, target date) | `Tasks/<id>/Events/*` |
+| Table view, board-by-status view, compact list | `TaskManager.tsx` |
+| Filters: active / assigned-to-me / created-by-me / closed / all | `filterTasks()` |
+| Project-level default assignee | `Projects/<pid>.settings.defaultAssignee` |
+| Task-level file attachments (GCS) | `addTaskAttachment()` |
+
+## 3. Gap analysis
+
+| # | Asana capability | Root CMS today | Verdict |
+| --- | --- | --- | --- |
+| 1 | Custom fields (select, multi-select, text, number, date) surfaced as list columns | none — metadata is flattened into the description | **close** |
+| 2 | Subtasks | none | **close** |
+| 3 | Multiple collaborators / followers | single `assignee` | **close** |
+| 4 | Due date *with time*, plus a start date | date-only `targetLaunchDate` | **close** |
+| 5 | Tags / labels | none | **close** |
+| 6 | Dependencies ("blocked by" / "blocking") | none | **close** |
+| 7 | Inline completion toggle from the list | must open the task and change a `<Select>` | **close** |
+| 8 | Full-text search across tasks | none | **close** |
+| 9 | Sortable list columns | fixed `createdAt` desc | **close** |
+| 10 | Rich-text task description | plain `<Textarea>` (comments *are* rich text) | **close** |
+| 11 | Attachments on comments | task-level only | **close** |
+| 12 | Task permalink into the originating tracker | none — URL buried in description prose | **close** |
+| 13 | Import preserving original author + timestamp | `serverTimestamp()` and the signed-in user are always stamped | **close** |
+| 14 | Drag-and-drop between board columns | board is read-only | defer (v2) |
+| 15 | Comment reactions | none | defer (v2) |
+| 16 | Delivered notifications for `@mentions` | mentions are stored but never delivered | defer (v2) |
+| 17 | Sections / grouping within a project | none | defer (v2) |
+| 18 | Timeline, portfolios, rules, forms, workload, recurring tasks | none | out of scope (§1) |
+
+### Why 13 matters
+
+`createTask()` and `addTaskComment()` unconditionally write
+`serverTimestamp()` and `window.firebase.user.email`. There is no supported
+path to import a thread from another tracker with its real authors and
+dates, so a migration either loses the history or is hand-written straight
+into Firestore, bypassing every validation in the data layer. Attribution
+then reads as though one person wrote a year of discussion in an afternoon.
+
+## 4. Data model
+
+All additions are optional fields on the existing docs, so existing tasks
+keep working and no migration is required.
+
+### 4.1 Custom field definitions
+
+Definitions are project-level so a field can be shown as a list column and
+reused across tasks. Stored on the project doc under
+`settings.taskFields` as an ordered array:
+
+```ts
+interface TaskFieldDef {
+  id: string;                  // stable key, used in Task.fields
+  label: string;
+  type: 'text' | 'number' | 'date' | 'select' | 'multiselect' | 'checkbox';
+  options?: TaskFieldOption[]; // select/multiselect only
+  showInList?: boolean;        // render as a table column
+}
+
+interface TaskFieldOption {
+  value: string;
+  label: string;
+  color?: string;              // badge color, mirrors Asana's colored chips
+}
+```
+
+### 4.2 Task additions
+
+```ts
+interface Task {
+  // ...existing fields
+  fields?: Record<string, TaskFieldValue>;  // keyed by TaskFieldDef.id
+  tags?: string[];
+  followers?: string[];                     // emails, deduped + lowercased
+  parentId?: string | null;                 // subtask -> parent task id
+  blockedBy?: string[];                     // task ids
+  startDate?: Timestamp | null;
+  dueDate?: Timestamp | null;               // supersedes targetLaunchDate
+  source?: TaskSource | null;
+  descriptionBody?: RichTextData | null;    // rich text; `description` kept
+                                            // as the plain-text projection
+}
+
+type TaskFieldValue = string | number | boolean | string[] | Timestamp | null;
+
+interface TaskSource {
+  provider: string;   // e.g. 'asana', 'jira', 'linear'
+  url?: string;
+  id?: string;
+}
+```
+
+`targetLaunchDate` is retained and kept in sync with `dueDate` so existing
+queries and the existing column keep working; `dueDate` is the field new
+code reads.
+
+### 4.3 Comment additions
+
+```ts
+interface TaskComment {
+  // ...existing fields
+  attachments?: TaskAttachment[];
+  importedAuthor?: string | null;  // display name from the source tracker
+}
+```
+
+### 4.4 Import affordance
+
+`createTask()` and `addTaskComment()` gain an optional `imported` block,
+accepted only when the caller supplies it explicitly:
+
+```ts
+interface TaskImportOptions {
+  createdAt?: Date | Timestamp;  // original creation time
+  author?: string;               // original author's display name
+  source?: TaskSource;
+}
+```
+
+When present, `createdAt` is written as a concrete `Timestamp` instead of
+`serverTimestamp()`, and `importedAuthor` is rendered in place of the
+account email, suffixed with the provider (e.g. "Dana Ruiz · via Asana").
+`createdBy` still records the *authenticated* account that performed the
+import, so the audit trail is not falsifiable — the imported name is
+presentational only.
+
+## 5. Implementation plan
+
+- **5.1 Data layer** — extend `ui/utils/tasks.ts` with the fields in §4,
+  plus `updateTaskFields`, `updateTaskTags`, `updateTaskFollowers`,
+  `updateTaskDependencies`, `setTaskParent`, and custom-field CRUD on the
+  project settings doc. Every mutation continues to write a `Tasks/<id>/
+  Events` entry so the timeline stays complete.
+- **5.2 Custom fields UI** — a definitions editor in task settings, typed
+  inputs in the detail page's metadata panel, and colored badges in the
+  list.
+- **5.3 Subtasks** — a subtask list on the detail page and a progress
+  indicator (`3/5`) on the parent's list row; subtasks are ordinary tasks
+  with `parentId` set, so they reuse the whole detail page.
+- **5.4 Followers, tags, dependencies** — chip inputs in the metadata
+  panel; a "blocked" badge in the list derived from `blockedBy` entries
+  whose status is still open.
+- **5.5 Dates** — `datetime-local` inputs for `startDate`/`dueDate`, with
+  overdue styling in the list.
+- **5.6 List usability** — a search box (client-side over title,
+  description, tags, id), sortable column headers, custom field columns,
+  and an inline completion checkbox.
+- **5.7 Rich text + comment attachments** — reuse `TaskCommentEditor` for
+  the description; reuse `uploadFileToGCS` for comment attachments.
+- **5.8 (v2)** — board drag-and-drop, reactions, mention notifications,
+  sections.
+
+## 6. Firestore considerations
+
+Subtasks, followers, and dependencies all add fan-out reads if implemented
+naively. The list view already subscribes to the whole `Tasks` collection
+via `subscribeTasks()`, so subtask rollups and "blocked by" resolution are
+computed client-side from that single snapshot rather than issuing
+per-task reads. Custom field *definitions* live on the project doc, which
+the UI already loads, so rendering a list column costs no extra read.

--- a/packages/root-cms/ui/components/TaskChipInput/TaskChipInput.css
+++ b/packages/root-cms/ui/components/TaskChipInput/TaskChipInput.css
@@ -1,0 +1,40 @@
+.TaskChipInput {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.TaskChipInput__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.TaskChipInput__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  max-width: 100%;
+  padding: 2px 2px 2px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--chip-background);
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-text-default);
+}
+
+.TaskChipInput__chip__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TaskChipInput__chip__remove {
+  flex-shrink: 0;
+  min-width: 16px;
+  width: 16px;
+  height: 16px;
+  color: var(--color-text-gray);
+}

--- a/packages/root-cms/ui/components/TaskChipInput/TaskChipInput.tsx
+++ b/packages/root-cms/ui/components/TaskChipInput/TaskChipInput.tsx
@@ -1,0 +1,98 @@
+import './TaskChipInput.css';
+
+import {ActionIcon, TextInput} from '@mantine/core';
+import {IconX} from '@tabler/icons-preact';
+import {ChangeEvent} from 'preact/compat';
+import {useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
+
+export interface TaskChipInputProps {
+  className?: string;
+  values: string[];
+  placeholder?: string;
+  disabled?: boolean;
+  /** Renders the chip label; defaults to the raw value. */
+  formatValue?: (value: string) => string;
+  /**
+   * Validates and normalizes a value before it is added. Return null to
+   * reject the entry (the input keeps the text so it can be corrected).
+   */
+  normalizeValue?: (value: string) => string | null;
+  onChange: (values: string[]) => void;
+}
+
+/**
+ * A token/chip input used for the task fields that hold a list of short
+ * strings (tags, followers, blocking task ids). Commas and Enter commit
+ * the current entry; Backspace on an empty input removes the last chip.
+ */
+export function TaskChipInput(props: TaskChipInputProps) {
+  const {values, onChange} = props;
+  const [draft, setDraft] = useState('');
+
+  function addDraft() {
+    const raw = draft.trim().replace(/,$/, '').trim();
+    if (!raw) {
+      setDraft('');
+      return;
+    }
+    const normalized = props.normalizeValue ? props.normalizeValue(raw) : raw;
+    if (!normalized) {
+      return;
+    }
+    if (!values.includes(normalized)) {
+      onChange([...values, normalized]);
+    }
+    setDraft('');
+  }
+
+  function removeValue(value: string) {
+    onChange(values.filter((item) => item !== value));
+  }
+
+  return (
+    <div className={joinClassNames(props.className, 'TaskChipInput')}>
+      {values.length > 0 && (
+        <div className="TaskChipInput__chips">
+          {values.map((value) => (
+            <span className="TaskChipInput__chip" key={value}>
+              <span className="TaskChipInput__chip__label">
+                {props.formatValue ? props.formatValue(value) : value}
+              </span>
+              <ActionIcon
+                className="TaskChipInput__chip__remove"
+                size="xs"
+                disabled={props.disabled}
+                aria-label={`Remove ${value}`}
+                onClick={() => removeValue(value)}
+              >
+                <IconX size={12} strokeWidth="2" />
+              </ActionIcon>
+            </span>
+          ))}
+        </div>
+      )}
+      <TextInput
+        size="xs"
+        value={draft}
+        disabled={props.disabled}
+        placeholder={props.placeholder}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setDraft(e.currentTarget.value)
+        }
+        onBlur={() => addDraft()}
+        onKeyDown={(e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            addDraft();
+            return;
+          }
+          if (e.key === 'Backspace' && !draft && values.length > 0) {
+            e.preventDefault();
+            removeValue(values[values.length - 1]);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/TaskFieldInput/TaskFieldInput.css
+++ b/packages/root-cms/ui/components/TaskFieldInput/TaskFieldInput.css
@@ -1,0 +1,37 @@
+.TaskFieldInput {
+  width: 100%;
+}
+
+input.TaskFieldInput__date {
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--surface-background);
+  font-family: var(--font-family-default);
+  font-size: 12px;
+  color: var(--color-text-default);
+}
+
+.TaskFieldValue {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--color-text-default);
+}
+
+.TaskFieldValue--empty {
+  color: var(--color-text-gray);
+}
+
+.TaskFieldValue__badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--chip-background);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: nowrap;
+}

--- a/packages/root-cms/ui/components/TaskFieldInput/TaskFieldInput.tsx
+++ b/packages/root-cms/ui/components/TaskFieldInput/TaskFieldInput.tsx
@@ -1,0 +1,227 @@
+import './TaskFieldInput.css';
+
+import {Checkbox, MultiSelect, Select, TextInput} from '@mantine/core';
+import {Timestamp} from 'firebase/firestore';
+import {ChangeEvent} from 'preact/compat';
+import {joinClassNames} from '../../utils/classes.js';
+import {
+  TaskFieldDef,
+  TaskFieldOption,
+  TaskFieldValue,
+} from '../../utils/tasks.js';
+
+export interface TaskFieldInputProps {
+  className?: string;
+  fieldDef: TaskFieldDef;
+  value: TaskFieldValue;
+  disabled?: boolean;
+  onChange: (value: TaskFieldValue) => void;
+}
+
+/** Renders the editing control for one project-defined custom field. */
+export function TaskFieldInput(props: TaskFieldInputProps) {
+  const {fieldDef, value, disabled, onChange} = props;
+  const className = joinClassNames(props.className, 'TaskFieldInput');
+  const options = (fieldDef.options || []).map((option) => ({
+    value: option.value,
+    label: option.label,
+  }));
+
+  switch (fieldDef.type) {
+    case 'number':
+      return (
+        <TextInput
+          className={className}
+          size="xs"
+          type="number"
+          disabled={disabled}
+          value={value === null || value === undefined ? '' : String(value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            const raw = e.currentTarget.value;
+            if (raw === '') {
+              onChange(null);
+              return;
+            }
+            const parsed = Number(raw);
+            onChange(Number.isNaN(parsed) ? null : parsed);
+          }}
+        />
+      );
+    case 'date':
+      return (
+        <input
+          className={joinClassNames(className, 'TaskFieldInput__date')}
+          type="date"
+          disabled={disabled}
+          value={formatTaskFieldDateInput(value)}
+          onInput={(e) => {
+            const raw = (e.currentTarget as HTMLInputElement).value;
+            onChange(raw ? parseTaskFieldDateInput(raw) : null);
+          }}
+        />
+      );
+    case 'select':
+      return (
+        <Select
+          className={className}
+          size="xs"
+          clearable
+          data={options}
+          disabled={disabled}
+          value={typeof value === 'string' ? value : null}
+          onChange={(next: string | null) => onChange(next || null)}
+        />
+      );
+    case 'multiselect':
+      return (
+        <MultiSelect
+          className={className}
+          size="xs"
+          data={options}
+          disabled={disabled}
+          value={Array.isArray(value) ? value : []}
+          onChange={(next: string[]) => onChange(next)}
+        />
+      );
+    case 'checkbox':
+      return (
+        <Checkbox
+          className={className}
+          size="xs"
+          disabled={disabled}
+          checked={value === true}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            onChange(e.currentTarget.checked)
+          }
+        />
+      );
+    case 'text':
+    default:
+      return (
+        <TextInput
+          className={className}
+          size="xs"
+          disabled={disabled}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            onChange(e.currentTarget.value || null)
+          }
+        />
+      );
+  }
+}
+
+/** Renders a read-only custom field value, using option colors when set. */
+export function TaskFieldValueDisplay(props: {
+  fieldDef: TaskFieldDef;
+  value: TaskFieldValue;
+}) {
+  const {fieldDef, value} = props;
+  if (fieldDef.type === 'select' || fieldDef.type === 'multiselect') {
+    const selected = Array.isArray(value)
+      ? value
+      : typeof value === 'string' && value
+        ? [value]
+        : [];
+    if (selected.length === 0) {
+      return <span className="TaskFieldValue TaskFieldValue--empty">—</span>;
+    }
+    return (
+      <span className="TaskFieldValue">
+        {selected.map((optionValue) => {
+          const option = findTaskFieldOption(fieldDef, optionValue);
+          return (
+            <span
+              className="TaskFieldValue__badge"
+              key={optionValue}
+              style={
+                option?.color
+                  ? {
+                      background: option.color,
+                      borderColor: option.color,
+                    }
+                  : undefined
+              }
+            >
+              {option?.label || optionValue}
+            </span>
+          );
+        })}
+      </span>
+    );
+  }
+
+  const text = formatTaskFieldValue(fieldDef, value);
+  return (
+    <span
+      className={joinClassNames(
+        'TaskFieldValue',
+        !text && 'TaskFieldValue--empty'
+      )}
+    >
+      {text || '—'}
+    </span>
+  );
+}
+
+/** Formats a custom field value as plain text (list columns, exports). */
+export function formatTaskFieldValue(
+  fieldDef: TaskFieldDef,
+  value: TaskFieldValue
+): string {
+  if (value === null || value === undefined || value === '') {
+    return '';
+  }
+  switch (fieldDef.type) {
+    case 'checkbox':
+      return value === true ? 'Yes' : 'No';
+    case 'date':
+      return value instanceof Timestamp
+        ? new Date(value.toMillis()).toLocaleDateString('en', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          })
+        : '';
+    case 'multiselect':
+      return (Array.isArray(value) ? value : [])
+        .map(
+          (optionValue) =>
+            findTaskFieldOption(fieldDef, optionValue)?.label || optionValue
+        )
+        .join(', ');
+    case 'select':
+      return typeof value === 'string'
+        ? findTaskFieldOption(fieldDef, value)?.label || value
+        : '';
+    default:
+      return String(value);
+  }
+}
+
+function findTaskFieldOption(
+  fieldDef: TaskFieldDef,
+  value: string
+): TaskFieldOption | undefined {
+  return (fieldDef.options || []).find((option) => option.value === value);
+}
+
+/** Formats a date field value for an `<input type="date">`. */
+function formatTaskFieldDateInput(value: TaskFieldValue): string {
+  if (!(value instanceof Timestamp)) {
+    return '';
+  }
+  const date = new Date(value.toMillis());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/** Parses a `yyyy-mm-dd` input value as a local-midnight timestamp. */
+function parseTaskFieldDateInput(value: string): Timestamp | null {
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) {
+    return null;
+  }
+  return Timestamp.fromDate(new Date(year, month - 1, day));
+}

--- a/packages/root-cms/ui/components/TaskFieldsModal/TaskFieldsModal.css
+++ b/packages/root-cms/ui/components/TaskFieldsModal/TaskFieldsModal.css
@@ -1,0 +1,72 @@
+.TaskFieldsModal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.TaskFieldsModal__intro,
+.TaskFieldsModal__empty {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-gray);
+}
+
+.TaskFieldsModal__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.TaskFieldsModal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--surface-border-radius);
+}
+
+.TaskFieldsModal__field__row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.TaskFieldsModal__field__label {
+  flex: 1 1 auto;
+}
+
+.TaskFieldsModal__field__type {
+  flex: 0 0 150px;
+}
+
+.TaskFieldsModal__field__actions {
+  display: flex;
+  gap: 2px;
+  padding-bottom: 2px;
+}
+
+.TaskFieldsModal__field__footer {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.TaskFieldsModal__field__id {
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  color: var(--color-text-gray);
+}
+
+.TaskFieldsModal__actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.TaskFieldsModal__actions__right {
+  display: flex;
+  gap: 8px;
+}

--- a/packages/root-cms/ui/components/TaskFieldsModal/TaskFieldsModal.tsx
+++ b/packages/root-cms/ui/components/TaskFieldsModal/TaskFieldsModal.tsx
@@ -1,0 +1,315 @@
+import './TaskFieldsModal.css';
+
+import {ActionIcon, Button, Checkbox, Select, TextInput} from '@mantine/core';
+import {ContextModalProps, useModals} from '@mantine/modals';
+import {showNotification} from '@mantine/notifications';
+import {
+  IconArrowDown,
+  IconArrowUp,
+  IconPlus,
+  IconTrash,
+} from '@tabler/icons-preact';
+import {ChangeEvent} from 'preact/compat';
+import {useState} from 'preact/hooks';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {errorMessage} from '../../utils/notifications.js';
+import {
+  setTaskFieldDefs,
+  TaskFieldDef,
+  TaskFieldType,
+} from '../../utils/tasks.js';
+
+const MODAL_ID = 'TaskFieldsModal';
+
+const FIELD_TYPE_OPTIONS: Array<{value: TaskFieldType; label: string}> = [
+  {value: 'text', label: 'Text'},
+  {value: 'number', label: 'Number'},
+  {value: 'date', label: 'Date'},
+  {value: 'select', label: 'Single select'},
+  {value: 'multiselect', label: 'Multi select'},
+  {value: 'checkbox', label: 'Checkbox'},
+];
+
+export interface TaskFieldsModalProps {
+  [key: string]: unknown;
+  fieldDefs: TaskFieldDef[];
+}
+
+export function useTaskFieldsModal() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  return {
+    open: (props: TaskFieldsModalProps) => {
+      modals.openContextModal(MODAL_ID, {
+        ...modalTheme,
+        title: 'Task fields',
+        innerProps: props,
+        size: '720px',
+        centered: true,
+      });
+    },
+    close: () => modals.closeModal(MODAL_ID),
+  };
+}
+
+/**
+ * Edits the project's custom task field definitions. Field ids are derived
+ * from the label on creation and then frozen, because changing an id would
+ * orphan every value already stored against it.
+ */
+export function TaskFieldsModal(
+  modalProps: ContextModalProps<TaskFieldsModalProps>
+) {
+  const {innerProps: props, context, id} = modalProps;
+  const [fieldDefs, setFieldDefs] = useState<TaskFieldDef[]>(
+    props.fieldDefs || []
+  );
+  const [saving, setSaving] = useState(false);
+
+  function updateFieldDef(index: number, updates: Partial<TaskFieldDef>) {
+    setFieldDefs((current) =>
+      current.map((fieldDef, i) =>
+        i === index ? {...fieldDef, ...updates} : fieldDef
+      )
+    );
+  }
+
+  function moveFieldDef(index: number, offset: number) {
+    const nextIndex = index + offset;
+    if (nextIndex < 0 || nextIndex >= fieldDefs.length) {
+      return;
+    }
+    setFieldDefs((current) => {
+      const next = [...current];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+  }
+
+  function addFieldDef() {
+    setFieldDefs((current) => [
+      ...current,
+      {
+        id: getUniqueFieldId('field', current),
+        label: '',
+        type: 'text',
+        showInList: false,
+      },
+    ]);
+  }
+
+  async function onSave() {
+    const invalid = fieldDefs.find((fieldDef) => !fieldDef.label.trim());
+    if (invalid) {
+      showNotification({
+        title: 'Could not save fields',
+        message: 'Every field needs a label.',
+        color: 'red',
+      });
+      return;
+    }
+    setSaving(true);
+    try {
+      await setTaskFieldDefs(
+        fieldDefs.map((fieldDef) => ({
+          ...fieldDef,
+          label: fieldDef.label.trim(),
+        }))
+      );
+      context.closeModal(id);
+    } catch (err) {
+      showNotification({
+        title: 'Could not save fields',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="TaskFieldsModal">
+      <div className="TaskFieldsModal__intro">
+        Custom fields appear on every task in this project. Enable "Show in
+        list" to add the field as a column in the task table.
+      </div>
+      {fieldDefs.length === 0 && (
+        <div className="TaskFieldsModal__empty">No custom fields yet.</div>
+      )}
+      <div className="TaskFieldsModal__fields">
+        {fieldDefs.map((fieldDef, index) => (
+          <div className="TaskFieldsModal__field" key={fieldDef.id}>
+            <div className="TaskFieldsModal__field__row">
+              <TextInput
+                className="TaskFieldsModal__field__label"
+                size="xs"
+                label="Label"
+                value={fieldDef.label}
+                placeholder="Request type"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const label = e.currentTarget.value;
+                  // Keep the id in step with the label until the field has
+                  // been saved once; after that the id is load-bearing.
+                  const isNew = !props.fieldDefs.some(
+                    (saved) => saved.id === fieldDef.id
+                  );
+                  updateFieldDef(index, {
+                    label,
+                    ...(isNew && label.trim()
+                      ? {
+                          id: getUniqueFieldId(
+                            label,
+                            fieldDefs.filter((_, i) => i !== index)
+                          ),
+                        }
+                      : {}),
+                  });
+                }}
+              />
+              <Select
+                className="TaskFieldsModal__field__type"
+                size="xs"
+                label="Type"
+                data={FIELD_TYPE_OPTIONS}
+                value={fieldDef.type}
+                onChange={(value: TaskFieldType | null) =>
+                  updateFieldDef(index, {type: value || 'text'})
+                }
+              />
+              <div className="TaskFieldsModal__field__actions">
+                <ActionIcon
+                  size="sm"
+                  aria-label="Move field up"
+                  disabled={index === 0}
+                  onClick={() => moveFieldDef(index, -1)}
+                >
+                  <IconArrowUp size={15} strokeWidth="1.8" />
+                </ActionIcon>
+                <ActionIcon
+                  size="sm"
+                  aria-label="Move field down"
+                  disabled={index === fieldDefs.length - 1}
+                  onClick={() => moveFieldDef(index, 1)}
+                >
+                  <IconArrowDown size={15} strokeWidth="1.8" />
+                </ActionIcon>
+                <ActionIcon
+                  size="sm"
+                  aria-label="Remove field"
+                  onClick={() =>
+                    setFieldDefs((current) =>
+                      current.filter((_, i) => i !== index)
+                    )
+                  }
+                >
+                  <IconTrash size={15} strokeWidth="1.8" />
+                </ActionIcon>
+              </div>
+            </div>
+            {(fieldDef.type === 'select' ||
+              fieldDef.type === 'multiselect') && (
+              <TextInput
+                size="xs"
+                label="Options (comma separated)"
+                value={(fieldDef.options || [])
+                  .map((option) => option.label)
+                  .join(', ')}
+                placeholder="Bug, Feature, Content"
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  updateFieldDef(index, {
+                    options: parseFieldOptions(e.currentTarget.value),
+                  })
+                }
+              />
+            )}
+            <div className="TaskFieldsModal__field__footer">
+              <Checkbox
+                size="xs"
+                label="Show in list"
+                checked={Boolean(fieldDef.showInList)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  updateFieldDef(index, {showInList: e.currentTarget.checked})
+                }
+              />
+              <code className="TaskFieldsModal__field__id">{fieldDef.id}</code>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="TaskFieldsModal__actions">
+        <Button
+          compact
+          size="xs"
+          variant="default"
+          leftIcon={<IconPlus size={14} strokeWidth="1.8" />}
+          onClick={addFieldDef}
+        >
+          Add field
+        </Button>
+        <div className="TaskFieldsModal__actions__right">
+          <Button
+            compact
+            size="xs"
+            variant="default"
+            onClick={() => context.closeModal(id)}
+          >
+            Cancel
+          </Button>
+          <Button
+            compact
+            size="xs"
+            color="dark"
+            loading={saving}
+            onClick={onSave}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+TaskFieldsModal.id = MODAL_ID;
+
+/** Parses the comma-separated options input into option objects. */
+function parseFieldOptions(value: string) {
+  const seen = new Set<string>();
+  return value
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean)
+    .map((label) => ({value: toFieldSlug(label) || label, label}))
+    .filter((option) => {
+      if (seen.has(option.value)) {
+        return false;
+      }
+      seen.add(option.value);
+      return true;
+    });
+}
+
+/** Lower-cases a label into a slug usable as a field or option key. */
+function toFieldSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Derives a stable, collision-free field id from a label. */
+function getUniqueFieldId(label: string, fieldDefs: TaskFieldDef[]) {
+  const base = toFieldSlug(label) || 'field';
+  const taken = new Set(fieldDefs.map((fieldDef) => fieldDef.id));
+  if (!taken.has(base)) {
+    return base;
+  }
+  let index = 2;
+  while (taken.has(`${base}-${index}`)) {
+    index += 1;
+  }
+  return `${base}-${index}`;
+}

--- a/packages/root-cms/ui/components/TaskManager/TaskManager.css
+++ b/packages/root-cms/ui/components/TaskManager/TaskManager.css
@@ -264,7 +264,7 @@
   color: inherit;
   display: grid;
   gap: 16px;
-  grid-template-columns: 28px minmax(0, 1fr) auto;
+  grid-template-columns: 24px 28px minmax(0, 1fr) auto;
   min-height: 64px;
   padding: 12px 18px;
   text-decoration: none;
@@ -605,12 +605,114 @@
 
   .TaskManager__taskRow {
     align-items: start;
-    grid-template-columns: 28px minmax(0, 1fr);
+    grid-template-columns: 24px 28px minmax(0, 1fr);
   }
 
   .TaskManager__taskRow__badges {
-    grid-column: 2;
+    grid-column: 3;
     justify-content: flex-start;
     justify-self: start;
   }
+
+  .TaskManager__search {
+    flex: 1 1 100%;
+  }
+}
+
+.TaskManager__search {
+  width: 220px;
+}
+
+.TaskManager__srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.TaskManager__sortHeader {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.TaskManager__sortHeader svg {
+  opacity: 0.4;
+}
+
+.TaskManager__sortHeader--active svg {
+  opacity: 1;
+}
+
+.TaskManager__completeToggle {
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-gray);
+}
+
+.TaskManager__completeToggle--done {
+  border-color: #1f8a4c;
+  background: #1f8a4c;
+  color: #fff;
+}
+
+.TaskManager__table__completeCol {
+  width: 36px;
+}
+
+.TaskManager__table__overdue {
+  color: #c0392b;
+  font-weight: 600;
+}
+
+.TaskManager__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--chip-background);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.TaskManager__badge--blocked {
+  border-color: #e0b400;
+  background: #fff6d6;
+  color: #7a5c00;
+}
+
+.TaskManager__badge--overdue {
+  border-color: #c0392b;
+  background: #fdecea;
+  color: #c0392b;
+}
+
+.TaskManager__tableTask__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.TaskManager__tableTask__badges:empty {
+  display: none;
+}
+
+.TaskManager__boardCard__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }

--- a/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
+++ b/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
@@ -1,6 +1,7 @@
 import './TaskManager.css';
 
 import {
+  ActionIcon,
   Button,
   Loader,
   Menu,
@@ -8,14 +9,21 @@ import {
   SegmentedControl,
   Table,
   TextInput,
+  Tooltip,
 } from '@mantine/core';
 import {showNotification} from '@mantine/notifications';
 import {
+  IconAlertTriangle,
   IconArrowRight,
   IconCalendar,
+  IconCheck,
   IconChevronDown,
   IconColumns3,
   IconFlag,
+  IconSearch,
+  IconSelector,
+  IconSortAscending,
+  IconSortDescending,
   IconTable,
   IconUserPlus,
 } from '@tabler/icons-preact';
@@ -26,14 +34,26 @@ import {joinClassNames} from '../../utils/classes.js';
 import {errorMessage} from '../../utils/notifications.js';
 import {
   createTask,
+  getSubtaskProgress,
+  getTaskDueDate,
   isOpenTaskStatus,
+  isTaskBlocked,
+  isTaskOverdue,
   normalizeTaskStatus,
+  searchTasks,
+  sortTasks,
   subscribeOpenTasks,
+  subscribeTaskFieldDefs,
   subscribeTasks,
   Task,
+  TaskFieldDef,
   TaskPriority,
+  TaskSortDirection,
+  TaskSortKey,
+  updateTaskStatus,
 } from '../../utils/tasks.js';
 import {Surface} from '../Surface/Surface.js';
+import {TaskFieldValueDisplay} from '../TaskFieldInput/TaskFieldInput.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 
 type TaskFilter =
@@ -107,7 +127,17 @@ export function TaskManager(props: TaskManagerProps) {
   const variant = props.variant || 'compact';
   const showPageLayout = variant === 'page';
   const {tasks, loading, error} = useTasks(showPageLayout ? 'all' : 'open');
+  const fieldDefs = useTaskFieldDefs();
   const [filter, setFilter] = useState<TaskFilter>('open');
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<{
+    key: TaskSortKey;
+    direction: TaskSortDirection;
+  }>({key: 'created', direction: 'desc'});
+  const [showSubtasks, setShowSubtasks] = useLocalStorage<boolean>(
+    'root-cms-task-manager-show-subtasks',
+    false
+  );
   const [layout, setLayout] = useLocalStorage<TaskLayout>(
     'root-cms-task-manager-layout-v2',
     'table'
@@ -124,8 +154,15 @@ export function TaskManager(props: TaskManagerProps) {
     ? TASK_PAGE_FILTER_OPTIONS
     : TASK_COMPACT_FILTER_OPTIONS;
   const visibleTasks = useMemo(() => {
-    return filterTasks(tasks, filter, currentUserEmail);
-  }, [tasks, filter, currentUserEmail]);
+    let nextTasks = filterTasks(tasks, filter, currentUserEmail);
+    // Subtasks are listed on their parent's page; showing them here too
+    // double-counts the work, so they're hidden unless asked for.
+    if (!showSubtasks) {
+      nextTasks = nextTasks.filter((task) => !task.parentId);
+    }
+    nextTasks = searchTasks(nextTasks, query);
+    return sortTasks(nextTasks, sort.key, sort.direction);
+  }, [tasks, filter, currentUserEmail, showSubtasks, query, sort]);
   const taskCount = visibleTasks.length;
   const taskCountLabel = showPageLayout
     ? `${taskCount} shown`
@@ -146,7 +183,7 @@ export function TaskManager(props: TaskManagerProps) {
         description: taskDraft.description,
         assignee: assigneeEmail.trim() || undefined,
         priority,
-        targetLaunchDate: parseTargetLaunchDate(targetLaunchDate),
+        dueDate: parseTargetLaunchDate(targetLaunchDate),
       });
       setDraft('');
       setAssigneeEmail('');
@@ -313,14 +350,14 @@ export function TaskManager(props: TaskManagerProps) {
                     <span>
                       {targetLaunchDate
                         ? formatTargetLaunchDateLabel(targetLaunchDate)
-                        : 'target launch date'}
+                        : 'due date'}
                     </span>
                   </button>
                 }
               >
                 <div className="TaskManager__composer__popover">
                   <label className="TaskManager__composer__dateLabel">
-                    Target launch date
+                    Due date
                     <input
                       type="date"
                       value={targetLaunchDate}
@@ -390,6 +427,28 @@ export function TaskManager(props: TaskManagerProps) {
           </div>
         </div>
         <div className="TaskManager__listHeader__actions">
+          <TextInput
+            className="TaskManager__search"
+            size="xs"
+            type="search"
+            value={query}
+            placeholder="Search tasks..."
+            aria-label="Search tasks"
+            icon={<IconSearch size={14} strokeWidth="1.8" />}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setQuery(e.currentTarget.value)
+            }
+          />
+          {showPageLayout && (
+            <Button
+              compact
+              size="xs"
+              variant={showSubtasks ? 'light' : 'default'}
+              onClick={() => setShowSubtasks(!showSubtasks)}
+            >
+              {showSubtasks ? 'Hide subtasks' : 'Show subtasks'}
+            </Button>
+          )}
           {showPageLayout ? (
             <SegmentedControl
               className="TaskManager__layoutToggle"
@@ -413,27 +472,43 @@ export function TaskManager(props: TaskManagerProps) {
       </div>
 
       <TaskListContent
+        allTasks={tasks}
         error={error}
+        fieldDefs={fieldDefs}
         filter={filter}
         layout={showPageLayout ? layout : 'compact'}
         loading={loading}
+        query={query}
+        sort={sort}
         tasks={visibleTasks}
+        onSortChange={setSort}
       />
     </div>
   );
 }
 
+interface TaskSortState {
+  key: TaskSortKey;
+  direction: TaskSortDirection;
+}
+
 interface TaskListContentProps {
+  /** Every task, used for subtask rollups and blocker resolution. */
+  allTasks: Task[];
   error: string;
+  fieldDefs: TaskFieldDef[];
   filter: TaskFilter;
   layout: TaskListLayout;
   loading: boolean;
+  query: string;
+  sort: TaskSortState;
   tasks: Task[];
+  onSortChange: (sort: TaskSortState) => void;
 }
 
 /** Renders the current task list view and shared loading states. */
 function TaskListContent(props: TaskListContentProps) {
-  const {error, filter, layout, loading, tasks} = props;
+  const {allTasks, error, fieldDefs, filter, layout, loading, tasks} = props;
   if (loading) {
     return (
       <Surface className="TaskManager__list">
@@ -454,28 +529,178 @@ function TaskListContent(props: TaskListContentProps) {
     return (
       <Surface className="TaskManager__list">
         <div className="TaskManager__list__state">
-          {getEmptyTaskMessage(filter, layout)}
+          {props.query
+            ? `No tasks match "${props.query}".`
+            : getEmptyTaskMessage(filter, layout)}
         </div>
       </Surface>
     );
   }
   if (layout === 'board') {
-    return <TaskBoard filter={filter} tasks={tasks} />;
+    return <TaskBoard allTasks={allTasks} filter={filter} tasks={tasks} />;
   }
   if (layout === 'table') {
-    return <TaskTable tasks={tasks} />;
+    return (
+      <TaskTable
+        allTasks={allTasks}
+        fieldDefs={fieldDefs}
+        sort={props.sort}
+        tasks={tasks}
+        onSortChange={props.onSortChange}
+      />
+    );
   }
   return (
     <Surface className="TaskManager__list">
       {tasks.map((task) => (
-        <TaskRow key={task.id} task={task} />
+        <TaskRow key={task.id} allTasks={allTasks} task={task} />
       ))}
     </Surface>
   );
 }
 
+/**
+ * Toggles a task between its current status and closed, so the list has
+ * the same one-click completion an Asana-style tracker does.
+ */
+async function toggleTaskComplete(task: Task) {
+  try {
+    await updateTaskStatus(
+      task.id,
+      isOpenTaskStatus(task.status) ? 'closed' : 'new'
+    );
+  } catch (err) {
+    showNotification({
+      title: 'Could not update task',
+      message: errorMessage(err),
+      color: 'red',
+      autoClose: false,
+    });
+  }
+}
+
+/** One-click completion toggle shared by the list and table views. */
+function TaskCompleteToggle(props: {task: Task}) {
+  const {task} = props;
+  const done = !isOpenTaskStatus(task.status);
+  return (
+    <Tooltip label={done ? 'Reopen task' : 'Mark complete'}>
+      <ActionIcon
+        className={joinClassNames(
+          'TaskManager__completeToggle',
+          done && 'TaskManager__completeToggle--done'
+        )}
+        size="sm"
+        aria-label={done ? 'Reopen task' : 'Mark complete'}
+        onClick={(e: MouseEvent) => {
+          // The toggle sits inside the row's <a>; don't navigate.
+          e.preventDefault();
+          e.stopPropagation();
+          toggleTaskComplete(task);
+        }}
+      >
+        <IconCheck size={14} strokeWidth="2.2" />
+      </ActionIcon>
+    </Tooltip>
+  );
+}
+
+/** Badges derived from other tasks: blocked state and subtask progress. */
+function TaskRollupBadges(props: {task: Task; allTasks: Task[]}) {
+  const {task, allTasks} = props;
+  const blocked = isTaskBlocked(task, allTasks);
+  const progress = getSubtaskProgress(allTasks, task.id);
+  const overdue = isTaskOverdue(task);
+  if (!blocked && progress.total === 0 && !overdue) {
+    return null;
+  }
+  return (
+    <>
+      {blocked && (
+        <span className="TaskManager__badge TaskManager__badge--blocked">
+          <IconAlertTriangle size={11} strokeWidth="2" />
+          blocked
+        </span>
+      )}
+      {overdue && (
+        <span className="TaskManager__badge TaskManager__badge--overdue">
+          overdue
+        </span>
+      )}
+      {progress.total > 0 && (
+        <span className="TaskManager__badge">
+          {progress.completed}/{progress.total} subtasks
+        </span>
+      )}
+    </>
+  );
+}
+
+/** A sortable table column header. */
+function TaskSortHeader(props: {
+  label: string;
+  sortKey: TaskSortKey;
+  sort: TaskSortState;
+  onSortChange: (sort: TaskSortState) => void;
+}) {
+  const {label, sortKey, sort, onSortChange} = props;
+  const active = sort.key === sortKey;
+  return (
+    <th>
+      <button
+        className={joinClassNames(
+          'TaskManager__sortHeader',
+          active && 'TaskManager__sortHeader--active'
+        )}
+        type="button"
+        aria-sort={
+          active
+            ? sort.direction === 'asc'
+              ? 'ascending'
+              : 'descending'
+            : 'none'
+        }
+        onClick={() =>
+          onSortChange({
+            key: sortKey,
+            // Re-clicking the active column flips it; a new column starts
+            // in the direction that reads as "most relevant first".
+            direction:
+              active && sort.direction === 'desc'
+                ? 'asc'
+                : active
+                  ? 'desc'
+                  : 'asc',
+          })
+        }
+      >
+        {label}
+        {active ? (
+          sort.direction === 'asc' ? (
+            <IconSortAscending size={12} strokeWidth="1.8" />
+          ) : (
+            <IconSortDescending size={12} strokeWidth="1.8" />
+          )
+        ) : (
+          <IconSelector size={12} strokeWidth="1.8" />
+        )}
+      </button>
+    </th>
+  );
+}
+
 /** Renders tasks in a tabular layout. */
-function TaskTable(props: {tasks: Task[]}) {
+function TaskTable(props: {
+  allTasks: Task[];
+  fieldDefs: TaskFieldDef[];
+  sort: TaskSortState;
+  tasks: Task[];
+  onSortChange: (sort: TaskSortState) => void;
+}) {
+  const {allTasks, sort, onSortChange} = props;
+  const listFieldDefs = props.fieldDefs.filter(
+    (fieldDef) => fieldDef.showInList
+  );
   return (
     <Surface className="TaskManager__tableSurface">
       <Table
@@ -487,19 +712,59 @@ function TaskTable(props: {tasks: Task[]}) {
       >
         <thead>
           <tr>
-            <th>task</th>
-            <th>status</th>
-            <th>priority</th>
-            <th>assignee</th>
-            <th>target</th>
-            <th>opened</th>
+            <th className="TaskManager__table__completeCol">
+              <span className="TaskManager__srOnly">Complete</span>
+            </th>
+            <TaskSortHeader
+              label="task"
+              sortKey="title"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            <TaskSortHeader
+              label="status"
+              sortKey="status"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            <TaskSortHeader
+              label="priority"
+              sortKey="priority"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            <TaskSortHeader
+              label="assignee"
+              sortKey="assignee"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            <TaskSortHeader
+              label="due"
+              sortKey="dueDate"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            {listFieldDefs.map((fieldDef) => (
+              <th key={fieldDef.id}>{fieldDef.label.toLowerCase()}</th>
+            ))}
+            <TaskSortHeader
+              label="opened"
+              sortKey="created"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
           </tr>
         </thead>
         <tbody>
           {props.tasks.map((task) => {
             const createdBy = task.createdBy || 'unknown';
+            const dueDate = getTaskDueDate(task);
             return (
               <tr key={task.id}>
+                <td className="TaskManager__table__completeCol">
+                  <TaskCompleteToggle task={task} />
+                </td>
                 <td>
                   <a
                     className="TaskManager__tableTask"
@@ -516,6 +781,17 @@ function TaskTable(props: {tasks: Task[]}) {
                       </span>
                       <span className="TaskManager__tableTask__meta">
                         #{task.id} by {formatTaskUser(createdBy)}
+                        {task.parentId && (
+                          <span> · subtask of #{task.parentId}</span>
+                        )}
+                      </span>
+                      <span className="TaskManager__tableTask__badges">
+                        <TaskRollupBadges task={task} allTasks={allTasks} />
+                        {(task.tags || []).map((tag) => (
+                          <span className="TaskManager__badge" key={tag}>
+                            {tag}
+                          </span>
+                        ))}
                       </span>
                     </span>
                   </a>
@@ -538,11 +814,21 @@ function TaskTable(props: {tasks: Task[]}) {
                 <td>
                   {task.assignee ? formatTaskUser(task.assignee) : 'Unassigned'}
                 </td>
-                <td>
-                  {task.targetLaunchDate
-                    ? formatTaskDate(task.targetLaunchDate)
-                    : 'None'}
+                <td
+                  className={joinClassNames(
+                    isTaskOverdue(task) && 'TaskManager__table__overdue'
+                  )}
+                >
+                  {dueDate ? formatTaskDate(dueDate) : 'None'}
                 </td>
+                {listFieldDefs.map((fieldDef) => (
+                  <td key={fieldDef.id}>
+                    <TaskFieldValueDisplay
+                      fieldDef={fieldDef}
+                      value={task.fields?.[fieldDef.id] ?? null}
+                    />
+                  </td>
+                ))}
                 <td>{formatTaskDate(task.createdAt)}</td>
               </tr>
             );
@@ -554,7 +840,11 @@ function TaskTable(props: {tasks: Task[]}) {
 }
 
 /** Renders tasks grouped by status in a board. */
-function TaskBoard(props: {filter: TaskFilter; tasks: Task[]}) {
+function TaskBoard(props: {
+  allTasks: Task[];
+  filter: TaskFilter;
+  tasks: Task[];
+}) {
   const columns = getTaskStatusColumns(props.tasks, props.filter);
   return (
     <div className="TaskManager__board">
@@ -573,7 +863,11 @@ function TaskBoard(props: {filter: TaskFilter; tasks: Task[]}) {
                 <div className="TaskManager__boardColumn__empty">No tasks</div>
               )}
               {columnTasks.map((task) => (
-                <TaskBoardCard key={task.id} task={task} />
+                <TaskBoardCard
+                  key={task.id}
+                  allTasks={props.allTasks}
+                  task={task}
+                />
               ))}
             </div>
           </section>
@@ -584,12 +878,16 @@ function TaskBoard(props: {filter: TaskFilter; tasks: Task[]}) {
 }
 
 /** Renders a single task card for the board. */
-function TaskBoardCard(props: {task: Task}) {
+function TaskBoardCard(props: {allTasks: Task[]; task: Task}) {
   const {task} = props;
   const createdBy = task.createdBy || 'unknown';
+  const dueDate = getTaskDueDate(task);
   return (
     <a className="TaskManager__boardCard" href={`/cms/tasks/${task.id}`}>
-      <div className="TaskManager__boardCard__title">{task.title}</div>
+      <div className="TaskManager__boardCard__header">
+        <TaskCompleteToggle task={task} />
+        <div className="TaskManager__boardCard__title">{task.title}</div>
+      </div>
       {task.description && (
         <div className="TaskManager__boardCard__description">
           {task.description}
@@ -610,11 +908,17 @@ function TaskBoardCard(props: {task: Task}) {
         <span className="TaskManager__boardCard__badge">
           {task.assignee ? formatTaskUser(task.assignee) : 'Unassigned'}
         </span>
-        {task.targetLaunchDate && (
-          <span className="TaskManager__boardCard__badge">
-            target {formatTaskDate(task.targetLaunchDate)}
+        {dueDate && (
+          <span
+            className={joinClassNames(
+              'TaskManager__boardCard__badge',
+              isTaskOverdue(task) && 'TaskManager__badge--overdue'
+            )}
+          >
+            due {formatTaskDate(dueDate)}
           </span>
         )}
+        <TaskRollupBadges task={task} allTasks={props.allTasks} />
       </div>
     </a>
   );
@@ -634,11 +938,13 @@ function parseTaskDraft(content: string) {
   };
 }
 
-function TaskRow(props: {task: Task}) {
+function TaskRow(props: {allTasks: Task[]; task: Task}) {
   const {task} = props;
   const createdBy = task.createdBy || 'unknown';
+  const dueDate = getTaskDueDate(task);
   return (
     <a className="TaskManager__taskRow" href={`/cms/tasks/${task.id}`}>
+      <TaskCompleteToggle task={task} />
       <div className="TaskManager__taskRow__avatar">
         {task.assignee && <UserAvatar email={task.assignee} size={28} />}
       </div>
@@ -649,6 +955,7 @@ function TaskRow(props: {task: Task}) {
         </div>
       </div>
       <div className="TaskManager__taskRow__badges">
+        <TaskRollupBadges task={task} allTasks={props.allTasks} />
         <div className="TaskManager__taskRow__status">
           <span></span>
           {formatTaskStatus(task.status)}
@@ -660,9 +967,14 @@ function TaskRow(props: {task: Task}) {
         >
           {formatTaskPriority(task.priority)}
         </div>
-        {task.targetLaunchDate && (
-          <div className="TaskManager__taskRow__date">
-            target {formatTaskDate(task.targetLaunchDate)}
+        {dueDate && (
+          <div
+            className={joinClassNames(
+              'TaskManager__taskRow__date',
+              isTaskOverdue(task) && 'TaskManager__badge--overdue'
+            )}
+          >
+            due {formatTaskDate(dueDate)}
           </div>
         )}
       </div>
@@ -693,6 +1005,19 @@ function useTasks(scope: TaskScope) {
   }, [scope]);
 
   return {tasks, loading, error};
+}
+
+/** Subscribes to the project's custom task field definitions. */
+function useTaskFieldDefs() {
+  const [fieldDefs, setFieldDefs] = useState<TaskFieldDef[]>([]);
+  useEffect(() => {
+    const unsubscribe = subscribeTaskFieldDefs(
+      (nextFieldDefs) => setFieldDefs(nextFieldDefs),
+      (err) => console.error('failed to load task fields:', err)
+    );
+    return () => unsubscribe();
+  }, []);
+  return fieldDefs;
 }
 
 function filterTasks(
@@ -793,7 +1118,7 @@ function parseTargetLaunchDate(value: string) {
 function formatTargetLaunchDateLabel(value: string) {
   const date = parseTargetLaunchDate(value);
   if (!date) {
-    return 'target launch date';
+    return 'due date';
   }
   return date.toLocaleDateString('en', {
     month: 'short',

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -608,3 +608,162 @@
     align-self: flex-end;
   }
 }
+
+.TaskPage__sourceBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--chip-background);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  color: var(--color-text-gray);
+  text-decoration: none;
+}
+
+.TaskPage__sourceBadge--link:hover {
+  color: var(--color-text-default);
+}
+
+.TaskPage__blockedBanner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1px solid #e0b400;
+  border-radius: var(--surface-border-radius);
+  background: #fff6d6;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #7a5c00;
+}
+
+.TaskPage__blockedBanner a {
+  color: inherit;
+  font-weight: 600;
+}
+
+.TaskPage__subtasks {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.TaskPage__subtasks__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.TaskPage__subtasks__label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-gray);
+}
+
+.TaskPage__subtasks__progress {
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  color: var(--color-text-gray);
+}
+
+.TaskPage__subtasks__list {
+  display: flex;
+  flex-direction: column;
+}
+
+.TaskPage__subtasks__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.TaskPage__subtasks__check {
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-gray);
+}
+
+.TaskPage__subtasks__check--done {
+  border-color: #1f8a4c;
+  background: #1f8a4c;
+  color: #fff;
+}
+
+.TaskPage__subtasks__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  color: var(--color-text-default);
+  text-decoration: none;
+}
+
+.TaskPage__subtasks__title:hover {
+  text-decoration: underline;
+}
+
+.TaskPage__subtasks__title--done {
+  color: var(--color-text-gray);
+  text-decoration: line-through;
+}
+
+.TaskPage__subtasks__assignee {
+  flex-shrink: 0;
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  color: var(--color-text-gray);
+}
+
+.TaskPage__subtasks__form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.TaskPage__subtasks__form > *:first-child {
+  flex: 1 1 auto;
+}
+
+.TaskPage__comment__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--color-border);
+}
+
+.TaskPage__comment__attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--chip-background);
+  font-size: 11px;
+}
+
+.TaskPage__comment__attachment a {
+  color: var(--color-text-default);
+  text-decoration: none;
+}
+
+.TaskPage__comment__attachment a:hover {
+  text-decoration: underline;
+}

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -6,20 +6,23 @@ import {
   Button,
   Loader,
   Select,
-  Textarea,
   TextInput,
   Tooltip,
 } from '@mantine/core';
 import {showNotification} from '@mantine/notifications';
 import {
+  IconAlertTriangle,
   IconCalendar,
   IconCheck,
   IconCornerDownRight,
   IconExternalLink,
   IconFlag,
+  IconListCheck,
   IconMessageCircle,
   IconPaperclip,
   IconPencil,
+  IconPlus,
+  IconTag,
   IconTrash,
   IconUser,
   IconX,
@@ -36,7 +39,9 @@ import {sanitizeInlineHtml} from '../../../shared/sanitize.js';
 import {Heading} from '../../components/Heading/Heading.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
 import {Surface} from '../../components/Surface/Surface.js';
+import {TaskChipInput} from '../../components/TaskChipInput/TaskChipInput.js';
 import {TaskCommentEditor} from '../../components/TaskCommentEditor/TaskCommentEditor.js';
+import {TaskFieldInput} from '../../components/TaskFieldInput/TaskFieldInput.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
@@ -45,25 +50,43 @@ import {errorMessage} from '../../utils/notifications.js';
 import {
   addTaskComment,
   addTaskAttachment,
+  addTaskCommentAttachment,
+  createTask,
   deleteTaskComment,
   editTaskComment,
+  getBlockingTasks,
+  getSubtasks,
+  getTaskDueDate,
+  isOpenTaskStatus,
   normalizeTaskStatus,
+  parseTaskCustomFieldKey,
   removeTaskAttachment,
+  removeTaskCommentAttachment,
   subscribeTask,
   subscribeTaskComments,
   subscribeTaskEvents,
+  subscribeTaskFieldDefs,
+  subscribeTasks,
   Task,
   TaskAttachment,
   TaskComment,
   TaskEvent,
+  TaskEventValue,
+  TaskFieldDef,
+  TaskFieldValue,
   TaskMetadataField,
   TaskPriority,
   updateTaskTitle,
+  updateTaskBlockedBy,
   updateTaskDescription,
   updateTaskAssignee,
+  updateTaskDueDate,
+  updateTaskFieldValue,
+  updateTaskFollowers,
   updateTaskPriority,
+  updateTaskStartDate,
   updateTaskStatus,
-  updateTaskTargetLaunchDate,
+  updateTaskTags,
 } from '../../utils/tasks.js';
 
 const TASK_STATUS_OPTIONS = [
@@ -90,6 +113,10 @@ export function TaskPage(props: {id: string}) {
   const [task, setTask] = useState<Task | null>(null);
   const [comments, setComments] = useState<TaskComment[]>([]);
   const [events, setEvents] = useState<TaskEvent[]>([]);
+  // The full task list backs subtask rollups and "blocked by" resolution,
+  // which would otherwise cost one read per related task.
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [fieldDefs, setFieldDefs] = useState<TaskFieldDef[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -120,6 +147,14 @@ export function TaskPage(props: {id: string}) {
         (nextEvents) => setEvents(nextEvents),
         (err) => setError(errorMessage(err))
       ),
+      subscribeTasks(
+        (nextTasks) => setTasks(nextTasks),
+        (err) => setError(errorMessage(err))
+      ),
+      subscribeTaskFieldDefs(
+        (nextFieldDefs) => setFieldDefs(nextFieldDefs),
+        (err) => setError(errorMessage(err))
+      ),
     ];
     return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
   }, [taskId]);
@@ -130,6 +165,9 @@ export function TaskPage(props: {id: string}) {
         <div className="TaskPage__header">
           <Breadcrumbs className="TaskPage__header__breadcrumbs">
             <a href="/cms/tasks">Tasks</a>
+            {task?.parentId ? (
+              <a href={`/cms/tasks/${task.parentId}`}>#{task.parentId}</a>
+            ) : null}
             <div>{taskId}</div>
           </Breadcrumbs>
           <div className="TaskPage__header__titleWrap">
@@ -144,6 +182,7 @@ export function TaskPage(props: {id: string}) {
                 {formatTaskStatus(task.status)}
               </span>
             )}
+            {task?.source && <TaskSourceLink source={task.source} />}
           </div>
         </div>
 
@@ -159,13 +198,24 @@ export function TaskPage(props: {id: string}) {
         {!loading && !error && task && (
           <div className="TaskPage__body">
             <main className="TaskPage__main">
+              <TaskBlockedBanner task={task} tasks={tasks} />
               <TaskDescription task={task} />
+              <TaskSubtasks task={task} tasks={tasks} />
               <TaskAttachments task={task} />
-              <TaskTimeline task={task} comments={comments} events={events} />
+              <TaskTimeline
+                task={task}
+                comments={comments}
+                events={events}
+                fieldDefs={fieldDefs}
+              />
               <TaskCommentComposer taskId={task.id} />
             </main>
             <aside className="TaskPage__side">
-              <TaskMetadataPanel task={task} />
+              <TaskMetadataPanel
+                task={task}
+                tasks={tasks}
+                fieldDefs={fieldDefs}
+              />
             </aside>
           </div>
         )}
@@ -289,23 +339,196 @@ function TaskTitle(props: {task: Task | null; taskId: string}) {
   );
 }
 
+/** Links back to the task's record in the tracker it was imported from. */
+function TaskSourceLink(props: {source: NonNullable<Task['source']>}) {
+  const {source} = props;
+  const label = `View in ${formatTaskProvider(source.provider)}`;
+  if (!source.url) {
+    return <span className="TaskPage__sourceBadge">{label}</span>;
+  }
+  return (
+    <a
+      className="TaskPage__sourceBadge TaskPage__sourceBadge--link"
+      href={source.url}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {label}
+      <IconExternalLink size={13} strokeWidth="1.8" />
+    </a>
+  );
+}
+
+/** Warns when unresolved tasks are blocking this one. */
+function TaskBlockedBanner(props: {task: Task; tasks: Task[]}) {
+  const blockers = getBlockingTasks(props.task, props.tasks);
+  if (blockers.length === 0) {
+    return null;
+  }
+  return (
+    <div className="TaskPage__blockedBanner">
+      <IconAlertTriangle size={16} strokeWidth="1.8" />
+      <div>
+        Blocked by{' '}
+        {blockers.map((blocker, index) => (
+          <span key={blocker.id}>
+            {index > 0 && ', '}
+            <a href={`/cms/tasks/${blocker.id}`}>
+              #{blocker.id} {blocker.title}
+            </a>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Lists the task's subtasks and creates new ones inline. */
+function TaskSubtasks(props: {task: Task; tasks: Task[]}) {
+  const {task} = props;
+  const subtasks = getSubtasks(props.tasks, task.id);
+  const completed = subtasks.filter((s) => !isOpenTaskStatus(s.status)).length;
+  const [draft, setDraft] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  async function onSubmit(e: Event) {
+    e.preventDefault();
+    const title = draft.trim();
+    if (!title) {
+      return;
+    }
+    setCreating(true);
+    try {
+      await createTask({title, parentId: task.id, assignee: task.assignee});
+      setDraft('');
+    } catch (err) {
+      showNotification({
+        title: 'Could not create subtask',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function toggleSubtask(subtask: Task) {
+    try {
+      await updateTaskStatus(
+        subtask.id,
+        isOpenTaskStatus(subtask.status) ? 'closed' : 'new'
+      );
+    } catch (err) {
+      showNotification({
+        title: 'Could not update subtask',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    }
+  }
+
+  return (
+    <section className="TaskPage__subtasks">
+      <div className="TaskPage__subtasks__top">
+        <div className="TaskPage__subtasks__label">
+          <IconListCheck size={15} strokeWidth="1.8" />
+          Subtasks
+        </div>
+        {subtasks.length > 0 && (
+          <span className="TaskPage__subtasks__progress">
+            {completed}/{subtasks.length}
+          </span>
+        )}
+      </div>
+      {subtasks.length > 0 && (
+        <div className="TaskPage__subtasks__list">
+          {subtasks.map((subtask) => {
+            const done = !isOpenTaskStatus(subtask.status);
+            return (
+              <div className="TaskPage__subtasks__item" key={subtask.id}>
+                <Tooltip label={done ? 'Reopen' : 'Mark complete'}>
+                  <ActionIcon
+                    className={joinClassNames(
+                      'TaskPage__subtasks__check',
+                      done && 'TaskPage__subtasks__check--done'
+                    )}
+                    size="sm"
+                    aria-label={done ? 'Reopen subtask' : 'Complete subtask'}
+                    onClick={() => toggleSubtask(subtask)}
+                  >
+                    <IconCheck size={14} strokeWidth="2.2" />
+                  </ActionIcon>
+                </Tooltip>
+                <a
+                  className={joinClassNames(
+                    'TaskPage__subtasks__title',
+                    done && 'TaskPage__subtasks__title--done'
+                  )}
+                  href={`/cms/tasks/${subtask.id}`}
+                >
+                  {subtask.title}
+                </a>
+                {subtask.assignee && (
+                  <span className="TaskPage__subtasks__assignee">
+                    {formatTaskUser(subtask.assignee)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <form className="TaskPage__subtasks__form" onSubmit={onSubmit}>
+        <TextInput
+          size="xs"
+          value={draft}
+          placeholder="Add a subtask..."
+          disabled={creating}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setDraft(e.currentTarget.value)
+          }
+        />
+        <Button
+          compact
+          size="xs"
+          color="dark"
+          type="submit"
+          loading={creating}
+          disabled={!draft.trim()}
+          leftIcon={<IconPlus size={14} strokeWidth="1.8" />}
+        >
+          Add
+        </Button>
+      </form>
+    </section>
+  );
+}
+
 /** Renders the editable task description. */
 function TaskDescription(props: {task: Task}) {
   const {task} = props;
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(task.description || '');
+  // Descriptions written before rich text existed are plain strings; lift
+  // them into rich text so editing one doesn't discard its line breaks.
+  const [draft, setDraft] = useState<RichTextData | null>(
+    task.descriptionBody || richTextFromPlainText(task.description || '')
+  );
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!editing) {
-      setDraft(task.description || '');
+      setDraft(
+        task.descriptionBody || richTextFromPlainText(task.description || '')
+      );
     }
-  }, [task.description, editing]);
+  }, [task.descriptionBody, task.description, editing]);
 
   async function saveDescription() {
     setSaving(true);
     try {
-      await updateTaskDescription(task.id, draft.trim());
+      await updateTaskDescription(task.id, draft || '');
       setEditing(false);
     } catch (err) {
       showNotification({
@@ -331,15 +554,11 @@ function TaskDescription(props: {task: Task}) {
       </div>
       {editing ? (
         <div className="TaskPage__description__edit">
-          <Textarea
-            autosize
+          <TaskCommentEditor
             autoFocus
-            minRows={4}
             value={draft}
             placeholder="Add task details, scope, and acceptance criteria."
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-              setDraft(e.currentTarget.value)
-            }
+            onChange={setDraft}
           />
           <div className="TaskPage__description__editActions">
             <Button
@@ -349,7 +568,10 @@ function TaskDescription(props: {task: Task}) {
               leftIcon={<IconX size={14} strokeWidth="1.8" />}
               onClick={() => {
                 setEditing(false);
-                setDraft(task.description || '');
+                setDraft(
+                  task.descriptionBody ||
+                    richTextFromPlainText(task.description || '')
+                );
               }}
             >
               Cancel
@@ -370,10 +592,19 @@ function TaskDescription(props: {task: Task}) {
         <div
           className={joinClassNames(
             'TaskPage__description__content',
-            !task.description && 'TaskPage__description__content--empty'
+            !task.description &&
+              !task.descriptionBody &&
+              'TaskPage__description__content--empty'
           )}
         >
-          {task.description || 'No description provided.'}
+          {task.descriptionBody ? (
+            <TaskRichText
+              className="TaskPage__description__richText"
+              data={task.descriptionBody}
+            />
+          ) : (
+            task.description || 'No description provided.'
+          )}
         </div>
       )}
     </Surface>
@@ -525,18 +756,26 @@ function TaskAttachments(props: {task: Task}) {
 }
 
 /** Renders editable task metadata and writes changes to history. */
-function TaskMetadataPanel(props: {task: Task}) {
-  const {task} = props;
+function TaskMetadataPanel(props: {
+  task: Task;
+  tasks: Task[];
+  fieldDefs: TaskFieldDef[];
+}) {
+  const {task, tasks, fieldDefs} = props;
   const [assignee, setAssignee] = useState(task.assignee || '');
-  const [targetLaunchDate, setTargetLaunchDate] = useState(
-    formatDateInputValue(task.targetLaunchDate)
+  const [startDate, setStartDate] = useState(
+    formatDateInputValue(task.startDate)
+  );
+  const [dueDate, setDueDate] = useState(
+    formatDateTimeInputValue(getTaskDueDate(task))
   );
   const [savingField, setSavingField] = useState<TaskMetadataField | ''>('');
 
   useEffect(() => {
     setAssignee(task.assignee || '');
-    setTargetLaunchDate(formatDateInputValue(task.targetLaunchDate));
-  }, [task.assignee, task.targetLaunchDate]);
+    setStartDate(formatDateInputValue(task.startDate));
+    setDueDate(formatDateTimeInputValue(getTaskDueDate(task)));
+  }, [task.assignee, task.startDate, task.dueDate, task.targetLaunchDate]);
 
   async function saveMetadata(
     field: TaskMetadataField,
@@ -567,13 +806,23 @@ function TaskMetadataPanel(props: {task: Task}) {
     );
   }
 
-  function saveTargetLaunchDate(value: string) {
-    setTargetLaunchDate(value);
-    if (formatDateInputValue(task.targetLaunchDate) === value) {
+  function saveStartDate(value: string) {
+    setStartDate(value);
+    if (formatDateInputValue(task.startDate) === value) {
       return;
     }
-    saveMetadata('targetLaunchDate', () =>
-      updateTaskTargetLaunchDate(task.id, parseTargetLaunchDate(value))
+    saveMetadata('startDate', () =>
+      updateTaskStartDate(task.id, parseDateInputValue(value))
+    );
+  }
+
+  function saveDueDate(value: string) {
+    setDueDate(value);
+    if (formatDateTimeInputValue(getTaskDueDate(task)) === value) {
+      return;
+    }
+    saveMetadata('dueDate', () =>
+      updateTaskDueDate(task.id, parseDateTimeInputValue(value))
     );
   }
 
@@ -614,6 +863,21 @@ function TaskMetadataPanel(props: {task: Task}) {
         </div>
       </div>
       <div className="TaskPage__metadata__field">
+        <label>Followers</label>
+        <TaskChipInput
+          values={task.followers || []}
+          placeholder="teammate@example.com"
+          disabled={savingField === 'followers'}
+          formatValue={formatTaskUser}
+          normalizeValue={(value) => value.trim().toLowerCase() || null}
+          onChange={(followers) =>
+            saveMetadata('followers', () =>
+              updateTaskFollowers(task.id, followers)
+            )
+          }
+        />
+      </div>
+      <div className="TaskPage__metadata__field">
         <label>Priority</label>
         <Select
           size="xs"
@@ -629,20 +893,86 @@ function TaskMetadataPanel(props: {task: Task}) {
         />
       </div>
       <div className="TaskPage__metadata__field">
-        <label>Target launch date</label>
+        <label>Tags</label>
+        <TaskChipInput
+          values={task.tags || []}
+          placeholder="Add a tag..."
+          disabled={savingField === 'tags'}
+          onChange={(tags) =>
+            saveMetadata('tags', () => updateTaskTags(task.id, tags))
+          }
+        />
+      </div>
+      <div className="TaskPage__metadata__field">
+        <label>Start date</label>
         <div className="TaskPage__metadata__date">
           <input
             type="date"
-            value={targetLaunchDate}
-            disabled={savingField === 'targetLaunchDate'}
+            value={startDate}
+            disabled={savingField === 'startDate'}
             onInput={(e) =>
-              saveTargetLaunchDate((e.currentTarget as HTMLInputElement).value)
+              saveStartDate((e.currentTarget as HTMLInputElement).value)
             }
           />
         </div>
       </div>
+      <div className="TaskPage__metadata__field">
+        <label>Due date</label>
+        <div className="TaskPage__metadata__date">
+          <input
+            type="datetime-local"
+            value={dueDate}
+            disabled={savingField === 'dueDate'}
+            onInput={(e) =>
+              saveDueDate((e.currentTarget as HTMLInputElement).value)
+            }
+          />
+        </div>
+      </div>
+      <div className="TaskPage__metadata__field">
+        <label>Blocked by</label>
+        <TaskChipInput
+          values={task.blockedBy || []}
+          placeholder="Task id, e.g. 12"
+          disabled={savingField === 'blockedBy'}
+          formatValue={(id) => formatBlockerLabel(id, tasks)}
+          normalizeValue={(value) => {
+            const id = value.replace(/^#/, '').trim();
+            if (!id || id === task.id) {
+              return null;
+            }
+            return id;
+          }}
+          onChange={(blockedBy) =>
+            saveMetadata('blockedBy', () =>
+              updateTaskBlockedBy(task.id, blockedBy)
+            )
+          }
+        />
+      </div>
+      {fieldDefs.map((fieldDef) => (
+        <div className="TaskPage__metadata__field" key={fieldDef.id}>
+          <label>{fieldDef.label}</label>
+          <TaskFieldInput
+            fieldDef={fieldDef}
+            value={task.fields?.[fieldDef.id] ?? null}
+            disabled={savingField === `field:${fieldDef.id}`}
+            onChange={(value: TaskFieldValue) =>
+              saveMetadata(`field:${fieldDef.id}`, () =>
+                updateTaskFieldValue(task.id, fieldDef.id, value)
+              )
+            }
+          />
+        </div>
+      ))}
     </Surface>
   );
+}
+
+/** Labels a blocker chip with its title when the task is loaded. */
+function formatBlockerLabel(id: string, tasks: Task[]) {
+  const blocker = tasks.find((task) => task.id === id);
+  return blocker ? `#${id} ${blocker.title}` : `#${id}`;
 }
 
 /** Combines task comments and metadata changes into a single timeline. */
@@ -650,8 +980,9 @@ function TaskTimeline(props: {
   task: Task;
   comments: TaskComment[];
   events: TaskEvent[];
+  fieldDefs: TaskFieldDef[];
 }) {
-  const {task, comments, events} = props;
+  const {task, comments, events, fieldDefs} = props;
   const repliesByParentId = useMemo(() => {
     const replies = new Map<string, TaskComment[]>();
     comments
@@ -697,7 +1028,13 @@ function TaskTimeline(props: {
           return <TaskOpenedTimelineItem key={item.id} task={task} />;
         }
         if (item.kind === 'event') {
-          return <TaskEventTimelineItem key={item.id} event={item.event} />;
+          return (
+            <TaskEventTimelineItem
+              key={item.id}
+              event={item.event}
+              fieldDefs={fieldDefs}
+            />
+          );
         }
         return (
           <TaskCommentCard
@@ -721,7 +1058,7 @@ function TaskOpenedTimelineItem(props: {task: Task}) {
         <IconCheck size={15} strokeWidth="2" />
       </div>
       <div className="TaskPage__timelineItem__content">
-        <b>{formatTaskUser(task.createdBy || 'unknown')}</b> opened this task{' '}
+        <b>{formatTaskAuthor(task)}</b> opened this task{' '}
         {formatTaskDateTime(task.createdAt)}.
       </div>
     </div>
@@ -729,18 +1066,27 @@ function TaskOpenedTimelineItem(props: {task: Task}) {
 }
 
 /** Renders one metadata mutation as a GitHub-style timeline event. */
-function TaskEventTimelineItem(props: {event: TaskEvent}) {
-  const {event} = props;
+function TaskEventTimelineItem(props: {
+  event: TaskEvent;
+  fieldDefs: TaskFieldDef[];
+}) {
+  const {event, fieldDefs} = props;
   return (
     <div className="TaskPage__timelineItem TaskPage__timelineItem--event">
       <div className="TaskPage__timelineItem__marker">
         {event.field === 'title' ? (
           <IconPencil size={15} strokeWidth="2" />
-        ) : event.field === 'assignee' ? (
+        ) : event.field === 'assignee' || event.field === 'followers' ? (
           <IconUser size={15} strokeWidth="2" />
         ) : event.field === 'priority' ? (
           <IconFlag size={15} strokeWidth="2" />
-        ) : event.field === 'targetLaunchDate' ? (
+        ) : event.field === 'tags' ? (
+          <IconTag size={15} strokeWidth="2" />
+        ) : event.field === 'blockedBy' ? (
+          <IconAlertTriangle size={15} strokeWidth="2" />
+        ) : event.field === 'parentId' ? (
+          <IconListCheck size={15} strokeWidth="2" />
+        ) : isTaskDateField(event.field) ? (
           <IconCalendar size={15} strokeWidth="2" />
         ) : (
           <IconCheck size={15} strokeWidth="2" />
@@ -748,13 +1094,13 @@ function TaskEventTimelineItem(props: {event: TaskEvent}) {
       </div>
       <div className="TaskPage__timelineItem__content">
         <b>{formatTaskUser(event.createdBy || 'unknown')}</b> changed{' '}
-        {formatTaskField(event.field)} from{' '}
+        {formatTaskField(event.field, fieldDefs)} from{' '}
         <span className="TaskPage__timelineValue">
-          {formatTaskEventValue(event.field, event.oldValue)}
+          {formatTaskEventValue(event.field, event.oldValue, fieldDefs)}
         </span>{' '}
         to{' '}
         <span className="TaskPage__timelineValue">
-          {formatTaskEventValue(event.field, event.newValue)}
+          {formatTaskEventValue(event.field, event.newValue, fieldDefs)}
         </span>{' '}
         {formatTaskDateTime(event.createdAt)}.
       </div>
@@ -840,7 +1186,7 @@ function TaskCommentCard(props: {
         <Surface className="TaskPage__comment">
           <div className="TaskPage__comment__header">
             <div>
-              <b>{formatTaskUser(comment.createdBy || 'unknown')}</b>{' '}
+              <b>{formatTaskAuthor(comment)}</b>{' '}
               <span>{formatTaskDateTime(comment.createdAt)}</span>
               {comment.updatedAt && !comment.isDeleted && (
                 <span> edited {formatTaskDateTime(comment.updatedAt)}</span>
@@ -927,6 +1273,9 @@ function TaskCommentCard(props: {
               )}
             </div>
           )}
+          {!comment.isDeleted && (
+            <TaskCommentAttachments comment={comment} canModify={canModify} />
+          )}
         </Surface>
         {replying && (
           <TaskCommentComposer
@@ -950,6 +1299,118 @@ function TaskCommentCard(props: {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/** Lists a comment's attachments, with upload/remove for its author. */
+function TaskCommentAttachments(props: {
+  comment: TaskComment;
+  canModify?: boolean;
+}) {
+  const {comment} = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const attachments = comment.attachments || [];
+
+  async function uploadFiles(files: FileList | File[]) {
+    const selectedFiles = Array.from(files);
+    if (selectedFiles.length === 0) {
+      return;
+    }
+    setUploading(true);
+    try {
+      for (const file of selectedFiles) {
+        const uploadedFile = await uploadFileToGCS(file);
+        await addTaskCommentAttachment(comment.taskId, comment.id, {
+          ...uploadedFile,
+          filename: uploadedFile.filename || file.name,
+          contentType: file.type || undefined,
+          size: file.size,
+        });
+      }
+    } catch (err) {
+      showNotification({
+        title: 'Could not attach file',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setUploading(false);
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  }
+
+  async function removeAttachment(attachment: TaskAttachment) {
+    if (!window.confirm(`Remove ${formatTaskAttachmentName(attachment)}?`)) {
+      return;
+    }
+    try {
+      await removeTaskCommentAttachment(
+        comment.taskId,
+        comment.id,
+        attachment.id
+      );
+    } catch (err) {
+      showNotification({
+        title: 'Could not remove attachment',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    }
+  }
+
+  if (attachments.length === 0 && !props.canModify) {
+    return null;
+  }
+
+  return (
+    <div className="TaskPage__comment__attachments">
+      {attachments.map((attachment) => (
+        <span className="TaskPage__comment__attachment" key={attachment.id}>
+          <IconPaperclip size={13} strokeWidth="1.8" />
+          <a href={attachment.src} target="_blank" rel="noreferrer">
+            {formatTaskAttachmentName(attachment)}
+          </a>
+          {props.canModify && (
+            <ActionIcon
+              size="xs"
+              aria-label="Remove attachment"
+              onClick={() => removeAttachment(attachment)}
+            >
+              <IconX size={12} strokeWidth="2" />
+            </ActionIcon>
+          )}
+        </span>
+      ))}
+      {props.canModify && (
+        <>
+          <Button
+            compact
+            size="xs"
+            variant="subtle"
+            type="button"
+            loading={uploading}
+            leftIcon={<IconPaperclip size={13} strokeWidth="1.8" />}
+            onClick={() => inputRef.current?.click()}
+          >
+            Attach
+          </Button>
+          <input
+            ref={inputRef}
+            className="TaskPage__attachments__input"
+            type="file"
+            multiple
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              uploadFiles(e.currentTarget.files || [])
+            }
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -1225,25 +1686,65 @@ function formatTaskStatus(status?: string) {
   return normalizeTaskStatus(status).replace(/[-_]/g, ' ');
 }
 
-function formatTaskField(field: TaskMetadataField) {
+function formatTaskField(
+  field: TaskMetadataField,
+  fieldDefs: TaskFieldDef[] = []
+) {
+  const customFieldId = parseTaskCustomFieldKey(field);
+  if (customFieldId) {
+    const fieldDef = fieldDefs.find((def) => def.id === customFieldId);
+    return fieldDef?.label.toLowerCase() || customFieldId;
+  }
   return field.replace(/([A-Z])/g, ' $1').toLowerCase();
 }
 
 function formatTaskEventValue(
   field: TaskMetadataField,
-  value: string | Timestamp | null
-) {
-  if (!value) {
+  value: TaskEventValue,
+  fieldDefs: TaskFieldDef[] = []
+): string {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return 'none';
+    }
+    return value
+      .map((item) =>
+        field === 'followers'
+          ? formatTaskUser(item)
+          : field === 'blockedBy'
+            ? `#${item}`
+            : item
+      )
+      .join(', ');
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'yes' : 'no';
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (value === null || value === '') {
     return 'none';
   }
   if (value instanceof Timestamp) {
-    return formatTaskDate(value);
+    return field === 'dueDate'
+      ? formatTaskDateTime(value)
+      : formatTaskDate(value);
+  }
+  const customFieldId = parseTaskCustomFieldKey(field);
+  if (customFieldId) {
+    const fieldDef = fieldDefs.find((def) => def.id === customFieldId);
+    const option = fieldDef?.options?.find((item) => item.value === value);
+    return option?.label || value;
   }
   if (field === 'assignee') {
     return formatTaskUser(value);
   }
   if (field === 'title') {
     return value;
+  }
+  if (field === 'parentId') {
+    return `#${value}`;
   }
   return value.replace(/[-_]/g, ' ');
 }
@@ -1265,7 +1766,7 @@ function formatDateInputValue(value?: Timestamp | null) {
   return `${year}-${month}-${day}`;
 }
 
-function parseTargetLaunchDate(value: string) {
+function parseDateInputValue(value: string) {
   if (!value) {
     return null;
   }
@@ -1274,4 +1775,56 @@ function parseTargetLaunchDate(value: string) {
     return null;
   }
   return new Date(year, month - 1, day);
+}
+
+/** Formats a timestamp for an `<input type="datetime-local">`. */
+function formatDateTimeInputValue(value?: Timestamp | null) {
+  if (!value?.toMillis) {
+    return '';
+  }
+  const date = new Date(value.toMillis());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function parseDateTimeInputValue(value: string) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isTaskDateField(field: TaskMetadataField) {
+  return (
+    field === 'dueDate' || field === 'startDate' || field === 'targetLaunchDate'
+  );
+}
+
+function formatTaskProvider(provider: string) {
+  if (!provider) {
+    return 'source';
+  }
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+/**
+ * Names the comment's author. Imported comments show the original author
+ * with their source, since `createdBy` records the importing account.
+ */
+function formatTaskAuthor(item: {
+  createdBy?: string;
+  importedAuthor?: string | null;
+  source?: Task['source'];
+}) {
+  if (item.importedAuthor) {
+    const provider = item.source?.provider;
+    return provider
+      ? `${item.importedAuthor} · via ${formatTaskProvider(provider)}`
+      : item.importedAuthor;
+  }
+  return formatTaskUser(item.createdBy || 'unknown');
 }

--- a/packages/root-cms/ui/pages/TasksPage/TasksPage.css
+++ b/packages/root-cms/ui/pages/TasksPage/TasksPage.css
@@ -13,3 +13,10 @@
     padding: 20px;
   }
 }
+
+.TasksPage__header {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}

--- a/packages/root-cms/ui/pages/TasksPage/TasksPage.tsx
+++ b/packages/root-cms/ui/pages/TasksPage/TasksPage.tsx
@@ -1,18 +1,43 @@
 import './TasksPage.css';
 
+import {Button} from '@mantine/core';
+import {IconAdjustmentsHorizontal} from '@tabler/icons-preact';
+import {useEffect, useState} from 'preact/hooks';
 import {Heading} from '../../components/Heading/Heading.js';
+import {useTaskFieldsModal} from '../../components/TaskFieldsModal/TaskFieldsModal.js';
 import {TaskManager} from '../../components/TaskManager/TaskManager.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
+import {subscribeTaskFieldDefs, TaskFieldDef} from '../../utils/tasks.js';
 
 /** Renders the main task manager page. */
 export function TasksPage() {
   usePageTitle('Tasks');
+  const [fieldDefs, setFieldDefs] = useState<TaskFieldDef[]>([]);
+  const taskFieldsModal = useTaskFieldsModal();
+
+  useEffect(() => {
+    const unsubscribe = subscribeTaskFieldDefs(
+      (nextFieldDefs) => setFieldDefs(nextFieldDefs),
+      (err) => console.error('failed to load task fields:', err)
+    );
+    return () => unsubscribe();
+  }, []);
+
   return (
     <Layout>
       <div className="TasksPage">
         <div className="TasksPage__header">
           <Heading size="h1">Tasks</Heading>
+          <Button
+            compact
+            size="xs"
+            variant="default"
+            leftIcon={<IconAdjustmentsHorizontal size={14} strokeWidth="1.8" />}
+            onClick={() => taskFieldsModal.open({fieldDefs})}
+          >
+            Fields
+          </Button>
         </div>
         <TaskManager variant="page" />
       </div>

--- a/packages/root-cms/ui/ui.tsx
+++ b/packages/root-cms/ui/ui.tsx
@@ -38,6 +38,7 @@ import {PruneTranslationsModal} from './components/PruneTranslationsModal/PruneT
 import {PublishDocModal} from './components/PublishDocModal/PublishDocModal.js';
 import {ReferenceFieldEditorModal} from './components/ReferenceFieldEditorModal/ReferenceFieldEditorModal.js';
 import {ScheduleReleaseModal} from './components/ScheduleReleaseModal/ScheduleReleaseModal.js';
+import {TaskFieldsModal} from './components/TaskFieldsModal/TaskFieldsModal.js';
 import {VersionHistoryModal} from './components/VersionHistoryModal/VersionHistoryModal.js';
 import {FirebaseContext, FirebaseContextObject} from './hooks/useFirebase.js';
 import {PendingReleasesProvider} from './hooks/usePendingReleases.js';
@@ -371,6 +372,7 @@ function App() {
                         [ReferenceFieldEditorModal.id]:
                           ReferenceFieldEditorModal,
                         [ScheduleReleaseModal.id]: ScheduleReleaseModal,
+                        [TaskFieldsModal.id]: TaskFieldsModal,
                         [VersionHistoryModal.id]: VersionHistoryModal,
                       }}
                     >

--- a/packages/root-cms/ui/utils/tasks.test.ts
+++ b/packages/root-cms/ui/utils/tasks.test.ts
@@ -1,0 +1,215 @@
+import {Timestamp} from 'firebase/firestore';
+import {describe, expect, it} from 'vitest';
+import {
+  getBlockingTasks,
+  getSubtaskProgress,
+  getSubtasks,
+  getTaskDueDate,
+  isTaskBlocked,
+  isTaskOverdue,
+  parseTaskCustomFieldKey,
+  searchTasks,
+  sortTasks,
+  Task,
+  taskCustomFieldKey,
+} from './tasks.js';
+
+function task(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    createdAt: Timestamp.fromMillis(1000),
+    createdBy: 'author@example.com',
+    ...overrides,
+  };
+}
+
+describe('getTaskDueDate', () => {
+  it('prefers dueDate', () => {
+    const dueDate = Timestamp.fromMillis(2000);
+    const legacy = Timestamp.fromMillis(9000);
+    expect(
+      getTaskDueDate(task('1', {dueDate, targetLaunchDate: legacy}))
+    ).toEqual(dueDate);
+  });
+
+  it('falls back to targetLaunchDate for tasks written before dueDate', () => {
+    const legacy = Timestamp.fromMillis(9000);
+    expect(getTaskDueDate(task('1', {targetLaunchDate: legacy}))).toEqual(
+      legacy
+    );
+  });
+
+  it('returns null when neither is set', () => {
+    expect(getTaskDueDate(task('1'))).toBeNull();
+  });
+});
+
+describe('isTaskOverdue', () => {
+  const past = Timestamp.fromMillis(1000);
+  const future = Timestamp.fromMillis(9000);
+
+  it('flags an open task past its due date', () => {
+    expect(isTaskOverdue(task('1', {dueDate: past}), 5000)).toBe(true);
+  });
+
+  it('does not flag a task due in the future', () => {
+    expect(isTaskOverdue(task('1', {dueDate: future}), 5000)).toBe(false);
+  });
+
+  it('never flags a closed task', () => {
+    const closed = task('1', {dueDate: past, status: 'closed'});
+    expect(isTaskOverdue(closed, 5000)).toBe(false);
+  });
+
+  it('does not flag a task with no due date', () => {
+    expect(isTaskOverdue(task('1'), 5000)).toBe(false);
+  });
+});
+
+describe('subtasks', () => {
+  const tasks = [
+    task('1'),
+    task('2', {parentId: '1', createdAt: Timestamp.fromMillis(3000)}),
+    task('3', {
+      parentId: '1',
+      status: 'closed',
+      createdAt: Timestamp.fromMillis(2000),
+    }),
+    task('4', {parentId: '9'}),
+  ];
+
+  it('returns direct children oldest first', () => {
+    expect(getSubtasks(tasks, '1').map((t) => t.id)).toEqual(['3', '2']);
+  });
+
+  it('counts completed subtasks', () => {
+    expect(getSubtaskProgress(tasks, '1')).toEqual({completed: 1, total: 2});
+  });
+
+  it('reports zero progress for a task with no subtasks', () => {
+    expect(getSubtaskProgress(tasks, '2')).toEqual({completed: 0, total: 0});
+  });
+});
+
+describe('blocking tasks', () => {
+  it('ignores blockers that are already closed', () => {
+    const tasks = [
+      task('1', {blockedBy: ['2', '3']}),
+      task('2', {status: 'closed'}),
+      task('3', {status: 'in-progress'}),
+    ];
+    expect(getBlockingTasks(tasks[0], tasks).map((t) => t.id)).toEqual(['3']);
+    expect(isTaskBlocked(tasks[0], tasks)).toBe(true);
+  });
+
+  it('is unblocked once every blocker closes', () => {
+    const tasks = [task('1', {blockedBy: ['2']}), task('2', {status: 'done'})];
+    expect(isTaskBlocked(tasks[0], tasks)).toBe(false);
+  });
+
+  it('ignores blocker ids that no longer exist', () => {
+    const tasks = [task('1', {blockedBy: ['missing']})];
+    expect(isTaskBlocked(tasks[0], tasks)).toBe(false);
+  });
+});
+
+describe('searchTasks', () => {
+  const tasks = [
+    task('1', {title: 'Fix the header', tags: ['bug', 'nav']}),
+    task('2', {
+      title: 'Launch page',
+      description: 'Ship the homepage refresh',
+      assignee: 'dana@example.com',
+    }),
+    task('3', {title: 'Header audit', fields: {surface: 'marketing'}}),
+  ];
+
+  it('returns everything for an empty query', () => {
+    expect(searchTasks(tasks, '   ')).toHaveLength(3);
+  });
+
+  it('matches on title', () => {
+    expect(searchTasks(tasks, 'header').map((t) => t.id)).toEqual(['1', '3']);
+  });
+
+  it('matches on description, tags, assignee, and custom field values', () => {
+    expect(searchTasks(tasks, 'homepage').map((t) => t.id)).toEqual(['2']);
+    expect(searchTasks(tasks, 'nav').map((t) => t.id)).toEqual(['1']);
+    expect(searchTasks(tasks, 'dana').map((t) => t.id)).toEqual(['2']);
+    expect(searchTasks(tasks, 'marketing').map((t) => t.id)).toEqual(['3']);
+  });
+
+  it('matches the task id, with or without the hash', () => {
+    expect(searchTasks(tasks, '#2').map((t) => t.id)).toEqual(['2']);
+  });
+
+  it('requires every term to match', () => {
+    expect(searchTasks(tasks, 'header audit').map((t) => t.id)).toEqual(['3']);
+    expect(searchTasks(tasks, 'header nonexistent')).toHaveLength(0);
+  });
+});
+
+describe('sortTasks', () => {
+  it('sorts by priority, highest first', () => {
+    const tasks = [
+      task('1', {priority: 'normal'}),
+      task('2', {priority: 'high'}),
+      task('3', {priority: 'medium'}),
+    ];
+    expect(sortTasks(tasks, 'priority', 'asc').map((t) => t.id)).toEqual([
+      '2',
+      '3',
+      '1',
+    ]);
+  });
+
+  it('sorts by due date and pushes undated tasks last in both directions', () => {
+    const tasks = [
+      task('1', {dueDate: Timestamp.fromMillis(3000)}),
+      task('2'),
+      task('3', {dueDate: Timestamp.fromMillis(1000)}),
+    ];
+    expect(sortTasks(tasks, 'dueDate', 'asc').map((t) => t.id)).toEqual([
+      '3',
+      '1',
+      '2',
+    ]);
+    expect(sortTasks(tasks, 'dueDate', 'desc').map((t) => t.id)).toEqual([
+      '1',
+      '3',
+      '2',
+    ]);
+  });
+
+  it('sorts by title alphabetically', () => {
+    const tasks = [
+      task('1', {title: 'Charlie'}),
+      task('2', {title: 'alpha'}),
+      task('3', {title: 'Bravo'}),
+    ];
+    expect(sortTasks(tasks, 'title', 'asc').map((t) => t.id)).toEqual([
+      '2',
+      '3',
+      '1',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const tasks = [task('1', {title: 'b'}), task('2', {title: 'a'})];
+    sortTasks(tasks, 'title', 'asc');
+    expect(tasks.map((t) => t.id)).toEqual(['1', '2']);
+  });
+});
+
+describe('custom field keys', () => {
+  it('round-trips a field id', () => {
+    expect(parseTaskCustomFieldKey(taskCustomFieldKey('requestType'))).toBe(
+      'requestType'
+    );
+  });
+
+  it('returns null for built-in fields', () => {
+    expect(parseTaskCustomFieldKey('assignee')).toBeNull();
+  });
+});

--- a/packages/root-cms/ui/utils/tasks.ts
+++ b/packages/root-cms/ui/utils/tasks.ts
@@ -24,11 +24,35 @@ export interface Task {
   id: string;
   title: string;
   description?: string;
+  /**
+   * Rich-text description. `description` is kept in sync as the plain-text
+   * projection so existing search/list code keeps working.
+   */
+  descriptionBody?: RichTextData | null;
   attachments?: TaskAttachment[];
   assignee?: string | null;
+  /** Additional people following the task, beyond the assignee. */
+  followers?: string[];
   priority?: TaskPriority;
   status?: string;
+  tags?: string[];
+  /** Values for the project's custom fields, keyed by `TaskFieldDef.id`. */
+  fields?: Record<string, TaskFieldValue>;
+  /** Parent task id, set when this task is a subtask. */
+  parentId?: string | null;
+  /** Ids of tasks that must be resolved before this one can proceed. */
+  blockedBy?: string[];
+  startDate?: Timestamp | null;
+  dueDate?: Timestamp | null;
+  /**
+   * Retained for backwards compatibility. Kept in sync with `dueDate`; new
+   * code should read `dueDate`.
+   */
   targetLaunchDate?: Timestamp | null;
+  /** Provenance for tasks imported from an external tracker. */
+  source?: TaskSource | null;
+  /** Display name of the original author, for imported tasks. */
+  importedAuthor?: string | null;
   createdAt: Timestamp;
   createdBy: string;
   updatedAt?: Timestamp;
@@ -37,6 +61,60 @@ export interface Task {
 
 export type TaskPriority = 'high' | 'medium' | 'normal';
 export type TaskUnsubscribe = () => void;
+
+export type TaskFieldType =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'multiselect'
+  | 'checkbox';
+
+export type TaskFieldValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | Timestamp
+  | null;
+
+export interface TaskFieldOption {
+  value: string;
+  label: string;
+  /** Badge color for the option chip. */
+  color?: string;
+}
+
+/**
+ * A project-level custom field definition. Definitions live on the project
+ * doc so a field can be rendered as a list column without extra reads.
+ */
+export interface TaskFieldDef {
+  id: string;
+  label: string;
+  type: TaskFieldType;
+  options?: TaskFieldOption[];
+  /** Render this field as a column in the task list. */
+  showInList?: boolean;
+}
+
+/** Points back at the task's record in an external tracker. */
+export interface TaskSource {
+  provider: string;
+  url?: string;
+  id?: string;
+}
+
+/**
+ * Provenance for content migrated in from another tracker. `createdBy`
+ * always records the authenticated account that performed the import, so
+ * the audit trail can't be falsified; `author` is presentational only.
+ */
+export interface TaskImportOptions {
+  createdAt?: Date | Timestamp;
+  author?: string;
+  source?: TaskSource;
+}
 
 export interface TaskAttachment extends UploadedFile {
   id: string;
@@ -60,8 +138,13 @@ export interface TaskComment {
   parentId?: string | null;
   content: string;
   body?: RichTextData | null;
+  attachments?: TaskAttachment[];
   /** Lower-cased emails of users mentioned via `@<email>` in the content. */
   mentions?: string[];
+  /** Display name of the original author, for imported comments. */
+  importedAuthor?: string | null;
+  /** Source tracker the comment was imported from. */
+  source?: TaskSource | null;
   createdAt: Timestamp;
   createdBy: string;
   updatedAt?: Timestamp;
@@ -72,22 +155,46 @@ export interface TaskComment {
   history?: TaskCommentHistoryEntry[];
 }
 
+/**
+ * Fields tracked in the task timeline. Custom fields are tracked using a
+ * `field:<TaskFieldDef.id>` key.
+ */
 export type TaskMetadataField =
   | 'title'
   | 'assignee'
+  | 'followers'
   | 'priority'
   | 'status'
-  | 'targetLaunchDate';
+  | 'tags'
+  | 'blockedBy'
+  | 'parentId'
+  | 'startDate'
+  | 'dueDate'
+  | 'targetLaunchDate'
+  | `field:${string}`;
+
+/** Values that can be recorded on either side of a timeline event. */
+export type TaskEventValue = TaskFieldValue;
 
 export interface TaskEvent {
   id: string;
   taskId: string;
   type: 'metadata';
   field: TaskMetadataField;
-  oldValue: string | Timestamp | null;
-  newValue: string | Timestamp | null;
+  oldValue: TaskEventValue;
+  newValue: TaskEventValue;
   createdAt: Timestamp;
   createdBy: string;
+}
+
+/** Builds the timeline event key for a custom field. */
+export function taskCustomFieldKey(fieldId: string): TaskMetadataField {
+  return `field:${fieldId}`;
+}
+
+/** Returns the custom field id for a `field:<id>` event key, else null. */
+export function parseTaskCustomFieldKey(field: string): string | null {
+  return field.startsWith('field:') ? field.slice('field:'.length) : null;
 }
 
 function projectDocRef() {
@@ -156,12 +263,121 @@ export async function setDefaultTaskAssignee(assignee: string | null) {
   });
 }
 
+/**
+ * Subscribes to the project's custom task field definitions. Definitions
+ * live on the project doc so list columns cost no extra reads.
+ */
+export function subscribeTaskFieldDefs(
+  onFieldDefs: (fieldDefs: TaskFieldDef[]) => void,
+  onError?: (err: Error) => void
+): TaskUnsubscribe {
+  return onSnapshot(
+    projectDocRef(),
+    (snapshot) => {
+      const data: any = snapshot.data() || {};
+      onFieldDefs(normalizeTaskFieldDefs(data.settings?.taskFields));
+    },
+    onError
+  );
+}
+
+export async function getTaskFieldDefs(): Promise<TaskFieldDef[]> {
+  const snapshot = await getDoc(projectDocRef());
+  const data: any = snapshot.data() || {};
+  return normalizeTaskFieldDefs(data.settings?.taskFields);
+}
+
+/** Replaces the project's custom task field definitions. */
+export async function setTaskFieldDefs(fieldDefs: TaskFieldDef[]) {
+  const normalized = normalizeTaskFieldDefs(fieldDefs);
+  await updateDoc(
+    projectDocRef(),
+    new FieldPath('settings', 'taskFields'),
+    normalized
+  );
+  logAction('tasks.fieldDefs.update', {
+    metadata: {count: normalized.length},
+  });
+}
+
+function normalizeTaskFieldDefs(value: unknown): TaskFieldDef[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const fieldDefs: TaskFieldDef[] = [];
+  for (const item of value) {
+    const id = String(item?.id || '').trim();
+    const type = String(item?.type || '') as TaskFieldType;
+    if (!id || seen.has(id) || !TASK_FIELD_TYPES.includes(type)) {
+      continue;
+    }
+    seen.add(id);
+    const fieldDef: TaskFieldDef = {
+      id,
+      label: String(item?.label || id),
+      type,
+      showInList: Boolean(item?.showInList),
+    };
+    if (type === 'select' || type === 'multiselect') {
+      fieldDef.options = normalizeTaskFieldOptions(item?.options);
+    }
+    fieldDefs.push(fieldDef);
+  }
+  return fieldDefs;
+}
+
+function normalizeTaskFieldOptions(value: unknown): TaskFieldOption[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const options: TaskFieldOption[] = [];
+  for (const item of value) {
+    const optionValue = String(item?.value ?? '').trim();
+    if (!optionValue || seen.has(optionValue)) {
+      continue;
+    }
+    seen.add(optionValue);
+    const option: TaskFieldOption = {
+      value: optionValue,
+      label: String(item?.label || optionValue),
+    };
+    if (item?.color) {
+      option.color = String(item.color);
+    }
+    options.push(option);
+  }
+  return options;
+}
+
+const TASK_FIELD_TYPES: TaskFieldType[] = [
+  'text',
+  'number',
+  'date',
+  'select',
+  'multiselect',
+  'checkbox',
+];
+
 export async function createTask(options: {
   title: string;
   description?: string;
+  descriptionBody?: RichTextData | null;
   assignee?: string | null;
+  followers?: string[];
   priority?: TaskPriority;
+  status?: string;
+  tags?: string[];
+  fields?: Record<string, TaskFieldValue | Date>;
+  parentId?: string | null;
+  blockedBy?: string[];
+  startDate?: Date | Timestamp | null;
+  dueDate?: Date | Timestamp | null;
+  /** @deprecated Use `dueDate`. Kept in sync for existing callers. */
   targetLaunchDate?: Date | Timestamp | null;
+  source?: TaskSource | null;
+  imported?: TaskImportOptions;
 }) {
   if (!options.title) {
     throw new Error('missing task title');
@@ -170,10 +386,19 @@ export async function createTask(options: {
   const db = window.firebase.db;
   const assignee = options.assignee ?? (await getDefaultTaskAssignee());
   const priority = options.priority || 'normal';
-  const status = 'new';
-  const targetLaunchDate = normalizeTaskTargetLaunchDate(
-    options.targetLaunchDate
+  const status = options.status || 'new';
+  const dueDate = normalizeTaskDate(
+    options.dueDate ?? options.targetLaunchDate
   );
+  // `targetLaunchDate` predates `dueDate`; keep both in sync so existing
+  // list columns and queries keep working.
+  const targetLaunchDate = dueDate;
+  const startDate = normalizeTaskDate(options.startDate);
+  const imported = options.imported;
+  const createdAt = imported?.createdAt
+    ? normalizeTaskDate(imported.createdAt)
+    : null;
+  const source = normalizeTaskSource(options.source ?? imported?.source);
   const taskId = await runTransaction(db, async (transaction) => {
     const counterRef = taskCounterDocRef();
     const counterSnapshot = await transaction.get(counterRef);
@@ -198,12 +423,25 @@ export async function createTask(options: {
           id: String(nextTaskId),
           title: options.title,
           description: options.description || '',
+          descriptionBody: options.descriptionBody || null,
           assignee: assignee ?? null,
+          followers: normalizeTaskEmails(options.followers),
           priority,
           status,
+          tags: normalizeTaskTags(options.tags),
+          fields: normalizeTaskFieldValues(options.fields),
+          parentId: options.parentId || null,
+          blockedBy: normalizeTaskIds(options.blockedBy),
+          startDate,
+          dueDate,
           targetLaunchDate,
-          createdAt: serverTimestamp(),
+          source,
+          // An imported task keeps its original creation time, but
+          // `createdBy` still records the account that ran the import so
+          // the audit trail stays truthful.
+          createdAt: createdAt ?? serverTimestamp(),
           createdBy: window.firebase.user.email || '',
+          importedAuthor: imported?.author || null,
           updatedAt: serverTimestamp(),
           updatedBy: window.firebase.user.email || '',
         });
@@ -219,11 +457,278 @@ export async function createTask(options: {
   return taskId;
 }
 
-function normalizeTaskTargetLaunchDate(value?: Date | Timestamp | null) {
+function normalizeTaskDate(value?: Date | Timestamp | null) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : Timestamp.fromDate(value);
+  }
+  return value ?? null;
+}
+
+/** Dedupes and lower-cases a list of emails, dropping blanks. */
+function normalizeTaskEmails(value?: string[] | null): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const emails = value
+    .map((email) =>
+      String(email || '')
+        .trim()
+        .toLowerCase()
+    )
+    .filter(Boolean);
+  return Array.from(new Set(emails));
+}
+
+/** Dedupes and trims tags, preserving the caller's order. */
+function normalizeTaskTags(value?: string[] | null): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const tags = value.map((tag) => String(tag || '').trim()).filter(Boolean);
+  return Array.from(new Set(tags));
+}
+
+/** Dedupes task ids, dropping blanks. */
+function normalizeTaskIds(value?: string[] | null): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const ids = value.map((id) => String(id || '').trim()).filter(Boolean);
+  return Array.from(new Set(ids));
+}
+
+function normalizeTaskSource(value?: TaskSource | null): TaskSource | null {
+  const provider = String(value?.provider || '').trim();
+  if (!provider) {
+    return null;
+  }
+  const source: TaskSource = {provider};
+  if (value?.url) {
+    source.url = String(value.url);
+  }
+  if (value?.id) {
+    source.id = String(value.id);
+  }
+  return source;
+}
+
+/**
+ * Drops `undefined` values, which Firestore rejects, and normalizes each
+ * value to a type the field renderers understand.
+ */
+function normalizeTaskFieldValues(
+  value?: Record<string, TaskFieldValue | Date> | null
+): Record<string, TaskFieldValue> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  const fields: Record<string, TaskFieldValue> = {};
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (fieldValue === undefined) {
+      continue;
+    }
+    fields[key] = normalizeTaskFieldValue(fieldValue);
+  }
+  return fields;
+}
+
+function normalizeTaskFieldValue(value: TaskFieldValue | Date): TaskFieldValue {
   if (value instanceof Date) {
     return Timestamp.fromDate(value);
   }
-  return value ?? null;
+  if (Array.isArray(value)) {
+    return normalizeTaskTags(value);
+  }
+  if (value === undefined) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Returns the task's due date, falling back to the legacy
+ * `targetLaunchDate` for tasks written before `dueDate` existed.
+ */
+export function getTaskDueDate(task: Task): Timestamp | null {
+  return task.dueDate ?? task.targetLaunchDate ?? null;
+}
+
+/** True when an open task's due date is in the past. */
+export function isTaskOverdue(task: Task, now: number = Date.now()): boolean {
+  if (!isOpenTaskStatus(task.status)) {
+    return false;
+  }
+  const dueDate = getTaskDueDate(task);
+  return Boolean(dueDate?.toMillis && dueDate.toMillis() < now);
+}
+
+/** Returns the direct subtasks of `parentId`, oldest first. */
+export function getSubtasks(tasks: Task[], parentId: string): Task[] {
+  return tasks
+    .filter((task) => task.parentId === parentId)
+    .sort(
+      (a, b) => timestampMillis(a.createdAt) - timestampMillis(b.createdAt)
+    );
+}
+
+/** Counts completed vs. total subtasks, for the parent's list rollup. */
+export function getSubtaskProgress(tasks: Task[], parentId: string) {
+  const subtasks = getSubtasks(tasks, parentId);
+  const completed = subtasks.filter(
+    (task) => !isOpenTaskStatus(task.status)
+  ).length;
+  return {completed, total: subtasks.length};
+}
+
+/**
+ * Returns the still-open tasks blocking `task`. Resolved blockers are
+ * ignored so a task stops reading as blocked once its blockers close.
+ */
+export function getBlockingTasks(task: Task, tasks: Task[]): Task[] {
+  const blockedBy = task.blockedBy || [];
+  if (blockedBy.length === 0) {
+    return [];
+  }
+  const tasksById = new Map(tasks.map((item) => [item.id, item]));
+  return blockedBy
+    .map((id) => tasksById.get(id))
+    .filter((blocker): blocker is Task => {
+      return Boolean(blocker && isOpenTaskStatus(blocker.status));
+    });
+}
+
+export function isTaskBlocked(task: Task, tasks: Task[]): boolean {
+  return getBlockingTasks(task, tasks).length > 0;
+}
+
+/**
+ * Client-side search across id, title, description, tags, assignee, and
+ * custom field values. Every whitespace-separated term must match, so
+ * typing more words narrows the result set.
+ */
+export function searchTasks(tasks: Task[], query: string): Task[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) {
+    return tasks;
+  }
+  return tasks.filter((task) => {
+    const haystack = getTaskSearchText(task);
+    return terms.every((term) => haystack.includes(term));
+  });
+}
+
+function getTaskSearchText(task: Task): string {
+  const parts: string[] = [
+    `#${task.id}`,
+    task.title || '',
+    task.description || '',
+    task.assignee || '',
+    task.status || '',
+    task.priority || '',
+    ...(task.tags || []),
+    ...(task.followers || []),
+  ];
+  for (const value of Object.values(task.fields || {})) {
+    if (Array.isArray(value)) {
+      parts.push(value.join(' '));
+    } else if (value !== null && !(value instanceof Timestamp)) {
+      parts.push(String(value));
+    }
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+export type TaskSortKey =
+  | 'created'
+  | 'updated'
+  | 'title'
+  | 'status'
+  | 'priority'
+  | 'assignee'
+  | 'dueDate';
+
+export type TaskSortDirection = 'asc' | 'desc';
+
+const TASK_PRIORITY_RANK: Record<string, number> = {
+  high: 0,
+  medium: 1,
+  normal: 2,
+};
+
+const TASK_STATUS_RANK: Record<string, number> = {
+  new: 0,
+  'in-progress': 1,
+  'in-review': 2,
+  closed: 3,
+};
+
+/**
+ * Sorts a copy of `tasks`. Tasks with no value for the sort key always
+ * sort last regardless of direction, so "no due date" never displaces
+ * dated work at the top of the list.
+ */
+export function sortTasks(
+  tasks: Task[],
+  key: TaskSortKey,
+  direction: TaskSortDirection = 'desc'
+): Task[] {
+  const sign = direction === 'asc' ? 1 : -1;
+  return [...tasks].sort((a, b) => {
+    const aMissing = isTaskSortValueMissing(a, key);
+    const bMissing = isTaskSortValueMissing(b, key);
+    if (aMissing !== bMissing) {
+      return aMissing ? 1 : -1;
+    }
+    return sign * compareTaskSortValues(a, b, key);
+  });
+}
+
+function isTaskSortValueMissing(task: Task, key: TaskSortKey): boolean {
+  switch (key) {
+    case 'dueDate':
+      return !getTaskDueDate(task);
+    case 'assignee':
+      return !task.assignee;
+    case 'updated':
+      return !task.updatedAt;
+    default:
+      return false;
+  }
+}
+
+function compareTaskSortValues(a: Task, b: Task, key: TaskSortKey): number {
+  switch (key) {
+    case 'title':
+      return (a.title || '').localeCompare(b.title || '');
+    case 'assignee':
+      return (a.assignee || '').localeCompare(b.assignee || '');
+    case 'status':
+      return getTaskStatusRank(a) - getTaskStatusRank(b);
+    case 'priority':
+      return getTaskPriorityRank(a) - getTaskPriorityRank(b);
+    case 'dueDate':
+      return (
+        timestampMillis(getTaskDueDate(a)) - timestampMillis(getTaskDueDate(b))
+      );
+    case 'updated':
+      return timestampMillis(a.updatedAt) - timestampMillis(b.updatedAt);
+    case 'created':
+    default:
+      return timestampMillis(a.createdAt) - timestampMillis(b.createdAt);
+  }
+}
+
+function getTaskPriorityRank(task: Task): number {
+  return TASK_PRIORITY_RANK[task.priority || 'normal'] ?? 2;
+}
+
+function getTaskStatusRank(task: Task): number {
+  const status = normalizeTaskStatus(task.status);
+  return TASK_STATUS_RANK[status] ?? TASK_STATUS_RANK.closed;
+}
+
+function timestampMillis(ts?: Timestamp | null): number {
+  return ts?.toMillis?.() || 0;
 }
 
 export function isOpenTaskStatus(status?: string) {
@@ -426,36 +931,175 @@ export async function updateTaskPriority(
   }
 }
 
+/**
+ * Sets the task's due date. `targetLaunchDate` is mirrored in the same
+ * transaction so callers still reading the legacy field stay correct.
+ */
+export async function updateTaskDueDate(
+  taskId: string,
+  dueDate?: Date | Timestamp | null
+) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedDueDate = normalizeTaskDate(dueDate);
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'dueDate',
+    normalizedDueDate,
+    {targetLaunchDate: normalizedDueDate}
+  );
+  if (didUpdate) {
+    logAction('tasks.updateDueDate', {metadata: {taskId}});
+  }
+}
+
+/** @deprecated Use {@link updateTaskDueDate}. */
 export async function updateTaskTargetLaunchDate(
   taskId: string,
   targetLaunchDate?: Date | Timestamp | null
 ) {
-  if (!taskId) {
-    throw new Error('missing task id');
-  }
-  const normalizedTargetLaunchDate =
-    normalizeTaskTargetLaunchDate(targetLaunchDate);
-  const didUpdate = await updateTaskMetadataField(
-    taskId,
-    'targetLaunchDate',
-    normalizedTargetLaunchDate
-  );
-  if (didUpdate) {
-    logAction('tasks.updateTargetLaunchDate', {
-      metadata: {taskId},
-    });
-  }
+  await updateTaskDueDate(taskId, targetLaunchDate);
 }
 
-export async function updateTaskDescription(
+export async function updateTaskStartDate(
   taskId: string,
-  description: string
+  startDate?: Date | Timestamp | null
 ) {
   if (!taskId) {
     throw new Error('missing task id');
   }
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'startDate',
+    normalizeTaskDate(startDate)
+  );
+  if (didUpdate) {
+    logAction('tasks.updateStartDate', {metadata: {taskId}});
+  }
+}
+
+export async function updateTaskTags(taskId: string, tags: string[]) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedTags = normalizeTaskTags(tags);
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'tags',
+    normalizedTags
+  );
+  if (didUpdate) {
+    logAction('tasks.updateTags', {metadata: {taskId, tags: normalizedTags}});
+  }
+}
+
+export async function updateTaskFollowers(taskId: string, followers: string[]) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedFollowers = normalizeTaskEmails(followers);
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'followers',
+    normalizedFollowers
+  );
+  if (didUpdate) {
+    logAction('tasks.updateFollowers', {
+      metadata: {taskId, followers: normalizedFollowers},
+    });
+  }
+}
+
+/**
+ * Sets the tasks that block this one. Self-references are dropped; cycles
+ * are rejected so the "blocked" rollup in the list can't loop forever.
+ */
+export async function updateTaskBlockedBy(taskId: string, blockedBy: string[]) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedBlockedBy = normalizeTaskIds(blockedBy).filter(
+    (id) => id !== taskId
+  );
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'blockedBy',
+    normalizedBlockedBy
+  );
+  if (didUpdate) {
+    logAction('tasks.updateBlockedBy', {
+      metadata: {taskId, blockedBy: normalizedBlockedBy},
+    });
+  }
+}
+
+/** Makes `taskId` a subtask of `parentId`, or a top-level task when null. */
+export async function updateTaskParent(
+  taskId: string,
+  parentId: string | null
+) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedParentId = parentId?.trim() || null;
+  if (normalizedParentId === taskId) {
+    throw new Error('a task cannot be its own parent');
+  }
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    'parentId',
+    normalizedParentId
+  );
+  if (didUpdate) {
+    logAction('tasks.updateParent', {
+      metadata: {taskId, parentId: normalizedParentId},
+    });
+  }
+}
+
+/** Sets one custom field value, tracked in the timeline as `field:<id>`. */
+export async function updateTaskFieldValue(
+  taskId: string,
+  fieldId: string,
+  value: TaskFieldValue | Date
+) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  if (!fieldId) {
+    throw new Error('missing field id');
+  }
+  const didUpdate = await updateTaskMetadataField(
+    taskId,
+    taskCustomFieldKey(fieldId),
+    normalizeTaskFieldValue(value)
+  );
+  if (didUpdate) {
+    logAction('tasks.updateFieldValue', {metadata: {taskId, fieldId}});
+  }
+}
+
+/**
+ * Updates the task description. Accepts either plain text or rich text; a
+ * plain-text projection is always written to `description` so list search
+ * and previews keep working regardless of which form was used.
+ */
+export async function updateTaskDescription(
+  taskId: string,
+  description: string | RichTextData
+) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const body = typeof description === 'string' ? null : description;
+  const text =
+    typeof description === 'string'
+      ? description
+      : getRichTextPlainText(description);
   await updateDoc(taskDocRef(taskId), {
-    description,
+    description: text,
+    descriptionBody: body,
     updatedAt: serverTimestamp(),
     updatedBy: window.firebase.user.email || '',
   });
@@ -557,10 +1201,17 @@ export async function removeTaskAttachment(
   }
 }
 
+/**
+ * Writes one tracked field and records a timeline event describing the
+ * change. `extraUpdates` lets a caller keep a derived field in sync (e.g.
+ * the legacy `targetLaunchDate` mirror) inside the same transaction.
+ * Returns false when the value is unchanged, so no event is written.
+ */
 async function updateTaskMetadataField(
   taskId: string,
   field: TaskMetadataField,
-  value: string | Timestamp | null
+  value: TaskEventValue | Date,
+  extraUpdates?: Record<string, unknown>
 ) {
   const db = window.firebase.db;
   const taskRef = taskDocRef(taskId);
@@ -574,14 +1225,22 @@ async function updateTaskMetadataField(
     }
 
     const data = snapshot.data() as Task;
-    const oldValue = normalizeTaskMetadataValue(data[field]);
+    const oldValue = normalizeTaskMetadataValue(
+      readTaskMetadataField(data, field)
+    );
     const newValue = normalizeTaskMetadataValue(value);
     if (taskMetadataValuesEqual(oldValue, newValue)) {
       return false;
     }
 
+    const customFieldId = parseTaskCustomFieldKey(field);
+    const fieldUpdate = customFieldId
+      ? {[`fields.${customFieldId}`]: newValue}
+      : {[field]: newValue};
+
     transaction.update(taskRef, {
-      [field]: newValue,
+      ...fieldUpdate,
+      ...(extraUpdates || {}),
       updatedAt: serverTimestamp(),
       updatedBy: userEmail,
     });
@@ -599,19 +1258,42 @@ async function updateTaskMetadataField(
   });
 }
 
-function normalizeTaskMetadataValue(value: unknown): string | Timestamp | null {
-  if (value instanceof Timestamp || typeof value === 'string') {
+/** Reads either a top-level task field or a `field:<id>` custom field. */
+function readTaskMetadataField(data: Task, field: TaskMetadataField): unknown {
+  const customFieldId = parseTaskCustomFieldKey(field);
+  if (customFieldId) {
+    return data.fields?.[customFieldId];
+  }
+  return (data as Record<string, unknown>)[field];
+}
+
+function normalizeTaskMetadataValue(value: unknown): TaskEventValue {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : Timestamp.fromDate(value);
+  }
+  if (
+    value instanceof Timestamp ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
     return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
   }
   return null;
 }
 
-function taskMetadataValuesEqual(
-  a: string | Timestamp | null,
-  b: string | Timestamp | null
-) {
+function taskMetadataValuesEqual(a: TaskEventValue, b: TaskEventValue) {
   if (a instanceof Timestamp && b instanceof Timestamp) {
     return a.toMillis() === b.toMillis();
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => item === b[i]);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return false;
   }
   return a === b;
 }
@@ -629,7 +1311,11 @@ export async function addTaskComment(
   taskId: string,
   content: string | RichTextData,
   parentId?: string | null,
-  options?: {mentions?: string[]}
+  options?: {
+    mentions?: string[];
+    attachments?: TaskAttachment[];
+    imported?: TaskImportOptions;
+  }
 ) {
   if (!taskId) {
     throw new Error('missing task id');
@@ -640,13 +1326,18 @@ export async function addTaskComment(
   const body = normalizeTaskCommentBody(content);
   const contentText =
     typeof content === 'string' ? content : getRichTextPlainText(content);
-  if (!contentText.trim() && !body) {
+  const attachments = normalizeTaskAttachments(options?.attachments);
+  if (!contentText.trim() && !body && attachments.length === 0) {
     throw new Error('missing comment content');
   }
 
   const commentRef = doc(taskCommentsCollectionRef(taskId));
   const commentId = commentRef.id;
   const mentions = (options?.mentions || []).map((m) => m.toLowerCase());
+  const imported = options?.imported;
+  const importedCreatedAt = imported?.createdAt
+    ? normalizeTaskDate(imported.createdAt)
+    : null;
 
   await setDoc(commentRef, {
     id: commentId,
@@ -654,9 +1345,14 @@ export async function addTaskComment(
     parentId: parentId || null,
     content: contentText,
     body,
+    attachments,
     mentions,
-    createdAt: serverTimestamp(),
+    // Imported comments keep the original post time and show the original
+    // author's name, but `createdBy` still records the importing account.
+    createdAt: importedCreatedAt ?? serverTimestamp(),
     createdBy: window.firebase.user.email || '',
+    importedAuthor: imported?.author || null,
+    source: normalizeTaskSource(imported?.source),
     history: [],
   });
 
@@ -665,6 +1361,90 @@ export async function addTaskComment(
   });
 
   return commentId;
+}
+
+/** Attaches an uploaded file to a comment. */
+export async function addTaskCommentAttachment(
+  taskId: string,
+  commentId: string,
+  file: UploadedFile & {contentType?: string; size?: number}
+) {
+  if (!taskId || !commentId) {
+    throw new Error('missing task or comment id');
+  }
+  if (!file?.src) {
+    throw new Error('missing attachment file');
+  }
+
+  const db = window.firebase.db;
+  const commentRef = taskCommentDocRef(taskId, commentId);
+  const userEmail = window.firebase.user.email || '';
+  const attachment: TaskAttachment = {
+    ...file,
+    id: doc(taskCommentsCollectionRef(taskId)).id,
+    attachedAt: Timestamp.now(),
+    attachedBy: userEmail,
+  };
+
+  await runTransaction(db, async (transaction) => {
+    const snapshot = await transaction.get(commentRef);
+    if (!snapshot.exists()) {
+      throw new Error('comment not found');
+    }
+    const data = snapshot.data() as TaskComment;
+    transaction.update(commentRef, {
+      attachments: [...normalizeTaskAttachments(data.attachments), attachment],
+    });
+  });
+
+  logAction('tasks.comment.attachment.add', {
+    metadata: {
+      taskId,
+      commentId,
+      attachmentId: attachment.id,
+      filename: attachment.filename || attachment.src,
+    },
+  });
+
+  return attachment;
+}
+
+/** Removes an attachment from a comment. */
+export async function removeTaskCommentAttachment(
+  taskId: string,
+  commentId: string,
+  attachmentId: string
+) {
+  if (!taskId || !commentId || !attachmentId) {
+    throw new Error('missing task, comment, or attachment id');
+  }
+
+  const db = window.firebase.db;
+  const commentRef = taskCommentDocRef(taskId, commentId);
+
+  const didUpdate = await runTransaction(db, async (transaction) => {
+    const snapshot = await transaction.get(commentRef);
+    if (!snapshot.exists()) {
+      throw new Error('comment not found');
+    }
+    const data = snapshot.data() as TaskComment;
+    const attachments = normalizeTaskAttachments(data.attachments);
+    if (!attachments.some((attachment) => attachment.id === attachmentId)) {
+      return false;
+    }
+    transaction.update(commentRef, {
+      attachments: attachments.filter(
+        (attachment) => attachment.id !== attachmentId
+      ),
+    });
+    return true;
+  });
+
+  if (didUpdate) {
+    logAction('tasks.comment.attachment.remove', {
+      metadata: {taskId, commentId, attachmentId},
+    });
+  }
 }
 
 export async function editTaskComment(


### PR DESCRIPTION
## Why

The CMS task manager at `/cms/tasks` is fine for "leave a note for a teammate", but a team that runs its content intake in a dedicated tracker (Asana, Jira, Linear) can't move that workflow into the CMS without losing structure. Today the only place to put a structured request — its request type, target surface, device scope, blocked state — is free text at the top of the description, where it can't be filtered, sorted, or reported on.

`packages/root-cms/docs/tasks-parity-design.md` has the full gap analysis, the data model, and the scope boundaries.

## What's added

**Structure**
- Project-defined **custom fields** (text, number, date, select, multi-select, checkbox), edited from a new "Fields" modal on the tasks page. Fields marked "Show in list" render as task-table columns with colored option badges.
- **Subtasks** — ordinary tasks with `parentId`, so they reuse the whole detail page. The parent shows a `3/5` rollup; subtasks are hidden from the top-level list by default (toggleable).
- **Followers**, **tags**, and **dependencies** (`blockedBy`), via a shared chip input.
- **Start date** and a **due date that carries a time**.
- **Rich-text descriptions** (the comment editor, reused) and **attachments on comments**.

**List usability**
- Search across id, title, description, tags, assignee, and custom field values — every term must match, so more words narrow.
- Sortable column headers. Tasks missing the sort value always sort last, in both directions, so "no due date" never displaces dated work at the top.
- One-click completion toggle in the table, list, and board.
- Blocked / overdue / subtask-progress badges.

**Imports**
- `createTask()` and `addTaskComment()` accept an optional `imported` block (`createdAt`, `author`, `source`). A migrated thread keeps its original post times and shows the original author's name with its provider ("Dana Ruiz · via Asana"). `createdBy` still records the authenticated account that ran the import, so the imported name is presentational only and the audit trail can't be falsified. A `source` link renders in the task header.

## Compatibility

Every addition is an optional field, so no migration is needed. `targetLaunchDate` is superseded by `dueDate` but written in the same transaction, and `getTaskDueDate()` falls back to it — existing tasks, columns, and callers keep working.

## Notes on cost

Subtask rollups and blocker resolution are computed client-side from the task-list snapshot the views already subscribe to, rather than issuing a read per related task. Custom field *definitions* live on the project doc, which the UI already loads, so a list column costs no extra read.

## Out of scope / deferred

Deliberately not included (they belong to a PM product, not a CMS): timeline/Gantt, portfolios, workload, rules/automation, intake forms, recurring tasks, cross-project multi-homing.

Deferred to a follow-up: board drag-and-drop, comment reactions, delivering `@mention` notifications (mentions are stored today but never delivered), and sections/grouping.

## Testing

- `ui/utils/tasks.test.ts` — 24 new unit tests covering due-date fallback, overdue rules, subtask rollups, blocker resolution (closed blockers stop counting), search semantics, and sort ordering including the missing-value rule.
- `tsc --noEmit` and `eslint` clean on all touched files; the UI esbuild bundle builds.