### PR TITLE
feat: add paragraph size variants to the richtext editor

### DIFF
--- a/.changeset/olive-donkeys-invent.md
+++ b/.changeset/olive-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add paragraph size variants to the richtext editor

--- a/docs/templates/TemplateSandbox/TemplateSandbox.module.scss
+++ b/docs/templates/TemplateSandbox/TemplateSandbox.module.scss
@@ -87,4 +87,17 @@
   .preWrap {
     white-space: pre-wrap;
   }
+
+  /*
+   * Demonstrates the richtext field's `paragraphSizes` option. The CMS stores
+   * the size the editor picked and renders it as `<p data-size="...">`; what
+   * each size looks like is up to the site.
+   */
+  p[data-size='small'] {
+    font-size: 0.875rem;
+  }
+
+  p[data-size='large'] {
+    font-size: 1.25rem;
+  }
 }

--- a/docs/templates/TemplateSandbox/TemplateSandbox.schema.ts
+++ b/docs/templates/TemplateSandbox/TemplateSandbox.schema.ts
@@ -55,6 +55,7 @@ export default schema.define({
       label: 'RichTextField',
       autosize: true,
       translate: true,
+      paragraphSizes: ['small', {value: 'large', label: 'Larger'}],
       blockComponents: [
         schema.define({
           name: 'PeopleListBlock',

--- a/packages/root-cms/core/richtext.test.tsx
+++ b/packages/root-cms/core/richtext.test.tsx
@@ -51,3 +51,25 @@ test('inline component sees context providers from the parent render tree', () =
   expect(container.innerHTML).toContain('Alice');
   expect(container.innerHTML).toContain('Hello,');
 });
+
+test('paragraph size renders as a data-size attribute', () => {
+  const data: RichTextData = {
+    blocks: [
+      {type: 'paragraph', data: {text: 'Normal.'}},
+      {type: 'paragraph', data: {size: 'small', text: 'Small.'}},
+      // Sizes are site-defined, so any value is passed through as-is.
+      {type: 'paragraph', data: {size: 'body-3', text: 'Custom.'}},
+      {type: 'paragraph', data: {size: 42, text: 'Not a size.'}},
+    ],
+  };
+
+  const {container} = render(<RichText data={data} />);
+
+  const paragraphs = Array.from(container.querySelectorAll('p'));
+  expect(paragraphs.map((el) => el.getAttribute('data-size'))).toEqual([
+    null,
+    'small',
+    'body-3',
+    null,
+  ]);
+});

--- a/packages/root-cms/core/richtext.tsx
+++ b/packages/root-cms/core/richtext.tsx
@@ -2,6 +2,10 @@ import {StringParamsProvider, useTranslations} from '@blinkk/root';
 import {Component, FunctionalComponent, createContext} from 'preact';
 import {useContext} from 'preact/hooks';
 import {renderToString} from 'preact-render-to-string';
+import {
+  parseRichTextParagraphSize,
+  RichTextParagraphSize,
+} from '../shared/richtext.js';
 import {sanitizeBlockHtml, sanitizeInlineHtml} from '../shared/sanitize.js';
 
 export interface RichTextBlock {
@@ -143,6 +147,11 @@ class InlineComponentRenderer extends Component<InlineComponentRendererProps> {
 export interface RichTextParagraphBlockProps {
   type: 'paragraph';
   data?: {
+    /**
+     * Optional size variant, emitted as a `data-size` attribute. Sites decide
+     * what each size means in their own CSS.
+     */
+    size?: RichTextParagraphSize;
     text?: string;
     components?: Record<string, any>;
   };
@@ -154,7 +163,8 @@ RichText.ParagraphBlock = (props: RichTextParagraphBlockProps) => {
   }
   const t = useRichTextTranslations();
   const html = sanitizeInlineHtml(t(props.data.text));
-  return <p dangerouslySetInnerHTML={{__html: html}} />;
+  const size = parseRichTextParagraphSize(props.data.size);
+  return <p data-size={size} dangerouslySetInnerHTML={{__html: html}} />;
 };
 
 export interface RichTextHeadingBlockProps {

--- a/packages/root-cms/core/schema.ts
+++ b/packages/root-cms/core/schema.ts
@@ -1,3 +1,5 @@
+import type {RichTextParagraphSizeOption} from '../shared/richtext.js';
+
 export interface CommonFieldProps {
   /** The type that defines the structure of the field and its UI component. */
   type: string;
@@ -352,6 +354,24 @@ export type RichTextField = CommonFieldProps & {
   blockComponents?: Schema[];
   /** Custom inline component definitions to include in the rich text editor. */
   inlineComponents?: Schema[];
+  /**
+   * Paragraph size variants offered in the editor's block type dropdown. The
+   * values are the site's own: each is stored on the block and rendered as
+   * `<p data-size="...">`, and the site decides in its CSS what it means. Only
+   * list sizes the site has actually styled — an unstyled size renders as an
+   * ordinary paragraph. Omit the option to hide sizes entirely.
+   *
+   * ```ts
+   * schema.richtext({
+   *   id: 'body',
+   *   paragraphSizes: [
+   *     'small',
+   *     {value: 'large', label: 'Larger'},
+   *   ],
+   * })
+   * ```
+   */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
 };
 
 export function richtext(field: Omit<RichTextField, 'type'>): RichTextField {

--- a/packages/root-cms/shared/richtext.test.ts
+++ b/packages/root-cms/shared/richtext.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from 'vitest';
+import {
+  normalizeRichTextParagraphSizes,
+  parseRichTextParagraphSize,
+} from './richtext.js';
+
+describe('parseRichTextParagraphSize', () => {
+  test('accepts any non-empty string', () => {
+    expect(parseRichTextParagraphSize('small')).toBe('small');
+    expect(parseRichTextParagraphSize('body-3')).toBe('body-3');
+    expect(parseRichTextParagraphSize('  large  ')).toBe('large');
+  });
+
+  test('rejects missing and non-string values', () => {
+    expect(parseRichTextParagraphSize(undefined)).toBe(undefined);
+    expect(parseRichTextParagraphSize(null)).toBe(undefined);
+    expect(parseRichTextParagraphSize('')).toBe(undefined);
+    expect(parseRichTextParagraphSize('   ')).toBe(undefined);
+    expect(parseRichTextParagraphSize(2)).toBe(undefined);
+    expect(parseRichTextParagraphSize({value: 'small'})).toBe(undefined);
+  });
+});
+
+describe('normalizeRichTextParagraphSizes', () => {
+  test('defaults labels to the size value', () => {
+    expect(normalizeRichTextParagraphSizes(['small', 'large'])).toEqual([
+      {value: 'small', label: 'small'},
+      {value: 'large', label: 'large'},
+    ]);
+  });
+
+  test('preserves explicit labels and declaration order', () => {
+    expect(
+      normalizeRichTextParagraphSizes([
+        {value: 'large', label: 'Larger'},
+        'small',
+      ])
+    ).toEqual([
+      {value: 'large', label: 'Larger'},
+      {value: 'small', label: 'small'},
+    ]);
+  });
+
+  test('drops entries without a usable value', () => {
+    expect(
+      normalizeRichTextParagraphSizes([
+        'small',
+        '',
+        {value: '  '},
+        {label: 'No value'} as any,
+      ])
+    ).toEqual([{value: 'small', label: 'small'}]);
+  });
+
+  test('returns an empty list when the option is omitted', () => {
+    expect(normalizeRichTextParagraphSizes()).toEqual([]);
+    expect(normalizeRichTextParagraphSizes(null)).toEqual([]);
+  });
+});

--- a/packages/root-cms/shared/richtext.ts
+++ b/packages/root-cms/shared/richtext.ts
@@ -19,12 +19,83 @@ export type RichTextInlineComponentsMap = Record<
   RichTextInlineComponent
 >;
 
+/**
+ * Identifier for a paragraph size variant, e.g. `small` or `large`. Sites
+ * choose their own values and declare them per field via the richtext field's
+ * `paragraphSizes` option; the CMS only stores and round-trips them. The
+ * absence of a size means the site's default body size, so existing content
+ * requires no migration.
+ */
+export type RichTextParagraphSize = string;
+
+/**
+ * A paragraph size variant offered in the rich text block type dropdown.
+ */
+export interface RichTextParagraphSizeOption {
+  /** Stored on the block and rendered as `<p data-size="...">`. */
+  value: RichTextParagraphSize;
+  /** Label shown in the editor's dropdown. Defaults to `value`. */
+  label?: string;
+}
+
 export interface RichTextParagraphBlock {
   type: 'paragraph';
   data?: {
+    /**
+     * Optional size variant, rendered as a `data-size` attribute on the `<p>`.
+     * Sites decide what each size means in their own CSS.
+     */
+    size?: RichTextParagraphSize;
     text?: string;
     components?: RichTextInlineComponentsMap;
   };
+}
+
+/**
+ * Returns a usable paragraph size, or `undefined` when the value is missing or
+ * not a non-empty string. Used to guard values coming from stored documents,
+ * which the CMS never validates against a site's declared sizes.
+ */
+export function parseRichTextParagraphSize(
+  value: unknown
+): RichTextParagraphSize | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const size = value.trim();
+  return size || undefined;
+}
+
+/**
+ * Expands a field's `paragraphSizes` option into a uniform list of options,
+ * defaulting each label to its value.
+ *
+ * ```ts
+ * normalizeRichTextParagraphSizes(['small', {value: 'large', label: 'Larger'}]);
+ * // [{value: 'small', label: 'small'}, {value: 'large', label: 'Larger'}]
+ * ```
+ */
+export function normalizeRichTextParagraphSizes(
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string> | null
+): Array<Required<RichTextParagraphSizeOption>> {
+  if (!paragraphSizes) {
+    return [];
+  }
+  const options: Array<Required<RichTextParagraphSizeOption>> = [];
+  for (const option of paragraphSizes) {
+    const value = parseRichTextParagraphSize(
+      typeof option === 'string' ? option : option?.value
+    );
+    if (!value) {
+      continue;
+    }
+    const label =
+      typeof option === 'string'
+        ? undefined
+        : option.label?.trim() || undefined;
+    options.push({value, label: label || value});
+  }
+  return options;
 }
 
 export interface RichTextHeadingBlock {

--- a/packages/root-cms/shared/richtext.ts
+++ b/packages/root-cms/shared/richtext.ts
@@ -98,6 +98,47 @@ export function normalizeRichTextParagraphSizes(
   return options;
 }
 
+/**
+ * Returns whether any paragraph in the value carries a size, including
+ * paragraphs nested inside table cells.
+ *
+ * A field can hold sized paragraphs without declaring `paragraphSizes` (they
+ * can be pasted in from a field that does, and a site's CSS is global rather
+ * than per field), so the stored value — not just the schema — decides whether
+ * sizes need protecting.
+ */
+export function testRichTextParagraphSizes(
+  data?: RichTextData | null
+): boolean {
+  return testBlocksHaveParagraphSize(data?.blocks);
+}
+
+function testBlocksHaveParagraphSize(blocks?: RichTextBlock[]): boolean {
+  if (!blocks) {
+    return false;
+  }
+  for (const block of blocks) {
+    if (
+      block.type === 'paragraph' &&
+      parseRichTextParagraphSize((block.data as {size?: unknown})?.size)
+    ) {
+      return true;
+    }
+    if (block.type === 'table') {
+      const rows: RichTextTableRow[] =
+        (block.data as RichTextTableBlock['data'])?.rows || [];
+      for (const row of rows) {
+        for (const cell of row.cells || []) {
+          if (testBlocksHaveParagraphSize(cell.blocks)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 export interface RichTextHeadingBlock {
   type: 'heading';
   data?: {

--- a/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
@@ -30,6 +30,7 @@ export function RichTextField(props: FieldProps) {
       placeholder={field.placeholder}
       blockComponents={field.blockComponents}
       inlineComponents={field.inlineComponents}
+      paragraphSizes={field.paragraphSizes}
       onChange={onChange}
       onFocus={props.onFocus}
       onBlur={props.onBlur}

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.test.tsx
@@ -50,4 +50,76 @@ describe('RichTextEditor', () => {
     render(<RichTextEditor paragraphSizes={['  ']} />);
     expect(screen.queryByTestId('editorjs')).toBeTruthy();
   });
+
+  test('overrides the preference when the value already has a size', () => {
+    // The field never declared sizes, but a pasted paragraph carries one and a
+    // site's CSS is global, so the size renders and must not be stripped.
+    userPreferences.EnableEditorJSEditor = true;
+    render(
+      <RichTextEditor
+        value={{
+          version: '1',
+          time: 0,
+          blocks: [{type: 'paragraph', data: {size: 'small', text: 'Hi.'}}],
+        }}
+      />
+    );
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+    expect(screen.queryByTestId('editorjs')).toBeNull();
+  });
+
+  test('overrides the preference for a size inside a table cell', () => {
+    userPreferences.EnableEditorJSEditor = true;
+    render(
+      <RichTextEditor
+        value={{
+          version: '1',
+          time: 0,
+          blocks: [
+            {
+              type: 'table',
+              data: {
+                rows: [
+                  {
+                    cells: [
+                      {
+                        type: 'data',
+                        blocks: [
+                          {
+                            type: 'paragraph',
+                            data: {size: 'large', text: 'Cell.'},
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+  });
+
+  test('keeps the lexical editor once a size has been seen', () => {
+    userPreferences.EnableEditorJSEditor = true;
+    const value = {
+      version: '1',
+      time: 0,
+      blocks: [{type: 'paragraph', data: {size: 'small', text: 'Hi.'}}],
+    };
+    const {rerender} = render(<RichTextEditor value={value} />);
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+
+    // Removing the last sized paragraph must not swap the editor mid-edit.
+    rerender(
+      <RichTextEditor
+        value={{...value, blocks: [{type: 'paragraph', data: {text: 'Hi.'}}]}}
+      />
+    );
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+    expect(screen.queryByTestId('editorjs')).toBeNull();
+  });
 });

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,0 +1,53 @@
+import {cleanup, render, screen} from '@testing-library/preact';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {RichTextEditor} from './RichTextEditor.js';
+
+const userPreferences = {EnableEditorJSEditor: false};
+
+vi.mock('../../hooks/useUserPreferences.js', () => ({
+  useUserPreferences: () => ({preferences: userPreferences}),
+}));
+
+vi.mock('./editorjs/EditorJSEditor.js', () => ({
+  EditorJSEditor: () => <div data-testid="editorjs" />,
+}));
+
+vi.mock('./lexical/LexicalEditor.js', () => ({
+  LexicalEditor: () => <div data-testid="lexical" />,
+}));
+
+beforeEach(() => {
+  userPreferences.EnableEditorJSEditor = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RichTextEditor', () => {
+  test('uses the lexical editor by default', () => {
+    render(<RichTextEditor />);
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+  });
+
+  test('honors the legacy editor preference', () => {
+    userPreferences.EnableEditorJSEditor = true;
+    render(<RichTextEditor />);
+    expect(screen.queryByTestId('editorjs')).toBeTruthy();
+  });
+
+  test('overrides the legacy editor preference when the field offers sizes', () => {
+    // EditorJS rebuilds blocks on save and would drop `data.size`, so a field
+    // that offers sizes must never open in it.
+    userPreferences.EnableEditorJSEditor = true;
+    render(<RichTextEditor paragraphSizes={['small', 'large']} />);
+    expect(screen.queryByTestId('lexical')).toBeTruthy();
+    expect(screen.queryByTestId('editorjs')).toBeNull();
+  });
+
+  test('keeps the legacy editor when the sizes list is empty or unusable', () => {
+    userPreferences.EnableEditorJSEditor = true;
+    render(<RichTextEditor paragraphSizes={['  ']} />);
+    expect(screen.queryByTestId('editorjs')).toBeTruthy();
+  });
+});

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
@@ -1,8 +1,10 @@
+import {useRef} from 'preact/hooks';
 import * as schema from '../../../core/schema.js';
 import {
   normalizeRichTextParagraphSizes,
   RichTextData,
   RichTextParagraphSizeOption,
+  testRichTextParagraphSizes,
 } from '../../../shared/richtext.js';
 import {useUserPreferences} from '../../hooks/useUserPreferences.js';
 import {EditorJSEditor} from './editorjs/EditorJSEditor.js';
@@ -31,14 +33,25 @@ export interface RichTextEditorProps {
 
 export function RichTextEditor(props: RichTextEditorProps) {
   const userPrefs = useUserPreferences();
+  const editorJSPreferred = !!userPrefs.preferences.EnableEditorJSEditor;
   // The legacy EditorJS editor has no concept of paragraph size, and its
   // `editor.save()` rebuilds every block from its own tools — so a single edit
-  // there would silently strip `data.size` from paragraphs another user sized
-  // in the lexical editor. Fields that offer sizes always use the lexical
-  // editor, whatever the user's preference.
-  const offersParagraphSizes =
-    normalizeRichTextParagraphSizes(props.paragraphSizes).length > 0;
-  if (userPrefs.preferences.EnableEditorJSEditor && !offersParagraphSizes) {
+  // there would silently strip `data.size`. The lexical editor is used instead
+  // whenever sizes are in play, whatever the user's preference: either the
+  // field offers them, or the stored value already contains one (sizes can be
+  // pasted into a field that doesn't offer them, and still render, because a
+  // site's CSS is global rather than per field).
+  //
+  // Latched, because the value arrives after the first render and because
+  // removing the last sized paragraph mid-edit must not swap the editor out
+  // from under the user.
+  const requiresLexical = useRef(false);
+  if (editorJSPreferred && !requiresLexical.current) {
+    requiresLexical.current =
+      normalizeRichTextParagraphSizes(props.paragraphSizes).length > 0 ||
+      testRichTextParagraphSizes(props.value);
+  }
+  if (editorJSPreferred && !requiresLexical.current) {
     // EditorJSEditor understands neither `deepKey` nor `paragraphSizes`; strip
     // both before forwarding.
     const {

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
@@ -1,5 +1,6 @@
 import * as schema from '../../../core/schema.js';
 import {
+  normalizeRichTextParagraphSizes,
   RichTextData,
   RichTextParagraphSizeOption,
 } from '../../../shared/richtext.js';
@@ -30,9 +31,16 @@ export interface RichTextEditorProps {
 
 export function RichTextEditor(props: RichTextEditorProps) {
   const userPrefs = useUserPreferences();
-  if (userPrefs.preferences.EnableEditorJSEditor) {
-    // EditorJSEditor doesn't use `deepKey`, and it has no concept of paragraph
-    // sizes (it drops `data.size` on save); strip both before forwarding.
+  // The legacy EditorJS editor has no concept of paragraph size, and its
+  // `editor.save()` rebuilds every block from its own tools — so a single edit
+  // there would silently strip `data.size` from paragraphs another user sized
+  // in the lexical editor. Fields that offer sizes always use the lexical
+  // editor, whatever the user's preference.
+  const offersParagraphSizes =
+    normalizeRichTextParagraphSizes(props.paragraphSizes).length > 0;
+  if (userPrefs.preferences.EnableEditorJSEditor && !offersParagraphSizes) {
+    // EditorJSEditor understands neither `deepKey` nor `paragraphSizes`; strip
+    // both before forwarding.
     const {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       deepKey,

--- a/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/RichTextEditor.tsx
@@ -1,5 +1,8 @@
 import * as schema from '../../../core/schema.js';
-import {RichTextData} from '../../../shared/richtext.js';
+import {
+  RichTextData,
+  RichTextParagraphSizeOption,
+} from '../../../shared/richtext.js';
 import {useUserPreferences} from '../../hooks/useUserPreferences.js';
 import {EditorJSEditor} from './editorjs/EditorJSEditor.js';
 import {LexicalEditor} from './lexical/LexicalEditor.js';
@@ -21,15 +24,20 @@ export interface RichTextEditorProps {
   onBlur?: (e: FocusEvent) => void;
   blockComponents?: schema.Schema[];
   inlineComponents?: schema.Schema[];
+  /** Paragraph size variants offered in the block type dropdown. */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
 }
 
 export function RichTextEditor(props: RichTextEditorProps) {
   const userPrefs = useUserPreferences();
   if (userPrefs.preferences.EnableEditorJSEditor) {
-    // EditorJSEditor doesn't use `deepKey`; strip it before forwarding.
+    // EditorJSEditor doesn't use `deepKey`, and it has no concept of paragraph
+    // sizes (it drops `data.size` on save); strip both before forwarding.
     const {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       deepKey,
+      paragraphSizes,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
     } = props;
     return <EditorJSEditor {...rest} />;

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
@@ -24,7 +24,10 @@ import {$dfs} from '@lexical/utils';
 import {$getNodeByKey, $getRoot, $insertNodes, NodeKey} from 'lexical';
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
-import {RichTextData} from '../../../../shared/richtext.js';
+import {
+  RichTextData,
+  RichTextParagraphSizeOption,
+} from '../../../../shared/richtext.js';
 import {joinClassNames} from '../../../utils/classes.js';
 import {
   OPEN_RICHTEXT_BLOCK_EVENT,
@@ -56,6 +59,7 @@ import {
   $isInlineComponentNode,
   InlineComponentNode,
 } from './nodes/InlineComponentNode.js';
+import {SizedParagraphNode} from './nodes/SizedParagraphNode.js';
 import {SpecialCharacterNode} from './nodes/SpecialCharacterNode.js';
 import {FloatingLinkEditorPlugin} from './plugins/FloatingLinkEditorPlugin.js';
 import {FloatingToolbarPlugin} from './plugins/FloatingToolbarPlugin.js';
@@ -85,6 +89,7 @@ const INITIAL_CONFIG: InitialConfigType = {
     TableRowNode,
     BlockComponentNode,
     InlineComponentNode,
+    SizedParagraphNode,
     SpecialCharacterNode,
   ],
   // Lexical routes errors it catches while updating, reconciling, or parsing
@@ -126,6 +131,8 @@ export interface LexicalEditorProps {
   autoFocus?: boolean;
   blockComponents?: schema.Schema[];
   inlineComponents?: schema.Schema[];
+  /** Paragraph size variants offered in the block type dropdown. */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
 }
 
 export function LexicalEditor(props: LexicalEditorProps) {
@@ -156,6 +163,7 @@ export function LexicalEditor(props: LexicalEditorProps) {
               autoFocus={props.autoFocus}
               blockComponents={props.blockComponents}
               inlineComponents={props.inlineComponents}
+              paragraphSizes={props.paragraphSizes}
             />
           </div>
         </ToolbarProvider>
@@ -223,6 +231,8 @@ interface EditorProps {
   autoFocus?: boolean;
   blockComponents?: schema.Schema[];
   inlineComponents?: schema.Schema[];
+  /** Paragraph size variants offered in the block type dropdown. */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
 }
 
 function Editor(props: EditorProps) {
@@ -563,6 +573,7 @@ function Editor(props: EditorProps) {
           variant={props.variant}
           blockComponents={blockComponents}
           inlineComponents={inlineComponents}
+          paragraphSizes={props.paragraphSizes}
           onInsertBlockComponent={(blockName) =>
             openBlockComponentModal(blockName, {mode: 'create'})
           }

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalTheme.css
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalTheme.css
@@ -12,6 +12,18 @@
 .LexicalTheme__paragraph:first-child {
   margin-top: 0;
 }
+/*
+ * Approximations for the two conventional paragraph sizes, so that picking one
+ * is visible in the editor and not only in the split preview. Sites define
+ * their own size values and their own CSS, so a size named anything else
+ * renders at the normal size here and is still correct on the site.
+ */
+.LexicalTheme__paragraph[data-size='small'] {
+  font-size: 0.875em;
+}
+.LexicalTheme__paragraph[data-size='large'] {
+  font-size: 1.25em;
+}
 .LexicalTheme__quote {
   font-family: var(--font-family-default);
   font-size: 14px;

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/hooks/useToolbar.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/hooks/useToolbar.tsx
@@ -1,6 +1,7 @@
 import {ElementFormatType} from 'lexical';
 import {ComponentChildren, createContext} from 'preact';
 import {useCallback, useContext, useMemo, useState} from 'preact/hooks';
+import {RichTextParagraphSize} from '../../../../../shared/richtext.js';
 
 export const TOOLBAR_BLOCK_LABELS = {
   paragraph: 'Normal',
@@ -19,6 +20,12 @@ export type ToolbarBlockType = keyof typeof TOOLBAR_BLOCK_LABELS;
 
 const INITIAL_TOOLBAR_STATE = {
   blockType: 'paragraph' as ToolbarBlockType,
+  /**
+   * Size variant of the selected paragraph, or `undefined` when the selection
+   * isn't a sized paragraph. Tracked separately from `blockType` because the
+   * sizes are defined by each site rather than by a fixed list.
+   */
+  paragraphSize: undefined as RichTextParagraphSize | undefined,
   canRedo: false,
   canUndo: false,
   codeLanguage: '',

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/SizedParagraphNode.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/nodes/SizedParagraphNode.ts
@@ -1,0 +1,145 @@
+import {
+  EditorConfig,
+  LexicalNode,
+  NodeKey,
+  ParagraphNode,
+  RangeSelection,
+  SerializedParagraphNode,
+  Spread,
+} from 'lexical';
+import {
+  parseRichTextParagraphSize,
+  RichTextParagraphSize,
+} from '../../../../../shared/richtext.js';
+
+export type SerializedSizedParagraphNode = Spread<
+  {
+    type: 'sized-paragraph';
+    size: RichTextParagraphSize;
+  },
+  SerializedParagraphNode
+>;
+
+/**
+ * A paragraph with a site-defined size variant (e.g. "small" or "large").
+ *
+ * The size lives on the node rather than inside its text, so it never affects
+ * the paragraph's translation key. It is mirrored onto the editor DOM as
+ * `data-size`, which is also how sites render it, so a site's own CSS could
+ * style either surface the same way.
+ *
+ * Unsized paragraphs keep using lexical's built-in `ParagraphNode`: this node
+ * is only created when an editor explicitly picks a size, which leaves the
+ * behavior of every existing rich text field unchanged.
+ */
+export class SizedParagraphNode extends ParagraphNode {
+  // Named `__paragraphSize` rather than `__size`: `ElementNode.__size` is
+  // lexical's own child count.
+  __paragraphSize: RichTextParagraphSize;
+
+  static getType(): string {
+    return 'sized-paragraph';
+  }
+
+  static clone(node: SizedParagraphNode): SizedParagraphNode {
+    return new SizedParagraphNode(node.__paragraphSize, node.__key);
+  }
+
+  static importJSON(
+    serializedNode: SerializedSizedParagraphNode
+  ): SizedParagraphNode {
+    // An unusable stored value degrades to an ordinary paragraph rather than
+    // an unlabelable one.
+    const size = parseRichTextParagraphSize(serializedNode.size) || '';
+    return new SizedParagraphNode(size).updateFromJSON(serializedNode);
+  }
+
+  constructor(size: RichTextParagraphSize, key?: NodeKey) {
+    super(key);
+    this.__paragraphSize = size;
+  }
+
+  exportJSON(): SerializedSizedParagraphNode {
+    return {
+      ...super.exportJSON(),
+      type: 'sized-paragraph',
+      size: this.__paragraphSize,
+    };
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = super.createDOM(config);
+    if (this.__paragraphSize) {
+      dom.setAttribute('data-size', this.__paragraphSize);
+    }
+    return dom;
+  }
+
+  updateDOM(
+    prevNode: SizedParagraphNode,
+    dom: HTMLElement,
+    config: EditorConfig
+  ): boolean {
+    if (prevNode.__paragraphSize !== this.__paragraphSize) {
+      if (this.__paragraphSize) {
+        dom.setAttribute('data-size', this.__paragraphSize);
+      } else {
+        dom.removeAttribute('data-size');
+      }
+    }
+    return super.updateDOM(prevNode, dom, config);
+  }
+
+  /**
+   * Carries the size forward when the editor presses Enter, matching the
+   * behavior of other editors (a new paragraph keeps the current size).
+   */
+  insertNewAfter(
+    rangeSelection: RangeSelection,
+    restoreSelection: boolean
+  ): ParagraphNode {
+    const newElement = $createSizedParagraphNode(this.__paragraphSize);
+    newElement.setTextFormat(rangeSelection.format);
+    newElement.setTextStyle(rangeSelection.style);
+    newElement.setDirection(this.getDirection());
+    newElement.setFormat(this.getFormatType());
+    newElement.setStyle(this.getStyle());
+    this.insertAfter(newElement, restoreSelection);
+    return newElement;
+  }
+
+  getParagraphSize(): RichTextParagraphSize {
+    return this.getLatest().__paragraphSize;
+  }
+
+  setParagraphSize(size: RichTextParagraphSize): this {
+    const writable = this.getWritable();
+    writable.__paragraphSize = size;
+    return writable;
+  }
+}
+
+export function $createSizedParagraphNode(
+  size: RichTextParagraphSize
+): SizedParagraphNode {
+  return new SizedParagraphNode(size);
+}
+
+export function $isSizedParagraphNode(
+  node: LexicalNode | null | undefined
+): node is SizedParagraphNode {
+  return node instanceof SizedParagraphNode;
+}
+
+/**
+ * Returns the size variant of a paragraph node, or `undefined` when the node
+ * is an ordinary (unsized) paragraph.
+ */
+export function $getParagraphSize(
+  node: LexicalNode | null | undefined
+): RichTextParagraphSize | undefined {
+  if (!$isSizedParagraphNode(node)) {
+    return undefined;
+  }
+  return node.getParagraphSize() || undefined;
+}

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
@@ -44,10 +44,12 @@ import {
   IconBracketsAngle,
   IconSquare,
   IconCapsuleHorizontal,
+  IconTextSize,
 } from '@tabler/icons-preact';
 import {
   $getSelection,
   $isElementNode,
+  $isParagraphNode,
   $isRangeSelection,
   $isRootOrShadowRoot,
   CAN_REDO_COMMAND,
@@ -67,12 +69,18 @@ import {
   useState,
 } from 'preact/compat';
 import * as schema from '../../../../../core/schema.js';
+import {
+  normalizeRichTextParagraphSizes,
+  RichTextParagraphSize,
+  RichTextParagraphSizeOption,
+} from '../../../../../shared/richtext.js';
 import {joinClassNames} from '../../../../utils/classes.js';
 import {
   TOOLBAR_BLOCK_LABELS,
   ToolbarBlockType,
   useToolbar,
 } from '../hooks/useToolbar.js';
+import {$getParagraphSize} from '../nodes/SizedParagraphNode.js';
 import {getSelectedNode} from '../utils/selection.js';
 import {SHORTCUTS} from '../utils/shortcuts.js';
 import {
@@ -130,10 +138,25 @@ interface BlockFormatDropDownProps {
   rootType: 'root' | 'table';
   editor: LexicalEditor;
   disabled?: boolean;
+  /** Paragraph sizes declared by the field's schema. */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
+  /** Size of the currently selected paragraph, if it has one. */
+  paragraphSize?: RichTextParagraphSize;
 }
 
 function BlockFormatDropDown(props: BlockFormatDropDownProps) {
-  const {editor, blockType} = props;
+  const {editor, blockType, paragraphSize} = props;
+  const paragraphSizes = useMemo(
+    () => normalizeRichTextParagraphSizes(props.paragraphSizes),
+    [props.paragraphSizes]
+  );
+  // A paragraph can carry a size the field doesn't declare (e.g. pasted from a
+  // field that does), so fall back to the raw value rather than mislabeling it
+  // as "Normal".
+  const label = paragraphSize
+    ? paragraphSizes.find((option) => option.value === paragraphSize)?.label ||
+      paragraphSize
+    : TOOLBAR_BLOCK_LABELS[blockType];
   return (
     <Menu
       control={
@@ -144,20 +167,38 @@ function BlockFormatDropDown(props: BlockFormatDropDownProps) {
           )}
           variant="default"
           compact
-          leftIcon={<BlockTypeIcon blockType={blockType} />}
+          leftIcon={
+            paragraphSize ? (
+              <IconTextSize size={16} />
+            ) : (
+              <BlockTypeIcon blockType={blockType} />
+            )
+          }
           rightIcon={<IconChevronDown size={16} />}
         >
-          {TOOLBAR_BLOCK_LABELS[blockType]}
+          {label}
         </Button>
       }
     >
       <Menu.Item
         icon={<BlockTypeIcon blockType="paragraph" />}
-        className={dropDownActiveClass(blockType === 'paragraph')}
+        className={dropDownActiveClass(
+          blockType === 'paragraph' && !paragraphSize
+        )}
         onClick={() => formatParagraph(editor)}
       >
         Normal
       </Menu.Item>
+      {paragraphSizes.map((option) => (
+        <Menu.Item
+          key={option.value}
+          icon={<IconTextSize size={16} />}
+          className={dropDownActiveClass(paragraphSize === option.value)}
+          onClick={() => formatParagraph(editor, option.value)}
+        >
+          {option.label}
+        </Menu.Item>
+      ))}
       <Menu.Item
         icon={<BlockTypeIcon blockType="bullet" />}
         className={dropDownActiveClass(blockType === 'bullet')}
@@ -307,6 +348,8 @@ interface ToolbarPluginProps {
   onInsertBlockComponent?: (blockName: string) => void;
   inlineComponents?: schema.Schema[];
   onInsertInlineComponent?: (componentName: string) => void;
+  /** Paragraph sizes declared by the field's schema. */
+  paragraphSizes?: Array<RichTextParagraphSizeOption | string>;
 }
 
 export function ToolbarPlugin(props: ToolbarPluginProps) {
@@ -320,6 +363,7 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
     variant = 'document',
     onInsertBlockComponent,
     onInsertInlineComponent,
+    paragraphSizes,
   } = props;
   // TODO(stevenle): figure out if this is required or not.
   // const [selectedElementKey, setSelectedElementKey] = useState<NodeKey | null>(
@@ -381,7 +425,15 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
             : element.getListType();
 
           updateToolbarState('blockType', type as ToolbarBlockType);
+          updateToolbarState('paragraphSize', undefined);
+        } else if ($isParagraphNode(element)) {
+          // A sized paragraph is a `ParagraphNode` subclass with its own node
+          // type, so it would never match `TOOLBAR_BLOCK_LABELS` and would
+          // leave the dropdown showing whatever block was selected before.
+          updateToolbarState('blockType', 'paragraph');
+          updateToolbarState('paragraphSize', $getParagraphSize(element));
         } else {
+          updateToolbarState('paragraphSize', undefined);
           const type = $isHeadingNode(element)
             ? element.getTag()
             : element.getType();
@@ -544,6 +596,8 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
               blockType={toolbarState.blockType}
               rootType={toolbarState.rootType}
               editor={activeEditor}
+              paragraphSizes={paragraphSizes}
+              paragraphSize={toolbarState.paragraphSize}
             />
             <Divider />
           </>

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert-from-lexical.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert-from-lexical.ts
@@ -38,6 +38,7 @@ import {
   $isInlineComponentNode,
   InlineComponentNode,
 } from '../nodes/InlineComponentNode.js';
+import {$getParagraphSize} from '../nodes/SizedParagraphNode.js';
 
 interface TextExtractionResult {
   text: string;
@@ -293,6 +294,10 @@ function extractTableData(node: TableNode) {
                   text: result.text,
                 },
               };
+              const size = $getParagraphSize(child);
+              if (size) {
+                block.data!.size = size;
+              }
               if (hasInlineComponents(result.components)) {
                 block.data!.components = result.components;
               }
@@ -369,6 +374,10 @@ export function convertToRichTextData(): RichTextData | null {
           text: result.text,
         },
       };
+      const size = $getParagraphSize(node);
+      if (size) {
+        block.data!.size = size;
+      }
       if (hasInlineComponents(result.components)) {
         block.data!.components = result.components;
       }

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert-to-lexical.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert-to-lexical.ts
@@ -24,6 +24,7 @@ import {
   TextNode,
 } from 'lexical';
 import {
+  parseRichTextParagraphSize,
   RichTextData,
   RichTextInlineComponentsMap,
   RichTextListItem,
@@ -31,6 +32,7 @@ import {
 import {cloneData} from '../../../../utils/objects.js';
 import {$createBlockComponentNode} from '../nodes/BlockComponentNode.js';
 import {$createInlineComponentNode} from '../nodes/InlineComponentNode.js';
+import {$createSizedParagraphNode} from '../nodes/SizedParagraphNode.js';
 
 /**
  * Converts from lexical to rich text data and writes the output directly to
@@ -44,7 +46,7 @@ export function convertToLexical(data?: RichTextData | null) {
   const blocks = data?.blocks || [];
   for (const block of blocks) {
     if (block.type === 'paragraph') {
-      const paragraphNode = $createParagraphNode();
+      const paragraphNode = createParagraphNodeWithSize(block.data?.size);
       if (block.data.text) {
         const children = createNodesFromHTML(
           block.data.text,
@@ -100,7 +102,9 @@ export function convertToLexical(data?: RichTextData | null) {
           // Process each block in the cell
           cellBlocks.forEach((cellBlock: any) => {
             if (cellBlock.type === 'paragraph') {
-              const paragraphNode = $createParagraphNode();
+              const paragraphNode = createParagraphNodeWithSize(
+                cellBlock.data?.size
+              );
               if (cellBlock.data?.text) {
                 const children = createNodesFromHTML(
                   cellBlock.data.text,
@@ -169,6 +173,19 @@ export function convertToLexical(data?: RichTextData | null) {
       root.append(node);
     }
   }
+}
+
+/**
+ * Creates a paragraph node, using a sized paragraph when the stored block
+ * carries a usable size. Sizes are site-defined, so the value is only checked
+ * for usability, never against the field's declared list.
+ */
+function createParagraphNodeWithSize(size?: unknown) {
+  const paragraphSize = parseRichTextParagraphSize(size);
+  if (paragraphSize) {
+    return $createSizedParagraphNode(paragraphSize);
+  }
+  return $createParagraphNode();
 }
 
 function createNodesFromHTML(

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert.test.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/convert.test.ts
@@ -1,0 +1,182 @@
+import {AutoLinkNode, LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
+import {
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  createEditor,
+  LexicalEditor,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+import {RichTextData} from '../../../../../shared/richtext.js';
+import {BlockComponentNode} from '../nodes/BlockComponentNode.js';
+import {InlineComponentNode} from '../nodes/InlineComponentNode.js';
+import {
+  $getParagraphSize,
+  SizedParagraphNode,
+} from '../nodes/SizedParagraphNode.js';
+import {SpecialCharacterNode} from '../nodes/SpecialCharacterNode.js';
+import {convertToRichTextData} from './convert-from-lexical.js';
+import {convertToLexical} from './convert-to-lexical.js';
+
+/** Headless editor registering the same nodes as `<LexicalEditor>`. */
+function createTestEditor(): LexicalEditor {
+  return createEditor({
+    namespace: 'RootCMS',
+    nodes: [
+      AutoLinkNode,
+      HeadingNode,
+      QuoteNode,
+      LinkNode,
+      ListNode,
+      ListItemNode,
+      HorizontalRuleNode,
+      TableNode,
+      TableCellNode,
+      TableRowNode,
+      BlockComponentNode,
+      InlineComponentNode,
+      SizedParagraphNode,
+      SpecialCharacterNode,
+    ],
+    onError: (err: Error) => {
+      throw err;
+    },
+  });
+}
+
+/** Loads rich text data into an editor and reads it back out. */
+function roundTrip(data: RichTextData): RichTextData | null {
+  const editor = createTestEditor();
+  editor.update(() => convertToLexical(data), {discrete: true});
+  let result: RichTextData | null = null;
+  editor.read(() => {
+    result = convertToRichTextData();
+  });
+  return result;
+}
+
+const SIZED_PARAGRAPHS: RichTextData = {
+  version: '1',
+  time: 0,
+  blocks: [
+    {type: 'paragraph', data: {text: 'Normal paragraph.'}},
+    {type: 'paragraph', data: {size: 'small', text: 'Small paragraph.'}},
+    {type: 'paragraph', data: {size: 'large', text: 'Large paragraph.'}},
+    // The sizes are site-defined, so an arbitrary value must survive too.
+    {type: 'paragraph', data: {size: 'body-3', text: 'Custom paragraph.'}},
+    {
+      type: 'table',
+      data: {
+        rows: [
+          {
+            cells: [
+              {
+                type: 'data',
+                blocks: [
+                  {type: 'paragraph', data: {size: 'small', text: 'In cell.'}},
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('paragraph sizes', () => {
+  test('round-trip preserves sizes at the root and inside tables', () => {
+    expect(roundTrip(SIZED_PARAGRAPHS)?.blocks).toEqual(
+      SIZED_PARAGRAPHS.blocks
+    );
+  });
+
+  test('unsized paragraphs never gain a size', () => {
+    const result = roundTrip({
+      version: '1',
+      time: 0,
+      blocks: [
+        {type: 'paragraph', data: {text: 'Normal paragraph.'}},
+        {type: 'heading', data: {level: 2, text: 'A heading.'}},
+      ],
+    });
+    expect(result?.blocks[0]).toEqual({
+      type: 'paragraph',
+      data: {text: 'Normal paragraph.'},
+    });
+  });
+
+  test('an unusable stored size degrades to a normal paragraph', () => {
+    const result = roundTrip({
+      version: '1',
+      time: 0,
+      blocks: [
+        {type: 'paragraph', data: {size: '', text: 'Empty size.'}},
+        {type: 'paragraph', data: {size: 42, text: 'Numeric size.'}} as any,
+      ],
+    });
+    expect(result?.blocks).toEqual([
+      {type: 'paragraph', data: {text: 'Empty size.'}},
+      {type: 'paragraph', data: {text: 'Numeric size.'}},
+    ]);
+  });
+
+  test('pressing enter carries the size to the next paragraph', () => {
+    const editor = createTestEditor();
+    editor.update(
+      () =>
+        convertToLexical({
+          version: '1',
+          time: 0,
+          blocks: [{type: 'paragraph', data: {size: 'small', text: 'First.'}}],
+        }),
+      {discrete: true}
+    );
+    editor.update(
+      () => {
+        $getRoot().getFirstChildOrThrow<SizedParagraphNode>().selectEnd();
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertParagraph();
+        }
+      },
+      {discrete: true}
+    );
+
+    let result: RichTextData | null = null;
+    editor.read(() => {
+      result = convertToRichTextData();
+    });
+    // The trailing paragraph is empty, so it is dropped on save; typing into
+    // it is what makes the carried-over size observable.
+    expect(result?.blocks).toEqual([
+      {type: 'paragraph', data: {size: 'small', text: 'First.'}},
+    ]);
+    editor.read(() => {
+      const nodes = $getRoot().getChildren();
+      expect(nodes).toHaveLength(2);
+      expect($getParagraphSize(nodes[1])).toBe('small');
+    });
+  });
+
+  test('sizes survive lexical serialization (the internal clipboard path)', () => {
+    const editor = createTestEditor();
+    editor.update(() => convertToLexical(SIZED_PARAGRAPHS), {discrete: true});
+
+    // Serializing and reparsing is what copy/paste between rich text fields
+    // does, and it goes through the node's exportJSON/importJSON rather than
+    // through the converters.
+    const json = JSON.parse(JSON.stringify(editor.getEditorState().toJSON()));
+    editor.setEditorState(editor.parseEditorState(json));
+
+    let result: RichTextData | null = null;
+    editor.read(() => {
+      result = convertToRichTextData();
+    });
+    expect(result?.blocks).toEqual(SIZED_PARAGRAPHS.blocks);
+  });
+});

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/utils/toolbar.ts
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/utils/toolbar.ts
@@ -19,11 +19,22 @@ import {
   $isTextNode,
   LexicalEditor,
 } from 'lexical';
+import {RichTextParagraphSize} from '../../../../../shared/richtext.js';
+import {$createSizedParagraphNode} from '../nodes/SizedParagraphNode.js';
 
-export const formatParagraph = (editor: LexicalEditor) => {
+/**
+ * Converts the selected blocks into paragraphs. Pass a `size` to convert them
+ * into sized paragraphs instead (see the richtext field's `paragraphSizes`).
+ */
+export const formatParagraph = (
+  editor: LexicalEditor,
+  size?: RichTextParagraphSize
+) => {
   editor.update(() => {
     const selection = $getSelection();
-    $setBlocksType(selection, () => $createParagraphNode());
+    $setBlocksType(selection, () =>
+      size ? $createSizedParagraphNode(size) : $createParagraphNode()
+    );
   });
 };
 


### PR DESCRIPTION
Paragraphs can now carry a size the same way headings carry a level. The size is stored as `data.size` on the paragraph block and rendered as `<p data-size="...">`.

Because the size lives *outside* `data.text`, it never touches the HTML tag allowlist, the unknown-tag parser, or the translation pipeline — translation extraction reads strings only, so a size can never orphan a translation.

## Sites declare their own sizes

```ts
schema.richtext({
  id: 'body',
  paragraphSizes: ['small', {value: 'large', label: 'Larger'}],
})
```

The values are the site's own — `small`, `large`, `body-3`, whatever the design system calls them — and each site decides in its CSS what they mean, exactly as each site already decides what `h2` means inside a body. Entries may be a bare string or `{value, label}` when the dropdown should read differently from the stored value.

Fields that omit `paragraphSizes` behave exactly as they do today, which is what makes this safe across every existing richtext field. There is no `'normal'` value — absence means the site's default body size, so no document needs migrating.

## Editor

A `SizedParagraphNode` (a `ParagraphNode` subclass) carries the size and mirrors it onto the editor DOM as `data-size`. Plain paragraphs keep using lexical's built-in `ParagraphNode`; the subclass is only created when an editor explicitly picks a size.

Both converters round-trip the size on **both** paths — root-level paragraphs and table-cell paragraphs — and they ship together, since root-cms uses a bespoke serialiser and parser rather than lexical's `exportDOM`. Pressing Enter carries the size to the next paragraph, matching Docs and Word.

The block-type dropdown gains one entry per declared size, under "Normal".

## Notes for reviewers

- **Lexical only, enforced.** `EnableEditorJSEditor` is a per-user preference on every project, and the legacy EditorJS editor knows nothing about paragraph size: `editor.save()` rebuilds every block from its own tools, so one edit there would silently strip `data.size` from paragraphs another user had sized. A field that offers sizes therefore always opens in the lexical editor, whatever the user's preference.
- **Sizes travel on the internal clipboard.** `PasteCleanupPlugin` returns early for `application/x-lexical-editor`, so copying between richtext fields carries the size regardless of what either field declares. This is deliberate: stored values are checked for usability, never against a field's list. A paragraph carrying an undeclared size shows the raw value in the dropdown rather than being mislabelled "Normal".
- **Missing site CSS is graceful.** `<p data-size="small">` with no CSS renders as an ordinary paragraph. The editor previews the two conventional values (`small`, `large`) so picking one is visible without the split preview; a size named anything else previews at normal size in the editor and is still correct on the site.
- **`__paragraphSize`, not `__size`.** `ElementNode.__size` is lexical's own child count — using it fails with `ElementNode.splice: start + deleteCount > oldSize`. Caught by the round-trip test.
- **`FloatingToolbarPlugin` is untouched.** It has no block-type dropdown, only inline formats, so there is nothing to keep in sync.
- The `docs/` sandbox template declares `paragraphSizes` and styles them, so the feature is exercisable in the local playground.

## Testing

New tests cover the converter round-trip at the root and inside tables, arbitrary site-defined values, unusable stored values degrading to a normal paragraph, Enter carrying the size forward, lexical serialize/reparse (the internal clipboard path), and the renderer's `data-size` output.

Not run locally: the Firestore-emulator suite (no JDK on this machine) and the visual suite — three richtext visual tests time out identically on a clean `main` after the recent Playwright bump.

Generated with Claude Code (Opus 5).
