### PR TITLE
fix: keep tooltip targets from shifting when the tooltip opens

### DIFF
--- a/.changeset/tidy-tooltips-settle.md
+++ b/.changeset/tidy-tooltips-settle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: keep tooltip targets from shifting when the tooltip opens

--- a/packages/root-cms/ui/components/ActionLogs/ActionLogs.visual.test.tsx
+++ b/packages/root-cms/ui/components/ActionLogs/ActionLogs.visual.test.tsx
@@ -3,6 +3,7 @@ import '../../styles/theme.css';
 import {MantineProvider} from '@mantine/core';
 import {render, waitFor} from '@testing-library/preact';
 import {describe, expect, it, vi} from 'vitest';
+import {userEvent} from 'vitest/browser';
 import {ActionLogs} from './ActionLogs.js';
 
 const MOCK_ACTIONS = vi.hoisted(() => {
@@ -91,5 +92,34 @@ describe('ActionLogs', () => {
     expect(offsets[0].centerY).toBeCloseTo(offsets[1].centerY, 1);
     expect(offsets[0].right).toBeCloseTo(offsets[1].right, 1);
     expect(offsets[0].height).toBeCloseTo(offsets[1].height, 1);
+  });
+
+  it('keeps the timestamp in place when its tooltip opens', async () => {
+    const {container} = renderCompact();
+    const rows = await waitForRows(container);
+    const timestamp = rows[0].querySelector(
+      '.ActionsLogs__timestamp'
+    ) as HTMLElement;
+    expect(timestamp).not.toBeNull();
+    // Hovering scrolls the timestamp into view, so measure it relative to its
+    // row rather than to the viewport.
+    const offset = () => {
+      const rowRect = rows[0].getBoundingClientRect();
+      const rect = timestamp.getBoundingClientRect();
+      return {
+        top: rect.top - rowRect.top,
+        height: rect.height,
+        rowHeight: rowRect.height,
+      };
+    };
+    const before = offset();
+    await userEvent.hover(timestamp);
+    await waitFor(() => {
+      expect(document.querySelector('.mantine-Tooltip-body')).not.toBeNull();
+    });
+    const after = offset();
+    expect(after.top).toBeCloseTo(before.top, 1);
+    expect(after.height).toBeCloseTo(before.height, 1);
+    expect(after.rowHeight).toBeCloseTo(before.rowHeight, 1);
   });
 });

--- a/packages/root-cms/ui/components/Tooltip/Tooltip.css
+++ b/packages/root-cms/ui/components/Tooltip/Tooltip.css
@@ -6,3 +6,24 @@
 .Tooltip.mantine-Tooltip-root {
   display: inline-flex;
 }
+
+/*
+ * Take the popper's wrapper out of the flow while the tooltip is open.
+ *
+ * Mantine renders the tooltip's popper into a portal, but it leaves behind an
+ * empty div inside the wrapper for as long as the tooltip is visible. Since the
+ * wrapper is a flex box, that empty div becomes its first flex item, and a flex
+ * box takes its baseline from its first item. Swapping the child's text
+ * baseline for the empty div's synthesized one grows the line box, which nudges
+ * the child up or down every time the tooltip opens and closes. Absolute
+ * positioning stops the div from being a flex item, so the child always sets
+ * the baseline.
+ *
+ * The selector matches an empty div that is the first of exactly two children,
+ * which is what the leftover looks like (the tooltip's own child is the
+ * second). A closed tooltip renders a single child, so the leftover is the only
+ * element this can match.
+ */
+.Tooltip.mantine-Tooltip-root > div:first-child:nth-last-child(2):empty {
+  position: absolute;
+}


### PR DESCRIPTION
Fixes #1401.

## Problem

Hovering a date in "Recent actions" on the homepage nudged the time label up (and back down on mouse out) as the tooltip opened.

## Cause

`<Tooltip>` makes Mantine's wrapper `display: inline-flex` so it shrink-wraps its child (added in #1341 to fix a different alignment issue). While a tooltip is open, Mantine renders the popper into a portal but still leaves an empty `<div>` inside that wrapper. That empty div becomes the wrapper's *first* flex item, and a flex box takes its baseline from its first item — so the wrapper's baseline switched from the child's text baseline to the empty div's synthesized one, growing the line box and moving the child by ~1.5px.

## Fix

Take the leftover div out of the flow (`position: absolute`) so it is no longer a flex item and the tooltip's child always sets the wrapper's baseline. The selector matches an empty div that is the first of exactly two children, which only occurs while the tooltip is open.

## Testing

- Added a visual regression test that hovers a recent actions timestamp and asserts the label and its row don't move. It fails without the CSS change (1.5px shift) and passes with it.
- `vitest run --config=vitest.config.visual.ts` in `packages/root-cms`: the new test passes and the set of failing tests is unchanged from `main` (the pre-existing failures are screenshot goldens recorded on macOS, which don't match a Linux runner).
- `eslint` + `prettier --check` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgMSP6KbmAbxSgGgDtBzvw)_