### PR TITLE
fix: update the releases cache when releases are mutated

### DIFF
--- a/.changeset/olive-badges-refresh.md
+++ b/.changeset/olive-badges-refresh.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: refresh release badges when releases are updated

--- a/packages/root-cms/ui/components/AddToReleaseModal/AddToReleaseModal.tsx
+++ b/packages/root-cms/ui/components/AddToReleaseModal/AddToReleaseModal.tsx
@@ -11,6 +11,7 @@ import {
   Release,
   addRelease,
   generateReleaseId,
+  isPendingRelease,
   listReleases,
   updateRelease,
 } from '../../utils/release.js';
@@ -60,10 +61,7 @@ export function AddToReleaseModal(
       await notifyErrors(async () => {
         const allReleases = await listReleases();
         // Filter to unpublished, non-archived releases.
-        const unpublished = allReleases.filter(
-          (r) => !r.publishedAt && !r.archivedAt
-        );
-        setReleases(unpublished);
+        setReleases(allReleases.filter(isPendingRelease));
       });
       setLoading(false);
     }

--- a/packages/root-cms/ui/hooks/usePendingReleases.tsx
+++ b/packages/root-cms/ui/hooks/usePendingReleases.tsx
@@ -1,6 +1,12 @@
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useEffect, useRef, useState} from 'preact/hooks';
-import {Release, listReleases} from '../utils/release.js';
+import {
+  Release,
+  getCachedReleases,
+  isPendingRelease,
+  listReleasesFromCacheOrFetch,
+  subscribeToReleases,
+} from '../utils/release.js';
 
 export interface PendingReleasesContextValue {
   /** All pending (unpublished, unarchived) releases. */
@@ -17,9 +23,20 @@ interface InternalContextValue extends PendingReleasesContextValue {
 }
 
 export function PendingReleasesProvider(props: {children?: ComponentChildren}) {
-  const [releases, setReleases] = useState<Release[]>([]);
+  const [releases, setReleases] = useState<Release[]>(() =>
+    (getCachedReleases() || []).filter(isPendingRelease)
+  );
   const [loading, setLoading] = useState(false);
   const fetchState = useRef<'idle' | 'fetching' | 'done'>('idle');
+
+  // Keep the pending releases in sync with the shared releases cache so that
+  // release mutations (e.g. adding docs to a release) are reflected everywhere
+  // without requiring a page refresh.
+  useEffect(() => {
+    return subscribeToReleases((allReleases) => {
+      setReleases(allReleases.filter(isPendingRelease));
+    });
+  }, []);
 
   function fetchReleases() {
     if (fetchState.current !== 'idle') {
@@ -27,12 +44,9 @@ export function PendingReleasesProvider(props: {children?: ComponentChildren}) {
     }
     fetchState.current = 'fetching';
     setLoading(true);
-    listReleases()
+    listReleasesFromCacheOrFetch()
       .then((allReleases) => {
-        const pending = allReleases.filter(
-          (r) => !r.publishedAt && !r.archivedAt
-        );
-        setReleases(pending);
+        setReleases(allReleases.filter(isPendingRelease));
       })
       .catch((err) => {
         console.error('Failed to fetch pending releases:', err);
@@ -70,7 +84,8 @@ export function usePendingReleases(): PendingReleasesContextValue {
   }
   const {fetchReleases, ...value} = context;
   // Releases are only fetched the first time this hook is used. Subsequent
-  // calls use cached values.
+  // calls use the cached values, which are kept up to date as releases are
+  // mutated.
   useEffect(() => {
     fetchReleases();
   }, []);

--- a/packages/root-cms/ui/utils/release.cache.test.ts
+++ b/packages/root-cms/ui/utils/release.cache.test.ts
@@ -1,0 +1,194 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {Release} from './release.js';
+
+const mocks = vi.hoisted(() => ({
+  deleteDoc: vi.fn(),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  runTransaction: vi.fn(),
+  updateDoc: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  Timestamp: {
+    now: () => ({type: 'now'}),
+    fromMillis: (millis: number) => ({type: 'timestamp', millis}),
+  },
+  collection: (_db: unknown, ...path: string[]) => `col:${path.join('/')}`,
+  deleteDoc: mocks.deleteDoc,
+  deleteField: () => ({type: 'deleteField'}),
+  doc: (_db: unknown, ...path: string[]) => `doc:${path.join('/')}`,
+  getDoc: mocks.getDoc,
+  getDocs: mocks.getDocs,
+  orderBy: (field: string) => `orderBy:${field}`,
+  query: (ref: unknown) => ref,
+  runTransaction: mocks.runTransaction,
+  serverTimestamp: () => ({type: 'serverTimestamp'}),
+  updateDoc: mocks.updateDoc,
+}));
+
+vi.mock('./actions.js', () => ({logAction: vi.fn()}));
+vi.mock('./batch.js', () => ({MultiBatch: class {}}));
+vi.mock('./data-source.js', () => ({cmsPublishDataSources: vi.fn()}));
+vi.mock('./doc.js', () => ({
+  cmsPublishDocs: vi.fn(),
+  cmsSyncDependencyGraph: vi.fn(),
+}));
+
+/** Stubs the response of `listReleases()`. */
+function mockReleases(releases: Partial<Release>[]) {
+  mocks.getDocs.mockResolvedValue({
+    forEach: (cb: (doc: {data: () => Partial<Release>}) => void) => {
+      releases.forEach((release) => cb({data: () => release}));
+    },
+  });
+}
+
+// The releases cache is module-level state, so each test imports a fresh copy
+// of the module.
+async function importReleaseUtils() {
+  vi.resetModules();
+  return await import('./release.js');
+}
+
+describe('releases cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.__ROOT_CTX = {rootConfig: {projectId: 'test-project'}} as any;
+    window.firebase = {
+      db: {type: 'mock-db'},
+      user: {email: 'editor@example.com'},
+    } as any;
+    mocks.updateDoc.mockResolvedValue(undefined);
+    mocks.deleteDoc.mockResolvedValue(undefined);
+    mockReleases([]);
+  });
+
+  it('caches the releases and re-uses them on subsequent fetches', async () => {
+    const {listReleasesFromCacheOrFetch} = await importReleaseUtils();
+    mockReleases([{id: 'release-a'}]);
+
+    const first = await listReleasesFromCacheOrFetch();
+    const second = await listReleasesFromCacheOrFetch();
+
+    expect(mocks.getDocs).toHaveBeenCalledTimes(1);
+    expect(first).toEqual([{id: 'release-a'}]);
+    expect(second).toEqual([{id: 'release-a'}]);
+  });
+
+  it('dedupes concurrent fetches into a single request', async () => {
+    const {listReleasesFromCacheOrFetch} = await importReleaseUtils();
+    mockReleases([{id: 'release-a'}]);
+
+    await Promise.all([
+      listReleasesFromCacheOrFetch(),
+      listReleasesFromCacheOrFetch(),
+    ]);
+
+    expect(mocks.getDocs).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when forced', async () => {
+    const {listReleasesFromCacheOrFetch} = await importReleaseUtils();
+    mockReleases([{id: 'release-a'}]);
+
+    await listReleasesFromCacheOrFetch();
+    await listReleasesFromCacheOrFetch({force: true});
+
+    expect(mocks.getDocs).toHaveBeenCalledTimes(2);
+  });
+
+  it('notifies subscribers when docs are added to a release', async () => {
+    const {listReleasesFromCacheOrFetch, subscribeToReleases, updateRelease} =
+      await importReleaseUtils();
+    mockReleases([{id: 'release-a', docIds: ['Pages/foo']}]);
+    await listReleasesFromCacheOrFetch();
+
+    const listener = vi.fn();
+    subscribeToReleases(listener);
+    await updateRelease('release-a', {docIds: ['Pages/foo', 'Pages/bar']});
+
+    expect(listener).toHaveBeenCalledWith([
+      {id: 'release-a', docIds: ['Pages/foo', 'Pages/bar']},
+    ]);
+  });
+
+  it('adds newly created releases to the cache', async () => {
+    const {addRelease, getCachedReleases, listReleasesFromCacheOrFetch} =
+      await importReleaseUtils();
+    mockReleases([{id: 'release-a'}]);
+    await listReleasesFromCacheOrFetch();
+    mocks.runTransaction.mockImplementation(async (_db: unknown, fn: any) => {
+      await fn({
+        get: async () => ({exists: () => false}),
+        set: () => {},
+      });
+    });
+
+    await addRelease('release-b', {docIds: ['Pages/foo']});
+
+    expect(getCachedReleases()).toEqual([
+      {
+        id: 'release-b',
+        docIds: ['Pages/foo'],
+        createdAt: {type: 'now'},
+        createdBy: 'editor@example.com',
+      },
+      {id: 'release-a'},
+    ]);
+  });
+
+  it('removes deleted releases from the cache', async () => {
+    const {deleteRelease, getCachedReleases, listReleasesFromCacheOrFetch} =
+      await importReleaseUtils();
+    mockReleases([{id: 'release-a'}, {id: 'release-b'}]);
+    await listReleasesFromCacheOrFetch();
+
+    await deleteRelease('release-a');
+
+    expect(getCachedReleases()).toEqual([{id: 'release-b'}]);
+  });
+
+  it('marks archived releases as no longer pending', async () => {
+    const {
+      archiveRelease,
+      getCachedReleases,
+      isPendingRelease,
+      listReleasesFromCacheOrFetch,
+    } = await importReleaseUtils();
+    mockReleases([{id: 'release-a'}]);
+    await listReleasesFromCacheOrFetch();
+
+    await archiveRelease('release-a');
+
+    const releases = getCachedReleases()!;
+    expect(releases.filter(isPendingRelease)).toEqual([]);
+    expect(releases[0].archivedBy).toEqual('editor@example.com');
+  });
+
+  it('clears deleted fields from the cache when unarchiving', async () => {
+    const {
+      getCachedReleases,
+      isPendingRelease,
+      listReleasesFromCacheOrFetch,
+      unarchiveRelease,
+    } = await importReleaseUtils();
+    mockReleases([
+      {id: 'release-a', archivedAt: {type: 'now'} as any, archivedBy: 'a@b.c'},
+    ]);
+    await listReleasesFromCacheOrFetch();
+
+    await unarchiveRelease('release-a');
+
+    expect(getCachedReleases()).toEqual([{id: 'release-a'}]);
+    expect(getCachedReleases()!.filter(isPendingRelease)).toHaveLength(1);
+  });
+
+  it('does not populate a partial cache before the releases are fetched', async () => {
+    const {getCachedReleases, updateRelease} = await importReleaseUtils();
+
+    await updateRelease('release-a', {docIds: ['Pages/foo']});
+
+    expect(getCachedReleases()).toBe(null);
+  });
+});

--- a/packages/root-cms/ui/utils/release.ts
+++ b/packages/root-cms/ui/utils/release.ts
@@ -36,6 +36,132 @@ export interface Release {
 
 const COLLECTION_ID = 'Releases';
 
+/** Callback notified whenever the releases cache changes. */
+type ReleasesListener = (releases: Release[]) => void;
+
+/**
+ * In-memory cache of the project's releases, ordered by `createdAt` desc.
+ *
+ * Release state is rendered throughout the CMS (e.g. the "in release" badge in
+ * the doc list), so the releases are fetched once and then kept in sync locally
+ * as releases are mutated. `null` means the releases haven't been fetched yet.
+ */
+let releasesCache: Release[] | null = null;
+
+/** In-flight `listReleases()` request, shared by concurrent callers. */
+let pendingReleasesFetch: Promise<Release[]> | null = null;
+
+const releasesListeners = new Set<ReleasesListener>();
+
+/**
+ * Returns the cached releases, or `null` if the releases haven't been fetched
+ * yet.
+ */
+export function getCachedReleases(): Release[] | null {
+  return releasesCache;
+}
+
+/**
+ * Subscribes to changes to the releases cache. The listener is called whenever
+ * a release is added, updated, or removed. Returns an unsubscribe function.
+ *
+ * Usage:
+ *
+ * ```
+ * useEffect(() => subscribeToReleases(setReleases), []);
+ * ```
+ */
+export function subscribeToReleases(listener: ReleasesListener): () => void {
+  releasesListeners.add(listener);
+  return () => {
+    releasesListeners.delete(listener);
+  };
+}
+
+/**
+ * Fetches the project's releases, re-using the cached values when available.
+ * Pass `{force: true}` to bypass the cache and re-fetch from the db.
+ */
+export function listReleasesFromCacheOrFetch(options?: {
+  force?: boolean;
+}): Promise<Release[]> {
+  if (!options?.force && releasesCache) {
+    return Promise.resolve(releasesCache);
+  }
+  if (!pendingReleasesFetch) {
+    pendingReleasesFetch = listReleases().finally(() => {
+      pendingReleasesFetch = null;
+    });
+  }
+  return pendingReleasesFetch;
+}
+
+/** Returns true if a release is neither published nor archived. */
+export function isPendingRelease(release: Release): boolean {
+  return !release.publishedAt && !release.archivedAt;
+}
+
+function notifyReleasesListeners() {
+  const releases = releasesCache || [];
+  releasesListeners.forEach((listener) => listener(releases));
+}
+
+/** Replaces the cached releases and notifies listeners. */
+function setCachedReleases(releases: Release[]) {
+  releasesCache = releases;
+  notifyReleasesListeners();
+}
+
+/**
+ * Adds or replaces a release in the cache. New releases are prepended since the
+ * cache is ordered by `createdAt` desc. No-ops if the releases haven't been
+ * fetched yet, since the cache is only valid when it holds the full list.
+ */
+function addReleaseToCache(release: Release) {
+  if (!releasesCache) {
+    return;
+  }
+  if (releasesCache.some((r) => r.id === release.id)) {
+    setCachedReleases(
+      releasesCache.map((r) => (r.id === release.id ? release : r))
+    );
+    return;
+  }
+  setCachedReleases([release, ...releasesCache]);
+}
+
+/**
+ * Merges field updates into a cached release. Fields set to `undefined` are
+ * removed from the cached release, mirroring `deleteField()` writes.
+ */
+function updateReleaseInCache(id: string, updates: Partial<Release>) {
+  if (!releasesCache) {
+    return;
+  }
+  setCachedReleases(
+    releasesCache.map((release) => {
+      if (release.id !== id) {
+        return release;
+      }
+      const updated: Release = {...release, ...updates};
+      for (const key of Object.keys(updates)) {
+        if (updates[key as keyof Release] === undefined) {
+          delete (updated as Record<string, unknown>)[key];
+        }
+      }
+      return updated;
+    })
+  );
+}
+
+/** Removes a release from the cache. */
+function removeReleaseFromCache(id: string) {
+  if (!releasesCache) {
+    return;
+  }
+  setCachedReleases(releasesCache.filter((release) => release.id !== id));
+}
+
 export async function addRelease(id: string, release: Partial<Release>) {
   if (!id) {
     throw new Error('missing data source id');
@@ -55,6 +181,14 @@ export async function addRelease(id: string, release: Partial<Release>) {
       createdBy: window.firebase.user.email,
     });
   });
+  // Approximate the server-generated `createdAt` locally so that the release
+  // shows up in the cache in the right order.
+  addReleaseToCache({
+    ...release,
+    id: id,
+    createdAt: Timestamp.now(),
+    createdBy: window.firebase.user.email,
+  });
   logAction('release.create', {metadata: {releaseId: id}});
 }
 
@@ -68,6 +202,7 @@ export async function listReleases(): Promise<Release[]> {
   querySnapshot.forEach((doc) => {
     res.push(doc.data() as Release);
   });
+  setCachedReleases(res);
   return res;
 }
 
@@ -77,16 +212,20 @@ export async function getRelease(id: string) {
   const docRef = doc(db, 'Projects', projectId, COLLECTION_ID, id);
   const snapshot = await getDoc(docRef);
   if (!snapshot.exists()) {
+    removeReleaseFromCache(id);
     return null;
   }
-  return snapshot.data() as Release;
+  const release = snapshot.data() as Release;
+  addReleaseToCache(release);
+  return release;
 }
 
-export async function updateRelease(id: string, dataSource: Partial<Release>) {
+export async function updateRelease(id: string, release: Partial<Release>) {
   const projectId = window.__ROOT_CTX.rootConfig.projectId;
   const db = window.firebase.db;
   const docRef = doc(db, 'Projects', projectId, COLLECTION_ID, id);
-  await updateDoc(docRef, dataSource);
+  await updateDoc(docRef, release);
+  updateReleaseInCache(id, release);
   logAction('release.save', {metadata: {releaseId: id}});
 }
 
@@ -95,6 +234,7 @@ export async function deleteRelease(id: string) {
   const db = window.firebase.db;
   const docRef = doc(db, 'Projects', projectId, COLLECTION_ID, id);
   await deleteDoc(docRef);
+  removeReleaseFromCache(id);
   console.log(`deleted release ${id}`);
   logAction('release.delete', {metadata: {releaseId: id}});
 }
@@ -105,6 +245,10 @@ export async function archiveRelease(id: string) {
   const docRef = doc(db, 'Projects', projectId, COLLECTION_ID, id);
   await updateDoc(docRef, {
     archivedAt: serverTimestamp(),
+    archivedBy: window.firebase.user.email,
+  });
+  updateReleaseInCache(id, {
+    archivedAt: Timestamp.now(),
     archivedBy: window.firebase.user.email,
   });
   logAction('release.archive', {metadata: {releaseId: id}});
@@ -118,6 +262,7 @@ export async function unarchiveRelease(id: string) {
     archivedAt: deleteField(),
     archivedBy: deleteField(),
   });
+  updateReleaseInCache(id, {archivedAt: undefined, archivedBy: undefined});
   logAction('release.unarchive', {metadata: {releaseId: id}});
 }
 
@@ -167,6 +312,12 @@ export async function publishRelease(
     scheduledBy: deleteField(),
   });
   await batch.commit();
+  updateReleaseInCache(id, {
+    publishedAt: Timestamp.now(),
+    publishedBy: window.firebase.user.email,
+    scheduledAt: undefined,
+    scheduledBy: undefined,
+  });
   console.log(`published release: ${id}`);
   // Update the dependency graph for the released docs (cmsPublishDocs skips
   // the sync when writing to a shared batch, since the batch commits here).
@@ -213,6 +364,10 @@ export async function scheduleRelease(
     scheduledAt: timestamp,
     scheduledBy: window.firebase.user.email,
   });
+  updateReleaseInCache(id, {
+    scheduledAt: timestamp,
+    scheduledBy: window.firebase.user.email,
+  });
   const metadata: Record<string, unknown> = {
     releaseId: id,
     scheduledAt: timestamp.toMillis(),
@@ -242,5 +397,6 @@ export async function cancelScheduledRelease(id: string) {
     scheduledAt: deleteField(),
     scheduledBy: deleteField(),
   });
+  updateReleaseInCache(id, {scheduledAt: undefined, scheduledBy: undefined});
   logAction('release.unschedule', {metadata: {releaseId: id}});
 }


### PR DESCRIPTION
Fixes [#1396](https://github.com/blinkk/rootjs/issues/1396).

## Problem

`usePendingReleases` fetched the project's releases exactly once per session (`fetchState` never returns to `idle`) and nothing invalidated that list. Adding docs to a release therefore left the "in release" badge missing from the doc list until the page was refreshed.

## Fix

Move the cache out of the hook and into `ui/utils/release.ts`, where every release write already lives, and make it a small subscribable store:

- `listReleases()` populates the cache; `getRelease()` refreshes a single entry.
- `addRelease`, `updateRelease`, `deleteRelease`, `archiveRelease`, `unarchiveRelease`, `publishRelease`, `scheduleRelease`, and `cancelScheduledRelease` all update the cache after their write, so every call site (including the Root AI chat tool handlers) stays in sync without extra reads.
- New exports: `getCachedReleases()`, `subscribeToReleases()`, `listReleasesFromCacheOrFetch()` (which also dedupes concurrent fetches), and `isPendingRelease()`.
- Cache updates no-op while the cache is unpopulated, so a partial list is never served — the first fetch still hits the db.

`PendingReleasesProvider` now subscribes to that store and re-derives its pending releases on every change, so the badges in the doc list, `DocStatusBadges`, and `GlobalSearch` re-render as soon as a release is mutated.

`AddToReleaseModal` reuses `isPendingRelease` instead of duplicating the predicate.

## Testing

- New `ui/utils/release.cache.test.ts` covers cache reuse, concurrent-fetch deduping, forced re-fetch, subscriber notification when docs are added to a release, create/delete cache updates, archive/unarchive (including `deleteField()` clearing cached fields), and the unpopulated-cache no-op.
- Full root-cms suite passes in the Firestore emulator: 105 files, 1291 tests.
- `tsc --noEmit` and `eslint` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjYyi5esbCihDWpofcw6DE)_