### PR TITLE
fix: reset the document editor when navigating between documents

### DIFF
--- a/.changeset/document-editor-reset.md
+++ b/.changeset/document-editor-reset.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: reset the document editor when navigating between documents

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -426,7 +426,7 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
                   'DocumentPage__side__editor--centered'
               )}
             >
-              <DocEditor docId={docId} />
+              <DocEditor key={docId} docId={docId} />
             </div>
           </SplitPanel.Item>
           <SplitPanel.Item
@@ -665,11 +665,6 @@ function getLocaleLabel(locale: string) {
 
 DocumentPage.Preview = (props: PreviewProps) => {
   const draft = useDraftDoc();
-  // TODO(stevenle): add a loader here instead.
-  if (draft.loading) {
-    return null;
-  }
-
   const [collectionId, slug] = props.docId.split('/');
   const collections = window.__ROOT_CTX.collections;
   const rootCollection = collections[collectionId];
@@ -857,7 +852,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
     return () => {
       removeOnFlush?.();
     };
-  }, []);
+  }, [draft.controller]);
 
   // Navigate every visible iframe to the localized preview url. Runs on mount
   // (initial load) and whenever the selected locale changes.


### PR DESCRIPTION
Navigating from one document to another (via global search, a reference field, or an asset link) left the editor in a broken state:

- **The preview pane went blank.** `DocumentPage.Preview` early-returned `if (draft.loading) return null` *before* its hooks. `DraftDocProvider` isn't keyed, so on a doc change its `useMemo` swaps the controller while `loading` is still stale-`false`; the keyed `Preview` remounts and wires its iframes, and only then does the provider effect set `loading` back to `true`. That tears the iframes out of the DOM without unmounting the component, so no cleanups run — and when loading resolves, the `[selectedLocale]` and `[previewCount]` effects don't re-run (their deps are unchanged), leaving the fresh iframe with no `src` and no `load` listener.

- **Field values leaked across documents.** `DocEditor` wasn't keyed by doc id, and `useDraftDocValue` seeds its state on mount only. `JsonTrieStore.subscribe` skips its priming callback when the value is `undefined`, and `notifyOnUpdate` only fires when the value actually differs — so a field set on doc A and absent on doc B kept rendering doc A's value, and wrote it into doc B when touched.

## Changes

- Drop the pre-hook `draft.loading` gate in `DocumentPage.Preview`. Nothing in it reads loaded doc data except `getLocales()`, which returns the constructor-seeded value until the snapshot arrives. The preview iframe now also starts loading in parallel with the Firestore snapshot instead of after it.
- Key `<DocEditor>` by doc id so fields re-seed from the new controller.
- Change the `onFlush` effect deps from `[]` to `[draft.controller]`, so the reload listener re-registers against the current controller instead of relying on a sibling `key` to force a remount.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
