### PR TITLE
feat: add user autocomplete to the task assignee and cc fields

### DIFF
--- a/.changeset/shaggy-tasks-autocomplete.md
+++ b/.changeset/shaggy-tasks-autocomplete.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add user autocomplete to the task assignee and cc fields

--- a/packages/root-cms/ui/components/UserSelect/UserSelect.css
+++ b/packages/root-cms/ui/components/UserSelect/UserSelect.css
@@ -1,0 +1,58 @@
+.UserSelect .mantine-Select-input,
+.UserSelect .mantine-MultiSelect-input {
+  min-height: 30px;
+}
+
+.UserSelect__item {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.UserSelect__item__text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.3;
+  min-width: 0;
+}
+
+.UserSelect__item__label {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.UserSelect__item__email {
+  color: var(--color-text-gray);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.UserSelect__value {
+  align-items: center;
+  background: #f6f7f8;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-default);
+  display: inline-flex;
+  font-size: 12px;
+  gap: 4px;
+  margin: 2px;
+  max-width: 100%;
+  min-height: 24px;
+  padding: 1px 2px 1px 3px;
+}
+
+.UserSelect__value__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.UserSelect__value__remove {
+  color: var(--color-text-gray);
+}

--- a/packages/root-cms/ui/components/UserSelect/UserSelect.tsx
+++ b/packages/root-cms/ui/components/UserSelect/UserSelect.tsx
@@ -1,0 +1,255 @@
+import './UserSelect.css';
+
+import {CloseButton, MultiSelect, Select} from '@mantine/core';
+import {forwardRef} from 'preact/compat';
+import {useMemo, useState} from 'preact/hooks';
+import {useProjectUsers} from '../../hooks/useProjectUsers.js';
+import {joinClassNames} from '../../utils/classes.js';
+import {UserAvatar} from '../UserAvatar/UserAvatar.js';
+import {
+  buildUserSelectData,
+  matchesQuery,
+  shouldCreateItem,
+  toFreeValueItem,
+  toProfile,
+  UserSelectItem,
+} from './user-select-data.js';
+
+/** Loads the project's users and tracks any emails typed in by hand. */
+function useUserSelectData(selected: string[]) {
+  const {users, loading} = useProjectUsers();
+  const [created, setCreated] = useState<UserSelectItem[]>([]);
+
+  const data = useMemo(
+    () => buildUserSelectData({users, created, selected}),
+    [users, created, selected.join(',')]
+  );
+
+  function addCreated(query: string) {
+    setCreated((current) => [...current, toFreeValueItem(query)]);
+  }
+
+  return {data, loading, addCreated};
+}
+
+/** Returns a copy of `props` with the given keys removed. */
+function omitProps(props: Record<string, any>, keys: string[]) {
+  const rest: Record<string, any> = {};
+  Object.keys(props).forEach((key) => {
+    if (!keys.includes(key)) {
+      rest[key] = props[key];
+    }
+  });
+  return rest;
+}
+
+/** Fields supplied by the `data` entries, which must not reach the DOM. */
+const ITEM_PROPS = [
+  'value',
+  'label',
+  'email',
+  'displayName',
+  'photoURL',
+  'freeValue',
+];
+
+/**
+ * Dropdown option showing a user's avatar, display name, and email. Mantine
+ * passes each `data` entry's fields through as props.
+ */
+const UserSelectItemComponent = forwardRef((props: any, ref: any) => {
+  const {label, email} = props;
+  const others = omitProps(props, ITEM_PROPS);
+  const profile = toProfile(props);
+  return (
+    <div {...others} ref={ref}>
+      <div className="UserSelect__item">
+        <UserAvatar
+          email={email}
+          profile={profile}
+          size={24}
+          withTooltip={false}
+        />
+        <div className="UserSelect__item__text">
+          <div className="UserSelect__item__label">{label}</div>
+          {email && email !== label && (
+            <div className="UserSelect__item__email">{email}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export interface UserSelectProps {
+  /** Currently selected email, or an empty string when unset. */
+  value: string;
+  /** Called with the selected email (empty string when cleared). */
+  onChange: (email: string) => void;
+  /** Placeholder text shown when nothing is selected. */
+  placeholder?: string;
+  /** Disables interaction, e.g. while a save is in flight. */
+  disabled?: boolean;
+  /** Optional className for the wrapping element. */
+  className?: string;
+}
+
+/**
+ * Single-user picker: an autocomplete dropdown of the project's users (with
+ * avatars) that also accepts any email address typed in by hand.
+ *
+ * Example:
+ *   <UserSelect value={assignee} onChange={setAssignee} />
+ */
+export function UserSelect(props: UserSelectProps) {
+  const value = (props.value || '').trim().toLowerCase();
+  const selected = useMemo(() => (value ? [value] : []), [value]);
+  const {data, loading, addCreated} = useUserSelectData(selected);
+  const selectedItem = data.find((item) => item.value === value);
+
+  return (
+    <Select
+      className={joinClassNames('UserSelect', props.className)}
+      size="xs"
+      data={data}
+      value={value || null}
+      onChange={(newValue: string | null) => props.onChange(newValue || '')}
+      placeholder={props.placeholder || 'Search or enter an email'}
+      disabled={props.disabled}
+      searchable
+      clearable
+      creatable
+      icon={
+        value ? (
+          <UserAvatar
+            email={value}
+            // While the user list loads, `profile` is left undefined so the
+            // avatar falls back to fetching the profile on its own.
+            profile={selectedItem ? toProfile(selectedItem) : undefined}
+            size={20}
+            withTooltip={false}
+          />
+        ) : undefined
+      }
+      itemComponent={UserSelectItemComponent}
+      filter={(query: string, item: UserSelectItem) =>
+        matchesQuery(query, item)
+      }
+      shouldCreate={shouldCreateItem}
+      getCreateLabel={(query: string) => `+ Use "${query.trim()}"`}
+      onCreate={(query: string) => addCreated(query)}
+      nothingFound={loading ? 'Loading…' : 'No users found'}
+      maxDropdownHeight={280}
+      // Due to issues with preact/compat, use a div for the dropdown el.
+      dropdownComponent="div"
+    />
+  );
+}
+
+/** Styling props Mantine passes to `valueComponent` that the chip handles. */
+const VALUE_PROPS = [
+  ...ITEM_PROPS,
+  'onRemove',
+  'classNames',
+  'styles',
+  'size',
+  'radius',
+  'variant',
+  'disabled',
+  'readOnly',
+];
+
+/** Chip rendered for each selected user in the multi-user picker. */
+const UserSelectValueComponent = forwardRef((props: any, ref: any) => {
+  const {label, email, onRemove} = props;
+  const others = omitProps(props, VALUE_PROPS);
+  const profile = toProfile(props);
+  return (
+    <div
+      {...others}
+      ref={ref}
+      className="UserSelect__value"
+      title={email}
+      // Lets callers read the underlying email off the chip, e.g. to copy the
+      // full addresses instead of the display names.
+      data-user-email={email}
+    >
+      <UserAvatar
+        email={email}
+        profile={profile}
+        size={18}
+        withTooltip={false}
+      />
+      <span className="UserSelect__value__label">{label}</span>
+      {!props.disabled && !props.readOnly && (
+        <CloseButton
+          className="UserSelect__value__remove"
+          onMouseDown={onRemove}
+          size={16}
+          iconSize={12}
+          variant="transparent"
+        />
+      )}
+    </div>
+  );
+});
+
+export interface UserMultiSelectProps {
+  /** Currently selected emails. */
+  value: string[];
+  /** Called with the updated list of emails. */
+  onChange: (emails: string[]) => void;
+  /** Placeholder text shown when nothing is selected. */
+  placeholder?: string;
+  /** Disables interaction, e.g. while a save is in flight. */
+  disabled?: boolean;
+  /** Optional className for the wrapping element. */
+  className?: string;
+}
+
+/**
+ * Multi-user picker: an autocomplete dropdown of the project's users (with
+ * avatars) that also accepts any email address typed in by hand. Selected
+ * users render as removable chips.
+ *
+ * Example:
+ *   <UserMultiSelect value={cc} onChange={setCc} />
+ */
+export function UserMultiSelect(props: UserMultiSelectProps) {
+  const value = useMemo(
+    () => (props.value || []).map((email) => email.trim().toLowerCase()),
+    [(props.value || []).join(',')]
+  );
+  const {data, loading, addCreated} = useUserSelectData(value);
+
+  return (
+    <MultiSelect
+      className={joinClassNames(
+        'UserSelect',
+        'UserSelect--multi',
+        props.className
+      )}
+      size="xs"
+      data={data}
+      value={value}
+      onChange={(newValue: string[]) => props.onChange(newValue)}
+      placeholder={props.placeholder || 'Search or enter an email'}
+      disabled={props.disabled}
+      searchable
+      clearSearchOnChange
+      creatable
+      itemComponent={UserSelectItemComponent}
+      valueComponent={UserSelectValueComponent}
+      filter={(query: string, selected: boolean, item: UserSelectItem) =>
+        !selected && matchesQuery(query, item)
+      }
+      shouldCreate={shouldCreateItem}
+      getCreateLabel={(query: string) => `+ Add "${query.trim()}"`}
+      onCreate={(query: string) => addCreated(query)}
+      nothingFound={loading ? 'Loading…' : 'No users found'}
+      maxDropdownHeight={280}
+      // Due to issues with preact/compat, use a div for the dropdown el.
+      dropdownComponent="div"
+    />
+  );
+}

--- a/packages/root-cms/ui/components/UserSelect/user-select-data.test.ts
+++ b/packages/root-cms/ui/components/UserSelect/user-select-data.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from 'vitest';
+import {ProjectUser} from '../../hooks/useProjectUsers.js';
+import {
+  buildUserSelectData,
+  isEmailLike,
+  matchesQuery,
+  shouldCreateItem,
+  toFreeValueItem,
+  toProfile,
+  toUserItem,
+} from './user-select-data.js';
+
+const USERS: ProjectUser[] = [
+  {
+    email: 'ada@example.com',
+    displayName: 'Ada Lovelace',
+    photoURL: 'https://example.com/ada.png',
+    role: 'ADMIN',
+  },
+  {email: 'grace@example.com', displayName: 'Grace Hopper'},
+  {email: 'noname@example.com'},
+];
+
+describe('isEmailLike', () => {
+  it('accepts email addresses', () => {
+    expect(isEmailLike('ada@example.com')).toBe(true);
+    expect(isEmailLike('  ada@example.com  ')).toBe(true);
+    expect(isEmailLike('ada+tasks@example.co.uk')).toBe(true);
+  });
+
+  it('rejects values that are not addressable', () => {
+    expect(isEmailLike('ada')).toBe(false);
+    expect(isEmailLike('')).toBe(false);
+    expect(isEmailLike('@example.com')).toBe(false);
+    expect(isEmailLike('ada@')).toBe(false);
+    expect(isEmailLike('ada lovelace@example.com')).toBe(false);
+    // Domain wildcards are role entries, not people.
+    expect(isEmailLike('*@example.com')).toBe(false);
+  });
+});
+
+describe('toUserItem', () => {
+  it('labels users by display name, falling back to the email', () => {
+    expect(toUserItem(USERS[0])).toEqual({
+      value: 'ada@example.com',
+      label: 'Ada Lovelace',
+      email: 'ada@example.com',
+      displayName: 'Ada Lovelace',
+      photoURL: 'https://example.com/ada.png',
+    });
+    expect(toUserItem(USERS[2]).label).toBe('noname@example.com');
+  });
+});
+
+describe('toFreeValueItem', () => {
+  it('normalizes the email and flags it as a free value', () => {
+    expect(toFreeValueItem('  Outside@Other.COM ')).toEqual({
+      value: 'outside@other.com',
+      label: 'outside@other.com',
+      email: 'outside@other.com',
+      freeValue: true,
+    });
+  });
+});
+
+describe('buildUserSelectData', () => {
+  it('lists the project users', () => {
+    const data = buildUserSelectData({users: USERS, created: [], selected: []});
+    expect(data.map((item) => item.value)).toEqual([
+      'ada@example.com',
+      'grace@example.com',
+      'noname@example.com',
+    ]);
+  });
+
+  it('includes typed-in values and keeps unknown selections', () => {
+    const data = buildUserSelectData({
+      users: USERS,
+      created: [toFreeValueItem('typed@other.com')],
+      selected: ['ada@example.com', 'Legacy@Other.com'],
+    });
+    expect(data.map((item) => item.value)).toEqual([
+      'ada@example.com',
+      'grace@example.com',
+      'noname@example.com',
+      'typed@other.com',
+      'legacy@other.com',
+    ]);
+    expect(
+      data.find((item) => item.value === 'legacy@other.com')
+    ).toMatchObject({label: 'legacy@other.com', freeValue: true});
+  });
+
+  it('does not duplicate a typed-in value that is a project user', () => {
+    const data = buildUserSelectData({
+      users: USERS,
+      created: [toFreeValueItem('ada@example.com')],
+      selected: ['ada@example.com'],
+    });
+    expect(
+      data.filter((item) => item.value === 'ada@example.com')
+    ).toHaveLength(1);
+    expect(data[0].displayName).toBe('Ada Lovelace');
+  });
+});
+
+describe('toProfile', () => {
+  it('returns the profile for a project user', () => {
+    expect(toProfile(toUserItem(USERS[0]))).toEqual({
+      email: 'ada@example.com',
+      displayName: 'Ada Lovelace',
+      photoURL: 'https://example.com/ada.png',
+    });
+  });
+
+  it('returns null for free values so no profile lookup is attempted', () => {
+    expect(toProfile(toFreeValueItem('outside@other.com'))).toBeNull();
+  });
+});
+
+describe('matchesQuery', () => {
+  const ada = toUserItem(USERS[0]);
+
+  it('matches on display name and on email', () => {
+    expect(matchesQuery('lovelace', ada)).toBe(true);
+    expect(matchesQuery('ADA@EXAM', ada)).toBe(true);
+    expect(matchesQuery('  ada  ', ada)).toBe(true);
+    expect(matchesQuery('grace', ada)).toBe(false);
+  });
+
+  it('matches everything when the query is empty', () => {
+    expect(matchesQuery('', ada)).toBe(true);
+    expect(matchesQuery('   ', ada)).toBe(true);
+  });
+});
+
+describe('shouldCreateItem', () => {
+  const data = buildUserSelectData({users: USERS, created: [], selected: []});
+
+  it('offers to add an email that is not a project user', () => {
+    expect(shouldCreateItem('outside@other.com', data)).toBe(true);
+  });
+
+  it('does not offer to add a value that is not an email', () => {
+    expect(shouldCreateItem('ada', data)).toBe(false);
+    expect(shouldCreateItem('', data)).toBe(false);
+  });
+
+  it('does not offer to add an email already in the list', () => {
+    expect(shouldCreateItem('ada@example.com', data)).toBe(false);
+    expect(shouldCreateItem('  ADA@example.com ', data)).toBe(false);
+  });
+});

--- a/packages/root-cms/ui/components/UserSelect/user-select-data.ts
+++ b/packages/root-cms/ui/components/UserSelect/user-select-data.ts
@@ -1,0 +1,113 @@
+import {ProjectUser} from '../../hooks/useProjectUsers.js';
+import {UserProfile} from '../../utils/user-profile.js';
+
+/** A single option in the user dropdown. */
+export interface UserSelectItem {
+  /** The email address, used as the option's value. */
+  value: string;
+  /** The text shown in the input (display name when known, else the email). */
+  label: string;
+  /** The user's email. */
+  email: string;
+  /** The user's display name, when known. */
+  displayName?: string;
+  /** The user's profile photo, when known. */
+  photoURL?: string;
+  /** True when the option was typed in rather than sourced from the project. */
+  freeValue?: boolean;
+}
+
+/**
+ * Loose email check used to decide whether a typed value can be added. Keeps
+ * pace with the rest of the CMS, which only requires an `@` in an address.
+ */
+const EMAIL_RE = /^[^\s@*][^\s@]*@[^\s@]+$/;
+
+/** Returns true if the value looks like an email address. */
+export function isEmailLike(value: string): boolean {
+  return EMAIL_RE.test(value.trim());
+}
+
+/** Builds a dropdown option for a user in the project's user list. */
+export function toUserItem(user: ProjectUser): UserSelectItem {
+  return {
+    value: user.email,
+    label: user.displayName || user.email,
+    email: user.email,
+    displayName: user.displayName,
+    photoURL: user.photoURL,
+  };
+}
+
+/** Builds a dropdown option for an email that isn't a project user. */
+export function toFreeValueItem(email: string): UserSelectItem {
+  const value = email.trim().toLowerCase();
+  return {value: value, label: value, email: value, freeValue: true};
+}
+
+/**
+ * Builds the dropdown options from the project's user list, plus any values
+ * typed in by hand and any selected values that aren't project users, so their
+ * labels still render.
+ */
+export function buildUserSelectData(options: {
+  users: ProjectUser[];
+  created: UserSelectItem[];
+  selected: string[];
+}): UserSelectItem[] {
+  const itemsByValue = new Map<string, UserSelectItem>();
+  options.users.forEach((user) => {
+    itemsByValue.set(user.email, toUserItem(user));
+  });
+  options.created.forEach((item) => {
+    if (!itemsByValue.has(item.value)) {
+      itemsByValue.set(item.value, item);
+    }
+  });
+  options.selected.forEach((value) => {
+    const key = (value || '').trim().toLowerCase();
+    if (key && !itemsByValue.has(key)) {
+      itemsByValue.set(key, toFreeValueItem(key));
+    }
+  });
+  return Array.from(itemsByValue.values());
+}
+
+/**
+ * Returns the profile to render for an item, or `null` for free values (which
+ * have no profile to look up, so the avatar falls back to initials).
+ */
+export function toProfile(item: UserSelectItem): UserProfile | null {
+  if (item.freeValue) {
+    return null;
+  }
+  return {
+    email: item.email,
+    displayName: item.displayName,
+    photoURL: item.photoURL,
+  };
+}
+
+/** Matches the search query against both the display name and the email. */
+export function matchesQuery(query: string, item: UserSelectItem): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return true;
+  }
+  return (
+    (item.label || '').toLowerCase().includes(q) ||
+    (item.email || '').toLowerCase().includes(q)
+  );
+}
+
+/** Only offer to add a typed value when it looks like an email address. */
+export function shouldCreateItem(
+  query: string,
+  data: UserSelectItem[]
+): boolean {
+  const value = query.trim().toLowerCase();
+  if (!isEmailLike(value)) {
+    return false;
+  }
+  return !data.some((item) => item.value.toLowerCase() === value);
+}

--- a/packages/root-cms/ui/hooks/useProjectUsers.ts
+++ b/packages/root-cms/ui/hooks/useProjectUsers.ts
@@ -1,0 +1,67 @@
+import {useMemo} from 'preact/hooks';
+import {UserRole} from '../../core/client.js';
+import {UserProfile, isOrgEmail} from '../utils/user-profile.js';
+import {useProjectRoles} from './useProjectRoles.js';
+import {useAllUserProfiles} from './useUserProfile.js';
+
+/** A user known to the current project, for autocomplete pickers. */
+export interface ProjectUser {
+  /** Lower-cased email address. */
+  email: string;
+  /** Display name from the user's profile, if they've signed in before. */
+  displayName?: string;
+  /** Profile photo URL, if available. */
+  photoURL?: string;
+  /** The user's role on the project, if they're listed in the roles map. */
+  role?: UserRole;
+}
+
+export interface UseProjectUsersResult {
+  users: ProjectUser[];
+  loading: boolean;
+}
+
+/**
+ * Returns the list of users associated with the current project, merging the
+ * project's roles map with the saved user profiles (which supply display names
+ * and avatars). Domain wildcards (e.g. `*@example.com`) are excluded since
+ * they aren't addressable users.
+ *
+ * Both underlying sources are cached in memory, so mounting this hook on
+ * several pages issues at most one fetch each.
+ *
+ * Example:
+ *   const {users} = useProjectUsers();
+ */
+export function useProjectUsers(): UseProjectUsersResult {
+  const {roles, loading: rolesLoading} = useProjectRoles();
+  const {profiles, loading: profilesLoading} = useAllUserProfiles();
+
+  const users = useMemo(() => {
+    const byEmail = new Map<string, ProjectUser>();
+    const add = (email: string, values: Partial<ProjectUser>) => {
+      const key = email.trim().toLowerCase();
+      if (!key || !key.includes('@') || isOrgEmail(key)) {
+        return;
+      }
+      const existing = byEmail.get(key);
+      byEmail.set(key, {...(existing || {email: key}), ...values, email: key});
+    };
+    Object.entries(roles).forEach(([email, role]) => add(email, {role}));
+    profiles.forEach((profile: UserProfile) => {
+      if (profile.email) {
+        add(profile.email, {
+          displayName: profile.displayName,
+          photoURL: profile.photoURL,
+        });
+      }
+    });
+    return Array.from(byEmail.values()).sort((a, b) => {
+      const aLabel = (a.displayName || a.email).toLowerCase();
+      const bLabel = (b.displayName || b.email).toLowerCase();
+      return aLabel.localeCompare(bLabel);
+    });
+  }, [roles, profiles]);
+
+  return {users, loading: rolesLoading || profilesLoading};
+}

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.css
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.css
@@ -298,6 +298,12 @@
   gap: 8px;
 }
 
+.TaskPage__metadata__cc {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
 .TaskPage__metadata__date input {
   border: 1px solid #ced4da;
   border-radius: 4px;
@@ -599,27 +605,6 @@
   margin-bottom: 18px;
   max-width: var(--task-page-max-width);
   padding: 10px 14px;
-}
-
-.TaskPage__metadata__ccList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 8px;
-}
-
-.TaskPage__metadata__ccItem {
-  align-items: center;
-  background: #f6f7f8;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  color: var(--color-text-default);
-  display: inline-flex;
-  font-size: 12px;
-  gap: 3px;
-  max-width: 100%;
-  min-height: 24px;
-  padding: 1px 4px 1px 10px;
 }
 
 .TaskPage__metadata__danger {

--- a/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
+++ b/packages/root-cms/ui/pages/TaskPage/TaskPage.tsx
@@ -41,15 +41,17 @@ import {Markdown} from '../../components/Markdown/Markdown.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {TaskCommentEditor} from '../../components/TaskCommentEditor/TaskCommentEditor.js';
 import {Text} from '../../components/Text/Text.js';
+import {
+  UserMultiSelect,
+  UserSelect,
+} from '../../components/UserSelect/UserSelect.js';
 import {UserTag} from '../../components/UserTag/UserTag.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
-import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {Layout} from '../../layout/Layout.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {errorMessage} from '../../utils/notifications.js';
-import {getRole} from '../../utils/permissions.js';
 import {
   addTaskComment,
   addTaskAttachment,
@@ -593,9 +595,7 @@ function TaskMetadataPanel(props: {task: Task}) {
   const {route} = useLocation();
   const modals = useModals();
   const modalTheme = useModalTheme();
-  const {roles} = useProjectRoles();
   const [assignee, setAssignee] = useState(task.assignee || '');
-  const [ccDraft, setCcDraft] = useState('');
   const [targetLaunchDate, setTargetLaunchDate] = useState(
     formatDateInputValue(task.targetLaunchDate)
   );
@@ -632,9 +632,10 @@ function TaskMetadataPanel(props: {task: Task}) {
     }
   }
 
-  function saveAssignee() {
-    const normalizedAssignee = assignee.trim();
-    if ((task.assignee || '') === normalizedAssignee) {
+  function saveAssignee(value: string) {
+    const normalizedAssignee = value.trim().toLowerCase();
+    setAssignee(normalizedAssignee);
+    if ((task.assignee || '').toLowerCase() === normalizedAssignee) {
       return;
     }
     saveMetadata('assignee', () =>
@@ -646,61 +647,26 @@ function TaskMetadataPanel(props: {task: Task}) {
     if (!currentUserEmail || isAssignedToMe) {
       return;
     }
-    setAssignee(currentUserEmail);
-    saveMetadata('assignee', () =>
-      updateTaskAssignee(task.id, currentUserEmail)
-    );
+    saveAssignee(currentUserEmail);
+  }
+
+  function saveCcList(emails: string[]) {
+    const normalizedCc = normalizeTaskCcList(emails);
+    if (normalizeTaskCcList(ccList).join(',') === normalizedCc.join(',')) {
+      return;
+    }
+    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
   }
 
   function ccMe() {
     if (!currentUserEmail || isCcdToMe) {
       return;
     }
-    const normalizedCc = normalizeTaskCcList([...ccList, currentUserEmail]);
-    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
-  }
-
-  function addCcEmails() {
-    const draftEmails = ccDraft.split(/[,\s]+/).filter(Boolean);
-    if (draftEmails.length === 0) {
-      return;
-    }
-    if (draftEmails.some((email) => !email.includes('@'))) {
-      showNotification({
-        title: 'Could not add to CC',
-        message: 'Enter a valid email address.',
-        color: 'red',
-      });
-      return;
-    }
-    const notAllowed = draftEmails.filter(
-      (email) => !getRole(roles, email.trim().toLowerCase())
-    );
-    if (notAllowed.length > 0) {
-      showNotification({
-        title: 'Could not add to CC',
-        message: `${notAllowed.join(', ')} ${
-          notAllowed.length === 1 ? 'is' : 'are'
-        } not a member of this project.`,
-        color: 'red',
-      });
-      return;
-    }
-    const normalizedCc = normalizeTaskCcList([...ccList, ...draftEmails]);
-    setCcDraft('');
-    if (ccList.join(',') === normalizedCc.join(',')) {
-      return;
-    }
-    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
-  }
-
-  function removeCcEmail(email: string) {
-    const normalizedCc = ccList.filter((value) => value !== email);
-    saveMetadata('cc', () => updateTaskCcList(task.id, normalizedCc));
+    saveCcList([...ccList, currentUserEmail]);
   }
 
   // Copies the full email addresses of the selected chips, instead of the
-  // short names shown in the UI (e.g. "jeremydw" -> "jeremydw@example.com").
+  // display names shown in the UI (e.g. "Jeremy" -> "jeremydw@example.com").
   function handleCopyCc(e: ClipboardEvent) {
     const selection = window.getSelection();
     if (!selection || selection.isCollapsed) {
@@ -708,10 +674,10 @@ function TaskMetadataPanel(props: {task: Task}) {
     }
     const container = e.currentTarget as HTMLElement;
     const emails = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-cc-email]')
+      container.querySelectorAll<HTMLElement>('[data-user-email]')
     )
       .filter((el) => selection.containsNode(el, true))
-      .map((el) => el.dataset.ccEmail || '')
+      .map((el) => el.dataset.userEmail || '')
       .filter(Boolean);
     if (emails.length === 0) {
       return;
@@ -780,21 +746,10 @@ function TaskMetadataPanel(props: {task: Task}) {
       <div className="TaskPage__metadata__field">
         <label>Assignee</label>
         <div className="TaskPage__metadata__assignee">
-          <TextInput
-            size="xs"
-            type="email"
-            placeholder="teammate@example.com"
+          <UserSelect
             value={assignee}
             disabled={savingField === 'assignee'}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setAssignee(e.currentTarget.value)
-            }
-            onBlur={() => saveAssignee()}
-            onKeyDown={(e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
-                (e.currentTarget as HTMLInputElement).blur();
-              }
-            }}
+            onChange={(email: string) => saveAssignee(email)}
           />
         </div>
         {currentUserEmail && !isAssignedToMe && (
@@ -810,45 +765,12 @@ function TaskMetadataPanel(props: {task: Task}) {
       </div>
       <div className="TaskPage__metadata__field">
         <label>CC</label>
-        <div className="TaskPage__metadata__cc">
-          <TextInput
-            size="xs"
-            type="email"
-            placeholder="Add email and press enter"
-            value={ccDraft}
+        <div className="TaskPage__metadata__cc" onCopy={handleCopyCc}>
+          <UserMultiSelect
+            value={ccList}
             disabled={savingField === 'cc'}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setCcDraft(e.currentTarget.value)
-            }
-            onBlur={() => addCcEmails()}
-            onKeyDown={(e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                addCcEmails();
-              }
-            }}
+            onChange={(emails: string[]) => saveCcList(emails)}
           />
-          {ccList.length > 0 && (
-            <div className="TaskPage__metadata__ccList" onCopy={handleCopyCc}>
-              {ccList.map((email) => (
-                <div
-                  className="TaskPage__metadata__ccItem"
-                  key={email}
-                  data-cc-email={email}
-                >
-                  <UserTag email={email} />
-                  <ActionIcon
-                    size="xs"
-                    title="Remove from CC"
-                    disabled={savingField === 'cc'}
-                    onClick={() => removeCcEmail(email)}
-                  >
-                    <IconX size={12} strokeWidth="1.8" />
-                  </ActionIcon>
-                </div>
-              ))}
-            </div>
-          )}
           {currentUserEmail && !isCcdToMe && (
             <button
               type="button"

--- a/packages/root-cms/ui/utils/user-profile.ts
+++ b/packages/root-cms/ui/utils/user-profile.ts
@@ -15,6 +15,9 @@ export interface UserProfile {
 /** Time-to-live for cached profile entries. */
 const PROFILE_CACHE_TTL_MS = 60 * 60 * 1000;
 
+/** Time-to-live for the cached "list all profiles" result. */
+const PROFILE_LIST_CACHE_TTL_MS = 5 * 60 * 1000;
+
 interface CacheEntry {
   /** Cached profile, or `null` if no profile exists for the email. */
   value: UserProfile | null;
@@ -25,6 +28,10 @@ interface CacheEntry {
 const profileCache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<UserProfile | null>>();
 const subscribers = new Set<() => void>();
+
+/** Cached result of `listUserProfiles()`, shared by all callers. */
+let listCache: {value: UserProfile[]; fetchedAt: number} | null = null;
+let listInflight: Promise<UserProfile[]> | null = null;
 
 /** Lower-cases an email for use as a cache/db key. */
 function normalizeEmail(email: string): string {
@@ -131,23 +138,47 @@ export async function fetchUserProfiles(
 
 /**
  * Lists all user profiles for the current project. Results are merged into
- * the in-memory cache.
+ * the in-memory cache and the list itself is cached, so repeat callers (e.g.
+ * autocomplete pickers mounted on several pages) share a single fetch.
  */
-export async function listUserProfiles(): Promise<UserProfile[]> {
-  const snapshot = await getDocs(userProfilesCollectionRef());
-  const profiles: UserProfile[] = [];
-  snapshot.forEach((d) => {
-    const data = d.data() as UserProfile;
-    profiles.push(data);
-    if (data.email) {
-      profileCache.set(normalizeEmail(data.email), {
-        value: data,
-        fetchedAt: Date.now(),
-      });
+export async function listUserProfiles(options?: {
+  /** Bypasses the cached list and re-fetches from the DB. */
+  force?: boolean;
+}): Promise<UserProfile[]> {
+  if (!options?.force) {
+    if (
+      listCache &&
+      Date.now() - listCache.fetchedAt <= PROFILE_LIST_CACHE_TTL_MS
+    ) {
+      return listCache.value;
     }
-  });
-  notifySubscribers();
-  return profiles;
+    if (listInflight) {
+      return listInflight;
+    }
+  }
+  const promise = (async () => {
+    try {
+      const snapshot = await getDocs(userProfilesCollectionRef());
+      const profiles: UserProfile[] = [];
+      snapshot.forEach((d) => {
+        const data = d.data() as UserProfile;
+        profiles.push(data);
+        if (data.email) {
+          profileCache.set(normalizeEmail(data.email), {
+            value: data,
+            fetchedAt: Date.now(),
+          });
+        }
+      });
+      listCache = {value: profiles, fetchedAt: Date.now()};
+      notifySubscribers();
+      return profiles;
+    } finally {
+      listInflight = null;
+    }
+  })();
+  listInflight = promise;
+  return promise;
 }
 
 /** Subscribes to cache updates. Returns an unsubscribe function. */
@@ -162,6 +193,8 @@ export function subscribeToUserProfileCache(cb: () => void): () => void {
 export function clearUserProfileCache() {
   profileCache.clear();
   inflight.clear();
+  listCache = null;
+  listInflight = null;
 }
 
 /** Returns the initials to display when no photoURL is available. */


### PR DESCRIPTION
Replaces the plain email text inputs on the task details page with autocomplete pickers sourced from the project's user list, so assigning or cc'ing a teammate is a matter of searching for their name rather than typing their address exactly.

## Changes

**`UserSelect` / `UserMultiSelect`** (`ui/components/UserSelect/`)

- Each dropdown option renders the user's avatar (profile photo, or the initials fallback when there's none), their display name, and their email.
- Search matches against both the display name and the email, so `lovelace` and `ada@` both find Ada.
- Any address that isn't a project user can still be entered by hand — typing a valid email offers a `+ Use "…"` / `+ Add "…"` option. Non-email values don't offer it.
- `UserMultiSelect` renders each selection as a removable chip with an avatar.

**`useProjectUsers()`** (`ui/hooks/useProjectUsers.ts`)

Merges the project's roles map with the saved user profiles (which supply display names and photos), dropping domain wildcards like `*@example.com` since they aren't addressable people. Both sources are already cached in memory; `listUserProfiles()` now caches the list itself (5 min TTL, with in-flight de-duping), so the pickers open instantly after the first load instead of re-reading the collection on every mount.

**Task details page** (`ui/pages/TaskPage/TaskPage.tsx`)

Assignee uses `UserSelect`, cc uses `UserMultiSelect`. The separate cc chip list below the input is gone — chips now live in the field itself — but the "copy full email addresses instead of the short names" behavior is preserved: chips carry a `data-user-email` attribute that the existing `onCopy` handler reads.

## Behavior change worth flagging

Cc'ing someone who isn't a member of the project used to be rejected with a "not a member of this project" notification. That check is removed, since free-value entry was explicitly asked for and the assignee field never enforced membership either. Values still have to look like email addresses.

## Testing

- `user-select-data.test.ts` covers the extracted logic: email validation, option building (project users + typed-in values + unknown selections, de-duped), name/email matching, and when the "add this address" option is offered. 14 tests, passing.
- Verified end-to-end in Chromium (throwaway harness, not committed): options render with avatars and emails, filtering by email prefix narrows the list, selecting updates the value, and adding a free-value email to cc produces the expected chip.
- `eslint` clean on all touched files; `tsc --noEmit` shows no new errors; the UI bundle builds.

Mantine's jsdom rendering doesn't work in this repo's unit suite (existing component tests mock `@mantine/core` wholesale), which is why the component logic was extracted into a plain module rather than tested through the rendered component.

## Not included

The "new task" form in `TaskManager` still uses a plain text input for assignee — left alone since the request was scoped to the details page, but it's the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdfFotui2uNUiuaTD28WCs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdfFotui2uNUiuaTD28WCs)_