### PR TITLE
chore: polish task details page layout and timeline density

### DIFF
--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -1,11 +1,13 @@
 .TaskPage {
+  /* Shared width cap for the page's header, banners, and two-column body. */
+  --task-page-max-width: 1260px;
   background: var(--page-background);
   padding: var(--page-padding-lg);
 }
 
 .TaskPage__header {
   margin-bottom: 28px;
-  max-width: 1040px;
+  max-width: var(--task-page-max-width);
 }
 
 .TaskPage__header__breadcrumbs {
@@ -41,7 +43,7 @@
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(220px, 1fr) auto auto;
-  max-width: 760px;
+  max-width: 880px;
   min-width: 0;
   width: 100%;
 }
@@ -107,8 +109,8 @@
   align-items: start;
   display: grid;
   gap: 28px;
-  grid-template-columns: minmax(0, 760px) minmax(260px, 320px);
-  max-width: 1120px;
+  grid-template-columns: minmax(0, 880px) minmax(280px, 340px);
+  max-width: var(--task-page-max-width);
 }
 
 .TaskPage__main {
@@ -118,10 +120,15 @@
   min-width: 0;
 }
 
+/*
+ * The page element is itself the scroll container and already starts below the
+ * CMS header, so the sticky offset only needs a small gap from the top of the
+ * scroll port.
+ */
 .TaskPage__side {
   min-width: 0;
   position: sticky;
-  top: calc(var(--header-height) + 20px);
+  top: 20px;
 }
 
 .TaskPage__description {
@@ -589,7 +596,7 @@
   gap: 12px;
   justify-content: space-between;
   margin-bottom: 18px;
-  max-width: 1120px;
+  max-width: var(--task-page-max-width);
   padding: 10px 14px;
 }
 
@@ -633,7 +640,7 @@
 
 /* Highlights the comment targeted by a `#comment-N` deeplink. */
 .TaskPage__timelineItem:target {
-  scroll-margin-top: calc(var(--header-height) + 16px);
+  scroll-margin-top: 16px;
 }
 
 .TaskPage__timelineItem:target .TaskPage__comment {

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -1,6 +1,6 @@
 .TaskPage {
   /* Shared width cap for the page's header, banners, and two-column body. */
-  --task-page-max-width: 1260px;
+  --task-page-max-width: 1340px;
   background: var(--page-background);
   padding: var(--page-padding-lg);
 }
@@ -43,7 +43,7 @@
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(220px, 1fr) auto auto;
-  max-width: 880px;
+  max-width: 960px;
   min-width: 0;
   width: 100%;
 }
@@ -109,7 +109,7 @@
   align-items: start;
   display: grid;
   gap: 28px;
-  grid-template-columns: minmax(0, 880px) minmax(280px, 340px);
+  grid-template-columns: minmax(0, 960px) minmax(280px, 340px);
   max-width: var(--task-page-max-width);
 }
 
@@ -121,14 +121,15 @@
 }
 
 /*
- * The page element is itself the scroll container and already starts below the
- * CMS header, so the sticky offset only needs a small gap from the top of the
- * scroll port.
+ * The page element is itself the scroll container, and sticky offsets resolve
+ * against its content box, so the page's own `--page-padding-lg` already sits
+ * above the pinned sidebar. The negative offset trims that padding back to a
+ * ~40px gap; it never clips the panel, since the padding absorbs it.
  */
 .TaskPage__side {
   min-width: 0;
   position: sticky;
-  top: 20px;
+  top: -20px;
 }
 
 .TaskPage__description {

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -318,8 +318,8 @@
 
 .TaskPage__timelineItem {
   display: grid;
-  gap: 12px;
-  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  grid-template-columns: 24px minmax(0, 1fr);
   position: relative;
 }
 
@@ -327,18 +327,18 @@
   background: var(--color-border);
   bottom: 0;
   content: '';
-  left: 15px;
+  left: 11px;
   position: absolute;
   top: 0;
   width: 2px;
 }
 
 .TaskPage__timelineItem:first-child::before {
-  top: 18px;
+  top: 14px;
 }
 
 .TaskPage__timelineItem:last-child::before {
-  bottom: calc(100% - 18px);
+  bottom: calc(100% - 14px);
 }
 
 .TaskPage__timelineItem__marker {
@@ -348,23 +348,23 @@
   border-radius: 50%;
   color: var(--color-text-gray);
   display: flex;
-  height: 32px;
+  height: 24px;
   justify-content: center;
   position: relative;
-  width: 32px;
+  width: 24px;
   z-index: 1;
 }
 
 .TaskPage__timelineItem__content {
   min-width: 0;
-  padding-bottom: 18px;
+  padding-bottom: 12px;
 }
 
 .TaskPage__timelineItem--event .TaskPage__timelineItem__content {
   color: var(--color-text-gray);
-  font-size: 13px;
-  line-height: 1.5;
-  padding-top: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+  padding-top: 4px;
 }
 
 .TaskPage__timelineItem--event b {
@@ -384,7 +384,7 @@
 }
 
 .TaskPage__timelineItem--comment .TaskPage__timelineItem__content {
-  padding-bottom: 18px;
+  padding-bottom: 12px;
 }
 
 .TaskPage__timelineValue {
@@ -392,9 +392,9 @@
   border-radius: 4px;
   color: var(--color-text-default);
   font-family: var(--font-family-mono);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
-  padding: 2px 5px;
+  padding: 1px 5px;
 }
 
 .TaskPage__comment {
@@ -564,9 +564,9 @@
 .TaskPage__replies {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-left: 42px;
-  margin-top: 12px;
+  gap: 10px;
+  margin-left: 34px;
+  margin-top: 10px;
   padding-left: 0;
 }
 

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -1012,7 +1012,7 @@ function TaskOpenedTimelineItem(props: {task: Task}) {
   return (
     <div className="TaskPage__timelineItem TaskPage__timelineItem--event">
       <div className="TaskPage__timelineItem__marker">
-        <IconCheck size={15} strokeWidth="2" />
+        <IconCheck size={13} strokeWidth="2" />
       </div>
       <div className="TaskPage__timelineItem__content">
         <b>
@@ -1031,15 +1031,15 @@ function TaskEventTimelineItem(props: {event: TaskEvent}) {
     <div className="TaskPage__timelineItem TaskPage__timelineItem--event">
       <div className="TaskPage__timelineItem__marker">
         {event.field === 'title' ? (
-          <IconPencil size={15} strokeWidth="2" />
+          <IconPencil size={13} strokeWidth="2" />
         ) : event.field === 'assignee' ? (
-          <IconUser size={15} strokeWidth="2" />
+          <IconUser size={13} strokeWidth="2" />
         ) : event.field === 'priority' ? (
-          <IconFlag size={15} strokeWidth="2" />
+          <IconFlag size={13} strokeWidth="2" />
         ) : event.field === 'targetLaunchDate' ? (
-          <IconCalendar size={15} strokeWidth="2" />
+          <IconCalendar size={13} strokeWidth="2" />
         ) : (
-          <IconCheck size={15} strokeWidth="2" />
+          <IconCheck size={13} strokeWidth="2" />
         )}
       </div>
       <div className="TaskPage__timelineItem__content">
@@ -1175,9 +1175,9 @@ function TaskCommentCard(props: {
     >
       <div className="TaskPage__timelineItem__marker">
         {props.isReply ? (
-          <IconCornerDownRight size={15} strokeWidth="2" />
+          <IconCornerDownRight size={13} strokeWidth="2" />
         ) : (
-          <IconMessageCircle size={15} strokeWidth="2" />
+          <IconMessageCircle size={13} strokeWidth="2" />
         )}
       </div>
       <div className="TaskPage__timelineItem__content">


### PR DESCRIPTION
UI polish for the task details page (`TaskPage`) — width, sticky sidebar offset, and timeline density.

### Wider page

The page's width caps are consolidated into a single `--task-page-max-width` custom property on `.TaskPage` and raised from 1120px to 1340px, applied to the header, the deleted banner, and the two-column body. The grid columns widen to match: main `760px → 960px`, sidebar `260–320px → 280–340px`. The inline title-edit form widens to 960px so it stays aligned with the main column.

Side effect worth noting: the header previously capped at 1040px, narrower than the 1120px body. It now shares the same cap as everything else, so the breadcrumbs/title row lines up with the content below it.

### Less whitespace above the sticky sidebar

`.TaskPage__side` used `top: calc(var(--header-height) + 20px)`. That offset assumed the window was the scroll container, but it isn't — `.Layout__main > *:first-child` gives `.TaskPage` itself `height: calc(100vh - 48px); overflow: auto`, so the scroll port already starts below the 48px CMS header.

There is a second contribution on top of that. Sticky offsets resolve against the scroll container's **content** box, so `.TaskPage`'s own `--page-padding-lg` (60px) stacks onto whatever `top` is set to. Measured in Chromium against a reproduction of this layout, the rendered gap between the CMS header and the pinned panel was:

| `top` | rendered gap |
| --- | --- |
| `calc(var(--header-height) + 20px)` (before) | 128px |
| `20px` | 80px |
| `-20px` (this PR) | 40px |

The negative value is deliberate and safe: the 60px of page padding absorbs it, so the panel is never clipped and keeps its rounded top corners. There's a comment on the rule explaining this, since a bare negative `top` reads like a typo otherwise.

### Deeplink offset

`scroll-margin-top` on `.TaskPage__timelineItem:target` (the `#comment-N` deeplink) had the same header double-count, so it drops from `calc(var(--header-height) + 16px)` to `16px`. Note that `scroll-margin` does *not* behave like the sticky offset above — it resolves against the padding box, so no padding compensation is needed here. Verified both cases in Chromium: the target now lands 16px below the top of the scroll port instead of 64px.

### Tighter timeline

Timeline markers shrink from 32px to 24px, with the Tabler glyphs inside going from `size={15}` to `size={13}`. Surrounding type and spacing come in with them:

| | before | after |
| --- | --- | --- |
| marker | 32px | 24px |
| column gutter | 12px | 10px |
| event text | 13px / 1.5 | 12px / 1.45 |
| value chip | 12px, `2px 5px` | 11px, `1px 5px` |
| row padding-bottom | 18px | 12px |
| reply indent / gap | 42px / 12px | 34px / 10px |

Three values are derived from the marker size rather than picked, and were re-measured after the change: the rail's `left` (11px, so its 2px width centers on the 24px marker), the `first-child`/`last-child` rail stubs, and the event text's `padding-top` (4px, which puts the first line's center exactly on the marker's center). A rendered check confirms rail center and marker center both land at 12px, and the text/marker vertical delta is 0px. Net effect is event rows going from ~43.5px to ~32.4px tall.

Comment card internals (14px body, 13px header) are left alone — only the timeline row scaffolding changed.

### Testing

Layout and timeline geometry were verified by rendering the real `TaskPage.css` in headless Chromium against markup mirroring the component's DOM, and measuring marker/rail/text positions and the pinned panel and deeplink offsets. Prettier passes on both changed files. `eslint` couldn't run in this environment (monorepo deps aren't installed) and doesn't cover CSS. There are no visual test goldens for `TaskPage`, so nothing needed regenerating.