### PR TITLE
fix: keep the "open in new tab" checkbox checked when editing a link

### DIFF
--- a/.changeset/olive-links-toggle.md
+++ b/.changeset/olive-links-toggle.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: keep the "open in new tab" checkbox checked when editing a link

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.tsx
@@ -61,6 +61,31 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
   );
   // Track the previous linkUrl to detect when we switch to a different link.
   const prevLinkUrlRef = useRef<string>('');
+  // Whether the form holds unsaved edits. Pending edits are preserved across
+  // editor state updates so that interacting with the form (e.g. clicking the
+  // "open in new tab" checkbox, which moves focus out of the url input)
+  // doesn't revert the values back to what's stored on the link node.
+  const hasPendingEditsRef = useRef(false);
+
+  // Syncs the form with the values stored on the link node, discarding any
+  // pending edits.
+  const syncEditedValues = useCallback((url: string, target: string | null) => {
+    setEditedLinkUrl(normalizeUrl(url));
+    setEditedLinkTarget(target);
+    hasPendingEditsRef.current = false;
+  }, []);
+
+  // Updates the url field and flags the form as having unsaved edits.
+  const updateEditedLinkUrl = useCallback((url: string) => {
+    hasPendingEditsRef.current = true;
+    setEditedLinkUrl(url);
+  }, []);
+
+  // Updates the target field and flags the form as having unsaved edits.
+  const updateEditedLinkTarget = useCallback((target: string | null) => {
+    hasPendingEditsRef.current = true;
+    setEditedLinkTarget(target);
+  }, []);
 
   const $updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
@@ -79,13 +104,11 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
       }
       setLinkUrl(url);
       setLinkTarget(target);
-      // Always sync edited values when not actively editing (i.e., when the
-      // input is not focused), or when switching to a different link.
-      const isInputFocused = inputRef.current === document.activeElement;
+      // Sync the form with the link node's values unless the user has unsaved
+      // edits. Switching to a different link always resyncs.
       const isSwitchingLinks = url !== prevLinkUrlRef.current;
-      if (!isInputFocused || isSwitchingLinks) {
-        setEditedLinkUrl(normalizeUrl(url));
-        setEditedLinkTarget(target);
+      if (isSwitchingLinks || !hasPendingEditsRef.current) {
+        syncEditedValues(url, target);
       }
       prevLinkUrlRef.current = url;
     } else if ($isNodeSelection(selection)) {
@@ -104,11 +127,9 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
         }
         setLinkUrl(url);
         setLinkTarget(target);
-        const isInputFocused = inputRef.current === document.activeElement;
         const isSwitchingLinks = url !== prevLinkUrlRef.current;
-        if (!isInputFocused || isSwitchingLinks) {
-          setEditedLinkUrl(normalizeUrl(url));
-          setEditedLinkTarget(target);
+        if (isSwitchingLinks || !hasPendingEditsRef.current) {
+          syncEditedValues(url, target);
         }
         prevLinkUrlRef.current = url;
       }
@@ -156,10 +177,18 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
       setIsLinkEditMode(false);
       setLinkUrl('');
       prevLinkUrlRef.current = '';
+      hasPendingEditsRef.current = false;
     }
 
     return true;
-  }, [anchorElem, editor, setIsLinkEditMode, isLinkEditMode, linkUrl]);
+  }, [
+    anchorElem,
+    editor,
+    setIsLinkEditMode,
+    isLinkEditMode,
+    linkUrl,
+    syncEditedValues,
+  ]);
 
   useEffect(() => {
     const scrollerElem = anchorElem.parentElement;
@@ -364,6 +393,7 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
           }
         });
       }
+      hasPendingEditsRef.current = false;
       setIsLinkEditMode(false);
     }
   };
@@ -375,8 +405,7 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
 
   // Revert changes back to the original link values.
   const handleUndo = () => {
-    setEditedLinkUrl(linkUrl);
-    setEditedLinkTarget(linkTarget);
+    syncEditedValues(linkUrl, linkTarget);
   };
 
   return (
@@ -395,7 +424,7 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
             value={editedLinkUrl}
             onChange={(event: KeyboardEvent) => {
               const target = event.target as HTMLInputElement;
-              setEditedLinkUrl(target.value);
+              updateEditedLinkUrl(target.value);
             }}
             onKeyDown={(event: KeyboardEvent) => {
               monitorInputInteraction(event);
@@ -411,7 +440,7 @@ function FloatingLinkEditor(props: FloatingLinkEditorProps) {
               label="Open in new tab"
               checked={editedLinkTarget === '_blank'}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setEditedLinkTarget(
+                updateEditedLinkTarget(
                   event.currentTarget.checked ? '_blank' : null
                 )
               }

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.visual.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/FloatingLinkEditorPlugin.visual.test.tsx
@@ -1,0 +1,87 @@
+import '../../../../styles/global.css';
+import '../../../../styles/theme.css';
+
+import {MantineProvider} from '@mantine/core';
+import {cleanup, render} from '@testing-library/preact';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {page, userEvent} from 'vitest/browser';
+import {RichTextData} from '../../../../shared/richtext.js';
+import {LexicalEditor} from '../LexicalEditor.js';
+
+// Mock the context.
+window.__ROOT_CTX = {
+  experiments: {},
+  rootConfig: {
+    projectId: 'test-project',
+  },
+} as any;
+
+const LINK_VALUE: RichTextData = {
+  time: 1000,
+  version: '1',
+  blocks: [
+    {
+      type: 'paragraph',
+      data: {text: 'go to <a href="https://example.com">example</a> now'},
+    },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Renders the editor with a link and opens the floating link editor. */
+async function renderLinkEditor() {
+  page.viewport(800, 600);
+  const {container} = render(
+    <div style={{padding: '20px', width: '600px'}}>
+      <MantineProvider>
+        <LexicalEditor value={LINK_VALUE} onChange={() => {}} />
+      </MantineProvider>
+    </div>
+  );
+  const link = page.getByText('example');
+  await expect.element(link).toBeVisible();
+  // Clicking the link places the cursor inside it, which opens the floating
+  // link editor.
+  await userEvent.click(link);
+  const checkbox = page.getByLabelText('Open in new tab');
+  await expect.element(checkbox).toBeVisible();
+  return {container, link, checkbox};
+}
+
+describe('FloatingLinkEditorPlugin', () => {
+  it('keeps the "open in new tab" checkbox checked after clicking it', async () => {
+    const {link, checkbox} = await renderLinkEditor();
+    await expect.element(checkbox).not.toBeChecked();
+
+    // Clicking the checkbox moves focus out of the url input, which used to
+    // cause the resulting selection change to revert the pending value.
+    await userEvent.click(checkbox);
+    await expect.element(checkbox).toBeChecked();
+
+    // The value survives subsequent selection changes within the same link.
+    await userEvent.click(link);
+    await expect.element(checkbox).toBeChecked();
+  });
+
+  it('saves the target to the link', async () => {
+    const {container, checkbox} = await renderLinkEditor();
+    await userEvent.click(checkbox);
+    await userEvent.click(page.getByTitle('Save'));
+    await vi.waitFor(() => {
+      const anchor = container.querySelector('.LexicalEditor__editor a');
+      expect(anchor?.getAttribute('target')).toBe('_blank');
+    });
+    await expect.element(checkbox).toBeChecked();
+  });
+
+  it('reverts pending changes with undo', async () => {
+    const {checkbox} = await renderLinkEditor();
+    await userEvent.click(checkbox);
+    await expect.element(checkbox).toBeChecked();
+    await userEvent.click(page.getByTitle('Undo'));
+    await expect.element(checkbox).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
## Problem

In the lexical rich text editor, clicking the "Open in new tab" checkbox in the floating link editor immediately unchecks it, making the option impossible to set.

`$updateLinkEditor()` re-syncs the form's edited values from the link node whenever the url input is not focused:

```ts
const isInputFocused = inputRef.current === document.activeElement;
const isSwitchingLinks = url !== prevLinkUrlRef.current;
if (!isInputFocused || isSwitchingLinks) {
  setEditedLinkUrl(normalizeUrl(url));
  setEditedLinkTarget(target);
}
```

Clicking the checkbox moves focus out of the url input, so the selection change that follows the click runs this branch and overwrites `editedLinkTarget` with the link's saved target — the checkbox visibly reverts. Focus was only ever a proxy for "the user is mid-edit", and it doesn't cover the checkbox.

## Fix

Track unsaved edits explicitly instead:

- `hasPendingEditsRef` is set when the user changes the url or the target.
- `$updateLinkEditor()` only re-syncs the form when there are no pending edits, or when the selection moves to a different link.
- Pending edits are cleared on save, on undo, and when the link editor closes.

## Testing

Added `FloatingLinkEditorPlugin.visual.test.tsx` (browser suite, `pnpm test:visual`), which drives the real editor in Chromium: clicking the checkbox keeps it checked across subsequent selection changes, saving writes `target="_blank"` to the link, and undo reverts pending changes. All three fail on `main` and pass with this change.

`pnpm lint` is clean for the touched files, and the existing `RichTextEditor` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLaaNBkMUCuMxiPBU6NXBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLaaNBkMUCuMxiPBU6NXBZ)_