### PR TITLE
fix: respect the compact view options in the doc picker modal

### DIFF
--- a/.changeset/olive-pickers-condense.md
+++ b/.changeset/olive-pickers-condense.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: respect the compact view options in the doc picker modal

--- a/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.css
+++ b/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.css
@@ -169,3 +169,60 @@
   margin-bottom: 12px;
   padding: 0 4px;
 }
+
+/*
+ * Compact rows. Enabled when the collection forces the compact listing
+ * (`viewOptions: {compact: true}`) or when the user's preferred listing
+ * density is compact. Condenses each row onto a single line — small
+ * thumbnail, doc id, title, badges — mirroring the compact listing on the
+ * collection page.
+ */
+.DocPickerModal__DocCard--compact {
+  gap: 12px;
+  padding: 4px 8px 4px 0;
+}
+
+.DocPickerModal__DocCard--compact .DocPickerModal__DocCard__content {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  padding: 0 4px;
+}
+
+.DocPickerModal__DocCard--compact
+  .DocPickerModal__DocCard__content__header__docId {
+  font-size: 12px;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.DocPickerModal__DocCard--compact .DocPickerModal__DocCard__content__header {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 40%;
+  flex-wrap: nowrap;
+}
+
+.DocPickerModal__DocCard--compact .DocPickerModal__DocCard__content__title {
+  display: block;
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.DocPickerModal__DocCard--compact .DocPickerModal__DocCard__content__link {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.DocPickerModal__DocCard--compact .DocPickerModal__DocCard__content__badges {
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  margin-top: 0;
+}

--- a/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.tsx
+++ b/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.tsx
@@ -5,10 +5,12 @@ import {ContextModalProps, useModals} from '@mantine/modals';
 import {IconSearch} from '@tabler/icons-preact';
 import {useState} from 'preact/hooks';
 
+import {useDensity} from '../../hooks/useDensity.js';
 import {useDocsList} from '../../hooks/useDocsList.js';
 import {useFilteredDocs} from '../../hooks/useFilteredDocs.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
+import {joinClassNames} from '../../utils/classes.js';
 import {getNestedValue} from '../../utils/objects.js';
 import {DocStatusBadges} from '../DocStatusBadges/DocStatusBadges.js';
 import {FilePreview} from '../FilePreview/FilePreview.js';
@@ -174,6 +176,12 @@ DocPickerModal.DocsList = (props: {
   );
   const [newDocModalOpen, setNewDocModalOpen] = useState(false);
 
+  // Render the condensed rows when the collection forces the compact listing
+  // (`viewOptions: {compact: true}`) or when the user's preferred listing
+  // density is compact.
+  const {density} = useDensity(props.collection);
+  const compact = density === 'compact';
+
   const [loading, refreshDocs, docs] = useDocsList(props.collection || '', {
     orderBy: sortBy,
   });
@@ -278,6 +286,7 @@ DocPickerModal.DocsList = (props: {
                 multiSelect={props.multiSelect}
                 selected={selectedDocIds.includes(doc.id)}
                 enableStatusBadges={options.enableStatusBadges}
+                compact={compact}
               />
             ))}
           </div>
@@ -298,6 +307,11 @@ DocPickerModal.DocsList = (props: {
   );
 };
 
+/**
+ * A row in the doc picker's listing. The `compact` variant renders a condensed
+ * single-line row (small thumbnail, doc id, title, badges), mirroring the
+ * compact listing on the collection page.
+ */
 DocPickerModal.DocCard = (props: {
   doc: any;
   onDocSelected: (doc: any) => void;
@@ -305,8 +319,10 @@ DocPickerModal.DocCard = (props: {
   multiSelect?: boolean;
   selected?: boolean;
   enableStatusBadges?: boolean;
+  compact?: boolean;
 }) => {
   const [selected, setSelected] = useState(!!props.selected);
+  const compact = !!props.compact;
   const doc = props.doc;
   const [collection, slug] = doc.id.split('/');
   const fields = doc.fields || {};
@@ -320,15 +336,20 @@ DocPickerModal.DocCard = (props: {
     getNestedValue(fields, rootCollection.preview?.image || 'meta.image') ||
     rootCollection.preview?.defaultImage;
   return (
-    <div className="DocPickerModal__DocCard">
+    <div
+      className={joinClassNames(
+        'DocPickerModal__DocCard',
+        compact && 'DocPickerModal__DocCard--compact'
+      )}
+    >
       <div
         className="DocPickerModal__DocCard__image"
         onClick={() => window.open(cmsUrl, '_blank')}
       >
         <FilePreview
           file={previewImage}
-          width={120}
-          height={90}
+          width={compact ? 40 : 120}
+          height={compact ? 30 : 90}
           withPlaceholder={!previewImage?.src}
         />
       </div>
@@ -363,6 +384,7 @@ DocPickerModal.DocCard = (props: {
                 variant="light"
                 color="blue"
                 size="xs"
+                compact={compact}
                 onClick={() => {
                   setSelected(false);
                   props.onDocUnselected(props.doc);
@@ -375,6 +397,7 @@ DocPickerModal.DocCard = (props: {
                 variant="filled"
                 color="blue"
                 size="xs"
+                compact={compact}
                 onClick={() => {
                   setSelected(true);
                   props.onDocSelected(props.doc);
@@ -387,6 +410,7 @@ DocPickerModal.DocCard = (props: {
             <Button
               color="blue"
               size="xs"
+              compact={compact}
               onClick={() => props.onDocSelected(props.doc)}
             >
               Select

--- a/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.visual.test.tsx
+++ b/packages/root-cms/ui/components/DocPickerModal/DocPickerModal.visual.test.tsx
@@ -46,6 +46,16 @@ beforeEach(async () => {
           image: 'meta.image',
         },
       },
+      Redirects: {
+        name: 'Redirects',
+        preview: {
+          title: 'meta.title',
+          image: 'meta.image',
+        },
+        viewOptions: {
+          compact: true,
+        },
+      },
     },
     rootConfig: {
       projectId: 'test-project',
@@ -56,6 +66,16 @@ beforeEach(async () => {
 afterEach(() => {
   cleanup();
 });
+
+// The status badges read pending releases from a context provider that isn't
+// rendered in these tests.
+vi.mock('../../hooks/usePendingReleases.js', () => ({
+  usePendingReleases: () => ({
+    releases: [],
+    loading: false,
+    getReleasesForDoc: () => [],
+  }),
+}));
 
 vi.mock('../../hooks/useDocsList.js', () => ({
   useDocsList: vi.fn(() => {
@@ -261,6 +281,32 @@ describe('DocPickerModal', () => {
     const element = page.getByTestId('wrapper');
     await expect.element(element).toBeVisible();
     await expect.element(element).toMatchScreenshot('multiple-collections.png');
+  });
+
+  it('renders the compact view for collections with viewOptions.compact', async () => {
+    const modalProps: ContextModalProps<DocPickerModalProps> = {
+      context: {} as any,
+      id: 'test-modal',
+      innerProps: {
+        collections: ['Redirects'],
+        initialCollection: 'Redirects',
+        onChange: vi.fn(),
+        enableSearch: true,
+        enableSort: true,
+        enableCreate: true,
+        enableStatusBadges: true,
+      },
+    };
+
+    render(
+      <TestWrapper>
+        <DocPickerModal {...modalProps} />
+      </TestWrapper>
+    );
+
+    const element = page.getByTestId('wrapper');
+    await expect.element(element).toBeVisible();
+    await expect.element(element).toMatchScreenshot('compact-view.png');
   });
 
   it('renders initial state with collection selector and create button', async () => {

--- a/packages/root-cms/ui/hooks/useDensity.ts
+++ b/packages/root-cms/ui/hooks/useDensity.ts
@@ -1,0 +1,53 @@
+import {useLocalStorage} from './useLocalStorage.js';
+
+/** Document listing density. */
+export type Density = 'comfortable' | 'compact';
+
+/**
+ * Local storage key for the user's preferred listing density. The preference
+ * is global (not per-collection) so that the density stays sticky as the user
+ * navigates between collections and opens the doc picker.
+ */
+const DENSITY_KEY = 'root::CollectionPage:density';
+
+const DEFAULT_DENSITY: Density = 'comfortable';
+
+export interface UseDensityResult {
+  /** The density the doc listing should render with. */
+  density: Density;
+  /**
+   * Whether the density is locked by the collection's schema
+   * (`viewOptions: {compact: true}`), in which case the user's preference is
+   * ignored and any density control should be disabled.
+   */
+  locked: boolean;
+  /** Updates the user's preferred density. */
+  setDensity: (density: Density) => void;
+}
+
+/**
+ * Returns the density to use when rendering a listing of docs for a
+ * collection. Collections can force the compact listing via
+ * `viewOptions: {compact: true}`; otherwise the user's preferred density is
+ * used.
+ *
+ * Usage:
+ * ```tsx
+ * const {density, locked, setDensity} = useDensity(collectionId);
+ * ```
+ */
+export function useDensity(collectionId?: string): UseDensityResult {
+  const [userDensity, setUserDensity] = useLocalStorage<Density>(
+    DENSITY_KEY,
+    DEFAULT_DENSITY
+  );
+  const collection = collectionId
+    ? window.__ROOT_CTX.collections[collectionId]
+    : null;
+  const locked = Boolean(collection?.viewOptions?.compact);
+  return {
+    density: locked ? 'compact' : userDensity,
+    locked: locked,
+    setDensity: setUserDensity,
+  };
+}

--- a/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
+++ b/packages/root-cms/ui/pages/CollectionPage/CollectionPage.tsx
@@ -41,6 +41,7 @@ import {FilePreview} from '../../components/FilePreview/FilePreview.js';
 import {NewDocModal} from '../../components/NewDocModal/NewDocModal.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {UserActionTooltip} from '../../components/UserActionTooltip/UserActionTooltip.js';
+import {Density, useDensity} from '../../hooks/useDensity.js';
 import {useDocsList} from '../../hooks/useDocsList.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
@@ -58,9 +59,6 @@ import {
 import {getNestedValue} from '../../utils/objects.js';
 import {testCanEdit} from '../../utils/permissions.js';
 import {formatDateTime, getTimeAgo} from '../../utils/time.js';
-
-/** Document listing density. */
-type Density = 'comfortable' | 'compact';
 
 const DENSITY_OPTIONS: Array<{
   value: Density;
@@ -172,12 +170,11 @@ CollectionPage.Collection = (props: CollectionProps) => {
   // Collections can force the compact listing via schema
   // (`viewOptions: {compact: true}`). Otherwise the user's chosen density is
   // remembered globally (sticky as the user navigates between collections).
-  const forceCompactView = Boolean(collection.viewOptions?.compact);
-  const [userDensity, setUserDensity] = useLocalStorage<Density>(
-    'root::CollectionPage:density',
-    'comfortable'
-  );
-  const density: Density = forceCompactView ? 'compact' : userDensity;
+  const {
+    density,
+    locked: forceCompactView,
+    setDensity,
+  } = useDensity(props.collection);
   const compactView = density === 'compact';
 
   const sortOptions = [
@@ -251,7 +248,7 @@ CollectionPage.Collection = (props: CollectionProps) => {
               <DensityControl
                 density={density}
                 locked={forceCompactView}
-                onChange={setUserDensity}
+                onChange={setDensity}
               />
               <div className="CollectionPage__collection__docsTab__controls__newDoc">
                 <ConditionalTooltip


### PR DESCRIPTION
Fixes #1397.

## Problem

The doc picker modal always rendered the classic/expanded doc cards (120x90 thumbnail, 24px title), even for collections that force the compact listing via `viewOptions: {compact: true}`.

## Changes

- **New `useDensity()` hook** (`ui/hooks/useDensity.ts`) — resolves the listing density for a collection: the collection's `viewOptions.compact` wins (and reports `locked`), otherwise the user's globally-remembered density preference is used. This is the logic that previously lived inline in `CollectionPage`, unchanged (same local storage key, so existing preferences are preserved).
- **`CollectionPage`** now uses the hook instead of its own inline density state.
- **`DocPickerModal`** resolves the density for the currently selected collection and renders a `--compact` row variant: 40x30 thumbnail, doc id, title, and status badges on a single line, with a compact select button (row height goes from ~110px to ~40px). The expanded rendering is unchanged when the density is comfortable.
- **Visual tests** — added a case for a collection with `viewOptions: {compact: true}`, and mocked `usePendingReleases()`, which the existing cases have been throwing on since the status badges started reading pending releases from a context provider that the tests don't render.

## Testing

- `npx tsc --noEmit -p packages/root-cms/ui/tsconfig.json` — clean apart from the pre-existing `Layout.tsx` import-assertion error.
- `pnpm lint` — no new violations (the reported ones are pre-existing prettier drift in untouched files).
- `pnpm build:ui:bundle` — builds.
- Visual tests were run locally against Chromium and all six cases render as expected. The goldens in this repo are macOS-only (`*-chromium-darwin.png`), so **the new `compact-view.png` golden still needs to be generated on macOS** with `pnpm test:visual --update` before this leaves draft.