### PR TITLE
feat: warn and recursively delete non-empty asset folders

### DIFF
--- a/.changeset/olive-lions-repeat.md
+++ b/.changeset/olive-lions-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: warn and recursively delete non-empty asset folders

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.css
@@ -334,6 +334,14 @@
   font-size: 14px;
 }
 
+.AssetBrowser__deleteModal__checking {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-text-gray);
+}
+
 .AssetBrowser__deleteModal__warning {
   font-size: 13px;
   color: #c92a2a;

--- a/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
+++ b/packages/root-cms/ui/components/AssetBrowser/AssetBrowser.tsx
@@ -47,10 +47,12 @@ import {
   Asset,
   AssetFile,
   AssetFolder,
+  AssetFolderContents,
   AssetSort,
   AssetSortDir,
   AssetSortField,
   DEFAULT_ASSET_SORT,
+  countFolderContents,
   createAssetFile,
   createAssetFolder,
   createAssetFolderPaths,
@@ -1486,17 +1488,54 @@ function MoveAssetModal(props: {
  */
 const MAX_USAGE_LOOKUPS = 20;
 
+/**
+ * Max folders whose contents are counted before deleting. Each count is a
+ * query, so very large selections skip the check and fall back to a generic
+ * warning.
+ */
+const MAX_FOLDER_LOOKUPS = 20;
+
+/**
+ * Formats a recursive folder content count for the delete warning, e.g.
+ * `3 file(s) and 1 folder(s)`.
+ */
+function formatFolderContents(contents: AssetFolderContents): string {
+  const parts: string[] = [];
+  if (contents.files > 0) {
+    parts.push(`${contents.files} file(s)`);
+  }
+  if (contents.folders > 0) {
+    parts.push(`${contents.folders} folder(s)`);
+  }
+  return parts.join(' and ');
+}
+
+/**
+ * Confirmation modal for deleting assets. Selected folders are checked for
+ * contents first so that deleting a non-empty folder warns about the nested
+ * assets it removes instead of failing.
+ */
 function DeleteAssetModal(props: {
   assets: Asset[];
   onClose: () => void;
   onDeleted: () => void;
 }) {
   const assets = props.assets;
+  const files = assets.filter((asset) => asset.type === 'file');
+  const folders = assets.filter(
+    (asset) => asset.type === 'folder'
+  ) as AssetFolder[];
+  const assetIds = assets.map((asset) => asset.id).join(',');
+
   const [loading, setLoading] = useState(false);
   const [usageCount, setUsageCount] = useState<number | null>(null);
-
-  const files = assets.filter((asset) => asset.type === 'file');
-  const hasFolders = assets.some((asset) => asset.type === 'folder');
+  const [folderContents, setFolderContents] =
+    useState<AssetFolderContents | null>(null);
+  // Initialized to the value the effect below uses so the first render already
+  // shows the pending check instead of flashing the unknown-contents warning.
+  const [checkingFolders, setCheckingFolders] = useState(
+    folders.length > 0 && folders.length <= MAX_FOLDER_LOOKUPS
+  );
 
   useEffect(() => {
     if (files.length === 0 || files.length > MAX_USAGE_LOOKUPS) {
@@ -1508,7 +1547,32 @@ function DeleteAssetModal(props: {
         setUsageCount(docIds.size);
       })
       .catch(() => setUsageCount(null));
-  }, [assets.map((asset) => asset.id).join(',')]);
+  }, [assetIds]);
+
+  useEffect(() => {
+    if (folders.length === 0 || folders.length > MAX_FOLDER_LOOKUPS) {
+      return;
+    }
+    setCheckingFolders(true);
+    Promise.all(folders.map((folder) => countFolderContents(folder)))
+      .then((results) => {
+        setFolderContents({
+          files: results.reduce((total, res) => total + res.files, 0),
+          folders: results.reduce((total, res) => total + res.folders, 0),
+          total: results.reduce((total, res) => total + res.total, 0),
+        });
+      })
+      .catch((err) => {
+        console.error('failed to count folder contents:', err);
+        setFolderContents(null);
+      })
+      .finally(() => setCheckingFolders(false));
+  }, [assetIds]);
+
+  // Folders are only known to be empty once the check above succeeds; an
+  // unknown count still warns since the delete removes nested assets.
+  const deletesFolderContents =
+    folders.length > 0 && (!folderContents || folderContents.total > 0);
 
   async function onDelete() {
     setLoading(true);
@@ -1516,7 +1580,7 @@ function DeleteAssetModal(props: {
     let numDeleted = 0;
     for (const asset of assets) {
       try {
-        await deleteAsset(asset);
+        await deleteAsset(asset, {recursive: true});
         numDeleted += 1;
       } catch (err) {
         console.error(`failed to delete ${asset.name}:`, err);
@@ -1527,7 +1591,7 @@ function DeleteAssetModal(props: {
     if (failed.length > 0) {
       showNotification({
         title: 'Delete failed',
-        message: `Failed to delete: ${failed.join(', ')}. Note that folders must be empty before they can be deleted.`,
+        message: `Failed to delete: ${failed.join(', ')}.`,
         color: 'red',
         autoClose: false,
       });
@@ -1572,10 +1636,24 @@ function DeleteAssetModal(props: {
               currently use the assets keep their copy of the files.
             </>
           )}
-          {hasFolders && (
-            <> Folders must be empty before they can be deleted.</>
-          )}
         </div>
+        {checkingFolders && (
+          <div className="AssetBrowser__deleteModal__checking">
+            <Loader size="xs" />
+            <span>Checking folder contents...</span>
+          </div>
+        )}
+        {!checkingFolders && deletesFolderContents && (
+          <div className="AssetBrowser__deleteModal__warning">
+            {folders.length === 1 ? 'This folder is' : 'These folders are'} not
+            empty.{' '}
+            {folderContents
+              ? `Deleting also permanently removes the ${formatFolderContents(
+                  folderContents
+                )} nested inside.`
+              : 'Deleting also permanently removes everything nested inside.'}
+          </div>
+        )}
         {usageCount !== null && usageCount > 0 && (
           <div className="AssetBrowser__deleteModal__warning">
             {assets.length === 1 ? 'This asset is' : 'These assets are'}{' '}
@@ -1587,8 +1665,13 @@ function DeleteAssetModal(props: {
           <Button variant="default" onClick={props.onClose} disabled={loading}>
             Cancel
           </Button>
-          <Button color="red" loading={loading} onClick={() => onDelete()}>
-            Delete
+          <Button
+            color="red"
+            loading={loading}
+            disabled={checkingFolders}
+            onClick={() => onDelete()}
+          >
+            {deletesFolderContents ? 'Delete all' : 'Delete'}
           </Button>
         </div>
       </div>

--- a/packages/root-cms/ui/utils/assets.delete.test.ts
+++ b/packages/root-cms/ui/utils/assets.delete.test.ts
@@ -1,0 +1,280 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  Asset,
+  AssetFolder,
+  FolderNotEmptyError,
+  countFolderContents,
+  deleteAsset,
+} from './assets.js';
+
+const mocks = vi.hoisted(() => ({
+  collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  deleteField: vi.fn(),
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  limit: vi.fn(),
+  logAction: vi.fn(),
+  query: vi.fn(),
+  removeDocsFromCache: vi.fn(),
+  serverTimestamp: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  Timestamp: {now: () => ({type: 'timestamp'})},
+  collection: mocks.collection,
+  deleteDoc: mocks.deleteDoc,
+  deleteField: mocks.deleteField,
+  doc: mocks.doc,
+  getDoc: mocks.getDoc,
+  getDocs: mocks.getDocs,
+  limit: mocks.limit,
+  query: mocks.query,
+  serverTimestamp: mocks.serverTimestamp,
+  setDoc: mocks.setDoc,
+  updateDoc: mocks.updateDoc,
+  where: mocks.where,
+  writeBatch: mocks.writeBatch,
+}));
+
+vi.mock('./actions.js', () => ({
+  logAction: mocks.logAction,
+}));
+
+vi.mock('./doc-cache.js', () => ({
+  removeDocsFromCache: mocks.removeDocsFromCache,
+}));
+
+/** The asset docs the mocked firestore queries read from. */
+let assetDocs: Asset[] = [];
+/** Ids passed to `deleteDoc()`. */
+let deletedIds: string[] = [];
+/** Ids deleted per committed write batch. */
+let batchCommits: string[][] = [];
+
+function testFolder(parent: string, name: string): AssetFolder {
+  const path = parent ? `${parent}/${name}` : name;
+  return {
+    id: `folder-${path}`,
+    type: 'folder',
+    parent: parent,
+    name: name,
+  } as AssetFolder;
+}
+
+function testFile(parent: string, name: string): Asset {
+  return {
+    id: `file-${parent}-${name}`,
+    type: 'file',
+    parent: parent,
+    name: name,
+  } as Asset;
+}
+
+/** Applies a mocked `where()` constraint to an in-memory asset doc. */
+function testConstraint(asset: any, constraint: any): boolean {
+  const value = asset[constraint.field];
+  if (constraint.op === '==') {
+    return value === constraint.value;
+  }
+  if (constraint.op === '>=') {
+    return value >= constraint.value;
+  }
+  if (constraint.op === '<=') {
+    return value <= constraint.value;
+  }
+  return true;
+}
+
+/** Wires the firestore mocks up to the in-memory `assetDocs`. */
+function setupFirestoreMocks() {
+  vi.clearAllMocks();
+  assetDocs = [];
+  deletedIds = [];
+  batchCommits = [];
+  window.__ROOT_CTX = {rootConfig: {projectId: 'test-project'}} as any;
+  window.firebase = {
+    db: {type: 'mock-db'},
+    user: {email: 'editor@example.com'},
+  } as any;
+  mocks.collection.mockImplementation(
+    (_db: unknown, ...path: string[]) => `col:${path.join('/')}`
+  );
+  mocks.doc.mockImplementation((_colRef: unknown, id: string) => ({id: id}));
+  mocks.where.mockImplementation((field: string, op: string, value: any) => ({
+    field: field,
+    op: op,
+    value: value,
+  }));
+  mocks.query.mockImplementation((_colRef: unknown, ...constraints: any[]) => ({
+    constraints: constraints,
+  }));
+  mocks.getDocs.mockImplementation(async (q: any) => {
+    const matches = assetDocs.filter((asset) =>
+      (q.constraints || []).every((constraint: any) =>
+        testConstraint(asset, constraint)
+      )
+    );
+    return {
+      forEach: (cb: (snap: any) => void) =>
+        matches.forEach((asset) => cb({data: () => asset})),
+    };
+  });
+  mocks.deleteDoc.mockImplementation(async (ref: any) => {
+    deletedIds.push(ref.id);
+  });
+  mocks.writeBatch.mockImplementation(() => {
+    const ops: string[] = [];
+    return {
+      delete: (ref: any) => ops.push(ref.id),
+      set: () => {},
+      update: () => {},
+      commit: async () => {
+        batchCommits.push([...ops]);
+        deletedIds.push(...ops);
+        ops.length = 0;
+      },
+    };
+  });
+}
+
+describe('deleteAsset', () => {
+  beforeEach(() => {
+    setupFirestoreMocks();
+  });
+
+  it('deletes an empty folder', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [folder];
+
+    await deleteAsset(folder);
+
+    expect(deletedIds).toEqual(['folder-marketing']);
+  });
+
+  it('throws a FolderNotEmptyError for a non-empty folder', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [folder, testFile('marketing', 'hero.png')];
+
+    await expect(deleteAsset(folder)).rejects.toThrow(FolderNotEmptyError);
+    expect(deletedIds).toEqual([]);
+  });
+
+  it('recursively deletes a folder and its descendants', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [
+      folder,
+      testFile('marketing', 'hero.png'),
+      testFolder('marketing', 'q1'),
+      testFile('marketing/q1', 'banner.png'),
+      testFolder('marketing/q1', 'social'),
+      testFile('marketing/q1/social', 'og.png'),
+    ];
+
+    await deleteAsset(folder, {recursive: true});
+
+    expect(deletedIds.sort()).toEqual(
+      [
+        'file-marketing-hero.png',
+        'file-marketing/q1-banner.png',
+        'file-marketing/q1/social-og.png',
+        'folder-marketing',
+        'folder-marketing/q1',
+        'folder-marketing/q1/social',
+      ].sort()
+    );
+  });
+
+  it('leaves folders that merely share a name prefix alone', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [
+      folder,
+      testFile('marketing', 'hero.png'),
+      testFolder('', 'marketing-archive'),
+      testFile('marketing-archive', 'old.png'),
+    ];
+
+    await deleteAsset(folder, {recursive: true});
+
+    expect(deletedIds.sort()).toEqual(
+      ['file-marketing-hero.png', 'folder-marketing'].sort()
+    );
+  });
+
+  it('splits large recursive deletes across multiple write batches', async () => {
+    const folder = testFolder('', 'marketing');
+    const files = Array.from({length: 900}, (_unused, i) =>
+      testFile('marketing', `file-${i}.png`)
+    );
+    assetDocs = [folder, ...files];
+
+    await deleteAsset(folder, {recursive: true});
+
+    expect(batchCommits.map((ops) => ops.length)).toEqual([400, 400, 100]);
+    expect(deletedIds).toHaveLength(901);
+  });
+
+  it('records the number of deleted descendants in the action log', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [folder, testFile('marketing', 'hero.png')];
+
+    await deleteAsset(folder, {recursive: true});
+
+    expect(mocks.logAction).toHaveBeenCalledWith('asset.delete', {
+      metadata: {
+        assetId: 'folder-marketing',
+        name: 'marketing',
+        folder: 'marketing',
+        numDescendants: 1,
+      },
+    });
+  });
+
+  it('deletes a file without querying for descendants', async () => {
+    const file = testFile('marketing', 'hero.png');
+    assetDocs = [file];
+
+    await deleteAsset(file);
+
+    expect(mocks.getDocs).not.toHaveBeenCalled();
+    expect(deletedIds).toEqual(['file-marketing-hero.png']);
+  });
+});
+
+describe('countFolderContents', () => {
+  beforeEach(() => {
+    setupFirestoreMocks();
+  });
+
+  it('counts nested files and folders at any depth', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [
+      folder,
+      testFile('marketing', 'hero.png'),
+      testFolder('marketing', 'q1'),
+      testFile('marketing/q1', 'banner.png'),
+    ];
+
+    expect(await countFolderContents(folder)).toEqual({
+      files: 2,
+      folders: 1,
+      total: 3,
+    });
+  });
+
+  it('returns zeroes for an empty folder', async () => {
+    const folder = testFolder('', 'marketing');
+    assetDocs = [folder];
+
+    expect(await countFolderContents(folder)).toEqual({
+      files: 0,
+      folders: 0,
+      total: 0,
+    });
+  });
+});

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -172,6 +172,13 @@ export interface AssetSyncResult {
 
 export class AssetNameError extends Error {}
 
+/**
+ * Thrown when deleting a folder that still contains assets. Callers can
+ * re-run the delete with `recursive: true` to remove the folder's contents
+ * along with it (see {@link deleteAsset}).
+ */
+export class FolderNotEmptyError extends Error {}
+
 const MAX_NAME_LENGTH = 200;
 
 /** Folder and file names must not contain slashes or control chars. */
@@ -680,6 +687,32 @@ function isDescendantPath(path: string, parentPath: string) {
 }
 
 /**
+ * Fetches every asset nested below a folder, at any depth. Because folders
+ * are stored as `parent` path strings, all descendants are fetched with a
+ * single auto-indexed range query on the path prefix.
+ */
+async function listFolderDescendants(folderPath: string): Promise<Asset[]> {
+  const colRef = getAssetsDbCollection();
+  // The range query matches by string prefix, e.g. querying `foo` also
+  // matches `foobar`, so exact descendants are filtered below.
+  const q = query(
+    colRef,
+    where('parent', '>=', folderPath),
+    where('parent', '<=', `${folderPath}\uf8ff`)
+  );
+  const snapshot = await getDocs(q);
+  const descendants: Asset[] = [];
+  snapshot.forEach((snap) => {
+    const data = snap.data() as Asset;
+    const descendant = {...data, parent: normalizeParentPath(data.parent)};
+    if (isDescendantPath(descendant.parent, folderPath)) {
+      descendants.push(descendant);
+    }
+  });
+  return descendants;
+}
+
+/**
  * Moves/renames a folder. Folder ids are derived from their path, so this
  * creates a new folder doc, re-parents all descendants and removes the old
  * folder doc. Writes are batched (max 500 ops per batch).
@@ -694,22 +727,7 @@ async function moveFolder(
   const colRef = getAssetsDbCollection();
   const db = window.firebase.db;
 
-  // Fetch all descendants. `parent` range query matches `oldPath` prefixes,
-  // e.g. querying `foo` also matches `foobar`, so filter exact matches below.
-  const q = query(
-    colRef,
-    where('parent', '>=', oldPath),
-    where('parent', '<=', `${oldPath}\uf8ff`)
-  );
-  const snapshot = await getDocs(q);
-  const descendants: Asset[] = [];
-  snapshot.forEach((snap) => {
-    const data = snap.data() as Asset;
-    const descendant = {...data, parent: normalizeParentPath(data.parent)};
-    if (isDescendantPath(descendant.parent, oldPath)) {
-      descendants.push(descendant);
-    }
-  });
+  const descendants = await listFolderDescendants(oldPath);
 
   let batch = writeBatch(db);
   let numOps = 0;
@@ -778,23 +796,78 @@ async function moveFolder(
   }
 }
 
+/** Number of assets nested below a folder, by type. */
+export interface AssetFolderContents {
+  files: number;
+  folders: number;
+  /** Total number of nested assets, i.e. `files` + `folders`. */
+  total: number;
+}
+
 /**
- * Deletes an asset from the asset library. Folders must be empty. The
- * underlying GCS file is left untouched since published docs may still
- * reference it.
+ * Counts the assets nested below a folder, at any depth. Used to warn users
+ * about what a recursive delete removes before they confirm it.
  */
-export async function deleteAsset(asset: Asset) {
+export async function countFolderContents(
+  folder: AssetFolder
+): Promise<AssetFolderContents> {
+  const folderPath = joinFolderPath(folder.parent, folder.name);
+  const descendants = await listFolderDescendants(folderPath);
+  const numFolders = descendants.filter(
+    (asset) => asset.type === 'folder'
+  ).length;
+  return {
+    files: descendants.length - numFolders,
+    folders: numFolders,
+    total: descendants.length,
+  };
+}
+
+/** Deletes asset docs in batches (max 500 ops per batch). */
+async function deleteAssetDocs(assets: Asset[]) {
+  const colRef = getAssetsDbCollection();
+  let batch = writeBatch(window.firebase.db);
+  let numOps = 0;
+  for (const asset of assets) {
+    batch.delete(doc(colRef, asset.id));
+    numOps += 1;
+    if (numOps >= 400) {
+      await batch.commit();
+      batch = writeBatch(window.firebase.db);
+      numOps = 0;
+    }
+  }
+  if (numOps > 0) {
+    await batch.commit();
+  }
+}
+
+/**
+ * Deletes an asset from the asset library. Deleting a folder that still has
+ * contents throws a {@link FolderNotEmptyError} unless `recursive` is set, in
+ * which case everything nested below the folder is deleted along with it. The
+ * underlying GCS files are left untouched since published docs may still
+ * reference them.
+ */
+export async function deleteAsset(
+  asset: Asset,
+  options?: {recursive?: boolean}
+) {
+  const metadata: Record<string, any> = {assetId: asset.id, name: asset.name};
   if (asset.type === 'folder') {
     const folderPath = joinFolderPath(asset.parent, asset.name);
-    const children = await listAssets(folderPath);
-    if (children.length > 0) {
-      throw new Error('Folder is not empty.');
+    const descendants = await listFolderDescendants(folderPath);
+    if (descendants.length > 0) {
+      if (!options?.recursive) {
+        throw new FolderNotEmptyError('Folder is not empty.');
+      }
+      await deleteAssetDocs(descendants);
+      metadata.folder = folderPath;
+      metadata.numDescendants = descendants.length;
     }
   }
   await deleteDoc(doc(getAssetsDbCollection(), asset.id));
-  logAction('asset.delete', {
-    metadata: {assetId: asset.id, name: asset.name},
-  });
+  logAction('asset.delete', {metadata: metadata});
 }
 
 /**


### PR DESCRIPTION
Deleting a folder in the asset library that still had contents failed with a `Folder is not empty.` error, leaving users to empty the folder by hand before it could be removed. The delete confirmation now surfaces this as a warning up front and lets the user proceed with a recursive delete.

## Changes

**`ui/utils/assets.ts`**

- `deleteAsset()` takes a new `options.recursive` flag. When set, every asset nested below the folder (at any depth) is deleted along with it, in batches of 400 writes. Without it, a non-empty folder still refuses to delete — now throwing a typed `FolderNotEmptyError` instead of a bare `Error`.
- New `countFolderContents()` returns the number of nested files and folders, so the UI can say exactly what a recursive delete removes.
- Extracted `listFolderDescendants()`, the descendants range-query previously inlined in `moveFolder()`, and reused it in both places.
- Recursive deletes record `folder` and `numDescendants` in the `asset.delete` action log.

**`ui/components/AssetBrowser/AssetBrowser.tsx`**

- `DeleteAssetModal` counts the contents of any selected folders when it opens (showing a small "Checking folder contents..." spinner, with the confirm button disabled until it resolves).
- Non-empty folders render a red warning — *"This folder is not empty. Deleting also permanently removes the 12 file(s) and 3 folder(s) nested inside."* — and the confirm button becomes **Delete all**. Empty folders warn about nothing and keep the plain **Delete** button.
- Selections above `MAX_FOLDER_LOOKUPS` (20 folders) skip the per-folder count to bound the query cost and fall back to a generic "everything nested inside" warning, as does a failed count.
- Dropped the now-inaccurate "Folders must be empty before they can be deleted." copy from the modal body and the delete-failure notification.

Underlying GCS files are still left untouched, since published docs may reference them.

## Testing

- New `ui/utils/assets.delete.test.ts` covers empty-folder deletes, the `FolderNotEmptyError`, recursive deletion across nesting levels, prefix-collision siblings (`marketing-archive` is not swept up by deleting `marketing`), write-batch splitting at 900 descendants, the action-log metadata, and `countFolderContents()`.
- `npx vitest run ui/` — 455 tests across 45 files pass.
- `eslint` and `prettier --check` pass on the changed files; `tsc --noEmit` reports only the pre-existing `Layout.tsx` import-assertion error.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZvSdTeFNKYC27yztDDky7)_