### PR TITLE
fix: sort JSON metadata keys immediately after their parent key

### DIFF
--- a/.changeset/quiet-moons-order.md
+++ b/.changeset/quiet-moons-order.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: sort JSON metadata keys immediately after their parent key

--- a/packages/root-cms/ui/utils/objects.test.ts
+++ b/packages/root-cms/ui/utils/objects.test.ts
@@ -89,9 +89,48 @@ describe('sortObjectKeysDeep', () => {
       z: 1,
     });
   });
+
+  it('sorts metadata keys immediately after their parent key', () => {
+    const data = {
+      '@title': {translate: false},
+      title: 'foo',
+      body: {
+        '@text': {translate: false},
+        text: 'bar',
+      },
+      '@image': {alt: 'baz'},
+    };
+
+    // A metadata key without a parent key sorts in its parent's position.
+    expect(Object.keys(sortObjectKeysDeep(data))).toEqual([
+      'body',
+      '@image',
+      'title',
+      '@title',
+    ]);
+    expect(Object.keys(sortObjectKeysDeep(data).body)).toEqual([
+      'text',
+      '@text',
+    ]);
+  });
 });
 
 describe('stableJsonStringify', () => {
+  it('serializes metadata keys immediately after their parent key', () => {
+    const data = {'@title': {translate: false}, title: 'foo'};
+
+    expect(stableJsonStringify(data)).toBe(
+      [
+        '{',
+        '  "title": "foo",',
+        '  "@title": {',
+        '    "translate": false',
+        '  }',
+        '}',
+      ].join('\n')
+    );
+  });
+
   it('returns the same string for different key insertion orders', () => {
     const before = {
       block: {

--- a/packages/root-cms/ui/utils/objects.ts
+++ b/packages/root-cms/ui/utils/objects.ts
@@ -191,7 +191,26 @@ export function cloneData<T>(data: T): T {
 }
 
 /**
- * Returns a deep-cloned value with object keys sorted alphabetically.
+ * Compares two object keys, sorting alphabetically but keeping metadata keys
+ * (e.g. `@title`) immediately after the key they describe (e.g. `title`).
+ */
+function compareObjectKeys(a: string, b: string): number {
+  const aIsMeta = a.startsWith('@');
+  const bIsMeta = b.startsWith('@');
+  const aBase = aIsMeta ? a.slice(1) : a;
+  const bBase = bIsMeta ? b.slice(1) : b;
+  if (aBase !== bBase) {
+    return aBase.localeCompare(bBase);
+  }
+  if (aIsMeta === bIsMeta) {
+    return 0;
+  }
+  return aIsMeta ? 1 : -1;
+}
+
+/**
+ * Returns a deep-cloned value with object keys sorted alphabetically. Metadata
+ * keys (e.g. `@title`) are sorted immediately after their parent key.
  */
 export function sortObjectKeysDeep<T>(data: T): T {
   if (Array.isArray(data)) {
@@ -200,8 +219,8 @@ export function sortObjectKeysDeep<T>(data: T): T {
 
   if (isObject(data)) {
     const sortedData: Record<string, unknown> = {};
-    const keys = Object.keys(data as Record<string, unknown>).sort((a, b) =>
-      a.localeCompare(b)
+    const keys = Object.keys(data as Record<string, unknown>).sort(
+      compareObjectKeys
     );
     for (const key of keys) {
       sortedData[key] = sortObjectKeysDeep(


### PR DESCRIPTION
## Summary

Updates the object key sorting logic to keep metadata keys (prefixed with `@`) immediately after their parent key, rather than sorting them purely alphabetically. This improves the readability and logical grouping of serialized JSON data.

## Changes

- **Added `compareObjectKeys()` function** in `objects.ts` that implements custom sorting logic:
  - Extracts the base name from metadata keys (e.g., `@title` → `title`)
  - Sorts by base name alphabetically
  - Places metadata keys immediately after their parent key
  
- **Updated `sortObjectKeysDeep()`** to use the new comparison function instead of simple alphabetic sorting

- **Added test coverage** for both `sortObjectKeysDeep()` and `stableJsonStringify()` to verify metadata keys are positioned correctly relative to their parent keys

## Implementation Details

The sorting algorithm compares keys by:
1. Extracting the base name (removing `@` prefix if present)
2. Comparing base names alphabetically
3. If base names match, placing the non-metadata key before its metadata counterpart

This ensures output like:
```json
{
  "title": "foo",
  "@title": { "translate": false }
}
```

Rather than:
```json
{
  "@title": { "translate": false },
  "title": "foo"
}
```

https://claude.ai/code/session_01H5XERaG2ZwHaspjqbNn29h