### PR TITLE
fix: remove blank paragraphs when pasting into the rich text editor

### DIFF
--- a/.changeset/tame-jars-repeat.md
+++ b/.changeset/tame-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: remove blank paragraphs when pasting into the rich text editor

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/PasteCleanupPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/PasteCleanupPlugin.tsx
@@ -8,50 +8,13 @@ import {
   PASTE_COMMAND,
 } from 'lexical';
 import {useEffect} from 'preact/hooks';
-
-/**
- * Strips `text-decoration:underline` from elements inside `<a>` tags.
- * Google Docs formats links as:
- * `<a href="..." style="text-decoration:none;"><span style="...text-decoration:underline;...">text</span></a>`
- */
-function cleanLinkUnderlines(doc: Document): boolean {
-  let modified = false;
-  doc.querySelectorAll('a [style]').forEach((el) => {
-    if (!(el instanceof HTMLElement)) return;
-    const style = el.style;
-    if (
-      style.textDecoration?.includes('underline') ||
-      style.getPropertyValue('text-decoration')?.includes('underline')
-    ) {
-      style.removeProperty('text-decoration');
-      style.removeProperty('text-decoration-skip-ink');
-      style.removeProperty('-webkit-text-decoration-skip');
-      modified = true;
-    }
-  });
-  return modified;
-}
-
-/**
- * Strips `text-align` styles from all elements. The CMS rich text editor
- * doesn't currently support text alignment.
- */
-function cleanTextAlign(doc: Document): boolean {
-  let modified = false;
-  doc.querySelectorAll('[style]').forEach((el) => {
-    if (!(el instanceof HTMLElement)) return;
-    if (el.style.textAlign) {
-      el.style.removeProperty('text-align');
-      modified = true;
-    }
-  });
-  return modified;
-}
+import {cleanPastedHtml} from '../utils/paste-cleanup.js';
 
 /**
  * Plugin that cleans up pasted HTML to remove unsupported formatting.
  * - Removes `text-decoration:underline` from spans inside links (Google Docs).
  * - Removes `text-align` styles (not currently supported in the CMS).
+ * - Removes blank paragraphs and stray line breaks used for spacing.
  */
 export function PasteCleanupPlugin() {
   const [editor] = useLexicalComposerContext();
@@ -65,6 +28,12 @@ export function PasteCleanupPlugin() {
           return false;
         }
 
+        // Let lexical handle copy/paste between editors, which uses a
+        // lossless serialization of the copied nodes.
+        if (clipboardData.getData('application/x-lexical-editor')) {
+          return false;
+        }
+
         const html = clipboardData.getData('text/html');
         if (!html) {
           return false;
@@ -73,11 +42,7 @@ export function PasteCleanupPlugin() {
         const parser = new DOMParser();
         const dom = parser.parseFromString(html, 'text/html');
 
-        let modified = false;
-        modified = cleanLinkUnderlines(dom) || modified;
-        modified = cleanTextAlign(dom) || modified;
-
-        if (!modified) {
+        if (!cleanPastedHtml(dom)) {
           return false;
         }
 

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/paste-cleanup.test.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/paste-cleanup.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from 'vitest';
+import {cleanPastedHtml} from './paste-cleanup.js';
+
+function clean(html: string) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const modified = cleanPastedHtml(doc);
+  return {modified, html: doc.body.innerHTML};
+}
+
+describe('cleanPastedHtml', () => {
+  it('removes blank paragraphs between paragraphs', () => {
+    const res = clean(
+      '<p>one</p><p></p><p>two</p><p><span></span></p><p><span>&nbsp;</span></p><p>three</p>'
+    );
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe('<p>one</p><p>two</p><p>three</p>');
+  });
+
+  it('removes paragraphs containing only line breaks', () => {
+    const res = clean('<p>one</p><p><br></p><p>two</p>');
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe('<p>one</p><p>two</p>');
+  });
+
+  it('removes stray line breaks between block elements', () => {
+    // Google Docs wraps pasted content in a `<b>` tag and uses `<br>` to
+    // represent empty lines.
+    const res = clean(
+      '<b id="docs-internal-guid-1" style="font-weight:normal;">' +
+        '<p dir="ltr"><span>one</span></p><br><br>' +
+        '<p dir="ltr"><span>two</span></p>' +
+        '</b>'
+    );
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe(
+      '<b id="docs-internal-guid-1" style="font-weight:normal;">' +
+        '<p dir="ltr"><span>one</span></p>' +
+        '<p dir="ltr"><span>two</span></p>' +
+        '</b>'
+    );
+  });
+
+  it('preserves line breaks within a paragraph', () => {
+    const res = clean('<p>one<br>two</p>');
+    expect(res.modified).toBe(false);
+    expect(res.html).toBe('<p>one<br>two</p>');
+  });
+
+  it('removes blank wrappers and list items', () => {
+    const res = clean(
+      '<p>one</p><div><p><br></p></div><ul><li>a</li><li></li></ul>'
+    );
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe('<p>one</p><ul><li>a</li></ul>');
+  });
+
+  it('keeps blocks that render media', () => {
+    const res = clean('<p>one</p><p><img src="foo.png"></p><p></p>');
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe('<p>one</p><p><img src="foo.png"></p>');
+  });
+
+  it('keeps empty table cells', () => {
+    const res = clean(
+      '<table><tbody><tr><td>a</td><td></td></tr></tbody></table>'
+    );
+    expect(res.modified).toBe(false);
+    expect(res.html).toBe(
+      '<table><tbody><tr><td>a</td><td></td></tr></tbody></table>'
+    );
+  });
+
+  it('leaves blank-only pastes untouched', () => {
+    const res = clean('<p><br></p>');
+    expect(res.modified).toBe(false);
+    expect(res.html).toBe('<p><br></p>');
+  });
+
+  it('removes underlines from spans inside links', () => {
+    const res = clean(
+      '<a href="#" style="text-decoration:none;">' +
+        '<span style="color:#000;text-decoration:underline;">link</span></a>'
+    );
+    expect(res.modified).toBe(true);
+    expect(res.html).toContain('color: rgb(0, 0, 0);');
+    expect(res.html).not.toContain('underline');
+  });
+
+  it('removes text-align styles', () => {
+    const res = clean('<p style="text-align:center;">one</p>');
+    expect(res.modified).toBe(true);
+    expect(res.html).toBe('<p style="">one</p>');
+  });
+
+  it('is a no-op for clean html', () => {
+    const res = clean('<p>one</p><h2>two</h2><p>three</p>');
+    expect(res.modified).toBe(false);
+    expect(res.html).toBe('<p>one</p><h2>two</h2><p>three</p>');
+  });
+});

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/paste-cleanup.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/paste-cleanup.ts
@@ -1,0 +1,174 @@
+/**
+ * Block-level tags that may safely be dropped when they contain no visible
+ * content. Table cells are intentionally excluded since removing them would
+ * change the shape of the table.
+ */
+const BLOCK_TAGS = new Set([
+  'ADDRESS',
+  'BLOCKQUOTE',
+  'DIV',
+  'DL',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'LI',
+  'OL',
+  'P',
+  'PRE',
+  'SECTION',
+  'UL',
+]);
+
+/**
+ * Tags that render content on their own, i.e. an element containing any of
+ * these is never considered blank even when it has no text.
+ */
+const EMBED_TAGS = [
+  'audio',
+  'canvas',
+  'embed',
+  'hr',
+  'iframe',
+  'img',
+  'input',
+  'object',
+  'picture',
+  'svg',
+  'table',
+  'video',
+];
+
+/** Whitespace, non-breaking spaces and zero-width characters. */
+const BLANK_CHARS_RE = /[\s\u00a0\u200b-\u200d\u2060\ufeff]/g;
+
+/** Selector matching elements that render content of their own. */
+const EMBED_SELECTOR = EMBED_TAGS.join(',');
+
+/** Returns true if the element renders no visible text. */
+function isBlankText(el: Element): boolean {
+  return (el.textContent || '').replace(BLANK_CHARS_RE, '').length === 0;
+}
+
+/**
+ * Returns true if the element is a block-level element that renders nothing,
+ * e.g. `<p></p>`, `<p><br></p>` or Google Docs' `<p><span>&nbsp;</span></p>`.
+ */
+function isBlankBlock(el: Element): boolean {
+  if (!BLOCK_TAGS.has(el.tagName)) {
+    return false;
+  }
+  if (el.querySelector(EMBED_SELECTOR)) {
+    return false;
+  }
+  return isBlankText(el);
+}
+
+/**
+ * Returns true if the `<br>` sits between block-level elements instead of
+ * between inline text. Google Docs uses these to represent empty lines.
+ */
+function isStrayLineBreak(br: Element): boolean {
+  const parent = br.parentElement;
+  if (!parent) {
+    return false;
+  }
+  return Array.from(parent.children).some(
+    (child) => child !== br && BLOCK_TAGS.has(child.tagName)
+  );
+}
+
+/**
+ * Strips `text-decoration:underline` from elements inside `<a>` tags.
+ * Google Docs formats links as:
+ * `<a href="..." style="text-decoration:none;"><span style="...text-decoration:underline;...">text</span></a>`
+ */
+function cleanLinkUnderlines(doc: Document): boolean {
+  let modified = false;
+  doc.querySelectorAll('a [style]').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    const style = el.style;
+    if (
+      style.textDecoration?.includes('underline') ||
+      style.getPropertyValue('text-decoration')?.includes('underline')
+    ) {
+      style.removeProperty('text-decoration');
+      style.removeProperty('text-decoration-skip-ink');
+      style.removeProperty('-webkit-text-decoration-skip');
+      modified = true;
+    }
+  });
+  return modified;
+}
+
+/**
+ * Strips `text-align` styles from all elements. The CMS rich text editor
+ * doesn't currently support text alignment.
+ */
+function cleanTextAlign(doc: Document): boolean {
+  let modified = false;
+  doc.querySelectorAll('[style]').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    if (el.style.textAlign) {
+      el.style.removeProperty('text-align');
+      modified = true;
+    }
+  });
+  return modified;
+}
+
+/**
+ * Removes blank paragraphs and stray line breaks used purely for vertical
+ * spacing. Google Docs represents empty lines as `<br>` siblings of the
+ * paragraphs, or as paragraphs containing nothing but an empty `<span>`, which
+ * otherwise end up as a run of blank paragraphs in the editor.
+ *
+ * Pastes that contain nothing but blank content are left untouched so that
+ * e.g. pasting a newline still inserts a newline.
+ */
+function cleanBlankParagraphs(doc: Document): boolean {
+  const body = doc.body;
+  if (!body) {
+    return false;
+  }
+  // Leave blank-only pastes alone so that pasting a newline still inserts one.
+  if (isBlankText(body) && !body.querySelector(EMBED_SELECTOR)) {
+    return false;
+  }
+
+  let modified = false;
+
+  Array.from(doc.querySelectorAll('br')).forEach((br) => {
+    if (isStrayLineBreak(br)) {
+      br.remove();
+      modified = true;
+    }
+  });
+
+  // Iterate depth-first so that a wrapper whose children were all removed is
+  // itself removed (e.g. `<div><p><br></p></div>`).
+  const walk = (el: Element) => {
+    Array.from(el.children).forEach(walk);
+    if (isBlankBlock(el)) {
+      el.remove();
+      modified = true;
+    }
+  };
+  Array.from(body.children).forEach(walk);
+
+  return modified;
+}
+
+/**
+ * Cleans up pasted HTML in place to remove unsupported formatting and
+ * excessive whitespace. Returns true if the document was modified.
+ */
+export function cleanPastedHtml(doc: Document): boolean {
+  let modified = false;
+  modified = cleanLinkUnderlines(doc) || modified;
+  modified = cleanTextAlign(doc) || modified;
+  modified = cleanBlankParagraphs(doc) || modified;
+  return modified;
+}


### PR DESCRIPTION
Pasting from Google Docs into a rich text field often produced a run of blank paragraphs between each real paragraph.

Google Docs represents empty lines in two ways, and lexical turns both into blank paragraph nodes:

- bare `<br>` elements sitting as siblings of the `<p>` tags inside the `<b id="docs-internal-guid-…">` wrapper,
- paragraphs containing nothing but an empty or `&nbsp;`-only `<span>`.

`PasteCleanupPlugin` now strips both from the pasted HTML before it's converted to lexical nodes.

## Changes

- Added `cleanBlankParagraphs()`, which removes blank block-level elements (`p`, `h1`–`h6`, `li`, `ul`/`ol`, `div`, `blockquote`, …) and stray `<br>`s that sit between block elements. It walks depth-first so a wrapper left empty by the pass is removed too.
- Moved the existing DOM cleanup helpers (`cleanLinkUnderlines`, `cleanTextAlign`) out of the plugin into `lexical/utils/paste-cleanup.ts` behind a single `cleanPastedHtml(doc)` entry point, so the logic is unit testable without mounting an editor.
- The plugin now bails out when the clipboard carries `application/x-lexical-editor`, letting lexical handle copy/paste between editors with its lossless serialization instead of round-tripping through HTML.

Deliberately preserved:

- blank-only pastes (pasting a newline still inserts one),
- `<br>`s inside a paragraph (`<p>one<br>two</p>`),
- empty table cells, since removing them would change the shape of the table,
- blocks whose only content is media (`<p><img></p>`).

## Testing

- New `ui/components/RichTextEditor/lexical/utils/paste-cleanup.test.ts` — 11 cases covering the above, all passing.
- `vitest run ui shared` in `packages/root-cms`: 627 tests across 60 files pass.
- `pnpm lint` reports no problems in the changed files. (The repo currently has pre-existing lint errors in unrelated files.)
- Verified end to end against a realistic Google Docs clipboard payload: blank paragraphs, the stray `<br>`, the link underline and `text-align` are removed while paragraphs, the heading, the link and the list structure are preserved.

The full `pnpm test` run could not complete in this environment — the Firestore emulator jar download is blocked by the sandbox proxy — so the emulator-backed `core/` tests were not exercised. They are untouched by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y22AneNc9aVjpg5qAjXS9)_