### PR TITLE
fix: flush rich text editors when draft edits are discarded

### DIFF
--- a/.changeset/lucky-moons-tickle.md
+++ b/.changeset/lucky-moons-tickle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: flush rich text editors when draft edits are discarded

--- a/packages/root-cms/shared/richtext.test.ts
+++ b/packages/root-cms/shared/richtext.test.ts
@@ -3,6 +3,8 @@ import {
   getRichTextParagraphEditorStyles,
   normalizeRichTextParagraphSizes,
   parseRichTextParagraphSize,
+  RichTextData,
+  testSameRichTextContent,
 } from './richtext.js';
 
 describe('parseRichTextParagraphSize', () => {
@@ -112,5 +114,93 @@ describe('getRichTextParagraphEditorStyles', () => {
 
   test('is empty when the option is omitted', () => {
     expect(getRichTextParagraphEditorStyles()).toEqual({});
+  });
+});
+
+describe('testSameRichTextContent', () => {
+  function richText(text: string, time: number): RichTextData {
+    return {time, version: '1', blocks: [{type: 'paragraph', data: {text}}]};
+  }
+
+  test('ignores the timestamp and version', () => {
+    expect(
+      testSameRichTextContent(richText('hello', 1), richText('hello', 2))
+    ).toBe(true);
+    expect(
+      testSameRichTextContent(
+        {time: 1, version: 'editorjs', blocks: []},
+        {time: 2, version: 'lexical-0.31.2', blocks: []}
+      )
+    ).toBe(true);
+  });
+
+  test('compares block content', () => {
+    expect(
+      testSameRichTextContent(richText('hello', 1), richText('world', 1))
+    ).toBe(false);
+    expect(
+      testSameRichTextContent(richText('hello', 1), {
+        time: 1,
+        version: '1',
+        blocks: [
+          {type: 'paragraph', data: {text: 'hello'}},
+          {type: 'paragraph', data: {text: 'world'}},
+        ],
+      })
+    ).toBe(false);
+    expect(
+      testSameRichTextContent(
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'heading', data: {level: 2, text: 'hello'}}],
+        },
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'heading', data: {text: 'hello', level: 2}}],
+        }
+      )
+    ).toBe(true);
+  });
+
+  test('treats empty values as equal', () => {
+    expect(testSameRichTextContent(null, undefined)).toBe(true);
+    expect(
+      testSameRichTextContent(null, {time: 1, version: '1', blocks: []})
+    ).toBe(true);
+    expect(testSameRichTextContent(null, richText('hello', 1))).toBe(false);
+  });
+
+  test('treats missing and empty keys as equal', () => {
+    // Values that round-trip through firestore lose their `undefined` keys.
+    expect(
+      testSameRichTextContent(
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'paragraph', data: {text: 'hello', size: undefined}}],
+        },
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'paragraph', data: {text: 'hello'}}],
+        }
+      )
+    ).toBe(true);
+    expect(
+      testSameRichTextContent(
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'paragraph', data: {text: 'hello', size: 'large'}}],
+        },
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'paragraph', data: {text: 'hello'}}],
+        }
+      )
+    ).toBe(false);
   });
 });

--- a/packages/root-cms/shared/richtext.test.ts
+++ b/packages/root-cms/shared/richtext.test.ts
@@ -172,6 +172,27 @@ describe('testSameRichTextContent', () => {
     expect(testSameRichTextContent(null, richText('hello', 1))).toBe(false);
   });
 
+  test('compares keys that one side swapped for another', () => {
+    // Same key count, different keys: a block that dropped `components` and
+    // gained `size` is not the same content.
+    expect(
+      testSameRichTextContent(
+        {
+          time: 1,
+          version: '1',
+          blocks: [
+            {type: 'paragraph', data: {text: 'hello', components: undefined}},
+          ],
+        },
+        {
+          time: 1,
+          version: '1',
+          blocks: [{type: 'paragraph', data: {text: 'hello', size: 'large'}}],
+        }
+      )
+    ).toBe(false);
+  });
+
   test('treats missing and empty keys as equal', () => {
     // Values that round-trip through firestore lose their `undefined` keys.
     expect(

--- a/packages/root-cms/shared/richtext.ts
+++ b/packages/root-cms/shared/richtext.ts
@@ -299,3 +299,60 @@ export function testValidRichTextData(data: RichTextData | unknown) {
     (data as Record<string, any>).blocks.length > 0
   );
 }
+
+/**
+ * Returns true if two rich text values hold the same content.
+ *
+ * Only `blocks` are compared: `time` and `version` are editor bookkeeping that
+ * change on every save and say nothing about what the user sees. Editors use
+ * this to decide whether an incoming value is an echo of their own last change
+ * (ignore it, so the cursor isn't reset on every keystroke) or an external
+ * replacement they need to re-render (e.g. "discard draft edits", which
+ * restores published content whose `time` is older than the draft's).
+ */
+export function testSameRichTextContent(
+  a?: RichTextData | null,
+  b?: RichTextData | null
+): boolean {
+  return testSameJsonValue(getRichTextBlocks(a), getRichTextBlocks(b));
+}
+
+/** Returns a rich text value's blocks, or an empty list if it has none. */
+function getRichTextBlocks(data?: RichTextData | null): RichTextBlock[] {
+  if (!isObject(data) || !Array.isArray((data as RichTextData).blocks)) {
+    return [];
+  }
+  return (data as RichTextData).blocks;
+}
+
+/**
+ * Deep-compares two JSON-like values. `null` and `undefined` are treated as
+ * equivalent, since a value that round-trips through firestore loses its
+ * `undefined` keys.
+ */
+function testSameJsonValue(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || a === undefined || b === null || b === undefined) {
+    return (a === null || a === undefined) && (b === null || b === undefined);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, i) => testSameJsonValue(item, b[i]));
+  }
+  if (isObject(a) && isObject(b)) {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
+    for (const key of keys) {
+      if (!testSameJsonValue(aObj[key], bObj[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}

--- a/packages/root-cms/shared/richtext.ts
+++ b/packages/root-cms/shared/richtext.ts
@@ -309,6 +309,10 @@ export function testValidRichTextData(data: RichTextData | unknown) {
  * (ignore it, so the cursor isn't reset on every keystroke) or an external
  * replacement they need to re-render (e.g. "discard draft edits", which
  * restores published content whose `time` is older than the draft's).
+ *
+ * The keystroke path exits on reference equality: an editor's own value is
+ * handed back to it by the same object, so the deep walk only runs for values
+ * that arrived from somewhere else (the db, undo/redo, a revert).
  */
 export function testSameRichTextContent(
   a?: RichTextData | null,
@@ -346,9 +350,16 @@ function testSameJsonValue(a: unknown, b: unknown): boolean {
   if (isObject(a) && isObject(b)) {
     const aObj = a as Record<string, unknown>;
     const bObj = b as Record<string, unknown>;
-    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
-    for (const key of keys) {
+    for (const key of Object.keys(aObj)) {
       if (!testSameJsonValue(aObj[key], bObj[key])) {
+        return false;
+      }
+    }
+    // A key only `b` has matches a's missing (i.e. `undefined`) value only when
+    // it's empty itself. Key counts can't stand in for this check: `a` and `b`
+    // can hold the same number of keys and still not hold the same ones.
+    for (const key of Object.keys(bObj)) {
+      if (!(key in aObj) && !testSameJsonValue(undefined, bObj[key])) {
         return false;
       }
     }

--- a/packages/root-cms/ui/components/DocEditor/fields/RichTextField.test.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/RichTextField.test.tsx
@@ -1,0 +1,85 @@
+import {cleanup, render} from '@testing-library/preact';
+import {act} from 'preact/test-utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import * as schema from '../../../../core/schema.js';
+import {RichTextData} from '../../../../shared/richtext.js';
+import {FieldProps} from './FieldProps.js';
+
+// Capture the props passed to the rich text editor so the test can drive its
+// `onChange()` and inspect the value it receives.
+let editorProps: any = null;
+vi.mock('../../RichTextEditor/RichTextEditor.js', () => ({
+  RichTextEditor: (props: any) => {
+    editorProps = props;
+    return <div data-testid="editor" />;
+  },
+}));
+
+// Mock the draft doc controller so the field can be rendered without the full
+// draft doc context. `fieldCallback` stands in for the db subscription.
+const updateKey = vi.fn();
+let fieldCallback: ((value: any) => void) | null = null;
+vi.mock('../../../hooks/useDraftDoc.js', () => ({
+  useDraftDoc: () => ({controller: {updateKey}}),
+  useDraftDocField: (_deepKey: string, cb: (value: any) => void) => {
+    fieldCallback = cb;
+  },
+}));
+
+// Import after mocks are registered.
+const {RichTextField} = await import('./RichTextField.js');
+
+function richText(text: string, time: number): RichTextData {
+  return {time, version: '1', blocks: [{type: 'paragraph', data: {text}}]};
+}
+
+function renderField() {
+  const field: schema.RichTextField = {
+    type: 'richtext',
+    id: 'body',
+  };
+  const props: FieldProps = {
+    field,
+    deepKey: 'fields.body',
+  };
+  return render(<RichTextField {...props} />);
+}
+
+beforeEach(() => {
+  editorProps = null;
+  fieldCallback = null;
+  updateKey.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RichTextField', () => {
+  test('passes db values to the editor', () => {
+    renderField();
+    act(() => fieldCallback!(richText('published text', 1000)));
+    expect(editorProps.value).toEqual(richText('published text', 1000));
+  });
+
+  test('saves edits to the draft', () => {
+    renderField();
+    act(() => fieldCallback!(richText('published text', 1000)));
+    act(() => editorProps.onChange(richText('draft text', 2000)));
+    expect(updateKey).toHaveBeenCalledWith(
+      'fields.body',
+      richText('draft text', 2000)
+    );
+  });
+
+  test('does not save an editor echo of the current value', () => {
+    // After an external replacement (e.g. "discard draft edits") the editor
+    // re-emits the value it was given with a fresh timestamp. Saving that would
+    // mark the doc as edited again.
+    // https://github.com/blinkk/rootjs/issues/1393
+    renderField();
+    act(() => fieldCallback!(richText('published text', 1000)));
+    act(() => editorProps.onChange(richText('published text', 9000)));
+    expect(updateKey).not.toHaveBeenCalled();
+  });
+});

--- a/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/RichTextField.tsx
@@ -1,6 +1,9 @@
 import {useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
-import {RichTextData} from '../../../../shared/richtext.js';
+import {
+  RichTextData,
+  testSameRichTextContent,
+} from '../../../../shared/richtext.js';
 import {useDraftDoc, useDraftDocField} from '../../../hooks/useDraftDoc.js';
 import {RichTextEditor} from '../../RichTextEditor/RichTextEditor.js';
 import {FieldProps} from './FieldProps.js';
@@ -12,7 +15,11 @@ export function RichTextField(props: FieldProps) {
 
   const onChange = (newValue: RichTextData | null) => {
     setValue((oldValue: RichTextData | null) => {
-      if (oldValue?.time !== newValue?.time) {
+      // Only write when the content actually changed. An editor re-emits its
+      // value with a fresh `time` after rendering an external replacement
+      // (e.g. "discard draft edits"), and that echo must not re-dirty the
+      // draft.
+      if (!testSameRichTextContent(oldValue, newValue)) {
         draft.updateKey(props.deepKey, newValue);
       }
       return newValue;

--- a/packages/root-cms/ui/components/RichTextEditor/editorjs/EditorJSEditor.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/editorjs/EditorJSEditor.tsx
@@ -6,7 +6,10 @@ import NestedList from '@editorjs/nested-list';
 import RawHtmlTool from '@editorjs/raw';
 import {useEffect, useRef, useState} from 'preact/hooks';
 import * as schema from '../../../../core/schema.js';
-import {RichTextData} from '../../../../shared/richtext.js';
+import {
+  RichTextData,
+  testSameRichTextContent,
+} from '../../../../shared/richtext.js';
 import {joinClassNames} from '../../../utils/classes.js';
 import {uploadFileToGCS} from '../../../utils/gcs.js';
 import {isObject} from '../../../utils/objects.js';
@@ -28,11 +31,13 @@ export interface EditorJSEditorProps {
 export function EditorJSEditor(props: EditorJSEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [editor, setEditor] = useState<any>(null);
-  const [currentValue, setCurrentValue] = useState<RichTextData>({
-    blocks: [{type: 'paragraph', data: {}}],
-    time: 0,
-    version: '',
-  });
+  /**
+   * The content currently reflected in the editor, either because the user
+   * typed it or because it was rendered from `props.value`. Compared against
+   * incoming values to tell an echo of the editor's own change apart from an
+   * external replacement.
+   */
+  const currentValueRef = useRef<RichTextData | null>(null);
 
   const placeholder = props.placeholder || 'Start typing...';
 
@@ -40,23 +45,26 @@ export function EditorJSEditor(props: EditorJSEditorProps) {
     if (!editor) {
       return;
     }
-    const newValue = props.value;
-    if (currentValue?.time !== newValue?.time) {
-      const currentTime = currentValue?.time || 0;
-      const newValueTime = newValue?.time || 0;
-      if (newValueTime > currentTime && validateRichTextData(newValue)) {
-        const blocks = newValue?.blocks || [];
-        if (blocks.length > 0) {
-          editor.render(newValue);
-        } else {
-          editor.render({
-            ...newValue,
-            blocks: [{type: 'paragraph', data: {text: ''}}],
-          });
-        }
-        setCurrentValue(newValue);
-      }
+    // Values that match what the editor already holds are ignored, so typing
+    // doesn't re-render (and reset the cursor).
+    // NOTE(stevenle): the content is compared rather than `time` because an
+    // external replacement can carry an older timestamp, e.g. "discard draft
+    // edits" restores the published version of the doc.
+    const newValue: RichTextData | null = isObject(props.value)
+      ? props.value
+      : null;
+    if (testSameRichTextContent(currentValueRef.current, newValue)) {
+      return;
     }
+    currentValueRef.current = newValue;
+    const blocks = newValue?.blocks || [];
+    editor.render({
+      ...newValue,
+      // EditorJS requires at least one block, so an empty value renders as an
+      // empty paragraph.
+      blocks:
+        blocks.length > 0 ? blocks : [{type: 'paragraph', data: {text: ''}}],
+    });
   }, [editor, props.value]);
 
   useEffect(() => {
@@ -140,7 +148,7 @@ export function EditorJSEditor(props: EditorJSEditorProps) {
         editor
           .save()
           .then((richTextData: RichTextData) => {
-            setCurrentValue(richTextData);
+            currentValueRef.current = richTextData;
             if (props.onChange) {
               props.onChange(richTextData);
             }
@@ -165,10 +173,6 @@ export function EditorJSEditor(props: EditorJSEditorProps) {
       className={joinClassNames(props.className, 'EditorJSEditor')}
     />
   );
-}
-
-export function validateRichTextData(data: RichTextData) {
-  return isObject(data) && Array.isArray(data.blocks) && data.blocks.length > 0;
 }
 
 function gcsUploader() {

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.test.tsx
@@ -1,0 +1,170 @@
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {cleanup, render} from '@testing-library/preact';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  LexicalEditor,
+} from 'lexical';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {RichTextData} from '../../../../../shared/richtext.js';
+import {OnChangePlugin} from './OnChangePlugin.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function richText(text: string, time: number): RichTextData {
+  return {
+    time,
+    version: '1',
+    blocks: [{type: 'paragraph', data: {text}}],
+  };
+}
+
+interface TestEditorProps {
+  value: RichTextData | null;
+  onChange?: (value: RichTextData | null) => void;
+  onReady?: (editor: LexicalEditor) => void;
+}
+
+/**
+ * Minimal lexical setup with the OnChangePlugin under test. The full
+ * <LexicalEditor> can't render in jsdom (its toolbar uses mantine), and the
+ * value syncing being tested here lives entirely in the plugin.
+ */
+function TestEditor(props: TestEditorProps) {
+  return (
+    <LexicalComposer
+      initialConfig={{
+        namespace: 'test',
+        nodes: [HeadingNode, QuoteNode],
+        onError: (err: Error) => {
+          throw err;
+        },
+      }}
+    >
+      <OnChangePlugin value={props.value} onChange={props.onChange} />
+      <RichTextPlugin
+        contentEditable={<ContentEditable />}
+        ErrorBoundary={LexicalErrorBoundary}
+      />
+      <EditorRef onReady={props.onReady} />
+    </LexicalComposer>
+  );
+}
+
+function EditorRef(props: {onReady?: (editor: LexicalEditor) => void}) {
+  const [editor] = useLexicalComposerContext();
+  if (props.onReady) {
+    props.onReady(editor);
+  }
+  return null;
+}
+
+/** Yields to the microtask/timer queue so lexical can reconcile the DOM. */
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('OnChangePlugin', () => {
+  test('renders the incoming value', async () => {
+    const {container} = render(<TestEditor value={richText('hello', 1000)} />);
+    await flush();
+    expect(container.textContent).toContain('hello');
+  });
+
+  test('renders external replacements with an older timestamp', async () => {
+    // "Discard draft edits" restores the published version of the doc, whose
+    // rich text data was serialized before the draft edits.
+    // https://github.com/blinkk/rootjs/issues/1393
+    const {container, rerender} = render(
+      <TestEditor value={richText('draft text', 2000)} />
+    );
+    await flush();
+    expect(container.textContent).toContain('draft text');
+
+    rerender(<TestEditor value={richText('published text', 1000)} />);
+    await flush();
+    expect(container.textContent).toContain('published text');
+    expect(container.textContent).not.toContain('draft text');
+  });
+
+  test('clears the editor when the value is emptied', async () => {
+    const {container, rerender} = render(
+      <TestEditor value={richText('draft text', 2000)} />
+    );
+    await flush();
+    expect(container.textContent).toContain('draft text');
+
+    rerender(<TestEditor value={null} />);
+    await flush();
+    expect(container.textContent).not.toContain('draft text');
+  });
+
+  test('ignores values that echo the editor content', async () => {
+    // Values flow back into the editor after every keystroke. Re-rendering
+    // them would reset the user's cursor.
+    let editor!: LexicalEditor;
+    const onChange = vi.fn();
+    const value = richText('hello', 1000);
+    const {rerender} = render(
+      <TestEditor
+        value={value}
+        onChange={onChange}
+        onReady={(e) => (editor = e)}
+      />
+    );
+    await flush();
+
+    // Simulate a user edit.
+    editor.update(() => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('hello world'));
+      const root = $getRoot();
+      root.clear();
+      root.append(paragraph);
+    });
+    await flush();
+    expect(onChange).toHaveBeenCalled();
+    const editedValue = onChange.mock.lastCall![0] as RichTextData;
+    const editorState = editor.getEditorState();
+
+    // The edit round-trips back through the parent component.
+    rerender(
+      <TestEditor
+        value={editedValue}
+        onChange={onChange}
+        onReady={(e) => (editor = e)}
+      />
+    );
+    await flush();
+    expect(editor.getEditorState()).toBe(editorState);
+  });
+
+  test('ignores values that only differ by timestamp', async () => {
+    let editor!: LexicalEditor;
+    const {rerender} = render(
+      <TestEditor
+        value={richText('hello', 1000)}
+        onReady={(e) => (editor = e)}
+      />
+    );
+    await flush();
+    const editorState = editor.getEditorState();
+
+    rerender(
+      <TestEditor
+        value={richText('hello', 5000)}
+        onReady={(e) => (editor = e)}
+      />
+    );
+    await flush();
+    expect(editor.getEditorState()).toBe(editorState);
+  });
+});

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/OnChangePlugin.tsx
@@ -2,7 +2,10 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {OnChangePlugin as LexicalOnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {EditorState} from 'lexical';
 import {useEffect, useRef} from 'preact/hooks';
-import {RichTextData} from '../../../../../shared/richtext.js';
+import {
+  RichTextData,
+  testSameRichTextContent,
+} from '../../../../../shared/richtext.js';
 import {convertToRichTextData} from '../utils/convert-from-lexical.js';
 import {convertToLexical} from '../utils/convert-to-lexical.js';
 
@@ -14,20 +17,31 @@ export interface OnChangePluginProps {
 export function OnChangePlugin(props: OnChangePluginProps) {
   const [editor] = useLexicalComposerContext();
 
-  const timeSavedRef = useRef(0);
+  /**
+   * The content currently reflected in the editor, either because the user
+   * typed it or because it was rendered from `props.value`. Compared against
+   * incoming values to tell an echo of the editor's own change apart from an
+   * external replacement.
+   */
+  const currentValueRef = useRef<RichTextData | null>(null);
   const isUpdatingRef = useRef(false);
 
   useEffect(() => {
     // When props.value changes, convert the RichTextData to lexical data and
-    // write to the active editor.
-    const time = props.value?.time || 0;
-    if (time > timeSavedRef.current) {
-      timeSavedRef.current = time;
-      editor.update(() => {
-        isUpdatingRef.current = true;
-        convertToLexical(props.value);
-      });
+    // write to the active editor. Values that match what the editor already
+    // holds are ignored, so typing doesn't re-render (and reset the cursor).
+    // NOTE(stevenle): the content is compared rather than `time` because an
+    // external replacement can carry an older timestamp, e.g. "discard draft
+    // edits" restores the published version of the doc.
+    const newValue = props.value ?? null;
+    if (testSameRichTextContent(currentValueRef.current, newValue)) {
+      return;
     }
+    currentValueRef.current = newValue;
+    editor.update(() => {
+      isUpdatingRef.current = true;
+      convertToLexical(newValue);
+    });
   }, [editor, props.value]);
 
   const onChange = (editorState: EditorState) => {
@@ -41,7 +55,7 @@ export function OnChangePlugin(props: OnChangePluginProps) {
     editorState.read(
       () => {
         const richTextData = convertToRichTextData();
-        timeSavedRef.current = richTextData?.time || 0;
+        currentValueRef.current = richTextData;
         if (props.onChange) {
           props.onChange(richTextData);
         }


### PR DESCRIPTION
Fixes #1393.

## Problem

Both rich text editors ignored an incoming `value` unless its `time` was newer than the value they last rendered:

- `lexical/plugins/OnChangePlugin.tsx` — `if (time > timeSavedRef.current)`
- `editorjs/EditorJSEditor.tsx` — `if (newValueTime > currentTime && ...)`

"Discard draft edits" copies the published doc over the draft, and the published rich text data was serialized *before* the draft edits, so its `time` is older. The draft doc's snapshot listener pushed the published value down to the field, the editor compared timestamps, and kept showing the discarded content. The same gate drops any external replacement that carries an older timestamp — version restore, and undo/redo (which by construction writes the *previous* value).

## Fix

Compare the incoming value's `blocks` against the content the editor already holds, instead of comparing timestamps:

- New `testSameRichTextContent()` in `shared/richtext.ts` compares blocks only (`time`/`version` are editor bookkeeping) and treats missing/`null`/`undefined` keys as equivalent, since values that round-trip through Firestore lose their `undefined` keys.
- Both editors track the content currently reflected in the editor and re-render only when an incoming value differs from it. Echoes of the editor's own change still no-op, so typing never resets the cursor; a genuine replacement re-renders whatever its timestamp says.
- `RichTextField` also compares content rather than `time` before writing to the draft, so an editor re-emitting the value it was just handed (with a fresh `time`) doesn't immediately re-dirty the doc that was just discarded.
- Emptying a field now clears the editor too — previously an empty value failed the `blocks.length > 0` validity check in EditorJS and was dropped.
- Removed `validateRichTextData()`, which had no remaining callers.

## Why a content compare rather than a cheaper timestamp check

Two cheaper-looking alternatives don't cover the bug:

- **`time !== lastTime` instead of `>`** would re-render on the discard, but `time` is a serialization timestamp, not a content identity. After the discard the editor re-serializes and emits with a fresh `Date.now()`; a timestamp comparison in `RichTextField` reads that echo as a change and writes it straight back to the draft, so the doc goes "saving..." and is modified again seconds after the user discarded. It also re-renders (resetting the cursor) whenever a content-identical value arrives with a new timestamp.
- **Resetting the editor from the discard action** (remount / key bump) only covers the button. `cmsRevertDraft()` is also reachable from the collection list page and the `doc_revertDraft` AI tool, and a discard performed in another tab reaches this editor only through the snapshot listener — the same path version restore and undo/redo use.

The cost is not where it looks. Measured on a synthetic doc (numbers are per call, Node 22, this container):

| | 65 blocks (10KB) | 260 blocks (40KB) | 1300 blocks (200KB) |
|---|---|---|---|
| same-reference (the typing path) | 0.05µs | 0.04µs | 0.04µs |
| deep walk, equal | 24µs | 58µs | 308µs |
| `deepEqual(blocks)` the trie store already runs per update | 9µs | 36µs | 185µs |

The keystroke path exits on reference equality, because an editor's own value object is what comes back to it — the deep walk only runs for values that arrived from somewhere else (db, undo, revert), i.e. at human rate. Meanwhile `JsonTrieStore.update()` already runs a full `deepEqual` over the same blocks on *every* `updateKey()`, so a keystroke pays ~4600× more there than in this check.

The principled way to delete the heuristic entirely is to tag draft updates with an origin so a field can recognize its own writes and skip the comparison altogether — but that changes the controller/store subscription API every field uses, so it's left out of this fix.

## Tests

- `shared/richtext.test.ts` — unit tests for `testSameRichTextContent()`.
- `lexical/plugins/OnChangePlugin.test.tsx` (new) — mounts a minimal lexical composer around the plugin and covers: rendering an external replacement with an older timestamp (verified to fail before the fix), clearing on an emptied value, and ignoring echoes/timestamp-only changes (asserted via editor state identity, i.e. no re-render).
- `DocEditor/fields/RichTextField.test.tsx` (new) — covers passing db values through and not saving an editor echo of the current value.

`pnpm --filter @blinkk/root-cms vitest run ui shared` → 69 files / 740 tests pass; `tsc --noEmit` and eslint clean on the changed files.

## Not covered

The EditorJS path (legacy, opt-in via the `EnableEditorJSEditor` preference) got the same fix but no automated test — EditorJS doesn't mount usefully under jsdom.