### PR TITLE
feat: add a search filter to the rich text components dropdown

### DIFF
--- a/.changeset/richtext-components-search.md
+++ b/.changeset/richtext-components-search.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add a search filter to the rich text components dropdown

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.css
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/LexicalEditor.css
@@ -107,6 +107,24 @@
   white-space: nowrap;
 }
 
+/* Filter input pinned to the top of the components dropdown. The negative
+ * margins let it span the menu's own padding. */
+.LexicalEditor__toolbar__insertDropdown__filter {
+  background: #fff;
+  border-bottom: 1px solid #e9ecef;
+  margin: -4px -4px 4px;
+  padding: 6px;
+  position: sticky;
+  top: -4px;
+  z-index: 1;
+}
+
+.LexicalEditor__toolbar__insertDropdown__empty {
+  color: #868e96;
+  font-size: 12px;
+  padding: 8px 12px;
+}
+
 .LexicalEditor__editor {
   border: 1px solid #ced4da;
   background: #fff;

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.tsx
@@ -15,6 +15,7 @@ import {
   ActionIconVariant,
   Button,
   Menu,
+  TextInput,
   Tooltip,
 } from '@mantine/core';
 import {
@@ -45,6 +46,7 @@ import {
   IconCube,
   IconCapsuleHorizontal,
   IconTextSize,
+  IconSearch,
 } from '@tabler/icons-preact';
 import {
   $getSelection,
@@ -93,8 +95,36 @@ import {
 } from '../utils/toolbar.js';
 import {sanitizeUrl} from '../utils/url.js';
 
+/**
+ * Number of custom components at which the components dropdown starts offering
+ * a filter input.
+ */
+const COMPONENT_FILTER_MIN_COMPONENTS = 8;
+
 function dropDownActiveClass(active: boolean) {
   return active ? 'active dropdown-item-active' : '';
+}
+
+/** Returns the menu item elements of the dropdown that contains `element`. */
+function getMenuItems(element: HTMLElement): HTMLElement[] {
+  const menu = element.closest('[role="menu"]');
+  if (!menu) {
+    return [];
+  }
+  return Array.from(menu.querySelectorAll<HTMLElement>('.mantine-Menu-item'));
+}
+
+/**
+ * Moves focus onto a menu item. Mantine tracks the highlighted item through
+ * `mouseenter` rather than focus, so dispatch one to keep its highlight (and
+ * its own arrow key handling) in sync.
+ */
+function focusMenuItem(item?: HTMLElement) {
+  if (!item) {
+    return;
+  }
+  item.dispatchEvent(new MouseEvent('mouseenter'));
+  item.focus();
 }
 
 interface BlockTypeIconProps {
@@ -567,6 +597,64 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
     });
   }, [inlineComponents]);
 
+  const [componentsMenuOpened, setComponentsMenuOpened] = useState(false);
+  const [componentFilter, setComponentFilter] = useState('');
+
+  // Focus the filter as soon as it mounts, i.e. when the menu opens. The popper
+  // mounts the dropdown body asynchronously, so an effect keyed on the menu's
+  // open state would run before the input exists.
+  const componentFilterRef = useCallback((input: HTMLInputElement | null) => {
+    input?.focus();
+  }, []);
+
+  // Only offer the filter input once the list is long enough to be worth
+  // searching.
+  const showComponentFilter =
+    sortedInlineComponents.length + sortedBlockComponents.length >=
+    COMPONENT_FILTER_MIN_COMPONENTS;
+
+  const filterQuery = componentFilter.trim().toLowerCase();
+  const matchesComponentFilter = (...values: Array<string | undefined>) => {
+    if (!filterQuery) {
+      return true;
+    }
+    return values.some((value) => value?.toLowerCase().includes(filterQuery));
+  };
+
+  const filteredInlineComponents = sortedInlineComponents.filter((component) =>
+    matchesComponentFilter(component.label, component.name)
+  );
+  const filteredBlockComponents = sortedBlockComponents.filter((block) =>
+    matchesComponentFilter(block.label, block.name)
+  );
+  const showTableItem = matchesComponentFilter('Table');
+  const showHorizontalRuleItem = matchesComponentFilter('Horizontal Rule');
+  const hasFilterResults =
+    showTableItem ||
+    showHorizontalRuleItem ||
+    filteredInlineComponents.length > 0 ||
+    filteredBlockComponents.length > 0;
+
+  const onComponentFilterKeyDown = (event: KeyboardEvent) => {
+    const input = event.currentTarget as HTMLInputElement;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      focusMenuItem(getMenuItems(input)[0]);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      getMenuItems(input)[0]?.click();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      // Clear the query first so that Escape doesn't discard a long search by
+      // accident; a second Escape closes the menu.
+      if (componentFilter) {
+        setComponentFilter('');
+      } else {
+        setComponentsMenuOpened(false);
+      }
+    }
+  };
+
   const getComponentIcon = (componentName: string) => {
     switch (componentName) {
       case 'image':
@@ -671,6 +759,12 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
               classNames={{
                 body: 'LexicalEditor__toolbar__insertDropdown__body',
               }}
+              opened={componentsMenuOpened}
+              onOpen={() => {
+                setComponentFilter('');
+                setComponentsMenuOpened(true);
+              }}
+              onClose={() => setComponentsMenuOpened(false)}
               control={
                 <Button
                   className={joinClassNames(
@@ -686,34 +780,56 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
                 </Button>
               }
             >
-              <Menu.Label>Insert</Menu.Label>
-              <Menu.Item
-                icon={<IconTable size={16} />}
-                onClick={() => {
-                  activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
-                    columns: '3',
-                    rows: '3',
-                  });
-                }}
-              >
-                Table
-              </Menu.Item>
-              <Menu.Item
-                icon={<IconSeparatorHorizontal size={16} />}
-                onClick={() => {
-                  activeEditor.dispatchCommand(
-                    INSERT_HORIZONTAL_RULE_COMMAND,
-                    undefined
-                  );
-                }}
-              >
-                Horizontal Rule
-              </Menu.Item>
+              {showComponentFilter && (
+                <div className="LexicalEditor__toolbar__insertDropdown__filter">
+                  <TextInput
+                    ref={componentFilterRef}
+                    size="xs"
+                    icon={<IconSearch size={14} />}
+                    placeholder="Search components"
+                    aria-label="Search components"
+                    value={componentFilter}
+                    onInput={(event: any) =>
+                      setComponentFilter(event.currentTarget.value)
+                    }
+                    onKeyDown={onComponentFilterKeyDown}
+                  />
+                </div>
+              )}
+              {(showTableItem || showHorizontalRuleItem) && (
+                <Menu.Label>Insert</Menu.Label>
+              )}
+              {showTableItem && (
+                <Menu.Item
+                  icon={<IconTable size={16} />}
+                  onClick={() => {
+                    activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
+                      columns: '3',
+                      rows: '3',
+                    });
+                  }}
+                >
+                  Table
+                </Menu.Item>
+              )}
+              {showHorizontalRuleItem && (
+                <Menu.Item
+                  icon={<IconSeparatorHorizontal size={16} />}
+                  onClick={() => {
+                    activeEditor.dispatchCommand(
+                      INSERT_HORIZONTAL_RULE_COMMAND,
+                      undefined
+                    );
+                  }}
+                >
+                  Horizontal Rule
+                </Menu.Item>
+              )}
 
-              {sortedInlineComponents.length > 0 && (
+              {filteredInlineComponents.length > 0 && (
                 <>
                   <Menu.Label>Inline Components</Menu.Label>
-                  {sortedInlineComponents.map((component) => (
+                  {filteredInlineComponents.map((component) => (
                     <Menu.Item
                       key={component.name}
                       icon={<IconCapsuleHorizontal size={16} />}
@@ -725,10 +841,10 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
                   ))}
                 </>
               )}
-              {sortedBlockComponents.length > 0 && (
+              {filteredBlockComponents.length > 0 && (
                 <>
                   <Menu.Label>Block Components</Menu.Label>
-                  {sortedBlockComponents.map((block) => (
+                  {filteredBlockComponents.map((block) => (
                     <Menu.Item
                       key={block.name}
                       icon={getComponentIcon(block.name)}
@@ -739,6 +855,11 @@ export function ToolbarPlugin(props: ToolbarPluginProps) {
                     </Menu.Item>
                   ))}
                 </>
+              )}
+              {!hasFilterResults && (
+                <div className="LexicalEditor__toolbar__insertDropdown__empty">
+                  No components found.
+                </div>
               )}
             </Menu>
             <Divider />

--- a/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.visual.test.tsx
+++ b/packages/root-cms/ui/components/RichTextEditor/lexical/plugins/ToolbarPlugin.visual.test.tsx
@@ -1,0 +1,164 @@
+import '../LexicalEditor.css';
+import '../../../../styles/global.css';
+import '../../../../styles/theme.css';
+
+import {MantineProvider} from '@mantine/core';
+import {cleanup, render, screen} from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {DeeplinkProvider} from '../../../../hooks/useDeeplink.js';
+import {LexicalEditor} from '../LexicalEditor.js';
+
+vi.mock('../../../EditTranslationsModal/EditTranslationsModal.js', () => ({
+  useEditTranslationsModal: () => ({
+    open: vi.fn(),
+  }),
+}));
+
+// Mock the context.
+window.__ROOT_CTX = {
+  experiments: {},
+  rootConfig: {
+    projectId: 'test-project',
+  },
+} as any;
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Enough components that the dropdown offers its filter input. */
+const FILTER_BLOCKS = [
+  {name: 'heroBanner', label: 'Hero Banner', fields: []},
+  {name: 'pullQuote', label: 'Pull Quote', fields: []},
+  ...Array.from({length: 8}, (unused, i) => ({
+    name: `filler${i}`,
+    label: `Filler ${i}`,
+    fields: [],
+  })),
+] as any;
+
+const FILTER_INLINE = [
+  {name: 'heroLink', label: 'Hero Link', fields: []},
+] as any;
+
+function renderFilterableEditor() {
+  render(
+    <MantineProvider>
+      <DeeplinkProvider>
+        <div style={{minHeight: '500px', padding: '20px'}}>
+          <LexicalEditor
+            blockComponents={FILTER_BLOCKS}
+            inlineComponents={FILTER_INLINE}
+          />
+        </div>
+      </DeeplinkProvider>
+    </MantineProvider>
+  );
+  return userEvent.setup();
+}
+
+function componentsFilter() {
+  return screen.queryByRole('textbox', {name: 'Search components'});
+}
+
+function menuItemLabels() {
+  return screen
+    .queryAllByRole('menuitem')
+    .map((item) => item.textContent)
+    .filter(Boolean);
+}
+
+describe('ToolbarPlugin components dropdown', () => {
+  it('omits the filter when there are only a few components', async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <DeeplinkProvider>
+          <LexicalEditor />
+        </DeeplinkProvider>
+      </MantineProvider>
+    );
+
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    expect(componentsFilter()).toBeNull();
+    expect(menuItemLabels()).toContain('HTML Code');
+  });
+
+  it('focuses the filter and narrows the list as you type', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    expect(document.activeElement).toBe(componentsFilter());
+
+    await user.keyboard('hero');
+
+    // Matches across both the inline and the block sections.
+    expect(menuItemLabels()).toEqual(['Hero Link', 'Hero Banner']);
+  });
+
+  it('matches the component name as well as its label', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    await user.keyboard('pullquote');
+
+    expect(menuItemLabels()).toEqual(['Pull Quote']);
+  });
+
+  it('shows an empty state when nothing matches', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    await user.keyboard('nothingmatchesthis');
+
+    expect(menuItemLabels()).toEqual([]);
+    expect(screen.getByText('No components found.')).toBeTruthy();
+  });
+
+  it('inserts the first match on enter', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    await user.keyboard('html code{Enter}');
+
+    // The HTML block opens its editor modal.
+    expect(screen.getByRole('button', {name: 'Insert block'})).toBeTruthy();
+  });
+
+  it('moves focus into the list on arrow down', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    await user.keyboard('hero{ArrowDown}');
+
+    expect(document.activeElement?.textContent).toBe('Hero Link');
+  });
+
+  it('clears the filter on escape, then closes the menu', async () => {
+    const user = renderFilterableEditor();
+    await user.click(screen.getAllByRole('button', {name: 'Components'})[0]);
+
+    await user.keyboard('hero{Escape}');
+    expect(componentsFilter()).toHaveProperty('value', '');
+    expect(menuItemLabels()).toContain('Pull Quote');
+
+    await user.keyboard('{Escape}');
+    await vi.waitFor(() => expect(componentsFilter()).toBeNull());
+  });
+
+  it('resets the filter when the menu is reopened', async () => {
+    const user = renderFilterableEditor();
+    const control = screen.getAllByRole('button', {name: 'Components'})[0];
+
+    await user.click(control);
+    await user.keyboard('hero');
+    await user.click(control);
+    await vi.waitFor(() => expect(componentsFilter()).toBeNull());
+
+    await user.click(control);
+    expect(componentsFilter()).toHaveProperty('value', '');
+    expect(menuItemLabels()).toContain('Pull Quote');
+  });
+});


### PR DESCRIPTION
Adds type-to-filter to the **Components** dropdown in the rich text toolbar, so projects with a lot of custom components don't have to scroll a long menu. Builds on #1408.

### Behavior

A search input appears above the list once there are at least 8 components (`COMPONENT_FILTER_MIN_COMPONENTS`), so small projects keep the plain menu. It filters every entry — inline components, block components, and the built-in Table / Horizontal Rule — matching on both the display label and the schema `name`, and section headings disappear along with their contents.

Keyboard:

| Key | Action |
| --- | --- |
| *(on open)* | the input is focused automatically |
| ArrowDown | moves into the list; Mantine's own arrow navigation takes over from there |
| Enter | inserts the first match |
| Escape | clears the query; a second Escape closes the menu |

The query resets whenever the menu is reopened, and an empty result shows "No components found."

### Implementation notes

- The input is focused via a **callback ref**, not an effect. The popper mounts the dropdown body asynchronously, so an effect keyed on the menu's open state runs before the input exists — confirmed empirically (`document.activeElement` was still the toolbar button).
- Mantine 4 tracks the highlighted menu item through `mouseenter`, not focus, and its items set `outline: 0`. Focusing an item directly would therefore move focus invisibly, so `focusMenuItem()` dispatches a `mouseenter` alongside `.focus()`. That also leaves Mantine's internal `hovered` index consistent, so its ArrowDown/ArrowUp handling continues correctly from the item you landed on rather than restarting at the top.
- The menu is now controlled (`opened`/`onOpen`/`onClose`) so Escape can close it — Mantine's own key handling is bound to the control and to the items, and never sees keystrokes typed in the input.

### Testing

- New `ToolbarPlugin.visual.test.tsx` — 8 browser tests covering the threshold, autofocus, filtering by label and by name, the empty state, Enter-inserts-first-match (asserted through the real HTML block modal opening), ArrowDown, Escape, and reset-on-reopen. No screenshot assertions, so they are platform-independent. Ran repeatedly in Chromium: 8/8 every time.
- `pnpm test` (root-cms, Firestore emulator): 1320 passed.
- `pnpm lint` and `pnpm build` clean; `tsc --noEmit` reports nothing in the changed files.

**Unrelated pre-existing flake, worth flagging:** `LexicalEditor.visual.test.tsx > renders html block` times out intermittently in my environment — it failed 4 of 6 runs on a clean checkout with no changes at all. I first suspected this change and bisected it; it reproduces without any of this work, and `LexicalEditor.visual.test.tsx` is untouched here. Also note that CI installs Playwright but `pnpm test` excludes `*.visual.test.tsx`, so the visual suite — including these new tests — only runs via `pnpm test:visual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdbXifpmvTejSCdKRtTy29

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdbXifpmvTejSCdKRtTy29)_