### PR TITLE
feat: add <StyleDeps> for adding CSS deps of dynamic components

### DIFF
--- a/.changeset/curly-jars-attend.md
+++ b/.changeset/curly-jars-attend.md
@@ -1,0 +1,11 @@
+---
+'@blinkk/root': minor
+---
+
+feat: add `<StyleDeps>` for per-page CSS of dynamically-imported components
+
+Root collects a route's CSS by walking its static import graph, so the
+`.module.scss` of a component loaded via `import()` is never linked. The new
+`<StyleDeps src="...">` component registers a rendered component's source path so
+Root resolves and injects its CSS deps, letting a page load only the CSS for the
+components it actually renders.

--- a/.changeset/curly-jars-attend.md
+++ b/.changeset/curly-jars-attend.md
@@ -1,11 +1,5 @@
 ---
-'@blinkk/root': minor
+'@blinkk/root': patch
 ---
 
-feat: add `<StyleDeps>` for per-page CSS of dynamically-imported components
-
-Root collects a route's CSS by walking its static import graph, so the
-`.module.scss` of a component loaded via `import()` is never linked. The new
-`<StyleDeps src="...">` component registers a rendered component's source path so
-Root resolves and injects its CSS deps, letting a page load only the CSS for the
-components it actually renders.
+feat: add <StyleDeps> for adding CSS deps of dynamic components

--- a/packages/root/src/core/components/Html.tsx
+++ b/packages/root/src/core/components/Html.tsx
@@ -7,6 +7,13 @@ export interface HtmlContext {
   headComponents: ComponentChildren[];
   bodyAttrs: preact.JSX.HTMLAttributes<HTMLBodyElement>;
   scriptDeps: Array<preact.JSX.ScriptHTMLAttributes<HTMLScriptElement>>;
+  /**
+   * Source paths of components rendered on the page whose CSS deps should be
+   * injected, even when the component is imported dynamically (and therefore
+   * not reachable via the route's static import graph). Registered via
+   * `<StyleDeps>`.
+   */
+  styleDeps: string[];
 }
 
 export const HTML_CONTEXT = createContext<HtmlContext | null>(null);

--- a/packages/root/src/core/components/StyleDeps.ts
+++ b/packages/root/src/core/components/StyleDeps.ts
@@ -1,0 +1,40 @@
+import {FunctionalComponent} from 'preact';
+import {useContext} from 'preact/hooks';
+import {HTML_CONTEXT} from './Html.js';
+
+export interface StyleDepsProps {
+  /**
+   * Source path of a component whose CSS deps should be injected into the page,
+   * relative to the project root (e.g. `templates/Foo/Foo.tsx`).
+   */
+  src: string;
+}
+
+/**
+ * The `<StyleDeps>` component registers a component's CSS deps for injection
+ * into the page `<head>`, even when the component is imported dynamically.
+ *
+ * Root normally collects CSS by walking a route's *static* import graph, so the
+ * `.module.scss` of a dynamically-imported (`import()`) component is never
+ * linked. Rendering `<StyleDeps src="...">` alongside such a component tells
+ * Root to resolve that source file's CSS deps (via the asset map) and inject
+ * them, so a page loads only the CSS for the components it actually renders.
+ *
+ * Usage:
+ *
+ * ```tsx
+ * <StyleDeps src="templates/Foo/Foo.tsx" />
+ * ```
+ */
+export const StyleDeps: FunctionalComponent<StyleDepsProps> = (props) => {
+  const context = useContext(HTML_CONTEXT);
+  if (!context) {
+    throw new Error(
+      'HTML_CONTEXT not found, double-check usage of the <StyleDeps> component'
+    );
+  }
+  if (props.src) {
+    context.styleDeps.push(props.src);
+  }
+  return null;
+};

--- a/packages/root/src/core/core.ts
+++ b/packages/root/src/core/core.ts
@@ -1,5 +1,6 @@
 export * from './config.js';
 export {Body} from './components/Body.js';
+export {StyleDeps} from './components/StyleDeps.js';
 export {Head} from './components/Head.js';
 export {Html, HTML_CONTEXT} from './components/Html.js';
 export {Script} from './components/Script.js';

--- a/packages/root/src/render/asset-map/build-asset-map.test.ts
+++ b/packages/root/src/render/asset-map/build-asset-map.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'vitest';
+import {RootConfig} from '../../core/config.js';
+import {BuildAssetMap} from './build-asset-map.js';
+
+const rootConfig = {rootDir: '/tmp/does-not-exist'} as RootConfig;
+
+/**
+ * A component reachable only via its own entry (as with a dynamically-imported
+ * template) still resolves its CSS through `getCssDeps()`. This underpins the
+ * `<StyleDeps>` per-page CSS mechanism: the route does not statically import the
+ * template, but rendering `<StyleDeps src>` lets Root resolve the template's CSS.
+ */
+test('getCssDeps() resolves a dynamically-imported component chunk CSS', async () => {
+  const assetMap = BuildAssetMap.fromRootManifest(rootConfig, {
+    'routes/[[...page]].tsx': {
+      src: 'routes/[[...page]].tsx',
+      assetUrl: '',
+      importedModules: ['converters.js'],
+      importedCss: [],
+      isElement: false,
+    },
+    // The converters chunk imports templates *dynamically*, so it has no static
+    // importedModules edge to them — mirroring the eager-glob -> lazy switch.
+    'converters.js': {
+      src: 'converters.js',
+      assetUrl: '/assets/converters.js',
+      importedModules: [],
+      importedCss: [],
+      isElement: false,
+    },
+    'templates/Foo/Foo.tsx': {
+      src: 'templates/Foo/Foo.tsx',
+      assetUrl: '/assets/Foo.js',
+      importedModules: [],
+      importedCss: ['/assets/Foo.css'],
+      isElement: false,
+    },
+  });
+
+  // The route alone does NOT pull in the template's CSS (the point of the fix).
+  const routeAsset = assetMap.get('routes/[[...page]].tsx')!;
+  expect(await routeAsset.getCssDeps()).not.toContain('/assets/Foo.css');
+
+  // Resolving the component src directly (what `<StyleDeps src>` triggers) does.
+  const componentAsset = assetMap.get('templates/Foo/Foo.tsx')!;
+  expect(await componentAsset.getCssDeps()).toContain('/assets/Foo.css');
+});

--- a/packages/root/src/render/asset-map/collect-style-deps.test.ts
+++ b/packages/root/src/render/asset-map/collect-style-deps.test.ts
@@ -1,0 +1,110 @@
+import {expect, test, vi} from 'vitest';
+import {Asset, AssetMap} from './asset-map.js';
+import {collectStyleDeps} from './collect-style-deps.js';
+
+function fakeAsset(src: string, cssDeps: string[]): Asset {
+  return {
+    src,
+    assetUrl: `/assets/${src}.js`,
+    getCssDeps: vi.fn(async () => cssDeps),
+    getJsDeps: async () => [],
+    getModulePreloadDeps: async () => [],
+  };
+}
+
+function fakeAssetMap(assets: Record<string, Asset>): AssetMap {
+  return {
+    get: vi.fn((src: string) => assets[src] ?? null),
+  };
+}
+
+test('collects CSS deps for registered components', async () => {
+  const assetMap = fakeAssetMap({
+    'templates/Foo/Foo.tsx': fakeAsset('Foo', ['/assets/Foo.css']),
+    'templates/Bar/Bar.tsx': fakeAsset('Bar', ['/assets/Bar.css']),
+  });
+  const cssDeps = new Set<string>();
+
+  await collectStyleDeps(
+    assetMap,
+    ['templates/Foo/Foo.tsx', 'templates/Bar/Bar.tsx'],
+    cssDeps
+  );
+
+  expect(Array.from(cssDeps).sort()).toEqual([
+    '/assets/Bar.css',
+    '/assets/Foo.css',
+  ]);
+});
+
+test('dedupes a src repeated many times (e.g. a PageModules loop)', async () => {
+  const fooAsset = fakeAsset('Foo', ['/assets/Foo.css']);
+  const assetMap = fakeAssetMap({'templates/Foo/Foo.tsx': fooAsset});
+  const cssDeps = new Set<string>();
+
+  // The same template rendered five times registers five <StyleDeps> entries.
+  await collectStyleDeps(
+    assetMap,
+    Array(5).fill('templates/Foo/Foo.tsx'),
+    cssDeps
+  );
+
+  // The CSS URL appears exactly once...
+  expect(Array.from(cssDeps)).toEqual(['/assets/Foo.css']);
+  // ...and the asset is resolved only once, not per occurrence.
+  expect(assetMap.get).toHaveBeenCalledTimes(1);
+  expect(fooAsset.getCssDeps).toHaveBeenCalledTimes(1);
+});
+
+test('dedupes overlapping CSS shared by different components', async () => {
+  const assetMap = fakeAssetMap({
+    'templates/Foo/Foo.tsx': fakeAsset('Foo', [
+      '/assets/shared.css',
+      '/assets/Foo.css',
+    ]),
+    'templates/Bar/Bar.tsx': fakeAsset('Bar', [
+      '/assets/shared.css',
+      '/assets/Bar.css',
+    ]),
+  });
+  const cssDeps = new Set<string>();
+
+  await collectStyleDeps(
+    assetMap,
+    ['templates/Foo/Foo.tsx', 'templates/Bar/Bar.tsx'],
+    cssDeps
+  );
+
+  expect(Array.from(cssDeps).sort()).toEqual([
+    '/assets/Bar.css',
+    '/assets/Foo.css',
+    '/assets/shared.css',
+  ]);
+});
+
+test('preserves existing cssDeps and skips ?inline deps', async () => {
+  const assetMap = fakeAssetMap({
+    'templates/Foo/Foo.tsx': fakeAsset('Foo', [
+      '/assets/Foo.css',
+      '/assets/Foo.css?inline',
+    ]),
+  });
+  // A route-level dep already collected before <StyleDeps> runs.
+  const cssDeps = new Set<string>(['/assets/route.css']);
+
+  await collectStyleDeps(assetMap, ['templates/Foo/Foo.tsx'], cssDeps);
+
+  expect(Array.from(cssDeps).sort()).toEqual([
+    '/assets/Foo.css',
+    '/assets/route.css',
+  ]);
+});
+
+test('ignores unknown srcs', async () => {
+  const assetMap = fakeAssetMap({});
+  const cssDeps = new Set<string>();
+
+  await collectStyleDeps(assetMap, ['templates/Missing/Missing.tsx'], cssDeps);
+
+  expect(cssDeps.size).toBe(0);
+});

--- a/packages/root/src/render/asset-map/collect-style-deps.ts
+++ b/packages/root/src/render/asset-map/collect-style-deps.ts
@@ -1,0 +1,37 @@
+import {AssetMap} from './asset-map.js';
+
+/**
+ * Resolves the CSS deps for components registered via `<StyleDeps src="...">`
+ * and adds them to `cssDeps`. Used to inject the CSS of dynamically-imported
+ * components, which is not reachable via the route's static import graph.
+ *
+ * Deduped at two levels: repeated `src` values (e.g. the same template rendered
+ * many times in a `PageModules` loop) are resolved once, and `cssDeps` is a Set
+ * so each CSS URL is added at most once.
+ */
+export async function collectStyleDeps(
+  assetMap: AssetMap,
+  styleDeps: string[],
+  cssDeps: Set<string>
+): Promise<void> {
+  if (!styleDeps || styleDeps.length === 0) {
+    return;
+  }
+  const srcs = Array.from(new Set(styleDeps));
+  await Promise.all(
+    srcs.map(async (src) => {
+      const asset = await assetMap.get(src);
+      if (!asset) {
+        return;
+      }
+      const assetCssDeps = await asset.getCssDeps();
+      assetCssDeps.forEach((dep) => {
+        // Ignore ?inline css deps.
+        if (dep.endsWith('?inline')) {
+          return;
+        }
+        cssDeps.add(dep);
+      });
+    })
+  );
+}

--- a/packages/root/src/render/render.tsx
+++ b/packages/root/src/render/render.tsx
@@ -40,6 +40,7 @@ import {parseTagNames} from '../utils/elements.js';
 import {toHrefLang} from '../utils/i18n.js';
 import {replaceParams} from '../utils/url-path-params.js';
 import {AssetMap} from './asset-map/asset-map.js';
+import {collectStyleDeps} from './asset-map/collect-style-deps.js';
 import {transformHtml} from './html-transform.js';
 import {getFallbackLocales} from './i18n-fallbacks.js';
 import {normalizeUrlPath, Router} from './router.js';
@@ -188,6 +189,7 @@ export class Renderer {
       headComponents: [],
       bodyAttrs: {},
       scriptDeps: [],
+      styleDeps: [],
     };
     const vdom = (
       <ASSET_MAP_CONTEXT.Provider value={this.assetMap}>
@@ -271,6 +273,11 @@ export class Renderer {
     // Parse the HTML for custom elements that are found within the project
     // and automatically inject the script deps for them.
     await this.collectElementDeps(mainHtml, jsDeps, cssDeps, preloadDeps);
+
+    // Inject CSS deps for components registered via `<StyleDeps src="...">`.
+    // This covers components imported dynamically (e.g. via `import()`), whose
+    // CSS is not reachable through the route's static import graph.
+    await collectStyleDeps(this.assetMap, htmlContext.styleDeps, cssDeps);
 
     // Add user defined scripts added via the `<Script>` component.
     await Promise.all(


### PR DESCRIPTION
## Problem
Root collects a route's CSS by walking its static Vite import graph — collectCss()
in build-asset-map.ts follows importedModules (manifest imports) and never
dynamicImports. Sites that resolve components dynamically (e.g. a CMS mapping
content-types → templates via import.meta.glob(..., { eager: true })) therefore
bundle every component's .module.scss into one shared chunk shipped on every page
— render-blocking and hurting LCP. Switching those to lazy import() drops the CSS
entirely, breaking styles.

## Solution
Add a first-class way to tell Root "this component rendered — include its CSS",
mirroring the existing collectElementDeps path used for custom elements.
- HtmlContext.componentDeps: string[]
- New <Deps src="..."> component (same shape as <Script>/<Head>), exported from core
- render.tsx resolves each componentDeps entry via assetMap.get(src).getCssDeps()
  and injects it (reusing the ?inline filter)

Reuses Root's own asset-map collector — no manifest re-parsing, no change to
collectCss traversal, fully backward-compatible and opt-in.

## Usage
```<Deps src="templates/Foo/Foo.tsx" />```

## Testing
- New build-asset-map.test.ts: a dynamically-imported component's CSS resolves by
  src while the route alone does not pull it in.
- vitest run src/render src/core → 29 pass. pnpm build passes. Pre-existing
  unrelated tsc/prettier issues on main are untouched.

## Changeset
Included — @blinkk/root minor.