### PR TITLE
fix: honor the preserveFilename option in the file field

### DIFF
--- a/.changeset/tidy-pots-repeat.md
+++ b/.changeset/tidy-pots-repeat.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: honor the `preserveFilename` option in the file field

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.test.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.test.tsx
@@ -1,0 +1,132 @@
+import {cleanup, fireEvent, render, waitFor} from '@testing-library/preact';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import * as schema from '../../../../core/schema.js';
+
+// Mock Mantine components. The real components require a MantineProvider
+// context that isn't available under @preact/compat in jsdom; these stubs keep
+// the test focused on the field's own upload logic.
+vi.mock('@mantine/core', () => {
+  const Passthrough = ({children}: any) => <div>{children}</div>;
+  const Menu: any = Passthrough;
+  Menu.Target = Passthrough;
+  Menu.Dropdown = Passthrough;
+  Menu.Item = Passthrough;
+  Menu.Label = Passthrough;
+  Menu.Divider = Passthrough;
+  return {
+    ActionIcon: Passthrough,
+    Box: Passthrough,
+    Button: Passthrough,
+    Checkbox: Passthrough,
+    Divider: Passthrough,
+    Group: Passthrough,
+    Loader: Passthrough,
+    LoadingOverlay: Passthrough,
+    Menu,
+    Modal: Passthrough,
+    Select: Passthrough,
+    Table: Passthrough,
+    Text: Passthrough,
+    Textarea: Passthrough,
+    Tooltip: Passthrough,
+    useMantineTheme: () => ({
+      colorScheme: 'light',
+      primaryColor: 'blue',
+      colors: {
+        blue: Array(10).fill('#228be6'),
+        dark: Array(10).fill('#1a1b1e'),
+        gray: Array(10).fill('#ced4da'),
+      },
+    }),
+  };
+});
+
+vi.mock('./GenerateImageForm.js', () => ({
+  GenerateImageForm: () => null,
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  showNotification: vi.fn(),
+  hideNotification: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useGapiClient.js', () => ({
+  useGapiClient: () => ({enabled: false}),
+}));
+
+vi.mock('../../AssetPickerModal/AssetPickerModal.js', () => ({
+  useAssetPickerModal: () => ({open: vi.fn(), close: vi.fn()}),
+}));
+
+const uploadFileToGCS = vi.fn(async () => ({
+  src: 'https://example.com/hero.png',
+  filename: 'hero.png',
+}));
+
+vi.mock('../../../utils/gcs.js', async (importOriginal) => {
+  const gcs = await importOriginal<typeof import('../../../utils/gcs.js')>();
+  return {
+    ...gcs,
+    uploadFileToGCS: (...args: any[]) => uploadFileToGCS(...(args as [])),
+    checkFileExists: async () => false,
+  };
+});
+
+window.__ROOT_CTX = {
+  experiments: {},
+  rootConfig: {projectId: 'test-project'},
+} as any;
+
+// Import after the mocks are registered.
+const {FileFieldInternal} = await import('./FileField.js');
+
+function renderField(field: schema.FileField) {
+  return render(
+    <FileFieldInternal
+      field={field}
+      value={null}
+      setValue={vi.fn()}
+      loadingState={null}
+      setLoadingState={vi.fn()}
+    />
+  );
+}
+
+/** Drops a file onto the field's dropzone. */
+function dropFile(container: HTMLElement) {
+  const dropZone = container.querySelector('.FileField__Dropzone')!;
+  const file = new File(['hello'], 'hero.png', {type: 'image/png'});
+  fireEvent.drop(dropZone, {dataTransfer: {files: [file]}});
+}
+
+describe('FileField naming mode', () => {
+  beforeEach(() => {
+    uploadFileToGCS.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('hashes the filename by default', async () => {
+    const {container} = renderField({type: 'file', label: 'File'});
+    dropFile(container);
+    await waitFor(() => expect(uploadFileToGCS).toHaveBeenCalled());
+    expect((uploadFileToGCS.mock.calls[0] as any)[1]).toMatchObject({
+      namingMode: 'hash',
+    });
+  });
+
+  it('preserves the filename when the field opts in', async () => {
+    const {container} = renderField({
+      type: 'file',
+      label: 'File',
+      preserveFilename: true,
+    });
+    dropFile(container);
+    await waitFor(() => expect(uploadFileToGCS).toHaveBeenCalled());
+    expect((uploadFileToGCS.mock.calls[0] as any)[1]).toMatchObject({
+      namingMode: 'hash-path',
+    });
+  });
+});

--- a/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
+++ b/packages/root-cms/ui/components/DocEditor/fields/FileField.tsx
@@ -169,9 +169,14 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
   const assetPickerModal = useAssetPickerModal();
   const allowEditing = props.allowEditing !== false;
 
+  // The naming mode configured by the schema. Fields that set
+  // `preserveFilename: true` upload to `{hash}/{filename}.{ext}` so that the
+  // original filename is kept in the serving URL without risking collisions.
+  const defaultNamingMode = field.preserveFilename ? 'hash-path' : 'hash';
+
   // New state from FileUploader
   const [namingMode, setNamingMode] = useState<'hash' | 'hash-path' | 'clean'>(
-    'hash'
+    defaultNamingMode
   );
   const [pendingUpload, setPendingUpload] = useState<File | null>(null);
   const [overwriteConfirmed, setOverwriteConfirmed] = useState(false);
@@ -200,9 +205,9 @@ export function FileFieldInternal(props: FileFieldInternalProps) {
   ) {
     try {
       setLoadingState('loading');
-      // Use prop namingMode if available, otherwise fall back to field config
-      const mode =
-        options?.namingMode || (field.preserveFilename ? 'clean' : 'hash');
+      // Use the requested namingMode if available, otherwise fall back to the
+      // field config.
+      const mode = options?.namingMode || defaultNamingMode;
 
       // When using the original filename without a hash, the file can be
       // overwritten by a subsequent upload, so disable caching.


### PR DESCRIPTION
## The bug

`schema.file({preserveFilename: true})` had no effect — uploads were always named `{hash}.{ext}`.

`FileFieldInternal` keeps a local `namingMode` state (used by the "File name options" select, which only renders when `showNamingOptions` is set) that was initialized to `'hash'`. The drop/upload handler passed that state unconditionally:

```ts
uploadFile(fileObj, undefined, {namingMode: namingMode});
```

and `uploadFile()` only fell back to the field config when no mode was passed:

```ts
const mode = options?.namingMode || (field.preserveFilename ? 'clean' : 'hash');
```

Since `'hash'` is truthy, the fallback was unreachable for every normal doc-editor upload. (Re-uploads from the image editor, which pass no options, did hit the fallback — so the same field behaved differently on the initial upload vs. after an edit.)

## The fix

- Derive `defaultNamingMode` from the field config and use it to initialize the `namingMode` state, so both the select and the upload handler start from the schema's intent.
- `uploadFile()` falls back to the same value.

`preserveFilename: true` now resolves to the `hash-path` mode (`{hash}/{filename}.{ext}`) rather than `clean`. That matches the mapping the deprecated `preserveFilename` upload option still uses in `ui/utils/gcs.ts` and the pre-`namingMode` behavior: the original filename is preserved in the serving URL, uploads can't overwrite each other, and the 1-year `cache-control` stays in place (`clean` would have forced `no-cache`).

## Tests

Added `ui/components/DocEditor/fields/FileField.test.tsx`, which drops a file onto the field and asserts the naming mode handed to `uploadFileToGCS`:

- default field → `hash`
- `preserveFilename: true` → `hash-path`

The second case fails on `main` and passes here. `pnpm lint` reports no errors in the touched files (the repo has pre-existing lint failures elsewhere).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9RpWtH6AvrqcpCsN6mSQA)_