### PR TITLE
fix: default sys.locales when overwriting a doc without locales

### DIFF
--- a/.changeset/copy-doc-overwrite-locales.md
+++ b/.changeset/copy-doc-overwrite-locales.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: default sys.locales when overwriting a doc without locales

--- a/packages/root-cms/ui/utils/doc.test.ts
+++ b/packages/root-cms/ui/utils/doc.test.ts
@@ -146,6 +146,38 @@ describe('cmsCopyDoc', () => {
       })
     );
   });
+
+  it('defaults locales when overwriting a doc without locales', async () => {
+    mocks.getDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          fields: {title: 'Hello'},
+          sys: {},
+        }),
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          sys: {
+            createdAt: 'old-created-at',
+            createdBy: 'previous@example.com',
+          },
+        }),
+      });
+
+    await cmsCopyDoc('pages/source', 'pages/copy', {overwrite: true});
+
+    expect(mocks.setDoc).toHaveBeenCalledWith(
+      'doc:Projects/test-project/Collections/pages/Drafts/copy',
+      expect.objectContaining({
+        fields: {title: 'Hello'},
+        sys: expect.objectContaining({
+          locales: ['en'],
+        }),
+      })
+    );
+  });
 });
 
 function setupWindowMocks(collections?: Record<string, any>) {

--- a/packages/root-cms/ui/utils/doc.ts
+++ b/packages/root-cms/ui/utils/doc.ts
@@ -813,7 +813,7 @@ export async function cmsCreateDoc(
     const oldData = doc.data();
     data.sys = {
       ...oldData.sys,
-      locales: options?.locales ?? oldData.sys.locales,
+      locales: options?.locales ?? oldData.sys.locales ?? ['en'],
       modifiedAt: serverTimestamp(),
       modifiedBy: window.firebase.user.email,
     };


### PR DESCRIPTION
## Problem

Copying a doc with the **Overwrite** option fails with a Firestore error when the source doc has no `sys.locales` set:

```
FirebaseError: [code=invalid-argument]: Function setDoc() called with invalid data. Unsupported field value: undefined (found in field sys.locales ...)
```

## Root cause

In `cmsCreateDoc` (`packages/root-cms/ui/utils/doc.ts`), the new-doc path falls back to `['en']` when locales are missing, but the overwrite path passed the value straight through:

```ts
locales: options?.locales ?? oldData.sys.locales,
```

When neither `options.locales` nor `oldData.sys.locales` is defined, this resolves to `undefined`, and Firestore rejects the entire `setDoc()` write.

## Fix

Add the same `['en']` fallback to the overwrite path, matching the new-doc behavior.

## Tests

Added a unit test covering overwriting a doc that has no locales, and all existing `doc.test.ts` tests pass.