### PR TITLE
fix: remember the asset picker folder per tab session

### DIFF
--- a/.changeset/wild-pans-shake.md
+++ b/.changeset/wild-pans-shake.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: remember the asset picker folder per tab session

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -437,19 +437,23 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
    * The selected asset's file data is copied into the doc along with an
    * `assetId` backlink so updates to the asset can be synced to the doc.
    *
-   * The picker opens in the folder of the currently-linked asset (when
-   * replacing a value backed by `assetId`) or the user's last visited folder.
+   * The picker opens in the last folder visited during this tab session. For
+   * new tab sessions it falls back to the folder of the currently-linked
+   * asset (when replacing a value backed by `assetId`), or the project root.
    */
   async function requestAssetPicker() {
     let initialFolder = getAssetPickerLastFolder();
-    if (value?.assetId) {
-      try {
-        const asset = await getAsset(value.assetId);
-        if (asset) {
-          initialFolder = asset.parent || '';
+    if (initialFolder === null) {
+      initialFolder = '';
+      if (value?.assetId) {
+        try {
+          const asset = await getAsset(value.assetId);
+          if (asset) {
+            initialFolder = asset.parent || '';
+          }
+        } catch (err) {
+          console.warn('failed to resolve linked asset folder:', err);
         }
-      } catch (err) {
-        console.warn('failed to resolve linked asset folder:', err);
       }
     }
     assetPickerModal.open({

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -48,8 +48,7 @@ import {useGapiClient} from '../../../hooks/useGapiClient.js';
 import {testAiEnabled, testAiImageEditingEnabled} from '../../../utils/ai.js';
 import {
   buildAssetFieldValue,
-  getAsset,
-  getAssetPickerLastFolder,
+  resolveAssetPickerFolder,
 } from '../../../utils/assets.js';
 import {joinClassNames} from '../../../utils/classes.js';
 import {
@@ -442,20 +441,7 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
    * asset (when replacing a value backed by `assetId`), or the project root.
    */
   async function requestAssetPicker() {
-    let initialFolder = getAssetPickerLastFolder();
-    if (initialFolder === null) {
-      initialFolder = '';
-      if (value?.assetId) {
-        try {
-          const asset = await getAsset(value.assetId);
-          if (asset) {
-            initialFolder = asset.parent || '';
-          }
-        } catch (err) {
-          console.warn('failed to resolve linked asset folder:', err);
-        }
-      }
-    }
+    const initialFolder = await resolveAssetPickerFolder(value?.assetId);
     assetPickerModal.open({
       accept: acceptedFileTypes,
       initialFolder,

--- a/packages/root-cms/ui/utils/assets.picker.test.ts
+++ b/packages/root-cms/ui/utils/assets.picker.test.ts
@@ -1,0 +1,129 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  Asset,
+  resolveAssetPickerFolder,
+  setAssetPickerLastFolder,
+} from './assets.js';
+
+const mocks = vi.hoisted(() => ({
+  collection: vi.fn(),
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  Timestamp: {now: () => ({type: 'timestamp'})},
+  collection: mocks.collection,
+  doc: mocks.doc,
+  getDoc: mocks.getDoc,
+  deleteDoc: vi.fn(),
+  deleteField: vi.fn(),
+  getDocs: vi.fn(),
+  limit: vi.fn(),
+  query: vi.fn(),
+  serverTimestamp: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+/** The asset docs the mocked `getDoc()` reads from, keyed by asset id. */
+let assetDocs: Record<string, Asset> = {};
+
+function testFile(id: string, parent: string, name: string): Asset {
+  return {id: id, type: 'file', parent: parent, name: name} as Asset;
+}
+
+/** Simulates opening a new browser tab (a fresh `sessionStorage`). */
+function newTabSession() {
+  sessionStorage.clear();
+}
+
+describe('resolveAssetPickerFolder', () => {
+  const originalCtx = window.__ROOT_CTX;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.__ROOT_CTX = {rootConfig: {projectId: 'test-project'}} as any;
+    window.firebase = {db: {type: 'mock-db'}} as any;
+    newTabSession();
+    assetDocs = {
+      'asset-a': testFile('asset-a', 'folderA', 'a.png'),
+      'asset-b': testFile('asset-b', 'folderB', 'b.png'),
+      'asset-root': testFile('asset-root', '', 'root.png'),
+    };
+    mocks.collection.mockImplementation(
+      (_db: unknown, ...path: string[]) => `col:${path.join('/')}`
+    );
+    mocks.doc.mockImplementation((_colRef: unknown, id: string) => ({id: id}));
+    mocks.getDoc.mockImplementation(async (ref: any) => {
+      const asset = assetDocs[ref.id];
+      return {
+        exists: () => Boolean(asset),
+        data: () => asset,
+      };
+    });
+  });
+
+  afterEach(() => {
+    window.__ROOT_CTX = originalCtx;
+    newTabSession();
+  });
+
+  it("opens the folder of the field's asset in a new tab session", async () => {
+    expect(await resolveAssetPickerFolder('asset-a')).toEqual('folderA');
+  });
+
+  it('opens the last visited folder for subsequent fields in the same tab', async () => {
+    // Field A holds an asset from folder A, field B one from folder B.
+    // Open field A: no folder visited yet this tab, so it opens folder A.
+    expect(await resolveAssetPickerFolder('asset-a')).toEqual('folderA');
+
+    // The user picks a file from folder A. The browser records the folder.
+    setAssetPickerLastFolder('folderA');
+
+    // Opening field B keeps the user in folder A, not field B's folder B.
+    expect(await resolveAssetPickerFolder('asset-b')).toEqual('folderA');
+
+    // ...and it doesn't need to look field B's asset up at all.
+    expect(mocks.getDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts over from the field's asset folder in a new tab session", async () => {
+    setAssetPickerLastFolder('folderA');
+    expect(await resolveAssetPickerFolder('asset-b')).toEqual('folderA');
+
+    newTabSession();
+    expect(await resolveAssetPickerFolder('asset-b')).toEqual('folderB');
+  });
+
+  it('remembers the project root over the asset folder', async () => {
+    setAssetPickerLastFolder('');
+    expect(await resolveAssetPickerFolder('asset-a')).toEqual('');
+  });
+
+  it('opens the last visited folder for an empty field', async () => {
+    expect(await resolveAssetPickerFolder(undefined)).toEqual('');
+
+    setAssetPickerLastFolder('folderA');
+    expect(await resolveAssetPickerFolder(undefined)).toEqual('folderA');
+  });
+
+  it('falls back to the project root for an asset in the root', async () => {
+    expect(await resolveAssetPickerFolder('asset-root')).toEqual('');
+  });
+
+  it('falls back to the project root when the asset is missing', async () => {
+    expect(await resolveAssetPickerFolder('asset-gone')).toEqual('');
+  });
+
+  it('falls back to the project root when the asset lookup fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.getDoc.mockRejectedValue(new Error('permission-denied'));
+
+    expect(await resolveAssetPickerFolder('asset-a')).toEqual('');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/root-cms/ui/utils/assets.test.ts
+++ b/packages/root-cms/ui/utils/assets.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
   Asset,
   AssetFile,
@@ -7,11 +7,13 @@ import {
   buildSyncedFieldValue,
   collectAssetFieldPaths,
   extractAssetIds,
+  getAssetPickerLastFolder,
   getFolderId,
   getRelativeFolderPath,
   joinFolderPath,
   parseFolderPath,
   replaceFileExt,
+  setAssetPickerLastFolder,
   sortAssets,
   validateAssetName,
   validateFolderPath,
@@ -369,5 +371,49 @@ describe('sortAssets', () => {
     const input = [...assets];
     sortAssets(input, {field: 'modified', dir: 'desc'});
     expect(names(input)).toEqual(names(assets));
+  });
+});
+
+describe('assetPickerLastFolder', () => {
+  const originalCtx = window.__ROOT_CTX;
+
+  beforeEach(() => {
+    window.__ROOT_CTX = {rootConfig: {projectId: 'test-project'}} as any;
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    window.__ROOT_CTX = originalCtx;
+    sessionStorage.clear();
+  });
+
+  it('returns null when unset in the tab session', () => {
+    expect(getAssetPickerLastFolder()).toEqual(null);
+  });
+
+  it('round-trips the last folder within the tab session', () => {
+    setAssetPickerLastFolder('marketing/2026');
+    expect(getAssetPickerLastFolder()).toEqual('marketing/2026');
+  });
+
+  it('distinguishes the project root from an unset value', () => {
+    setAssetPickerLastFolder('');
+    expect(getAssetPickerLastFolder()).toEqual('');
+  });
+
+  it('stores the value in sessionStorage, not localStorage', () => {
+    setAssetPickerLastFolder('marketing');
+    expect(
+      sessionStorage.getItem('root-cms:assetPicker:lastFolder:test-project')
+    ).toEqual('marketing');
+    expect(
+      localStorage.getItem('root-cms:assetPicker:lastFolder:test-project')
+    ).toEqual(null);
+  });
+
+  it('scopes the value per project', () => {
+    setAssetPickerLastFolder('marketing');
+    window.__ROOT_CTX = {rootConfig: {projectId: 'other-project'}} as any;
+    expect(getAssetPickerLastFolder()).toEqual(null);
   });
 });

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -198,21 +198,32 @@ function getAssetPickerStorageKey(): string {
   return `${ASSET_PICKER_LAST_FOLDER_KEY}:${projectId}`;
 }
 
-/** Returns the last folder the user navigated to in the asset picker modal. */
-export function getAssetPickerLastFolder(): string {
+/**
+ * Returns the last folder the user navigated to in the asset picker modal
+ * during this tab session, or `null` if the picker hasn't been used yet in
+ * this tab. An empty string is a meaningful value (the project root), so
+ * callers should check for `null` rather than falsiness.
+ *
+ * The value is stored in `sessionStorage` so that each tab keeps its own
+ * folder history and new tabs start fresh.
+ */
+export function getAssetPickerLastFolder(): string | null {
   try {
-    return localStorage.getItem(getAssetPickerStorageKey()) || '';
+    return sessionStorage.getItem(getAssetPickerStorageKey());
   } catch {
-    return '';
+    return null;
   }
 }
 
-/** Persists the last folder the user navigated to in the asset picker modal. */
+/**
+ * Persists the last folder the user navigated to in the asset picker modal
+ * for the current tab session.
+ */
 export function setAssetPickerLastFolder(folder: string): void {
   try {
-    localStorage.setItem(getAssetPickerStorageKey(), folder || '');
+    sessionStorage.setItem(getAssetPickerStorageKey(), folder || '');
   } catch {
-    // localStorage may be unavailable; ignore.
+    // sessionStorage may be unavailable; ignore.
   }
 }
 

--- a/packages/root-cms/ui/utils/assets.ts
+++ b/packages/root-cms/ui/utils/assets.ts
@@ -228,6 +228,35 @@ export function setAssetPickerLastFolder(folder: string): void {
 }
 
 /**
+ * Resolves the folder the asset picker should open to for a field, where
+ * `assetId` is the asset the field currently points at (if any).
+ *
+ * Within a tab session the picker returns to the folder the user last
+ * visited, so picking assets across several fields keeps the user in the
+ * folder they were browsing. For a new tab session (nothing stored yet) it
+ * falls back to the folder of the field's current asset, or the project
+ * root.
+ */
+export async function resolveAssetPickerFolder(
+  assetId?: string
+): Promise<string> {
+  const lastFolder = getAssetPickerLastFolder();
+  if (lastFolder !== null) {
+    return lastFolder;
+  }
+  if (!assetId) {
+    return '';
+  }
+  try {
+    const asset = await getAsset(assetId);
+    return asset?.parent || '';
+  } catch (err) {
+    console.warn('failed to resolve linked asset folder:', err);
+    return '';
+  }
+}
+
+/**
  * Validates a file or folder display name. Returns the trimmed name or throws
  * an `AssetNameError`.
  */


### PR DESCRIPTION
## Summary

Updates which folder the "Select from asset library" picker opens to.

Previously the last visited folder was stored in `localStorage`, but the folder of the currently-linked asset unconditionally overrode it — so the picker never actually reopened where the user left off, and the remembered folder leaked across tabs and browser restarts.

Now:

- The last visited folder is stored in **`sessionStorage`**, so each tab keeps its own folder history and new tabs start fresh.
- Within a tab session, the picker opens to the **most recently opened folder**.
- On a **new tab session**, it falls back to the folder of the **currently selected asset** (when the field value has an `assetId`), or the project root.

## Changes

- `ui/utils/assets.ts` — `get/setAssetPickerLastFolder()` now use `sessionStorage`. The getter returns `string | null` so that the project root (`''`) is distinguishable from "not visited yet in this tab".
- `ui/components/DocEditor/fields/FileField.tsx` — `requestAssetPicker()` uses the session value when present, and only resolves the linked asset's folder when there is no session value.
- `ui/utils/assets.test.ts` — unit tests for the storage helpers (null when unset, round-trip, root vs. unset, sessionStorage not localStorage, per-project scoping).
- Changeset added (patch).

## Testing

- `pnpm test` in `packages/root-cms`: 1104 passing. The 11 failures in `core/project.integration.test.ts` / `core/route.ts` are pre-existing on a clean tree in this checkout (`@blinkk/root` isn't built) and unrelated to this change.
- `npx tsc --noEmit -p tsconfig.build.json` passes.
- `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcKExVQQDan5g6esXGguM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcKExVQQDan5g6esXGguM6)_