### PR TITLE
feat: move reset sign-in into the Site Admin settings section

### DIFF
--- a/.changeset/tidy-moons-shave.md
+++ b/.changeset/tidy-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: move reset sign-in into the Site Admin settings section

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.css
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.css
@@ -16,27 +16,8 @@
 }
 
 .ShareBox__user {
-  grid-template-columns: 24px minmax(0, 1fr) 24px 120px;
+  grid-template-columns: 24px minmax(0, 1fr) 120px;
   padding: 6px 16px;
-}
-
-.ShareBox__user__actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-}
-
-/* Kept out of the way until the row is hovered or the button is tabbed to.
- * The grid column is reserved either way so rows don't shift. */
-.ShareBox__user__resetSignIn {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.ShareBox__user:hover .ShareBox__user__resetSignIn,
-.ShareBox__user:focus-within .ShareBox__user__resetSignIn {
-  opacity: 1;
-  pointer-events: auto;
 }
 
 .ShareBox__user:hover {

--- a/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
+++ b/packages/root-cms/ui/components/ShareBox/ShareBox.tsx
@@ -1,8 +1,6 @@
-import {ActionIcon, Button, Select, TextInput, Tooltip} from '@mantine/core';
-import {IconKeyOff} from '@tabler/icons-preact';
+import {Button, Select, TextInput} from '@mantine/core';
 import {useState} from 'preact/hooks';
 import {UserRole} from '../../../core/client.js';
-import {useSignInStatuses} from '../../hooks/useSignInStatus.js';
 import {useUserProfiles} from '../../hooks/useUserProfile.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {sortByKey} from '../../utils/objects.js';
@@ -16,24 +14,15 @@ export interface ShareBoxProps {
   roles: Record<string, UserRole>;
   onChange: (roles: Record<string, UserRole>) => void;
   currentUserIsAdmin: boolean;
-  /**
-   * Called when an admin resets a user's sign-in. Omit to hide the action.
-   */
-  onResetSignIn?: (email: string) => void;
 }
 
 export function ShareBox(props: ShareBoxProps) {
-  const {roles, onChange, currentUserIsAdmin, onResetSignIn} = props;
+  const {roles, onChange, currentUserIsAdmin} = props;
   const [emailInput, setEmailInput] = useState('');
   const profileEmails = Object.keys(roles).filter(
     (email) => !isOrgEmail(email)
   );
   const {profiles} = useUserProfiles(profileEmails);
-  // Only admins can reset a sign-in, and only accounts that actually have a
-  // Google link have anything to reset.
-  const {statuses} = useSignInStatuses(profileEmails, {
-    enabled: currentUserIsAdmin && !!onResetSignIn,
-  });
 
   function setRole(email: string, role: UserRole) {
     onChange({...roles, [email]: role});
@@ -60,7 +49,6 @@ export function ShareBox(props: ShareBoxProps) {
         email,
         role: roles[email],
         profile: profiles.get(email.toLowerCase()) || null,
-        hasGoogleLink: !!statuses.get(email.toLowerCase())?.hasGoogleLink,
       };
     }),
     'email'
@@ -104,7 +92,6 @@ export function ShareBox(props: ShareBoxProps) {
             currentUserIsAdmin={currentUserIsAdmin}
             onRoleChange={setRole}
             onRemove={removeUser}
-            onResetSignIn={onResetSignIn}
           />
         ))}
       </div>
@@ -117,22 +104,12 @@ export interface ShareBoxUserProps {
   role: UserRole;
   profile?: UserProfile | null;
   currentUserIsAdmin: boolean;
-  /** True if the user has a Google sign-in link that could be reset. */
-  hasGoogleLink?: boolean;
   onRoleChange: (email: string, newRole: UserRole) => void;
   onRemove: (email: string) => void;
-  onResetSignIn?: (email: string) => void;
 }
 
 ShareBox.User = (props: ShareBoxUserProps) => {
   const isCurrentUser = props.email === window.firebase.user.email;
-  // Hidden unless there's a Google link to unlink. Domain-wide entries
-  // (`*@example.com`) and users who have never signed in don't have one.
-  const canResetSignIn =
-    !!props.onResetSignIn &&
-    props.currentUserIsAdmin &&
-    !isOrgEmail(props.email) &&
-    !!props.hasGoogleLink;
   return (
     <div className="ShareBox__user">
       <EmailAvatar
@@ -150,28 +127,6 @@ ShareBox.User = (props: ShareBoxUserProps) => {
         {props.email}
         {isCurrentUser && ' (you)'}
       </Text>
-      <div className="ShareBox__user__actions">
-        {canResetSignIn && (
-          <Tooltip
-            label="Reset sign-in"
-            withArrow
-            transition="pop"
-            position="left"
-          >
-            <ActionIcon
-              className="ShareBox__user__resetSignIn"
-              size="sm"
-              radius={0}
-              variant="subtle"
-              color="dark"
-              aria-label={`Reset sign-in for ${props.email}`}
-              onClick={() => props.onResetSignIn!(props.email)}
-            >
-              <IconKeyOff size={16} strokeWidth={1.75} />
-            </ActionIcon>
-          </Tooltip>
-        )}
-      </div>
       <div className="ShareBox__user__roleSelect">
         <Select
           data={[

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
@@ -73,6 +73,18 @@
   flex-wrap: wrap;
 }
 
+.SettingsPage__siteAdmin__resetSignIn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.SettingsPage__siteAdmin__resetSignIn__user {
+  flex: 1;
+  max-width: 360px;
+}
+
 .SettingsPage__share {
   position: relative;
   display: flex;

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.css
@@ -75,7 +75,7 @@
 
 .SettingsPage__siteAdmin__resetSignIn {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
 }

--- a/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/root-cms/ui/pages/SettingsPage/SettingsPage.tsx
@@ -11,10 +11,12 @@ import {PermissionGroupsBox} from '../../components/PermissionGroupsBox/Permissi
 import {ShareBox} from '../../components/ShareBox/ShareBox.js';
 import {Surface} from '../../components/Surface/Surface.js';
 import {Text} from '../../components/Text/Text.js';
+import {UserSelect} from '../../components/UserSelect/UserSelect.js';
 import {useSearchIndexStatus} from '../../hooks/useGlobalSearch.js';
 import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
+import {useSignInStatuses} from '../../hooks/useSignInStatus.js';
 import {SITE_SETTINGS, useSiteSettings} from '../../hooks/useSiteSettings.js';
 import {useUnsavedChangesWarning} from '../../hooks/useUnsavedChangesWarning.js';
 import {useUserPreferences} from '../../hooks/useUserPreferences.js';
@@ -58,6 +60,130 @@ function isCurrentUserAdmin(roles: Record<string, string>): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Admin control for clearing a user's stale Google sign-in link.
+ *
+ * Unlinks the Google account from the user's sign-in record so their next
+ * sign-in links it again. Used to recover accounts that fail sign-in with an
+ * error about the Google account no longer being linked. The user's role and
+ * content are untouched.
+ */
+function ResetSignInSetting() {
+  const modals = useModals();
+  const modalTheme = useModalTheme();
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const emails = useMemo(() => (email ? [email] : []), [email]);
+  const {statuses, loading} = useSignInStatuses(emails, {enabled: !!email});
+  const status = email ? statuses.get(email) : undefined;
+  // The lookup can fail (leaving `status` undefined), in which case the reset
+  // stays available rather than being blocked by a status we couldn't read.
+  const nothingToReset = !!status && !status.hasGoogleLink;
+
+  function statusHint() {
+    if (!email) {
+      return 'Pick a user to check whether their sign-in can be reset.';
+    }
+    if (loading) {
+      return 'Checking sign-in status…';
+    }
+    if (!status) {
+      return "Couldn't check this user's sign-in status.";
+    }
+    if (!status.exists) {
+      return `${email} has never signed in, so there's nothing to reset.`;
+    }
+    if (!status.hasGoogleLink) {
+      return `${email} has no Google sign-in link to reset. They may be signing in with a different address.`;
+    }
+    return `${email} has a Google sign-in link that can be reset.`;
+  }
+
+  function confirmReset() {
+    if (!email || submitting) {
+      return;
+    }
+    const modalId = modals.openConfirmModal({
+      ...modalTheme,
+      title: 'Reset sign-in',
+      children: (
+        <Text size="body-sm" weight="semi-bold">
+          <p>
+            Use this when {email} can't sign in and sees an error about their
+            Google account no longer being linked. It unlinks the Google account
+            from their sign-in record so the next sign-in links it again.
+          </p>
+          <p>
+            Their role and content are not affected, and they stay signed in
+            wherever they already are.
+          </p>
+        </Text>
+      ),
+      labels: {confirm: 'Reset sign-in', cancel: 'Cancel'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {color: 'red', size: 'xs'},
+      closeOnConfirm: false,
+      onConfirm: async () => {
+        setSubmitting(true);
+        await notifyErrors(async () => {
+          const reset = await resetUserSignIn(email);
+          showNotification({
+            title: reset ? 'Sign-in reset' : 'Nothing to reset',
+            message: reset
+              ? `${email} can sign in again.`
+              : `${email} has no Google sign-in link to reset. They may be signing in with a different address.`,
+            color: reset ? 'green' : 'yellow',
+            autoClose: 5000,
+          });
+          if (reset) {
+            setEmail('');
+          }
+        });
+        setSubmitting(false);
+        modals.closeModal(modalId);
+      },
+    });
+  }
+
+  return (
+    <div className="SettingsPage__section__setting">
+      <Text size="body" weight="semi-bold">
+        Reset sign-in
+      </Text>
+      <Text size="body-sm" weight="semi-bold" color="gray">
+        <p>
+          Unlinks a user's Google account from their sign-in record so the next
+          sign-in links it again. Use this when someone is blocked at sign-in
+          with an error about their Google account no longer being linked. Their
+          role and content are not affected.
+        </p>
+      </Text>
+      <div className="SettingsPage__siteAdmin__resetSignIn">
+        <UserSelect
+          className="SettingsPage__siteAdmin__resetSignIn__user"
+          value={email}
+          onChange={(value: string) => setEmail(value.trim().toLowerCase())}
+          placeholder="Search or enter an email"
+          disabled={submitting}
+        />
+        <Button
+          variant="default"
+          size="xs"
+          compact
+          loading={submitting}
+          disabled={!email || loading || nothingToReset}
+          onClick={confirmReset}
+        >
+          Reset sign-in
+        </Button>
+      </div>
+      <Text size="body-sm" weight="semi-bold" color="gray">
+        {statusHint()}
+      </Text>
+    </div>
+  );
 }
 
 function SiteAdminSection() {
@@ -222,6 +348,7 @@ function SiteAdminSection() {
             </Button>
           </div>
         </div>
+        <ResetSignInSetting />
       </Surface>
     </div>
   );
@@ -245,8 +372,6 @@ function ShareSection() {
   );
   const db = window.firebase.db;
   const docRef = doc(db, 'Projects', projectId);
-  const modals = useModals();
-  const modalTheme = useModalTheme();
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -308,49 +433,6 @@ function ShareSection() {
 
   function setGroups(permissionGroups: PermissionGroup[]) {
     setDraft((prev) => ({...prev, permissionGroups}));
-  }
-
-  /**
-   * Clears the stale Google link on a user's account so that they can sign in
-   * again. Their role and content are untouched; the account re-links itself
-   * on their next sign-in.
-   */
-  function resetSignIn(email: string) {
-    const modalId = modals.openConfirmModal({
-      ...modalTheme,
-      title: 'Reset sign-in',
-      children: (
-        <Text size="body-sm" weight="semi-bold">
-          <p>
-            Use this when {email} can't sign in and sees an error about their
-            Google account no longer being linked. It unlinks the Google account
-            from their sign-in record so the next sign-in links it again.
-          </p>
-          <p>
-            Their role and content are not affected, and they stay signed in
-            wherever they already are.
-          </p>
-        </Text>
-      ),
-      labels: {confirm: 'Reset sign-in', cancel: 'Cancel'},
-      cancelProps: {size: 'xs'},
-      confirmProps: {color: 'red', size: 'xs'},
-      closeOnConfirm: false,
-      onConfirm: async () => {
-        await notifyErrors(async () => {
-          const reset = await resetUserSignIn(email);
-          showNotification({
-            title: reset ? 'Sign-in reset' : 'Nothing to reset',
-            message: reset
-              ? `${email} can sign in again.`
-              : `${email} has no Google sign-in link to reset. They may be signing in with a different address.`,
-            color: reset ? 'green' : 'yellow',
-            autoClose: 5000,
-          });
-        });
-        modals.closeModal(modalId);
-      },
-    });
   }
 
   function discard() {
@@ -455,8 +537,8 @@ function ShareSection() {
           </p>
           <p>
             If a user is blocked at sign-in because their Google account is no
-            longer linked, hover their row and use{' '}
-            <strong>Reset sign-in</strong>.
+            longer linked, use <strong>Reset sign-in</strong> in the{' '}
+            <strong>Site Admin</strong> section.
           </p>
         </Text>
       </div>
@@ -475,7 +557,6 @@ function ShareSection() {
               roles={draft.globalRoles}
               onChange={setRoles}
               currentUserIsAdmin={currentUserIsAdmin}
-              onResetSignIn={resetSignIn}
             />
           </div>
           <div className="SettingsPage__share__subsection">


### PR DESCRIPTION
## Summary

The "Reset sign-in" action lived inside each `ShareBox` row as a hover-to-reveal icon button. It was easy to miss, it reserved a grid column that squeezed the role select, and its discoverability depended on a background `useSignInStatuses` lookup for every user in the project.

This moves it into the **Site Admin** section of the Settings page as a proper, labeled control: a `UserSelect` autocomplete (the same picker the task manager uses) paired with a "Reset sign-in" button.

## Changes

**`ui/pages/SettingsPage/SettingsPage.tsx`**
- New `ResetSignInSetting` component rendered inside `SiteAdminSection` (already admin-gated).
- Picks the target user with `UserSelect` — autocomplete over the project's users with avatars, and accepts an arbitrary email typed by hand for users who aren't in the roles map.
- Looks up the selected user's sign-in status via `useSignInStatuses` and surfaces it as a hint line below the control ("… has a Google sign-in link that can be reset", "… has never signed in, so there's nothing to reset", etc.). The button is disabled when the lookup confirms there is nothing to reset; a failed lookup leaves the action available rather than blocking on a status we couldn't read.
- Same confirm modal and success/no-op notifications as before. The selection clears after a successful reset.
- Removed `resetSignIn` and the now-unused `useModals`/`useModalTheme` from `ShareSection`.
- Updated the Share blurb to point at the Site Admin section instead of "hover their row".

**`ui/components/ShareBox/ShareBox.tsx`**
- Dropped the `onResetSignIn` prop, the `hasGoogleLink` field, the per-row action icon, and the `useSignInStatuses` call. `ShareBox` is back to being purely about roles.

**CSS**
- Removed the hover-reveal rules and the reserved action column from `ShareBox.css` (`grid-template-columns` goes from 4 columns to 3).
- Added `SettingsPage__siteAdmin__resetSignIn` layout for the new picker + button row.

## Testing

- `tsc --noEmit` passes for `@blinkk/root-cms`.
- `eslint` clean on both changed `.tsx` files (the 148 repo-wide lint errors are pre-existing on `main`).
- `pnpm build --filter="@blinkk/root-cms"` succeeds.
- No existing tests reference `ShareBox`, `SettingsPage`, or the sign-in status hooks.

No server-side changes — `/cms/api/users.reset_sign_in` and `/cms/api/users.sign_in_status` are untouched and remain ADMIN-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhUpqbhPpQwBrfnYDa9GZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhUpqbhPpQwBrfnYDa9GZe)_