### PR TITLE
fix: index content nested inside oneOf fields in site-wide search

### DIFF
--- a/.changeset/eleven-moons-search.md
+++ b/.changeset/eleven-moons-search.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: index content nested inside oneOf fields in site-wide search

--- a/packages/root-cms/core/search-extract.test.ts
+++ b/packages/root-cms/core/search-extract.test.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from 'vitest';
+import {convertOneOfTypes, SchemaModule} from './project.js';
 import * as schema from './schema.js';
 import {
   MAX_FIELD_TEXT_CHARS,
@@ -316,6 +317,104 @@ describe('extractDocRecords', () => {
       deepKey: 'fields.blocks.a.text',
       text: 'hello',
     });
+  });
+
+  it('resolves oneOf types given as string names via schema.types', () => {
+    const TextBlock = schema.define({
+      name: 'TextBlock',
+      fields: [schema.string({id: 'text'})],
+    });
+    // The shape produced by `convertOneOfTypes()`: `types` holds schema names
+    // and the schemas themselves are hoisted onto the collection.
+    const S: schema.SchemaWithTypes = {
+      name: 'O',
+      fields: [
+        schema.array({
+          id: 'blocks',
+          of: schema.oneOf({types: ['TextBlock'] as any}),
+        }),
+      ],
+      types: {TextBlock},
+    };
+    const records = extractDocRecords(S, {
+      collection: 'O',
+      slug: 's',
+      fields: {
+        blocks: {
+          _array: ['a'],
+          a: {_type: 'TextBlock', text: 'hello'},
+        },
+      },
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      deepKey: 'fields.blocks.a.text',
+      text: 'hello',
+    });
+  });
+
+  it('indexes nested modules of a collection run through convertOneOfTypes', () => {
+    const Nested = schema.define({
+      name: 'Nested',
+      fields: [schema.string({id: 'caption'})],
+    });
+    const Container = schema.define({
+      name: 'Container',
+      fields: [
+        schema.string({id: 'heading'}),
+        schema.array({
+          id: 'modules',
+          of: schema.oneOf({types: [Nested]}),
+        }),
+      ],
+    });
+    const schemaModules: Record<string, SchemaModule> = {
+      '/modules/Container.schema.ts': {default: Container},
+      '/modules/Nested.schema.ts': {default: Nested},
+    };
+    const collection = convertOneOfTypes(
+      {
+        id: 'Pages',
+        name: 'Pages',
+        url: '/[...slug]',
+        fields: [
+          schema.string({id: 'title'}),
+          schema.array({
+            id: 'modules',
+            of: schema.oneOf({
+              types: schema.glob('/modules/*.schema.ts'),
+            }),
+          }),
+        ],
+      },
+      schemaModules
+    );
+
+    const records = extractDocRecords(collection, {
+      collection: 'Pages',
+      slug: 'home',
+      fields: {
+        title: 'Home',
+        modules: {
+          _array: ['m1'],
+          m1: {
+            _type: 'Container',
+            heading: 'Section heading',
+            modules: {
+              _array: ['n1'],
+              n1: {_type: 'Nested', caption: 'Deeply nested text'},
+            },
+          },
+        },
+      },
+    });
+
+    expect(records.map((r) => r.deepKey)).toEqual([
+      'fields.title',
+      'fields.modules.m1.heading',
+      'fields.modules.m1.modules.n1.caption',
+    ]);
+    expect(records.map((r) => r.text)).toContain('Deeply nested text');
   });
 
   it('truncates long text to MAX_FIELD_TEXT_CHARS', () => {

--- a/packages/root-cms/core/search-extract.ts
+++ b/packages/root-cms/core/search-extract.ts
@@ -20,6 +20,7 @@ import type {
   ObjectField,
   OneOfField,
   Schema,
+  SchemaWithTypes,
 } from './schema.js';
 
 /** Hard cap for any single extracted text value. */
@@ -46,6 +47,11 @@ interface EmitContext {
   docId: string;
   collection: string;
   slug: string;
+  /**
+   * Schema-name => Schema map used to resolve `oneOf` fields whose `types`
+   * were converted to string names by `convertOneOfTypes()`.
+   */
+  types: Record<string, Schema>;
 }
 
 type EmitFn = (record: ExtractedRecord) => void;
@@ -325,6 +331,11 @@ function walkOneOf(
           matchedSchema = schema;
           break;
         }
+      } else if (candidate === typeName) {
+        // `convertOneOfTypes()` rewrites `types` to string names and hoists the
+        // schemas onto `collection.types`.
+        matchedSchema = ctx.types[typeName] || null;
+        break;
       }
     }
   }
@@ -367,7 +378,7 @@ export interface ExtractDocOptions {
 
 /** Extracts every searchable record from a single doc. */
 export function extractDocRecords(
-  schema: Schema,
+  schema: SchemaWithTypes,
   options: ExtractDocOptions
 ): ExtractedRecord[] {
   const records: ExtractedRecord[] = [];
@@ -376,6 +387,7 @@ export function extractDocRecords(
     docId,
     collection: options.collection,
     slug: options.slug,
+    types: schema.types || {},
   };
   walkSchemaFields(schema.fields, options.fields || {}, 'fields', ctx, (rec) =>
     records.push(rec)

--- a/packages/root-cms/core/search-index.ts
+++ b/packages/root-cms/core/search-index.ts
@@ -26,7 +26,7 @@ import MiniSearch from 'minisearch';
 import glob from 'tiny-glob';
 import {getCmsPlugin} from './client.js';
 import type {CMSSearchIndexConfig} from './plugin.js';
-import type {Schema} from './schema.js';
+import type {SchemaWithTypes} from './schema.js';
 import {extractDocRecords, ExtractedRecord} from './search-extract.js';
 import {executeQuery, parseQuery} from './search-query.js';
 
@@ -209,8 +209,13 @@ export function withWeight(rec: ExtractedRecord): IndexableRecord {
 /**
  * Loader for a collection's schema. Pluggable so callers can provide a
  * dev-mode loader (Vite SSR) and prod uses the default (`dist/...json`).
+ *
+ * Both loaders return the post-`convertOneOfTypes()` shape, where `oneOf`
+ * fields hold schema *names* and the schemas themselves live on `types`.
  */
-export type LoadSchemaFn = (collectionId: string) => Promise<Schema | null>;
+export type LoadSchemaFn = (
+  collectionId: string
+) => Promise<SchemaWithTypes | null>;
 
 export class SearchIndexService {
   private readonly rootConfig: RootConfig;
@@ -288,7 +293,7 @@ export class SearchIndexService {
    */
   private async loadCollectionSchemaFromDist(
     collectionId: string
-  ): Promise<Schema | null> {
+  ): Promise<SchemaWithTypes | null> {
     const distPath = path.join(
       this.rootConfig.rootDir,
       'dist',
@@ -299,7 +304,7 @@ export class SearchIndexService {
       return null;
     }
     const contents = fs.readFileSync(distPath, 'utf8');
-    return JSON.parse(contents) as Schema;
+    return JSON.parse(contents) as SchemaWithTypes;
   }
 
   private async readMeta(): Promise<SearchIndexMeta | null> {
@@ -618,7 +623,7 @@ export class SearchIndexService {
     const changedDocs = await this.listChangedDocs(collectionIds, lastRun);
 
     // Schema lookups are amortized across changed docs.
-    const schemaCache = new Map<string, Schema | null>();
+    const schemaCache = new Map<string, SchemaWithTypes | null>();
     const getSchema = async (collectionId: string) => {
       if (!schemaCache.has(collectionId)) {
         schemaCache.set(collectionId, await this.loadSchema(collectionId));


### PR DESCRIPTION
## Problem

Site-wide search (the CMS spotlight, backed by `/cms/api/search.query`) returns no results for text that the doc editor's page-level search panel finds without trouble.

The cause is a shape mismatch. `walkOneOf()` in `core/search-extract.ts` only matched `oneOf` entries that are Schema **objects**:

```ts
for (const candidate of types) {
  if (candidate && typeof candidate === 'object') {
    if (candidate.name === typeName) matchedSchema = candidate;
  }
}
if (!matchedSchema) return;
```

But `getCollectionSchema()` runs `convertOneOfTypes()`, which rewrites every `oneOf` field's `types` into an array of **string names** and hoists the schemas onto `collection.types`. Both schema loaders used by the index return that converted shape — dev via Vite SSR (`app.getCollection`), prod via `dist/collections/<id>.schema.json`.

So `matchedSchema` was always `null`, and the walk **stopped at the first `oneOf`**.

For the common page layout — some metadata followed by an array of `oneOf` modules — that means only the fields *before* the modules array were ever indexed. Everything authors actually write inside modules was invisible to site-wide search.

The page-level search in `ui/utils/doc-search.ts` already handles both shapes, which is why the two disagree:

```ts
if (typeof fieldTypes[0] === 'string') {
  selectedSchema = ctx.types[selectedTypeName];
} else {
  selectedSchema = fieldTypes.find((s) => s?.name === selectedTypeName);
}
```

## Fix

Thread the schema's `types` map through `EmitContext` and resolve string type names against it. Also type the schema loaders as `SchemaWithTypes` rather than `Schema`, so the signature reflects what they actually return.

## Impact

Measured on a real page whose body is an array of nested `oneOf` modules:

| | records extracted | matches for a term nested in a module |
|---|---|---|
| before | 16 (metadata only) | 0 |
| after | 344 | 2 |

## Tests

Two regression tests in `core/search-extract.test.ts`, both verified to fail against the unpatched extractor:

- a direct test of the string-name + `types` shape
- an end-to-end test that runs a collection through the real `convertOneOfTypes()` and asserts a deeply nested module field is indexed

The existing `oneOf` test only exercised the object-typed shape, which is how this slipped through. The `search-index`, `search-query`, and `project` suites still pass, and `tsc --noEmit` is clean.

## Note for deployers

Existing persisted indexes are stale — they were built without the skipped fields. A forced rebuild (Settings → Site Admin) is needed to pick them up.
