### PR TITLE
feat: various polish features for CMS tasks

### DIFF
--- a/.changeset/tasks-polish-1385.md
+++ b/.changeset/tasks-polish-1385.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: various polish features for CMS tasks

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.tsx
@@ -57,6 +57,7 @@ import {
   InlineComponentNode,
 } from './nodes/InlineComponentNode.js';
 import {SpecialCharacterNode} from './nodes/SpecialCharacterNode.js';
+import {AutoLinkPlugin} from './plugins/AutoLinkPlugin.js';
 import {FloatingLinkEditorPlugin} from './plugins/FloatingLinkEditorPlugin.js';
 import {FloatingToolbarPlugin} from './plugins/FloatingToolbarPlugin.js';
 import {ImagePastePlugin} from './plugins/ImagePastePlugin.js';
@@ -589,6 +590,7 @@ function Editor(props: EditorProps) {
           ErrorBoundary={LexicalErrorBoundary}
         />
         <LinkPlugin />
+        <AutoLinkPlugin />
         <ListPlugin />
         {props.variant !== 'comment' && (
           <>

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/AutoLinkPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/AutoLinkPlugin.tsx
@@ -1,0 +1,24 @@
+import {
+  AutoLinkPlugin as LexicalAutoLinkPlugin,
+  createLinkMatcherWithRegExp,
+} from '@lexical/react/LexicalAutoLinkPlugin';
+
+const URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/;
+
+const EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])(\.(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])){3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+const MATCHERS = [
+  createLinkMatcherWithRegExp(URL_REGEX, (text) => {
+    return text.startsWith('http') ? text : `https://${text}`;
+  }),
+  createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => {
+    return `mailto:${text}`;
+  }),
+];
+
+/** Automatically converts typed or pasted URLs and emails into links. */
+export function AutoLinkPlugin() {
+  return <LexicalAutoLinkPlugin matchers={MATCHERS} />;
+}

--- a/packages/root-cms/ui/components/TaskCommentEditor/TaskCommentEditor.tsx
+++ b/packages/root-cms/ui/components/TaskCommentEditor/TaskCommentEditor.tsx
@@ -10,19 +10,47 @@ export interface TaskCommentEditorProps {
   value?: RichTextData | null;
   onChange?: (value: RichTextData | null) => void;
   autoFocus?: boolean;
+  /** Called when the user presses Cmd+Enter (or Ctrl+Enter) in the editor. */
+  onSubmitShortcut?: () => void;
+  /** Called when the user pastes files (e.g. a screenshot) into the editor. */
+  onPasteFiles?: (files: File[]) => void;
 }
 
 /** Lightweight Lexical editor for task comments and replies. */
 export function TaskCommentEditor(props: TaskCommentEditorProps) {
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+      props.onSubmitShortcut?.();
+    }
+  }
+
+  function onPaste(e: ClipboardEvent) {
+    if (!props.onPasteFiles) {
+      return;
+    }
+    const files = Array.from(e.clipboardData?.files || []);
+    if (files.length > 0) {
+      props.onPasteFiles(files);
+    }
+  }
+
   return (
-    <LexicalEditor
-      className={joinClassNames('TaskCommentEditor', props.className)}
-      placeholder={props.placeholder}
-      value={props.value}
-      onChange={props.onChange}
-      autoFocus={props.autoFocus}
-      autosize
-      variant="comment"
-    />
+    <div
+      className="TaskCommentEditor__wrap"
+      onKeyDown={onKeyDown}
+      onPaste={onPaste}
+    >
+      <LexicalEditor
+        className={joinClassNames('TaskCommentEditor', props.className)}
+        placeholder={props.placeholder}
+        value={props.value}
+        onChange={props.onChange}
+        autoFocus={props.autoFocus}
+        autosize
+        variant="comment"
+      />
+    </div>
   );
 }

--- a/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
+++ b/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
@@ -494,6 +494,7 @@ function TaskTable(props: {tasks: Task[]}) {
             <th>assignee</th>
             <th>target</th>
             <th>opened</th>
+            <th>updated</th>
           </tr>
         </thead>
         <tbody>
@@ -549,6 +550,7 @@ function TaskTable(props: {tasks: Task[]}) {
                     : 'None'}
                 </td>
                 <td>{formatTaskDate(task.createdAt)}</td>
+                <td>{formatTaskDate(task.updatedAt || task.createdAt)}</td>
               </tr>
             );
           })}

--- a/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
+++ b/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
@@ -33,7 +33,9 @@ import {
   Task,
   TaskPriority,
 } from '../../utils/tasks.js';
+import {formatDateTime} from '../../utils/time.js';
 import {Surface} from '../Surface/Surface.js';
+import {UserActionTooltip} from '../UserActionTooltip/UserActionTooltip.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
 import {UserTag} from '../UserTag/UserTag.js';
 
@@ -549,8 +551,13 @@ function TaskTable(props: {tasks: Task[]}) {
                     ? formatTaskDate(task.targetLaunchDate)
                     : 'None'}
                 </td>
-                <td>{formatTaskDate(task.createdAt)}</td>
-                <td>{formatTaskDate(task.updatedAt || task.createdAt)}</td>
+                <td>{renderTaskDate(task.createdAt, task.createdBy)}</td>
+                <td>
+                  {renderTaskDate(
+                    task.updatedAt || task.createdAt,
+                    task.updatedBy || task.createdBy
+                  )}
+                </td>
               </tr>
             );
           })}
@@ -753,6 +760,22 @@ function formatTaskDate(ts?: Task['createdAt']) {
     month: 'short',
     day: 'numeric',
   });
+}
+
+/**
+ * Renders a short task date (e.g. "Aug 12") with a tooltip showing the full
+ * date and the user who performed the action, matching the doc list.
+ */
+function renderTaskDate(ts?: Task['createdAt'], by?: string) {
+  const label = formatTaskDate(ts);
+  if (!ts?.toMillis) {
+    return label;
+  }
+  return (
+    <UserActionTooltip message={formatDateTime(ts)} user={by}>
+      <span>{label}</span>
+    </UserActionTooltip>
+  );
 }
 
 function formatTaskStatus(status?: string) {

--- a/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
+++ b/packages/root-cms/ui/components/TaskManager/TaskManager.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../utils/tasks.js';
 import {Surface} from '../Surface/Surface.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
+import {UserTag} from '../UserTag/UserTag.js';
 
 type TaskFilter =
   | 'open'
@@ -515,7 +516,7 @@ function TaskTable(props: {tasks: Task[]}) {
                         {task.title}
                       </span>
                       <span className="TaskManager__tableTask__meta">
-                        #{task.id} by {formatTaskUser(createdBy)}
+                        #{task.id} by <UserTag email={createdBy} />
                       </span>
                     </span>
                   </a>
@@ -536,7 +537,11 @@ function TaskTable(props: {tasks: Task[]}) {
                   </span>
                 </td>
                 <td>
-                  {task.assignee ? formatTaskUser(task.assignee) : 'Unassigned'}
+                  {task.assignee ? (
+                    <UserTag email={task.assignee} />
+                  ) : (
+                    'Unassigned'
+                  )}
                 </td>
                 <td>
                   {task.targetLaunchDate
@@ -597,7 +602,7 @@ function TaskBoardCard(props: {task: Task}) {
       )}
       <div className="TaskManager__boardCard__meta">
         #{task.id} opened {formatTaskDate(task.createdAt)} by{' '}
-        {formatTaskUser(createdBy)}
+        <UserTag email={createdBy} />
       </div>
       <div className="TaskManager__boardCard__badges">
         <span
@@ -608,7 +613,7 @@ function TaskBoardCard(props: {task: Task}) {
           {formatTaskPriority(task.priority)}
         </span>
         <span className="TaskManager__boardCard__badge">
-          {task.assignee ? formatTaskUser(task.assignee) : 'Unassigned'}
+          {task.assignee ? <UserTag email={task.assignee} /> : 'Unassigned'}
         </span>
         {task.targetLaunchDate && (
           <span className="TaskManager__boardCard__badge">
@@ -645,7 +650,8 @@ function TaskRow(props: {task: Task}) {
       <div className="TaskManager__taskRow__content">
         <div className="TaskManager__taskRow__title">{task.title}</div>
         <div className="TaskManager__taskRow__meta">
-          opened {formatTaskDate(task.createdAt)} by {formatTaskUser(createdBy)}
+          opened {formatTaskDate(task.createdAt)} by{' '}
+          <UserTag email={createdBy} />
         </div>
       </div>
       <div className="TaskManager__taskRow__badges">

--- a/packages/root-cms/ui/components/UserTag/UserTag.css
+++ b/packages/root-cms/ui/components/UserTag/UserTag.css
@@ -1,5 +1,13 @@
 .UserTag {
+  cursor: default;
   display: inline;
+}
+
+.UserTag__tooltip,
+.UserTag__tooltip__text span {
+  cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .UserTag__tooltip {

--- a/packages/root-cms/ui/components/UserTag/UserTag.css
+++ b/packages/root-cms/ui/components/UserTag/UserTag.css
@@ -1,0 +1,36 @@
+.UserTag {
+  display: inline;
+}
+
+.UserTag__tooltip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  /* Cap the tooltip width and allow long emails to wrap onto multiple lines. */
+  max-width: 240px;
+}
+
+.UserTag__tooltip__text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.UserTag__tooltip__text span {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.UserTag__tooltip__name {
+  font-weight: 600;
+}
+
+.UserTag__tooltip__email {
+  opacity: 0.85;
+}
+
+.UserTag__tooltip .UserAvatar {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}

--- a/packages/root-cms/ui/components/UserTag/UserTag.tsx
+++ b/packages/root-cms/ui/components/UserTag/UserTag.tsx
@@ -1,6 +1,7 @@
 import './UserTag.css';
 
 import {Tooltip} from '@mantine/core';
+import {useEffect, useRef, useState} from 'preact/hooks';
 import {useUserProfile} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {UserAvatar} from '../UserAvatar/UserAvatar.js';
@@ -24,6 +25,24 @@ export function UserTag(props: UserTagProps) {
   const {profile} = useUserProfile(email);
   const displayName = profile?.displayName || '';
   const shortName = email.split('@')[0] || email;
+  // Control the tooltip so it stays open while the cursor travels to (and
+  // interacts with) the popup, allowing the email to be selected/copied.
+  const [opened, setOpened] = useState(false);
+  const closeTimeoutRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    return () => window.clearTimeout(closeTimeoutRef.current);
+  }, []);
+
+  function open() {
+    window.clearTimeout(closeTimeoutRef.current);
+    setOpened(true);
+  }
+
+  function scheduleClose() {
+    window.clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = window.setTimeout(() => setOpened(false), 200);
+  }
 
   if (!email.includes('@')) {
     // Not an email (e.g. "unknown"); render as plain text without a tooltip.
@@ -35,7 +54,11 @@ export function UserTag(props: UserTagProps) {
   }
 
   const label = (
-    <div className="UserTag__tooltip">
+    <div
+      className="UserTag__tooltip"
+      onPointerEnter={open}
+      onPointerLeave={scheduleClose}
+    >
       <UserAvatar email={email} size={20} withTooltip={false} />
       <div className="UserTag__tooltip__text">
         {displayName && (
@@ -53,6 +76,9 @@ export function UserTag(props: UserTagProps) {
       transition="pop"
       // Keep the tooltip interactive so the email can be selected/copied.
       allowPointerEvents
+      opened={opened}
+      onPointerEnter={open}
+      onPointerLeave={scheduleClose}
     >
       <span className={joinClassNames('UserTag', props.className)}>
         {shortName}

--- a/packages/root-cms/ui/components/UserTag/UserTag.tsx
+++ b/packages/root-cms/ui/components/UserTag/UserTag.tsx
@@ -46,7 +46,14 @@ export function UserTag(props: UserTagProps) {
     </div>
   );
   return (
-    <Tooltip label={label} position="bottom" withArrow transition="pop">
+    <Tooltip
+      label={label}
+      position="bottom"
+      withArrow
+      transition="pop"
+      // Keep the tooltip interactive so the email can be selected/copied.
+      allowPointerEvents
+    >
       <span className={joinClassNames('UserTag', props.className)}>
         {shortName}
       </span>

--- a/packages/root-cms/ui/components/UserTag/UserTag.tsx
+++ b/packages/root-cms/ui/components/UserTag/UserTag.tsx
@@ -1,0 +1,55 @@
+import './UserTag.css';
+
+import {Tooltip} from '@mantine/core';
+import {useUserProfile} from '../../hooks/useUserProfile.js';
+import {joinClassNames} from '../../utils/classes.js';
+import {UserAvatar} from '../UserAvatar/UserAvatar.js';
+
+export interface UserTagProps {
+  /** Email of the user to render. */
+  email: string;
+  /** Optional className for the wrapping element. */
+  className?: string;
+}
+
+/**
+ * Renders a user's short name (the local part of their email) with a hover
+ * tooltip showing their avatar, display name (if available), and full email.
+ *
+ * Example:
+ *   <UserTag email="me@example.com" />
+ */
+export function UserTag(props: UserTagProps) {
+  const email = props.email || '';
+  const {profile} = useUserProfile(email);
+  const displayName = profile?.displayName || '';
+  const shortName = email.split('@')[0] || email;
+
+  if (!email.includes('@')) {
+    // Not an email (e.g. "unknown"); render as plain text without a tooltip.
+    return (
+      <span className={joinClassNames('UserTag', props.className)}>
+        {email}
+      </span>
+    );
+  }
+
+  const label = (
+    <div className="UserTag__tooltip">
+      <UserAvatar email={email} size={20} withTooltip={false} />
+      <div className="UserTag__tooltip__text">
+        {displayName && (
+          <span className="UserTag__tooltip__name">{displayName}</span>
+        )}
+        <span className="UserTag__tooltip__email">{email}</span>
+      </div>
+    </div>
+  );
+  return (
+    <Tooltip label={label} position="bottom" withArrow transition="pop">
+      <span className={joinClassNames('UserTag', props.className)}>
+        {shortName}
+      </span>
+    </Tooltip>
+  );
+}

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -575,14 +575,24 @@
 }
 
 .TaskPage__metadata__ccList {
-  color: var(--color-text-gray);
-  font-size: 12px;
-  line-height: 1.5;
-  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
 }
 
-.TaskPage__metadata__ccList .UserTag {
-  margin-right: 6px;
+.TaskPage__metadata__ccItem {
+  align-items: center;
+  background: #f6f7f8;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-default);
+  display: inline-flex;
+  font-size: 12px;
+  gap: 3px;
+  max-width: 100%;
+  min-height: 24px;
+  padding: 1px 4px 1px 10px;
 }
 
 .TaskPage__metadata__danger {

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -264,6 +264,25 @@
   font-weight: 700;
 }
 
+.TaskPage__metadata__selfLink {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--color-primary, #1c7ed6);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+}
+
+.TaskPage__metadata__selfLink:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.TaskPage__metadata__selfLink:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
 .TaskPage__metadata__assignee,
 .TaskPage__metadata__date {
   align-items: center;

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -559,6 +559,147 @@
   padding-bottom: 0;
 }
 
+.TaskPage__deletedBanner {
+  align-items: center;
+  background: #fef3f2;
+  border: 1px solid #fecdca;
+  border-radius: 8px;
+  color: #b42318;
+  display: flex;
+  font-size: 13px;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 18px;
+  max-width: 1120px;
+  padding: 10px 14px;
+}
+
+.TaskPage__metadata__ccList {
+  color: var(--color-text-gray);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-top: 6px;
+}
+
+.TaskPage__metadata__ccList .UserTag {
+  margin-right: 6px;
+}
+
+.TaskPage__metadata__danger {
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  justify-content: flex-start;
+  padding-top: 12px;
+}
+
+.TaskPage__comment__timestamp {
+  color: inherit;
+  text-decoration: none;
+}
+
+.TaskPage__comment__timestamp:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Highlights the comment targeted by a `#comment-N` deeplink. */
+.TaskPage__timelineItem:target {
+  scroll-margin-top: calc(var(--header-height) + 16px);
+}
+
+.TaskPage__timelineItem:target .TaskPage__comment {
+  outline: 2px solid #175cd3;
+  outline-offset: 2px;
+}
+
+/* External-link indicator appended to non-CMS links inside comments. */
+.TaskPage__externalLink::after {
+  background-color: currentColor;
+  content: '';
+  display: inline-block;
+  height: 11px;
+  margin-left: 3px;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6'/%3E%3Cpath d='M11 13l9 -9'/%3E%3Cpath d='M15 4h5v5'/%3E%3C/svg%3E")
+    no-repeat center / contain;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6'/%3E%3Cpath d='M11 13l9 -9'/%3E%3Cpath d='M15 4h5v5'/%3E%3C/svg%3E")
+    no-repeat center / contain;
+  vertical-align: -1px;
+  width: 11px;
+}
+
+.TaskPage__composer__fileInput {
+  display: none;
+}
+
+.TaskPage__composer__actions__spacer {
+  flex: 1;
+}
+
+.TaskPage__composer__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.TaskPage__composer__attachment {
+  align-items: center;
+  background: #f6f7f8;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-default);
+  display: inline-flex;
+  font-size: 12px;
+  gap: 5px;
+  max-width: 100%;
+  min-height: 26px;
+  padding: 2px 6px 2px 10px;
+}
+
+.TaskPage__composer__attachment__name,
+.TaskPage__comment__attachment__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TaskPage__comment__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.TaskPage__comment__body > .TaskPage__comment__attachments:first-child {
+  margin-top: 0;
+}
+
+.TaskPage__comment__attachment {
+  align-items: center;
+  background: #f6f7f8;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-default);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 6px;
+  max-width: 100%;
+  min-height: 28px;
+  padding: 3px 10px;
+  text-decoration: none;
+}
+
+.TaskPage__comment__attachment:hover {
+  border-color: #98a2b3;
+}
+
+.TaskPage__comment__attachment__thumb {
+  border-radius: 4px;
+  height: 28px;
+  object-fit: cover;
+  width: 28px;
+}
+
 @media (max-width: 900px) {
   .TaskPage {
     padding: 28px 18px;

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -44,10 +44,12 @@ import {Text} from '../../components/Text/Text.js';
 import {UserTag} from '../../components/UserTag/UserTag.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
+import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {errorMessage} from '../../utils/notifications.js';
+import {getRole} from '../../utils/permissions.js';
 import {
   addTaskComment,
   addTaskAttachment,
@@ -591,6 +593,7 @@ function TaskMetadataPanel(props: {task: Task}) {
   const {route} = useLocation();
   const modals = useModals();
   const modalTheme = useModalTheme();
+  const {roles} = useProjectRoles();
   const [assignee, setAssignee] = useState(task.assignee || '');
   const [ccDraft, setCcDraft] = useState('');
   const [targetLaunchDate, setTargetLaunchDate] = useState(
@@ -598,6 +601,12 @@ function TaskMetadataPanel(props: {task: Task}) {
   );
   const [savingField, setSavingField] = useState<TaskMetadataField | ''>('');
   const ccList = task.cc || [];
+  const currentUserEmail = (window.firebase.user.email || '').toLowerCase();
+  const isAssignedToMe =
+    (task.assignee || '').toLowerCase() === currentUserEmail;
+  const isCcdToMe = ccList.some(
+    (email) => email.toLowerCase() === currentUserEmail
+  );
 
   useEffect(() => {
     setAssignee(task.assignee || '');
@@ -633,6 +642,24 @@ function TaskMetadataPanel(props: {task: Task}) {
     );
   }
 
+  function assignToMe() {
+    if (!currentUserEmail || isAssignedToMe) {
+      return;
+    }
+    setAssignee(currentUserEmail);
+    saveMetadata('assignee', () =>
+      updateTaskAssignee(task.id, currentUserEmail)
+    );
+  }
+
+  function ccMe() {
+    if (!currentUserEmail || isCcdToMe) {
+      return;
+    }
+    const normalizedCc = normalizeTaskCcList([...ccList, currentUserEmail]);
+    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
+  }
+
   function addCcEmails() {
     const draftEmails = ccDraft.split(/[,\s]+/).filter(Boolean);
     if (draftEmails.length === 0) {
@@ -642,6 +669,19 @@ function TaskMetadataPanel(props: {task: Task}) {
       showNotification({
         title: 'Could not add to CC',
         message: 'Enter a valid email address.',
+        color: 'red',
+      });
+      return;
+    }
+    const notAllowed = draftEmails.filter(
+      (email) => !getRole(roles, email.trim().toLowerCase())
+    );
+    if (notAllowed.length > 0) {
+      showNotification({
+        title: 'Could not add to CC',
+        message: `${notAllowed.join(', ')} ${
+          notAllowed.length === 1 ? 'is' : 'are'
+        } not a member of this project.`,
         color: 'red',
       });
       return;
@@ -657,6 +697,27 @@ function TaskMetadataPanel(props: {task: Task}) {
   function removeCcEmail(email: string) {
     const normalizedCc = ccList.filter((value) => value !== email);
     saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
+  }
+
+  // Copies the full email addresses of the selected chips, instead of the
+  // short names shown in the UI (e.g. "jeremydw" -> "jeremydw@example.com").
+  function handleCopyCc(e: ClipboardEvent) {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) {
+      return;
+    }
+    const container = e.currentTarget as HTMLElement;
+    const emails = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-cc-email]')
+    )
+      .filter((el) => selection.containsNode(el, true))
+      .map((el) => el.dataset.ccEmail || '')
+      .filter(Boolean);
+    if (emails.length === 0) {
+      return;
+    }
+    e.preventDefault();
+    e.clipboardData?.setData('text/plain', emails.join(', '));
   }
 
   function onDeleteTask() {
@@ -736,6 +797,16 @@ function TaskMetadataPanel(props: {task: Task}) {
             }}
           />
         </div>
+        {currentUserEmail && !isAssignedToMe && (
+          <button
+            type="button"
+            className="TaskPage__metadata__selfLink"
+            disabled={savingField === 'assignee'}
+            onClick={assignToMe}
+          >
+            Assign me
+          </button>
+        )}
       </div>
       <div className="TaskPage__metadata__field">
         <label>CC</label>
@@ -758,9 +829,13 @@ function TaskMetadataPanel(props: {task: Task}) {
             }}
           />
           {ccList.length > 0 && (
-            <div className="TaskPage__metadata__ccList">
+            <div className="TaskPage__metadata__ccList" onCopy={handleCopyCc}>
               {ccList.map((email) => (
-                <div className="TaskPage__metadata__ccItem" key={email}>
+                <div
+                  className="TaskPage__metadata__ccItem"
+                  key={email}
+                  data-cc-email={email}
+                >
                   <UserTag email={email} />
                   <ActionIcon
                     size="xs"
@@ -773,6 +848,16 @@ function TaskMetadataPanel(props: {task: Task}) {
                 </div>
               ))}
             </div>
+          )}
+          {currentUserEmail && !isCcdToMe && (
+            <button
+              type="button"
+              className="TaskPage__metadata__selfLink"
+              disabled={savingField === 'cc'}
+              onClick={ccMe}
+            >
+              CC me
+            </button>
           )}
         </div>
       </div>
@@ -961,17 +1046,59 @@ function TaskEventTimelineItem(props: {event: TaskEvent}) {
         <b>
           <UserTag email={event.createdBy || 'unknown'} />
         </b>{' '}
-        changed {formatTaskField(event.field)} from{' '}
-        <span className="TaskPage__timelineValue">
-          {formatTaskEventValue(event.field, event.oldValue)}
-        </span>{' '}
-        to{' '}
-        <span className="TaskPage__timelineValue">
-          {formatTaskEventValue(event.field, event.newValue)}
-        </span>{' '}
+        {event.field === 'cc' ? (
+          <TaskCcEventSummary event={event} />
+        ) : (
+          <>
+            changed {formatTaskField(event.field)} from{' '}
+            <span className="TaskPage__timelineValue">
+              {formatTaskEventValue(event.field, event.oldValue)}
+            </span>{' '}
+            to{' '}
+            <span className="TaskPage__timelineValue">
+              {formatTaskEventValue(event.field, event.newValue)}
+            </span>
+          </>
+        )}{' '}
         {formatTaskDateTime(event.createdAt)}.
       </div>
     </div>
+  );
+}
+
+/** Renders a concise "added/removed X to/from cc" summary for a cc event. */
+function TaskCcEventSummary(props: {event: TaskEvent}) {
+  const {event} = props;
+  const toEmails = (value: TaskEvent['oldValue']) =>
+    typeof value === 'string' ? value.split(/,\s*/).filter(Boolean) : [];
+  const oldEmails = toEmails(event.oldValue);
+  const newEmails = toEmails(event.newValue);
+  const added = newEmails.filter((email) => !oldEmails.includes(email));
+  const removed = oldEmails.filter((email) => !newEmails.includes(email));
+  const renderEmails = (emails: string[]) =>
+    emails.map((email, index) => (
+      <span key={email}>
+        {index > 0 && ', '}
+        <UserTag email={email} />
+      </span>
+    ));
+  if (added.length > 0 && removed.length === 0) {
+    return <>added {renderEmails(added)} to cc</>;
+  }
+  if (removed.length > 0 && added.length === 0) {
+    return <>removed {renderEmails(removed)} from cc</>;
+  }
+  return (
+    <>
+      changed cc from{' '}
+      <span className="TaskPage__timelineValue">
+        {formatTaskEventValue(event.field, event.oldValue)}
+      </span>{' '}
+      to{' '}
+      <span className="TaskPage__timelineValue">
+        {formatTaskEventValue(event.field, event.newValue)}
+      </span>
+    </>
   );
 }
 

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   Tooltip,
 } from '@mantine/core';
+import {useModals} from '@mantine/modals';
 import {showNotification} from '@mantine/notifications';
 import {
   IconCalendar,
@@ -39,7 +40,9 @@ import {Heading} from '../../components/Heading/Heading.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {TaskCommentEditor} from '../../components/TaskCommentEditor/TaskCommentEditor.js';
+import {Text} from '../../components/Text/Text.js';
 import {UserTag} from '../../components/UserTag/UserTag.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
@@ -586,19 +589,20 @@ function TaskAttachments(props: {task: Task}) {
 function TaskMetadataPanel(props: {task: Task}) {
   const {task} = props;
   const {route} = useLocation();
+  const modals = useModals();
+  const modalTheme = useModalTheme();
   const [assignee, setAssignee] = useState(task.assignee || '');
-  const [cc, setCc] = useState((task.cc || []).join(', '));
+  const [ccDraft, setCcDraft] = useState('');
   const [targetLaunchDate, setTargetLaunchDate] = useState(
     formatDateInputValue(task.targetLaunchDate)
   );
   const [savingField, setSavingField] = useState<TaskMetadataField | ''>('');
-  const [deleting, setDeleting] = useState(false);
+  const ccList = task.cc || [];
 
   useEffect(() => {
     setAssignee(task.assignee || '');
-    setCc((task.cc || []).join(', '));
     setTargetLaunchDate(formatDateInputValue(task.targetLaunchDate));
-  }, [task.assignee, task.cc, task.targetLaunchDate]);
+  }, [task.assignee, task.targetLaunchDate]);
 
   async function saveMetadata(
     field: TaskMetadataField,
@@ -629,33 +633,62 @@ function TaskMetadataPanel(props: {task: Task}) {
     );
   }
 
-  function saveCc() {
-    const normalizedCc = normalizeTaskCcList(cc.split(/[,\s]+/));
-    if ((task.cc || []).join(',') === normalizedCc.join(',')) {
-      setCc(normalizedCc.join(', '));
+  function addCcEmails() {
+    const draftEmails = ccDraft.split(/[,\s]+/).filter(Boolean);
+    if (draftEmails.length === 0) {
+      return;
+    }
+    if (draftEmails.some((email) => !email.includes('@'))) {
+      showNotification({
+        title: 'Could not add to CC',
+        message: 'Enter a valid email address.',
+        color: 'red',
+      });
+      return;
+    }
+    const normalizedCc = normalizeTaskCcList([...ccList, ...draftEmails]);
+    setCcDraft('');
+    if (ccList.join(',') === normalizedCc.join(',')) {
       return;
     }
     saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
   }
 
-  async function onDeleteTask() {
-    if (!window.confirm(`Delete task #${task.id} "${task.title}"?`)) {
-      return;
-    }
-    setDeleting(true);
-    try {
-      await deleteTask(task.id);
-      route('/cms/tasks');
-    } catch (err) {
-      showNotification({
-        title: 'Could not delete task',
-        message: errorMessage(err),
-        color: 'red',
-        autoClose: false,
-      });
-    } finally {
-      setDeleting(false);
-    }
+  function removeCcEmail(email: string) {
+    const normalizedCc = ccList.filter((value) => value !== email);
+    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
+  }
+
+  function onDeleteTask() {
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: `Delete task #${task.id}`,
+      children: (
+        <Text size="body-sm" weight="semi-bold">
+          Are you sure you want to delete "{task.title}"? The task will no
+          longer appear in task lists.
+        </Text>
+      ),
+      labels: {confirm: 'Delete task', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      closeOnConfirm: false,
+      onConfirm: async () => {
+        try {
+          await deleteTask(task.id);
+          modals.closeModal(modalId);
+          route('/cms/tasks');
+        } catch (err) {
+          modals.closeModal(modalId);
+          showNotification({
+            title: 'Could not delete task',
+            message: errorMessage(err),
+            color: 'red',
+            autoClose: false,
+          });
+        }
+      },
+    });
   }
 
   function saveTargetLaunchDate(value: string) {
@@ -709,23 +742,35 @@ function TaskMetadataPanel(props: {task: Task}) {
         <div className="TaskPage__metadata__cc">
           <TextInput
             size="xs"
-            placeholder="a@example.com, b@example.com"
-            value={cc}
+            type="email"
+            placeholder="Add email and press enter"
+            value={ccDraft}
             disabled={savingField === 'cc'}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setCc(e.currentTarget.value)
+              setCcDraft(e.currentTarget.value)
             }
-            onBlur={() => saveCc()}
+            onBlur={() => addCcEmails()}
             onKeyDown={(e: KeyboardEvent) => {
               if (e.key === 'Enter') {
-                (e.currentTarget as HTMLInputElement).blur();
+                e.preventDefault();
+                addCcEmails();
               }
             }}
           />
-          {(task.cc || []).length > 0 && (
+          {ccList.length > 0 && (
             <div className="TaskPage__metadata__ccList">
-              {(task.cc || []).map((email) => (
-                <UserTag key={email} email={email} />
+              {ccList.map((email) => (
+                <div className="TaskPage__metadata__ccItem" key={email}>
+                  <UserTag email={email} />
+                  <ActionIcon
+                    size="xs"
+                    title="Remove from CC"
+                    disabled={savingField === 'cc'}
+                    onClick={() => removeCcEmail(email)}
+                  >
+                    <IconX size={12} strokeWidth="1.8" />
+                  </ActionIcon>
+                </div>
               ))}
             </div>
           )}
@@ -766,7 +811,6 @@ function TaskMetadataPanel(props: {task: Task}) {
             size="xs"
             variant="subtle"
             color="red"
-            loading={deleting}
             leftIcon={<IconTrash size={14} strokeWidth="1.8" />}
             onClick={onDeleteTask}
           >

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -25,8 +25,10 @@ import {
   IconX,
 } from '@tabler/icons-preact';
 import {Timestamp} from 'firebase/firestore';
+import {ComponentChildren} from 'preact';
 import {ChangeEvent} from 'preact/compat';
 import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
+import {useLocation} from 'preact-iso';
 import {
   RichTextBlock,
   RichTextData,
@@ -37,6 +39,7 @@ import {Heading} from '../../components/Heading/Heading.js';
 import {Markdown} from '../../components/Markdown/Markdown.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {TaskCommentEditor} from '../../components/TaskCommentEditor/TaskCommentEditor.js';
+import {UserTag} from '../../components/UserTag/UserTag.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
@@ -45,10 +48,14 @@ import {errorMessage} from '../../utils/notifications.js';
 import {
   addTaskComment,
   addTaskAttachment,
+  buildTaskAttachment,
+  deleteTask,
   deleteTaskComment,
   editTaskComment,
+  normalizeTaskCcList,
   normalizeTaskStatus,
   removeTaskAttachment,
+  restoreTask,
   subscribeTask,
   subscribeTaskComments,
   subscribeTaskEvents,
@@ -59,6 +66,7 @@ import {
   TaskMetadataField,
   TaskPriority,
   updateTaskTitle,
+  updateTaskCcList,
   updateTaskDescription,
   updateTaskAssignee,
   updateTaskPriority,
@@ -157,20 +165,70 @@ export function TaskPage(props: {id: string}) {
           <Surface className="TaskPage__notFound">Task not found.</Surface>
         )}
         {!loading && !error && task && (
-          <div className="TaskPage__body">
-            <main className="TaskPage__main">
-              <TaskDescription task={task} />
-              <TaskAttachments task={task} />
-              <TaskTimeline task={task} comments={comments} events={events} />
-              <TaskCommentComposer taskId={task.id} />
-            </main>
-            <aside className="TaskPage__side">
-              <TaskMetadataPanel task={task} />
-            </aside>
-          </div>
+          <>
+            {task.deleted && <TaskDeletedBanner task={task} />}
+            <div className="TaskPage__body">
+              <main className="TaskPage__main">
+                <TaskDescription task={task} />
+                <TaskAttachments task={task} />
+                <TaskTimeline task={task} comments={comments} events={events} />
+                <TaskCommentComposer taskId={task.id} />
+              </main>
+              <aside className="TaskPage__side">
+                <TaskMetadataPanel task={task} />
+              </aside>
+            </div>
+          </>
         )}
       </div>
     </Layout>
+  );
+}
+
+/** Banner shown when a task has been deleted, with an option to restore it. */
+function TaskDeletedBanner(props: {task: Task}) {
+  const {task} = props;
+  const [restoring, setRestoring] = useState(false);
+
+  async function onRestore() {
+    setRestoring(true);
+    try {
+      await restoreTask(task.id);
+    } catch (err) {
+      showNotification({
+        title: 'Could not restore task',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setRestoring(false);
+    }
+  }
+
+  return (
+    <div className="TaskPage__deletedBanner">
+      <div className="TaskPage__deletedBanner__text">
+        This task was deleted
+        {task.deletedBy && (
+          <>
+            {' '}
+            by <UserTag email={task.deletedBy} />
+          </>
+        )}
+        {task.deletedAt && <> {formatTaskDateTime(task.deletedAt)}</>}. It no
+        longer appears in task lists.
+      </div>
+      <Button
+        compact
+        size="xs"
+        variant="default"
+        loading={restoring}
+        onClick={onRestore}
+      >
+        Restore task
+      </Button>
+    </div>
   );
 }
 
@@ -489,7 +547,7 @@ function TaskAttachments(props: {task: Task}) {
                   {formatTaskAttachmentName(attachment)}
                 </a>
                 <div className="TaskPage__attachments__itemMeta">
-                  {formatTaskAttachmentMeta(attachment)}
+                  <TaskAttachmentMeta attachment={attachment} />
                 </div>
               </div>
               <div className="TaskPage__attachments__itemActions">
@@ -527,16 +585,20 @@ function TaskAttachments(props: {task: Task}) {
 /** Renders editable task metadata and writes changes to history. */
 function TaskMetadataPanel(props: {task: Task}) {
   const {task} = props;
+  const {route} = useLocation();
   const [assignee, setAssignee] = useState(task.assignee || '');
+  const [cc, setCc] = useState((task.cc || []).join(', '));
   const [targetLaunchDate, setTargetLaunchDate] = useState(
     formatDateInputValue(task.targetLaunchDate)
   );
   const [savingField, setSavingField] = useState<TaskMetadataField | ''>('');
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     setAssignee(task.assignee || '');
+    setCc((task.cc || []).join(', '));
     setTargetLaunchDate(formatDateInputValue(task.targetLaunchDate));
-  }, [task.assignee, task.targetLaunchDate]);
+  }, [task.assignee, task.cc, task.targetLaunchDate]);
 
   async function saveMetadata(
     field: TaskMetadataField,
@@ -565,6 +627,35 @@ function TaskMetadataPanel(props: {task: Task}) {
     saveMetadata('assignee', () =>
       updateTaskAssignee(task.id, normalizedAssignee || null)
     );
+  }
+
+  function saveCc() {
+    const normalizedCc = normalizeTaskCcList(cc.split(/[,\s]+/));
+    if ((task.cc || []).join(',') === normalizedCc.join(',')) {
+      setCc(normalizedCc.join(', '));
+      return;
+    }
+    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
+  }
+
+  async function onDeleteTask() {
+    if (!window.confirm(`Delete task #${task.id} "${task.title}"?`)) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await deleteTask(task.id);
+      route('/cms/tasks');
+    } catch (err) {
+      showNotification({
+        title: 'Could not delete task',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setDeleting(false);
+    }
   }
 
   function saveTargetLaunchDate(value: string) {
@@ -614,6 +705,33 @@ function TaskMetadataPanel(props: {task: Task}) {
         </div>
       </div>
       <div className="TaskPage__metadata__field">
+        <label>CC</label>
+        <div className="TaskPage__metadata__cc">
+          <TextInput
+            size="xs"
+            placeholder="a@example.com, b@example.com"
+            value={cc}
+            disabled={savingField === 'cc'}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setCc(e.currentTarget.value)
+            }
+            onBlur={() => saveCc()}
+            onKeyDown={(e: KeyboardEvent) => {
+              if (e.key === 'Enter') {
+                (e.currentTarget as HTMLInputElement).blur();
+              }
+            }}
+          />
+          {(task.cc || []).length > 0 && (
+            <div className="TaskPage__metadata__ccList">
+              {(task.cc || []).map((email) => (
+                <UserTag key={email} email={email} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="TaskPage__metadata__field">
         <label>Priority</label>
         <Select
           size="xs"
@@ -641,6 +759,21 @@ function TaskMetadataPanel(props: {task: Task}) {
           />
         </div>
       </div>
+      {!task.deleted && (
+        <div className="TaskPage__metadata__danger">
+          <Button
+            compact
+            size="xs"
+            variant="subtle"
+            color="red"
+            loading={deleting}
+            leftIcon={<IconTrash size={14} strokeWidth="1.8" />}
+            onClick={onDeleteTask}
+          >
+            Delete task
+          </Button>
+        </div>
+      )}
     </Surface>
   );
 }
@@ -652,6 +785,37 @@ function TaskTimeline(props: {
   events: TaskEvent[];
 }) {
   const {task, comments, events} = props;
+  // Assign stable 1-based numbers to comments (in createdAt order) for
+  // deeplink anchors like `#comment-1`.
+  const commentNumbers = useMemo(() => {
+    const numbers = new Map<string, number>();
+    [...comments]
+      .sort(
+        (a, b) => timestampMillis(a.createdAt) - timestampMillis(b.createdAt)
+      )
+      .forEach((comment, index) => {
+        numbers.set(comment.id, index + 1);
+      });
+    return numbers;
+  }, [comments]);
+
+  // Scroll to the comment referenced by the URL hash once comments load.
+  const didScrollToHashRef = useRef(false);
+  useEffect(() => {
+    if (didScrollToHashRef.current || comments.length === 0) {
+      return;
+    }
+    const hash = window.location.hash;
+    if (!/^#comment-\d+$/.test(hash)) {
+      return;
+    }
+    const el = document.getElementById(hash.slice(1));
+    if (el) {
+      didScrollToHashRef.current = true;
+      el.scrollIntoView({block: 'start'});
+    }
+  }, [comments]);
+
   const repliesByParentId = useMemo(() => {
     const replies = new Map<string, TaskComment[]>();
     comments
@@ -705,6 +869,7 @@ function TaskTimeline(props: {
             comment={item.comment}
             replies={repliesByParentId.get(item.comment.id) || []}
             threadParentId={item.comment.id}
+            commentNumbers={commentNumbers}
           />
         );
       })}
@@ -721,8 +886,10 @@ function TaskOpenedTimelineItem(props: {task: Task}) {
         <IconCheck size={15} strokeWidth="2" />
       </div>
       <div className="TaskPage__timelineItem__content">
-        <b>{formatTaskUser(task.createdBy || 'unknown')}</b> opened this task{' '}
-        {formatTaskDateTime(task.createdAt)}.
+        <b>
+          <UserTag email={task.createdBy || 'unknown'} />
+        </b>{' '}
+        opened this task {formatTaskDateTime(task.createdAt)}.
       </div>
     </div>
   );
@@ -747,8 +914,10 @@ function TaskEventTimelineItem(props: {event: TaskEvent}) {
         )}
       </div>
       <div className="TaskPage__timelineItem__content">
-        <b>{formatTaskUser(event.createdBy || 'unknown')}</b> changed{' '}
-        {formatTaskField(event.field)} from{' '}
+        <b>
+          <UserTag email={event.createdBy || 'unknown'} />
+        </b>{' '}
+        changed {formatTaskField(event.field)} from{' '}
         <span className="TaskPage__timelineValue">
           {formatTaskEventValue(event.field, event.oldValue)}
         </span>{' '}
@@ -768,8 +937,11 @@ function TaskCommentCard(props: {
   replies?: TaskComment[];
   isReply?: boolean;
   threadParentId?: string;
+  commentNumbers?: Map<string, number>;
 }) {
   const {comment} = props;
+  const commentNumber = props.commentNumbers?.get(comment.id);
+  const anchorId = commentNumber ? `comment-${commentNumber}` : undefined;
   const currentUserEmail = window.firebase.user.email || '';
   const [replying, setReplying] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -823,6 +995,7 @@ function TaskCommentCard(props: {
 
   return (
     <div
+      id={anchorId}
       className={joinClassNames(
         'TaskPage__timelineItem',
         'TaskPage__timelineItem--comment',
@@ -840,8 +1013,19 @@ function TaskCommentCard(props: {
         <Surface className="TaskPage__comment">
           <div className="TaskPage__comment__header">
             <div>
-              <b>{formatTaskUser(comment.createdBy || 'unknown')}</b>{' '}
-              <span>{formatTaskDateTime(comment.createdAt)}</span>
+              <b>
+                <UserTag email={comment.createdBy || 'unknown'} />
+              </b>{' '}
+              {anchorId ? (
+                <a
+                  className="TaskPage__comment__timestamp"
+                  href={`#${anchorId}`}
+                >
+                  {formatTaskDateTime(comment.createdAt)}
+                </a>
+              ) : (
+                <span>{formatTaskDateTime(comment.createdAt)}</span>
+              )}
               {comment.updatedAt && !comment.isDeleted && (
                 <span> edited {formatTaskDateTime(comment.updatedAt)}</span>
               )}
@@ -876,6 +1060,7 @@ function TaskCommentCard(props: {
                 value={editBody}
                 placeholder="Edit this comment..."
                 onChange={setEditBody}
+                onSubmitShortcut={onEdit}
               />
               <div className="TaskPage__comment__editActions">
                 <Button
@@ -911,6 +1096,7 @@ function TaskCommentCard(props: {
                 'TaskPage__comment__body',
                 comment.isDeleted && 'TaskPage__comment__body--deleted'
               )}
+              onClick={onCommentBodyClick}
             >
               {comment.isDeleted ? (
                 'Comment deleted.'
@@ -919,10 +1105,15 @@ function TaskCommentCard(props: {
                   className="TaskPage__comment__richText"
                   data={comment.body}
                 />
-              ) : (
+              ) : comment.content ? (
                 <Markdown
                   className="TaskPage__comment__markdown"
                   code={comment.content}
+                />
+              ) : null}
+              {!comment.isDeleted && (
+                <TaskCommentAttachments
+                  attachments={comment.attachments || []}
                 />
               )}
             </div>
@@ -945,6 +1136,7 @@ function TaskCommentCard(props: {
                 comment={reply}
                 isReply
                 threadParentId={comment.id}
+                commentNumbers={props.commentNumbers}
               />
             ))}
           </div>
@@ -963,19 +1155,55 @@ function TaskCommentComposer(props: {
   onCancel?: () => void;
 }) {
   const [body, setBody] = useState<RichTextData | null>(null);
+  const [attachments, setAttachments] = useState<TaskAttachment[]>([]);
+  const [uploading, setUploading] = useState(false);
   const [editorKey, setEditorKey] = useState(0);
   const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const isReply = Boolean(props.parentId);
+  const canSubmit =
+    Boolean(body || attachments.length > 0) && !submitting && !uploading;
 
-  async function onSubmit(e: Event) {
-    e.preventDefault();
-    if (!body) {
+  async function uploadFiles(files: File[]) {
+    if (files.length === 0) {
+      return;
+    }
+    setUploading(true);
+    try {
+      for (const file of files) {
+        const uploadedFile = await uploadFileToGCS(file);
+        const attachment = buildTaskAttachment({
+          ...uploadedFile,
+          filename: uploadedFile.filename || file.name,
+          contentType: file.type || undefined,
+          size: file.size,
+        });
+        setAttachments((current) => [...current, attachment]);
+      }
+    } catch (err) {
+      showNotification({
+        title: 'Could not attach file',
+        message: errorMessage(err),
+        color: 'red',
+        autoClose: false,
+      });
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  }
+
+  async function submit() {
+    if (!body && attachments.length === 0) {
       return;
     }
     setSubmitting(true);
     try {
-      await addTaskComment(props.taskId, body, props.parentId);
+      await addTaskComment(props.taskId, body, props.parentId, {attachments});
       setBody(null);
+      setAttachments([]);
       setEditorKey((value) => value + 1);
       props.onSubmitted?.();
     } catch (err) {
@@ -988,6 +1216,11 @@ function TaskCommentComposer(props: {
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function onSubmit(e: Event) {
+    e.preventDefault();
+    submit();
   }
 
   return (
@@ -1004,8 +1237,57 @@ function TaskCommentComposer(props: {
           placeholder={isReply ? 'Write a reply...' : 'Leave a comment...'}
           value={body}
           onChange={setBody}
+          onSubmitShortcut={submit}
+          onPasteFiles={uploadFiles}
         />
+        {attachments.length > 0 && (
+          <div className="TaskPage__composer__attachments">
+            {attachments.map((attachment) => (
+              <div
+                className="TaskPage__composer__attachment"
+                key={attachment.id}
+              >
+                <IconPaperclip size={14} strokeWidth="1.8" />
+                <span className="TaskPage__composer__attachment__name">
+                  {formatTaskAttachmentName(attachment)}
+                </span>
+                <ActionIcon
+                  size="xs"
+                  title="Remove attachment"
+                  onClick={() =>
+                    setAttachments((current) =>
+                      current.filter((a) => a.id !== attachment.id)
+                    )
+                  }
+                >
+                  <IconX size={12} strokeWidth="1.8" />
+                </ActionIcon>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="TaskPage__composer__actions">
+          <Button
+            compact
+            size="xs"
+            variant="subtle"
+            type="button"
+            loading={uploading}
+            leftIcon={<IconPaperclip size={14} strokeWidth="1.8" />}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Attach
+          </Button>
+          <input
+            ref={fileInputRef}
+            className="TaskPage__composer__fileInput"
+            type="file"
+            multiple
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              uploadFiles(Array.from(e.currentTarget.files || []));
+            }}
+          />
+          <div className="TaskPage__composer__actions__spacer" />
           {props.onCancel && (
             <Button
               compact
@@ -1017,20 +1299,120 @@ function TaskCommentComposer(props: {
               Cancel
             </Button>
           )}
-          <Button
-            compact
-            size="xs"
-            color="dark"
-            type="submit"
-            loading={submitting}
-            disabled={!body}
-          >
-            {isReply ? 'Reply' : 'Comment'}
-          </Button>
+          <Tooltip label="Cmd+Enter to submit" withArrow>
+            <Button
+              compact
+              size="xs"
+              color="dark"
+              type="submit"
+              loading={submitting}
+              disabled={!canSubmit}
+            >
+              {isReply ? 'Reply' : 'Comment'}
+            </Button>
+          </Tooltip>
         </div>
       </form>
     </Surface>
   );
+}
+
+/** Renders attachment chips nested within a comment. */
+function TaskCommentAttachments(props: {attachments: TaskAttachment[]}) {
+  const attachments = props.attachments;
+  if (attachments.length === 0) {
+    return null;
+  }
+  return (
+    <div className="TaskPage__comment__attachments">
+      {attachments.map((attachment) => (
+        <a
+          key={attachment.id}
+          className="TaskPage__comment__attachment"
+          href={attachment.src}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {isImageAttachment(attachment) ? (
+            <img
+              className="TaskPage__comment__attachment__thumb"
+              src={attachment.src}
+              alt={formatTaskAttachmentName(attachment)}
+            />
+          ) : (
+            <IconPaperclip size={14} strokeWidth="1.8" />
+          )}
+          <span className="TaskPage__comment__attachment__name">
+            {formatTaskAttachmentName(attachment)}
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function isImageAttachment(attachment: TaskAttachment) {
+  if (attachment.contentType?.startsWith('image/')) {
+    return true;
+  }
+  const ext =
+    attachment.src.split('?')[0].split('.').at(-1)?.toLowerCase() || '';
+  return ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif'].includes(ext);
+}
+
+/**
+ * Handles clicks on links inside comment bodies. Only `/cms` links are left to
+ * the SPA router; all other links open in a new window.
+ */
+function onCommentBodyClick(e: MouseEvent) {
+  const link = (e.target as HTMLElement)?.closest?.(
+    'a[href]'
+  ) as HTMLAnchorElement | null;
+  if (!link) {
+    return;
+  }
+  const href = link.getAttribute('href') || '';
+  if (!href || href.startsWith('#') || isCmsInternalUrl(href)) {
+    return;
+  }
+  e.preventDefault();
+  e.stopPropagation();
+  window.open(link.href, '_blank', 'noopener,noreferrer');
+}
+
+/** Returns true if a link should be handled by the CMS SPA router. */
+function isCmsInternalUrl(href: string) {
+  try {
+    const url = new URL(href, window.location.origin);
+    return (
+      url.origin === window.location.origin &&
+      (url.pathname === '/cms' || url.pathname.startsWith('/cms/'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Adds `target="_blank"` and an external-link marker class to any non-CMS
+ * links in sanitized comment HTML, so they bypass SPA navigation.
+ */
+function decorateCommentHtml(html: string) {
+  if (!html.includes('<a')) {
+    return html;
+  }
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  template.content.querySelectorAll('a[href]').forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    if (href.startsWith('#') || isCmsInternalUrl(href)) {
+      return;
+    }
+    link.setAttribute('target', '_blank');
+    link.setAttribute('rel', 'noopener noreferrer');
+    link.classList.add('TaskPage__externalLink');
+  });
+  return template.innerHTML;
 }
 
 function TaskRichText(props: {className?: string; data: RichTextData}) {
@@ -1101,7 +1483,9 @@ function TaskRichTextHtml(props: {
   const Component = props.tag;
   return (
     <Component
-      dangerouslySetInnerHTML={{__html: sanitizeInlineHtml(props.html)}}
+      dangerouslySetInnerHTML={{
+        __html: decorateCommentHtml(sanitizeInlineHtml(props.html)),
+      }}
     />
   );
 }
@@ -1112,7 +1496,7 @@ function TaskRichTextListItem(props: {item: RichTextListItem}) {
       {props.item.content && (
         <span
           dangerouslySetInnerHTML={{
-            __html: sanitizeInlineHtml(props.item.content),
+            __html: decorateCommentHtml(sanitizeInlineHtml(props.item.content)),
           }}
         />
       )}
@@ -1165,16 +1549,34 @@ function formatTaskAttachmentName(attachment: TaskAttachment) {
   }
 }
 
-function formatTaskAttachmentMeta(attachment: TaskAttachment) {
-  const parts = [
+/** Renders the meta line (size, type, uploader, date) for a task attachment. */
+function TaskAttachmentMeta(props: {attachment: TaskAttachment}) {
+  const {attachment} = props;
+  const parts: ComponentChildren[] = [
     formatFileSize(attachment.size),
     attachment.contentType || '',
-    attachment.attachedBy
-      ? `attached by ${formatTaskUser(attachment.attachedBy)}`
-      : '',
+    attachment.attachedBy ? (
+      <>
+        attached by <UserTag email={attachment.attachedBy} />
+      </>
+    ) : (
+      ''
+    ),
     attachment.attachedAt ? formatTaskDateTime(attachment.attachedAt) : '',
   ].filter(Boolean);
-  return parts.length > 0 ? parts.join(' - ') : 'Attached file';
+  if (parts.length === 0) {
+    return <>Attached file</>;
+  }
+  return (
+    <>
+      {parts.map((part, index) => (
+        <span key={index}>
+          {index > 0 && ' - '}
+          {part}
+        </span>
+      ))}
+    </>
+  );
 }
 
 function formatFileSize(size?: number) {
@@ -1192,10 +1594,6 @@ function formatFileSize(size?: number) {
     unitIndex += 1;
   }
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`;
-}
-
-function formatTaskUser(email: string) {
-  return email.split('@')[0] || email;
 }
 
 function formatTaskDate(ts?: Timestamp | null) {
@@ -1240,7 +1638,20 @@ function formatTaskEventValue(
     return formatTaskDate(value);
   }
   if (field === 'assignee') {
-    return formatTaskUser(value);
+    return <UserTag email={value} />;
+  }
+  if (field === 'cc') {
+    const emails = value.split(/,\s*/).filter(Boolean);
+    return (
+      <>
+        {emails.map((email, index) => (
+          <span key={email}>
+            {index > 0 && ', '}
+            <UserTag email={email} />
+          </span>
+        ))}
+      </>
+    );
   }
   if (field === 'title') {
     return value;

--- a/packages/root-cms/ui/utils/tasks.ts
+++ b/packages/root-cms/ui/utils/tasks.ts
@@ -26,6 +26,8 @@ export interface Task {
   description?: string;
   attachments?: TaskAttachment[];
   assignee?: string | null;
+  /** Emails of users cc'd on the task. */
+  cc?: string[];
   priority?: TaskPriority;
   status?: string;
   targetLaunchDate?: Timestamp | null;
@@ -33,6 +35,9 @@ export interface Task {
   createdBy: string;
   updatedAt?: Timestamp;
   updatedBy?: string;
+  deleted?: boolean;
+  deletedAt?: Timestamp;
+  deletedBy?: string;
 }
 
 export type TaskPriority = 'high' | 'medium' | 'normal';
@@ -60,6 +65,8 @@ export interface TaskComment {
   parentId?: string | null;
   content: string;
   body?: RichTextData | null;
+  /** Files attached to the comment (e.g. pasted images). */
+  attachments?: TaskAttachment[];
   /** Lower-cased emails of users mentioned via `@<email>` in the content. */
   mentions?: string[];
   createdAt: Timestamp;
@@ -75,6 +82,7 @@ export interface TaskComment {
 export type TaskMetadataField =
   | 'title'
   | 'assignee'
+  | 'cc'
   | 'priority'
   | 'status'
   | 'targetLaunchDate';
@@ -259,12 +267,14 @@ function readTasksFromSnapshot(snapshot: {
   docs: Array<{id: string; data(): unknown}>;
 }) {
   return sortTasksByCreatedAt(
-    snapshot.docs.map((docSnapshot) => {
-      return {
-        ...(docSnapshot.data() as Record<string, unknown>),
-        id: docSnapshot.id,
-      } as Task;
-    })
+    snapshot.docs
+      .map((docSnapshot) => {
+        return {
+          ...(docSnapshot.data() as Record<string, unknown>),
+          id: docSnapshot.id,
+        } as Task;
+      })
+      .filter((task) => !task.deleted)
   );
 }
 
@@ -375,6 +385,93 @@ export async function updateTaskAssignee(
       metadata: {taskId, assignee: normalizedAssignee},
     });
   }
+}
+
+/**
+ * Updates the cc list on a task. The task doc stores the list as an array;
+ * the history event records the values as comma-joined strings.
+ */
+export async function updateTaskCcList(taskId: string, cc: string[]) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  const normalizedCc = normalizeTaskCcList(cc);
+  const db = window.firebase.db;
+  const taskRef = taskDocRef(taskId);
+  const eventRef = taskEventDocRef(taskId);
+  const userEmail = window.firebase.user.email || '';
+
+  const didUpdate = await runTransaction(db, async (transaction) => {
+    const snapshot = await transaction.get(taskRef);
+    if (!snapshot.exists()) {
+      throw new Error('task not found');
+    }
+    const data = snapshot.data() as Task;
+    const oldCc = normalizeTaskCcList(data.cc || []);
+    if (oldCc.join(',') === normalizedCc.join(',')) {
+      return false;
+    }
+    transaction.update(taskRef, {
+      cc: normalizedCc,
+      updatedAt: serverTimestamp(),
+      updatedBy: userEmail,
+    });
+    transaction.set(eventRef, {
+      id: eventRef.id,
+      taskId,
+      type: 'metadata',
+      field: 'cc',
+      oldValue: oldCc.join(', ') || null,
+      newValue: normalizedCc.join(', ') || null,
+      createdAt: serverTimestamp(),
+      createdBy: userEmail,
+    });
+    return true;
+  });
+
+  if (didUpdate) {
+    logAction('tasks.updateCc', {metadata: {taskId, cc: normalizedCc}});
+  }
+}
+
+/** Trims, lower-cases, and de-dupes a list of cc emails. */
+export function normalizeTaskCcList(cc: string[]) {
+  const normalized: string[] = [];
+  cc.forEach((email) => {
+    const value = email.trim().toLowerCase();
+    if (value && !normalized.includes(value)) {
+      normalized.push(value);
+    }
+  });
+  return normalized;
+}
+
+/** Soft-deletes a task so it no longer appears in task lists. */
+export async function deleteTask(taskId: string) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  await updateDoc(taskDocRef(taskId), {
+    deleted: true,
+    deletedAt: serverTimestamp(),
+    deletedBy: window.firebase.user.email || '',
+    updatedAt: serverTimestamp(),
+    updatedBy: window.firebase.user.email || '',
+  });
+  logAction('tasks.delete', {metadata: {taskId}});
+}
+
+/** Restores a soft-deleted task. */
+export async function restoreTask(taskId: string) {
+  if (!taskId) {
+    throw new Error('missing task id');
+  }
+  await updateDoc(taskDocRef(taskId), {
+    deleted: false,
+    updatedAt: serverTimestamp(),
+    updatedBy: window.firebase.user.email || '',
+  });
+  logAction('tasks.restore', {metadata: {taskId}});
 }
 
 export async function updateTaskTitle(taskId: string, title: string) {
@@ -625,22 +722,43 @@ function normalizeTaskAttachments(value: unknown): TaskAttachment[] {
   });
 }
 
+/** Builds a `TaskAttachment` from an uploaded file, for embedding in a comment. */
+export function buildTaskAttachment(
+  file: UploadedFile & {contentType?: string; size?: number}
+): TaskAttachment {
+  const attachment: Record<string, unknown> = {};
+  // Skip undefined values, which firestore rejects.
+  Object.entries(file).forEach(([key, value]) => {
+    if (value !== undefined) {
+      attachment[key] = value;
+    }
+  });
+  attachment.id = doc(tasksCollectionRef()).id;
+  attachment.attachedAt = Timestamp.now();
+  attachment.attachedBy = window.firebase.user.email || '';
+  return attachment as unknown as TaskAttachment;
+}
+
 export async function addTaskComment(
   taskId: string,
-  content: string | RichTextData,
+  content: string | RichTextData | null,
   parentId?: string | null,
-  options?: {mentions?: string[]}
+  options?: {mentions?: string[]; attachments?: TaskAttachment[]}
 ) {
   if (!taskId) {
     throw new Error('missing task id');
   }
-  if (!content) {
+  const attachments = options?.attachments || [];
+  if (!content && attachments.length === 0) {
     throw new Error('missing comment content');
   }
-  const body = normalizeTaskCommentBody(content);
-  const contentText =
-    typeof content === 'string' ? content : getRichTextPlainText(content);
-  if (!contentText.trim() && !body) {
+  const body = content ? normalizeTaskCommentBody(content) : null;
+  const contentText = !content
+    ? ''
+    : typeof content === 'string'
+      ? content
+      : getRichTextPlainText(content);
+  if (!contentText.trim() && !body && attachments.length === 0) {
     throw new Error('missing comment content');
   }
 
@@ -654,6 +772,7 @@ export async function addTaskComment(
     parentId: parentId || null,
     content: contentText,
     body,
+    attachments,
     mentions,
     createdAt: serverTimestamp(),
     createdBy: window.firebase.user.email || '',

--- a/packages/root-cms/ui/utils/tasks.ts
+++ b/packages/root-cms/ui/utils/tasks.ts
@@ -779,6 +779,12 @@ export async function addTaskComment(
     history: [],
   });
 
+  // Bump the task's `updatedAt` so comment activity is reflected in lists.
+  await updateDoc(taskDocRef(taskId), {
+    updatedAt: serverTimestamp(),
+    updatedBy: window.firebase.user.email || '',
+  });
+
   logAction('tasks.comment.add', {
     metadata: {taskId, commentId, parentId: parentId || null, mentions},
   });


### PR DESCRIPTION
Implements most of #1385. The "@" / assignee autocomplete features (items 1–2) are intentionally deferred to a followup PR.

## Changes

- **CC list field** (#1385 item 3): New "CC" field in the task metadata panel. Accepts comma/space-separated emails, stored as a normalized array on the task doc, with changes recorded as history events.
- **Comment attachments** (item 4): Paste an image (e.g. a screenshot) into the comment box or use the new "Attach" button; files upload to GCS and render as attachment chips (with image thumbnails) nested within the comment.
- **User tooltips** (item 5): New `UserTag` component renders the short username with a hover tooltip showing the avatar, display name (when available), and full email — same data as the doc-editor status badges. Applied across the task page, task table/board/rows.
- **Cmd+Enter to submit** (item 6): Cmd/Ctrl+Enter submits the comment composer and reply composer, and saves comment edits.
- **Comment deeplinks** (item 7): Comments get stable `#comment-N` anchors; the timestamp is now a right-clickable "Copy link" anchor. Visiting `/cms/tasks/7#comment-1` scrolls to and highlights the comment once it loads.
- **Delete/restore tasks** (item 8): "Delete task" button (soft delete) in the metadata panel; deleted tasks are filtered from all task lists. Visiting a deleted task's URL shows a banner with a "Restore task" option.
- **Auto-linkify URLs** (item 9): URLs and emails typed or pasted into rich text fields (comments and doc editors) are automatically converted to links via Lexical's AutoLinkPlugin.
- **External links open in a new window** (comment follow-up): Links inside comments that don't point at `/cms` bypass SPA navigation — they get `target="_blank"` plus an external-link icon, fixing the 404 when sharing preview links like `/foo/bar/?preview=true`.

## Testing

- `pnpm build` (root-cms) passes.
- `tsc --noEmit -p ui/tsconfig.json` passes (one pre-existing unrelated error in `Layout.tsx`).
- `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)