### PR TITLE
feat: add follow mode to the document preview

### DIFF
--- a/.changeset/follow-mode.md
+++ b/.changeset/follow-mode.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add follow mode to the document preview

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -312,3 +312,8 @@
   overflow: hidden;
   background: white;
 }
+
+.DocumentPage__side__header__followToggle.active {
+  color: var(--mantine-color-blue-7, #1c7ed6);
+  background-color: var(--mantine-color-blue-0, #e7f5ff);
+}

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -1,7 +1,8 @@
 import './DocumentPage.css';
 
-import {ActionIcon, Button, Tooltip} from '@mantine/core';
+import {ActionIcon, Button, Loader, Tooltip} from '@mantine/core';
 import {useHotkeys} from '@mantine/hooks';
+import {showNotification} from '@mantine/notifications';
 import {
   IconArrowLeft,
   IconArrowUpRight,
@@ -9,8 +10,10 @@ import {
   IconDeviceFloppy,
   IconLayoutSidebarRightCollapse,
   IconLayoutSidebarRightExpand,
+  IconRoute,
 } from '@tabler/icons-preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
+import {useLocation} from 'preact-iso';
 import {ChecksPanel} from '../../components/ChecksPanel/ChecksPanel.js';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {DocEditor} from '../../components/DocEditor/DocEditor.js';
@@ -31,7 +34,14 @@ import {Layout} from '../../layout/Layout.js';
 import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocPreviewPath, getDocServingPath} from '../../utils/doc-urls.js';
+import {
+  FollowTarget,
+  resolveFollowTarget,
+  resetFollowRateLimit,
+  testFollowRateLimit,
+} from '../../utils/follow-mode.js';
 import {testCanEdit} from '../../utils/permissions.js';
+import {getPreviewDocCandidates} from '../../utils/preview-doc-match.js';
 import {
   getPreviewPathFromUrlKey,
   getPreviewSrcFromUrlKey,
@@ -137,6 +147,29 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
     `root::DocumentPage::previewVisible::${collectionId}`,
     hasCollectionUrl
   );
+  // Global rather than per-collection: following a link is exactly the case
+  // where the user crosses from one collection into another.
+  const [isFollowMode, setIsFollowMode] = useLocalStorage<boolean>(
+    'root::DocumentPage::followMode',
+    false
+  );
+
+  const toggleFollowMode = useCallback(() => {
+    setIsFollowMode((current) => {
+      if (!current) {
+        resetFollowRateLimit();
+      }
+      return !current;
+    });
+  }, [setIsFollowMode]);
+
+  const disableFollowMode = useCallback(() => {
+    setIsFollowMode(() => false);
+  }, [setIsFollowMode]);
+
+  // True while follow mode is resolving which doc the preview navigated to.
+  // The editor's own loading overlay takes over once the route changes.
+  const [isFollowing, setIsFollowing] = useState(false);
   const hasChecks = useMemo(() => {
     const allChecks = window.__ROOT_CTX.checks || [];
     return allChecks.some(
@@ -402,6 +435,32 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
                         )}
                       </ActionIcon>
                     </Tooltip>
+                    {isPreviewVisible && (
+                      <Tooltip
+                        label={
+                          isFollowMode
+                            ? 'Stop following preview navigation'
+                            : 'Follow preview navigation'
+                        }
+                      >
+                        <ActionIcon
+                          className={joinClassNames(
+                            'DocumentPage__side__header__followToggle',
+                            isFollowMode && 'active'
+                          )}
+                          aria-label="Follow preview navigation"
+                          aria-pressed={isFollowMode}
+                          aria-busy={isFollowing}
+                          onClick={toggleFollowMode}
+                        >
+                          {isFollowing ? (
+                            <Loader size={14} />
+                          ) : (
+                            <IconRoute size={16} />
+                          )}
+                        </ActionIcon>
+                      </Tooltip>
+                    )}
                     {!isPreviewVisible && (
                       <Tooltip label="Open preview in new tab">
                         <ActionIcon
@@ -438,7 +497,12 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
             fluid
           >
             {hasCollectionUrl && isPreviewVisible && (
-              <DocumentPage.Preview key={docId} docId={docId} />
+              <DocumentPage.Preview
+                docId={docId}
+                followMode={isFollowMode}
+                onDisableFollowMode={disableFollowMode}
+                onFollowingChange={setIsFollowing}
+              />
             )}
           </SplitPanel.Item>
         </SplitPanel>
@@ -620,6 +684,12 @@ function DocumentPageChecksPanel(props: DocumentPageChecksPanelProps) {
 
 interface PreviewProps {
   docId: string;
+  /** When true, navigating within a preview pane switches the edited doc. */
+  followMode: boolean;
+  /** Switches follow mode off, e.g. when a follow loop is detected. */
+  onDisableFollowMode: () => void;
+  /** Reports whether a follow is currently resolving, for the progress state. */
+  onFollowingChange: (isFollowing: boolean) => void;
 }
 
 const DeviceResolution = {
@@ -713,6 +783,31 @@ DocumentPage.Preview = (props: PreviewProps) => {
   // The url the preview panes are expected to be showing. Used to detect when
   // the user navigates within a pane so the other panes can be brought along.
   const syncedUrlKey = useRef<string | null>(null);
+  // Mirrors the follow mode prop so `onIframeLoad()`, which is registered once
+  // per viewport count change, always reads the live value rather than the
+  // value from the render that registered it.
+  const followModeRef = useRef(props.followMode);
+  followModeRef.current = props.followMode;
+  // Discards doc lookups that a newer navigation superseded while they were in
+  // flight.
+  const followRequestId = useRef(0);
+  // The url a follow is currently resolving, so the `load` event doesn't redo
+  // the work already started by the click that caused it.
+  const followingUrlKey = useRef<string | null>(null);
+  // A follow that has resolved and is waiting for the preview to finish
+  // loading before the editor switches documents.
+  const pendingFollow = useRef<{urlKey: string; target: FollowTarget} | null>(
+    null
+  );
+  // A follow resolves asynchronously, so it can outlive the preview. Routing
+  // after that would yank the user away from wherever they navigated in the
+  // meantime.
+  const isMounted = useRef(true);
+  // Set to the doc id follow mode is routing to, so the effect that reacts to a
+  // doc change knows the panes are already showing that doc and must be left
+  // alone.
+  const followedDocId = useRef<string | null>(null);
+  const {route} = useLocation();
   const previewFrameRef = useRef<HTMLDivElement>(null);
   // Remembers the viewport selection from before 2-up was enabled so it can be
   // restored when 2-up is turned back off.
@@ -778,6 +873,94 @@ DocumentPage.Preview = (props: PreviewProps) => {
   }
 
   /**
+   * Rewrites same-origin link clicks inside a preview pane so the page they
+   * navigate to keeps `preview=true`, and with it draft mode.
+   *
+   * The previewed site has no reason to carry a CMS-only param on its own
+   * links, so without this a click drops the pane into published mode -- while
+   * the other panes, which are navigated by the CMS, stay in draft mode. Under
+   * follow mode the mismatch is worse: the editor switches to the new doc's
+   * draft while the pane beside it renders that doc's published page.
+   *
+   * Rewriting the click is what keeps this to a single page load. Re-navigating
+   * after the fact would load the page twice.
+   *
+   * The listener is attached per load because the document is replaced on every
+   * navigation, which discards the previous one. It runs in the bubble phase so
+   * a previewed site that handles its own link clicks (client-side routing,
+   * analytics interstitials) still wins, and so the `defaultPrevented` check
+   * below has something to observe.
+   */
+  function keepPreviewParamOnLinkClicks(iframe: HTMLIFrameElement) {
+    let doc: Document | null;
+    try {
+      doc = iframe.contentDocument;
+    } catch {
+      // Cross-origin: the browser blocks access to the document.
+      return;
+    }
+    if (!doc) {
+      return;
+    }
+    doc.addEventListener('click', (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      // `closest()` works across realms; `instanceof` would not, since the
+      // iframe has its own copy of the DOM constructors.
+      const target = event.target as Element | null;
+      const link = target?.closest?.('a[href]') as HTMLAnchorElement | null;
+      if (!link || link.hasAttribute('download')) {
+        return;
+      }
+      // Links that open elsewhere leave the pane alone.
+      if (link.target && !/^_?self$/i.test(link.target)) {
+        return;
+      }
+      let url: URL;
+      try {
+        url = new URL(link.href);
+      } catch {
+        return;
+      }
+      if (url.origin !== window.location.origin) {
+        return;
+      }
+      // An in-page jump isn't a navigation to a different page. Rewriting it
+      // would turn a scroll into a full page load.
+      const current = iframe.contentWindow?.location;
+      if (
+        current &&
+        url.pathname === current.pathname &&
+        url.search === current.search
+      ) {
+        return;
+      }
+      // Start following now rather than waiting for the `load` event, so the
+      // editor switches documents while the page is still loading instead of
+      // afterwards. The `load` handler still follows navigations that don't
+      // come from a link click (form posts, redirects, back/forward).
+      const urlKey = getPreviewUrlKeyFromUrl(url.toString());
+      if (urlKey) {
+        followPreviewNavigation(urlKey);
+      }
+      if (url.searchParams.get('preview') === 'true') {
+        return;
+      }
+      url.searchParams.set('preview', 'true');
+      event.preventDefault();
+      iframe.contentWindow?.location.assign(url.toString());
+    });
+  }
+
+  /**
    * Called when a preview iframe finishes loading a page. When the user
    * navigates within a pane (e.g. by clicking a link), every other pane is sent
    * to the same page so all of the viewports stay comparable.
@@ -788,6 +971,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
    */
   function onIframeLoad(event: Event) {
     const iframe = event.currentTarget as HTMLIFrameElement;
+    keepPreviewParamOnLinkClicks(iframe);
     let urlKey: string | null = null;
     try {
       const loc = iframe.contentWindow?.location;
@@ -808,6 +992,167 @@ DocumentPage.Preview = (props: PreviewProps) => {
         other.src = nextUrl;
       }
     });
+    // The page the user clicked has finished loading, so a follow that was
+    // resolved at click time can now swap the editor over in step with it.
+    // Navigations with no click behind them (form posts, redirects,
+    // back/forward) resolve and commit here instead.
+    const pending = pendingFollow.current;
+    if (pending?.urlKey === urlKey) {
+      commitFollow(urlKey, pending.target);
+      return;
+    }
+    followPreviewNavigation(urlKey, {commit: true});
+  }
+
+  /**
+   * Switches the editor to the doc behind the page a preview pane navigated
+   * to, so clicking a link in the preview brings the editor along.
+   *
+   * Only called for loads the CMS didn't initiate itself (see the guard in
+   * `onIframeLoad()`), which is what keeps the CMS's own navigations from
+   * following themselves and dedupes the load events from multiple viewports
+   * down to a single follow.
+   *
+   * Pages that aren't CMS docs -- list pages, 404s, marketing routes -- are
+   * silently ignored. In follow mode those are common enough that notifying
+   * about each one would be unusable, and the preview url bar already shows
+   * where the pane went.
+   */
+  async function followPreviewNavigation(
+    urlKey: string,
+    options?: {commit?: boolean}
+  ) {
+    if (!followModeRef.current || followingUrlKey.current === urlKey) {
+      return;
+    }
+    const candidates = getPreviewDocCandidates(
+      getPreviewPathFromUrlKey(urlKey)
+    );
+    if (candidates.length === 0) {
+      return;
+    }
+    // Skip the db lookups entirely when the page is served by the doc already
+    // being edited, which covers reloads and redirects back onto the same page.
+    // Every candidate is checked, not just the best one: when two docs serve
+    // the same url, staying put is better than yanking the editor onto the
+    // other one. Checked before the progress state is set so a page that isn't
+    // a doc doesn't flash the indicator.
+    if (
+      candidates.some(
+        (candidate) =>
+          `${candidate.collectionId}/${candidate.slug}` === props.docId
+      )
+    ) {
+      return;
+    }
+    followingUrlKey.current = urlKey;
+    props.onFollowingChange(true);
+    const requestId = ++followRequestId.current;
+    let target: FollowTarget | null = null;
+    try {
+      target = await resolveFollowTarget(candidates);
+    } catch (err) {
+      console.warn('follow mode: failed to resolve the preview url:', err);
+    }
+    if (
+      !target ||
+      target.docId === props.docId ||
+      requestId !== followRequestId.current ||
+      !followModeRef.current ||
+      !isMounted.current
+    ) {
+      cancelPendingFollow(urlKey);
+      return;
+    }
+    if (options?.commit) {
+      commitFollow(urlKey, target);
+      return;
+    }
+    // Hold the resolved target until the preview finishes loading, so the
+    // editor and the preview swap to the new doc together. Resolving ahead of
+    // time also warms the db cache, so the doc is ready when the swap happens.
+    pendingFollow.current = {urlKey: urlKey, target: target};
+  }
+
+  /**
+   * Switches the editor to an already-resolved doc. Split out from resolution
+   * so the swap can be timed to the preview's `load` event rather than
+   * happening as soon as the lookup finishes.
+   */
+  function commitFollow(urlKey: string, target: FollowTarget) {
+    cancelPendingFollow(urlKey);
+    if (
+      !followModeRef.current ||
+      !isMounted.current ||
+      target.docId === props.docId
+    ) {
+      return;
+    }
+    // A page that redirects the preview to another doc would bounce the editor
+    // back and forth, so disarm follow mode when navigations come too fast.
+    if (!testFollowRateLimit()) {
+      props.onDisableFollowMode();
+      showNotification({
+        title: 'Follow mode turned off',
+        message:
+          'The preview navigated between documents too quickly. Turn follow mode back on to resume.',
+        color: 'yellow',
+        autoClose: 8000,
+      });
+      return;
+    }
+    // Autosave runs on a delay, so a link click can land mid-window. This isn't
+    // awaited: the update is handed to Firestore before the route changes, and
+    // the controller flushes again when it's disposed.
+    draft.controller?.flush();
+    followedDocId.current = target.docId;
+    const params = new URLSearchParams(window.location.search);
+    // Both of these point at a field in the doc being left behind.
+    params.delete('modal');
+    params.delete('deeplink');
+    if (target.locale) {
+      params.set('locale', target.locale);
+    } else {
+      params.delete('locale');
+    }
+    const query = params.toString();
+    // Replace rather than push: the iframe's own navigation already added a
+    // session history entry, so pushing another would make the back button
+    // take two presses per followed link.
+    route(
+      `/cms/content/${target.docId}${query ? `?${query}` : ''}`,
+      /* replace= */ true
+    );
+  }
+
+  /** Clears the in-flight and pending follow state for a url. */
+  function cancelPendingFollow(urlKey: string) {
+    if (followingUrlKey.current === urlKey) {
+      followingUrlKey.current = null;
+    }
+    if (pendingFollow.current?.urlKey === urlKey) {
+      pendingFollow.current = null;
+    }
+    props.onFollowingChange(false);
+  }
+
+  /**
+   * Returns the url key of the page the preview panes are showing, read from a
+   * live pane rather than from `syncedUrlKey`, which only tracks loads the CMS
+   * knows about.
+   */
+  function getCurrentPreviewUrlKey(): string | null {
+    for (const iframe of iframeRefs.current.values()) {
+      try {
+        const loc = iframe.contentWindow?.location;
+        if (loc?.href && !loc.href.startsWith('about:blank')) {
+          return getPreviewUrlKey(loc);
+        }
+      } catch {
+        // Cross-origin: the browser blocks reading the location.
+      }
+    }
+    return syncedUrlKey.current;
   }
 
   /**
@@ -844,6 +1189,27 @@ DocumentPage.Preview = (props: PreviewProps) => {
     iframeRefs.current.forEach((iframe) => reloadIframe(iframe));
   }
 
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // Catch the editor up when follow mode is switched on. The preview may
+  // already be showing a different doc's page, because navigating with follow
+  // mode off leaves the two panes out of sync -- switching it on should fix
+  // that rather than waiting for the next navigation.
+  useEffect(() => {
+    if (!props.followMode) {
+      return;
+    }
+    const urlKey = getCurrentPreviewUrlKey();
+    if (urlKey) {
+      followPreviewNavigation(urlKey, {commit: true});
+    }
+  }, [props.followMode]);
+
   // Reload every visible preview iframe whenever the draft is flushed.
   useEffect(() => {
     const removeOnFlush = draft.controller?.onFlush(() => {
@@ -854,13 +1220,23 @@ DocumentPage.Preview = (props: PreviewProps) => {
     };
   }, [draft.controller]);
 
-  // Navigate every visible iframe to the localized preview url. Runs on mount
-  // (initial load) and whenever the selected locale changes.
+  // Navigate every visible iframe to the localized preview url. Runs on mount,
+  // whenever the selected locale changes, and whenever the edited doc changes
+  // (e.g. via global search or a reference field).
+  //
+  // A doc change that follow mode caused is skipped: the panes are already
+  // showing that doc's page, and re-navigating them would reload the page the
+  // user just clicked.
   useEffect(() => {
+    const followed = followedDocId.current;
+    followedDocId.current = null;
+    if (followed === props.docId) {
+      return;
+    }
     iframeRefs.current.forEach((iframe) => {
       setIframeSrc(iframe, localizedPreviewUrl);
     });
-  }, [selectedLocale]);
+  }, [props.docId, selectedLocale]);
 
   // Wire up newly-mounted iframes when the number of viewports changes (e.g.
   // when a viewport is added to a multi-pane comparison). New iframes are
@@ -881,7 +1257,10 @@ DocumentPage.Preview = (props: PreviewProps) => {
         iframe.removeEventListener('load', onIframeLoad)
       );
     };
-  }, [previewCount]);
+    // `onIframeLoad` closes over the current doc, so the listeners have to be
+    // re-registered when the doc changes. The iframes already have a `src` at
+    // that point, so this doesn't re-navigate them.
+  }, [previewCount, props.docId]);
 
   const toggleDevice = useCallback(
     (targetDevice: DeviceType) => {

--- a/packages/root-cms/ui/utils/doc-urls.ts
+++ b/packages/root-cms/ui/utils/doc-urls.ts
@@ -106,7 +106,10 @@ export function getDocPreviewPath(options: DocUrlOptions) {
   });
 }
 
-function formatUrlPath(urlFormat: string, params: Record<string, string>) {
+export function formatUrlPath(
+  urlFormat: string,
+  params: Record<string, string>
+) {
   const urlPath = urlFormat.replaceAll(
     /\[\[?(\.\.\.)?([\w\-_]*)\]?\]/g,
     (match: string, _wildcard: string, key: string) => {
@@ -118,7 +121,7 @@ function formatUrlPath(urlFormat: string, params: Record<string, string>) {
   });
 }
 
-function normalizeUrlPath(
+export function normalizeUrlPath(
   urlPath: string,
   options?: {trailingSlash?: boolean}
 ) {

--- a/packages/root-cms/ui/utils/follow-mode.test.ts
+++ b/packages/root-cms/ui/utils/follow-mode.test.ts
@@ -1,0 +1,156 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  resetFollowRateLimit,
+  resolveFollowTarget,
+  testFollowRateLimit,
+} from './follow-mode.js';
+import {PreviewDocCandidate} from './preview-doc-match.js';
+
+const {getDocFromCacheOrFetch} = vi.hoisted(() => ({
+  getDocFromCacheOrFetch: vi.fn(),
+}));
+
+vi.mock('./doc-cache.js', () => ({
+  getDocFromCacheOrFetch: getDocFromCacheOrFetch,
+}));
+
+/** Builds a candidate, defaulting the fields the resolver doesn't read. */
+function candidate(
+  collectionId: string,
+  slug: string,
+  locale = ''
+): PreviewDocCandidate {
+  return {collectionId, slug, locale, specificity: 0, segments: 1};
+}
+
+/** Stubs the db with a fixed set of existing docs. */
+function setDocs(docs: Record<string, any>) {
+  getDocFromCacheOrFetch.mockImplementation(async (docId: string) => {
+    return docs[docId];
+  });
+}
+
+beforeEach(() => {
+  getDocFromCacheOrFetch.mockReset();
+  resetFollowRateLimit();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('resolveFollowTarget', () => {
+  it('returns the highest-ranked candidate that exists', async () => {
+    setDocs({'Pages/about': {sys: {}}});
+    const target = await resolveFollowTarget([
+      candidate('BlogPosts', 'about'),
+      candidate('Pages', 'about'),
+    ]);
+    expect(target).toEqual({docId: 'Pages/about', locale: ''});
+  });
+
+  // The first hit wins, so a well-ranked match shouldn't cost extra reads.
+  it('stops probing once a doc is found', async () => {
+    setDocs({'Pages/about': {sys: {}}, 'Pages/about--index': {sys: {}}});
+    await resolveFollowTarget([
+      candidate('Pages', 'about'),
+      candidate('Pages', 'about--index'),
+    ]);
+    expect(getDocFromCacheOrFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when no candidate exists', async () => {
+    setDocs({});
+    expect(await resolveFollowTarget([candidate('Pages', 'nope')])).toBe(null);
+  });
+
+  it('returns null for an empty candidate list', async () => {
+    setDocs({});
+    expect(await resolveFollowTarget([])).toBe(null);
+    expect(getDocFromCacheOrFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips candidates whose lookup fails', async () => {
+    getDocFromCacheOrFetch.mockImplementation(async (docId: string) => {
+      if (docId === 'Pages/denied') {
+        throw new Error('permission-denied');
+      }
+      return {sys: {}};
+    });
+    const target = await resolveFollowTarget([
+      candidate('Pages', 'denied'),
+      candidate('Pages', 'ok'),
+    ]);
+    expect(target).toEqual({docId: 'Pages/ok', locale: ''});
+  });
+
+  // `getDocFromCacheOrFetch()` only caches hits, so without a miss memo every
+  // load of a page that isn't a doc would re-read every candidate.
+  it('remembers misses so they are not re-read', async () => {
+    setDocs({});
+    await resolveFollowTarget([candidate('Pages', 'missing')]);
+    await resolveFollowTarget([candidate('Pages', 'missing')]);
+    expect(getDocFromCacheOrFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks a missing doc once the memo expires', async () => {
+    setDocs({});
+    await resolveFollowTarget([candidate('Pages', 'missing')]);
+    vi.advanceTimersByTime(61 * 1000);
+    setDocs({'Pages/missing': {sys: {}}});
+    const target = await resolveFollowTarget([candidate('Pages', 'missing')]);
+    expect(target).toEqual({docId: 'Pages/missing', locale: ''});
+  });
+
+  it('carries the locale over when the doc has it', async () => {
+    setDocs({'Pages/about': {sys: {locales: ['en', 'de']}}});
+    const target = await resolveFollowTarget([
+      candidate('Pages', 'about', 'de'),
+    ]);
+    expect(target).toEqual({docId: 'Pages/about', locale: 'de'});
+  });
+
+  // A locale the doc doesn't have would leave the editor's locale select
+  // showing a value that isn't one of its options.
+  it('drops a locale the doc does not have', async () => {
+    setDocs({'Pages/about': {sys: {locales: ['en']}}});
+    const target = await resolveFollowTarget([
+      candidate('Pages', 'about', 'de'),
+    ]);
+    expect(target).toEqual({docId: 'Pages/about', locale: ''});
+  });
+});
+
+describe('testFollowRateLimit', () => {
+  it('allows a normal rate of navigation', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(testFollowRateLimit()).toBe(true);
+      vi.advanceTimersByTime(3000);
+    }
+  });
+
+  it('trips on a burst of follows', () => {
+    const results = [];
+    for (let i = 0; i < 6; i++) {
+      results.push(testFollowRateLimit());
+    }
+    expect(results).toEqual([true, true, true, true, true, false]);
+  });
+
+  it('recovers once the window passes', () => {
+    for (let i = 0; i < 6; i++) {
+      testFollowRateLimit();
+    }
+    vi.advanceTimersByTime(5001);
+    expect(testFollowRateLimit()).toBe(true);
+  });
+
+  it('is cleared by resetFollowRateLimit', () => {
+    for (let i = 0; i < 6; i++) {
+      testFollowRateLimit();
+    }
+    resetFollowRateLimit();
+    expect(testFollowRateLimit()).toBe(true);
+  });
+});

--- a/packages/root-cms/ui/utils/follow-mode.ts
+++ b/packages/root-cms/ui/utils/follow-mode.ts
@@ -1,0 +1,116 @@
+/**
+ * The db-facing half of the doc editor's "follow mode", which switches the
+ * editor to whatever CMS doc the preview pane navigates to.
+ *
+ * The url matching itself is pure and lives in `preview-doc-match.js`. This
+ * module adds the parts that need the db (confirming a candidate doc actually
+ * exists) plus a rate limit that disarms follow mode if a page bounces the
+ * preview between docs.
+ */
+
+import {getDocFromCacheOrFetch} from './doc-cache.js';
+import {PreviewDocCandidate} from './preview-doc-match.js';
+
+/**
+ * Max number of candidates probed per navigation. A catch-all collection
+ * matches every url, so the candidate list grows with the number of
+ * collections and locales; the ranking puts the plausible ones first.
+ */
+const MAX_PROBES = 6;
+
+/** How long a "this doc doesn't exist" result is remembered. */
+const MISS_TTL_MS = 60 * 1000;
+
+/** Number of follows within {@link FOLLOW_WINDOW_MS} that trips the limiter. */
+const FOLLOW_LIMIT = 5;
+
+/** Sliding window used to detect a runaway follow loop. */
+const FOLLOW_WINDOW_MS = 5000;
+
+/**
+ * Doc ids that were probed and found missing, with the time of the probe.
+ * `getDocFromCacheOrFetch()` only caches hits, so without this every load of a
+ * page that isn't a doc (a list page, a 404) re-reads every candidate.
+ *
+ * Module-level rather than a ref: the preview remounts on every follow, which
+ * would reset a ref.
+ */
+const misses = new Map<string, number>();
+
+/** Timestamps of recent follows, used by {@link testFollowRateLimit}. */
+let recentFollows: number[] = [];
+
+/** The doc a preview url resolved to. */
+export interface FollowTarget {
+  /** The doc to edit, e.g. "Pages/about". */
+  docId: string;
+  /** The locale to open the editor at, or an empty string for the default. */
+  locale: string;
+}
+
+/**
+ * Returns the highest-ranked candidate doc that actually exists, or `null`
+ * when none of them do.
+ *
+ * The existence check isn't optional: a catch-all `/[...slug]` collection
+ * matches every url, and the draft doc controller loads a missing doc as an
+ * empty editor rather than erroring, so following an unverified candidate
+ * would silently open a blank document.
+ *
+ * Candidates are probed in rank order and the first hit wins, so a well-ranked
+ * match usually costs a single read.
+ */
+export async function resolveFollowTarget(
+  candidates: PreviewDocCandidate[]
+): Promise<FollowTarget | null> {
+  for (const candidate of candidates.slice(0, MAX_PROBES)) {
+    const docId = `${candidate.collectionId}/${candidate.slug}`;
+    const missedAt = misses.get(docId);
+    if (missedAt !== undefined) {
+      if (Date.now() - missedAt < MISS_TTL_MS) {
+        continue;
+      }
+      misses.delete(docId);
+    }
+    let data: any;
+    try {
+      data = await getDocFromCacheOrFetch(docId);
+    } catch (err) {
+      // A missing doc and a permission error both mean "don't follow".
+      console.warn('follow mode: failed to load doc:', err);
+      continue;
+    }
+    if (!data) {
+      misses.set(docId, Date.now());
+      continue;
+    }
+    // Only carry the url's locale over when the doc actually has it. The
+    // editor's locale select would otherwise show a value that isn't one of
+    // its options, and reloading the preview would navigate to a localized url
+    // the server doesn't serve.
+    const docLocales: string[] = data.sys?.locales || [];
+    const locale =
+      candidate.locale && docLocales.includes(candidate.locale)
+        ? candidate.locale
+        : '';
+    return {docId: docId, locale: locale};
+  }
+  return null;
+}
+
+/**
+ * Records a follow and returns whether follow mode should stay on. A page that
+ * redirects the preview to another doc would otherwise bounce the editor back
+ * and forth indefinitely, so a burst of follows disarms the mode.
+ */
+export function testFollowRateLimit(): boolean {
+  const now = Date.now();
+  recentFollows = recentFollows.filter((time) => now - time < FOLLOW_WINDOW_MS);
+  recentFollows.push(now);
+  return recentFollows.length <= FOLLOW_LIMIT;
+}
+
+/** Clears the follow rate limiter, e.g. when follow mode is switched back on. */
+export function resetFollowRateLimit() {
+  recentFollows = [];
+}

--- a/packages/root-cms/ui/utils/preview-doc-match.test.ts
+++ b/packages/root-cms/ui/utils/preview-doc-match.test.ts
@@ -1,0 +1,184 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {getDocPreviewPath} from './doc-urls.js';
+import {getPreviewDocCandidates} from './preview-doc-match.js';
+
+/** Mirrors the collections and config of the in-repo `docs/` project. */
+const DOCS_CTX = {
+  rootConfig: {
+    base: '/',
+    domain: 'https://rootjs.dev',
+    i18n: {locales: ['en', 'de', 'es', 'fr', 'it', 'pt']},
+    server: {trailingSlash: true},
+  },
+  collections: {
+    BlogPosts: {url: '/blog/[slug]'},
+    BlogSandbox: {url: '/blog/sandbox/[slug]'},
+    GlobalModules: {url: '/global-modules/[...slug]'},
+    Guide: {url: '/guide/[slug]'},
+    Pages: {url: '/[...slug]'},
+    Sandbox: {url: '/sandbox/[...slug]'},
+  },
+};
+
+/** Installs a `window.__ROOT_CTX` for the duration of a test. */
+function setRootCtx(ctx: any) {
+  (window as any).__ROOT_CTX = ctx;
+}
+
+/** Returns candidates as `"Collection/slug@locale"` strings, in rank order. */
+function ids(pathname: string): string[] {
+  return getPreviewDocCandidates(pathname).map(
+    (candidate) =>
+      `${candidate.collectionId}/${candidate.slug}@${candidate.locale}`
+  );
+}
+
+afterEach(() => {
+  delete (window as any).__ROOT_CTX;
+});
+
+describe('getPreviewDocCandidates', () => {
+  it('round-trips the urls the forward path produces', () => {
+    setRootCtx(DOCS_CTX);
+    const docs = [
+      {collectionId: 'Pages', slug: 'index', locale: ''},
+      {collectionId: 'Pages', slug: 'about', locale: ''},
+      {collectionId: 'Pages', slug: 'about--team', locale: ''},
+      {collectionId: 'Guide', slug: 'getting-started', locale: ''},
+      {collectionId: 'BlogPosts', slug: 'my-post', locale: ''},
+      {collectionId: 'BlogSandbox', slug: 'foo', locale: ''},
+      {collectionId: 'Pages', slug: 'about', locale: 'de'},
+      {collectionId: 'Guide', slug: 'getting-started', locale: 'fr'},
+    ];
+    for (const doc of docs) {
+      const path = getDocPreviewPath(doc);
+      expect(getPreviewDocCandidates(path)[0]).toMatchObject(doc);
+    }
+  });
+
+  // A catch-all `/[...slug]` collection matches every url, so overlapping
+  // matches are expected; the most specific literal prefix has to win.
+  it('ranks more specific collections first', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/blog/sandbox/foo/')).toEqual([
+      'BlogSandbox/foo@',
+      'BlogSandbox/foo--index@',
+      'BlogPosts/sandbox--foo@',
+      'BlogPosts/sandbox--foo--index@',
+      'Pages/blog--sandbox--foo@',
+      'Pages/blog--sandbox--foo--index@',
+    ]);
+  });
+
+  it('resolves the site root to the index doc', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/')).toContain('Pages/index@');
+  });
+
+  // `/foo` is served by both the slug `foo` and the slug `foo--index`, since
+  // the forward path renames a trailing `/index` to `/`.
+  it('offers the index form of a slug, ranked lower', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/about/')).toEqual(['Pages/about@', 'Pages/about--index@']);
+  });
+
+  it('matches urls authored without a trailing slash', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/guide/getting-started')[0]).toBe('Guide/getting-started@');
+  });
+
+  it('ignores the cms itself', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/cms')).toEqual([]);
+    expect(ids('/cms/content/Pages/about')).toEqual([]);
+  });
+
+  it('ignores static assets', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/static/main.js')).toEqual([]);
+    expect(ids('/images/hero.png')).toEqual([]);
+  });
+
+  it('ignores relative and empty paths', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('')).toEqual([]);
+    expect(ids('about')).toEqual([]);
+  });
+
+  it('handles projects without a trailing slash', () => {
+    setRootCtx({
+      ...DOCS_CTX,
+      rootConfig: {...DOCS_CTX.rootConfig, server: {trailingSlash: false}},
+    });
+    expect(ids('/blog/my-post')[0]).toBe('BlogPosts/my-post@');
+  });
+
+  // The pattern's own trailing slash needs a slash to match against, which the
+  // path doesn't have once trailing slashes are normalized away.
+  it('resolves a prefixed collection root without a trailing slash', () => {
+    setRootCtx({
+      ...DOCS_CTX,
+      rootConfig: {...DOCS_CTX.rootConfig, server: {trailingSlash: false}},
+    });
+    expect(ids('/blog')).toContain('BlogPosts/index@');
+    expect(ids('')).toEqual([]);
+  });
+
+  it('resolves a prefixed collection root with a trailing slash', () => {
+    setRootCtx(DOCS_CTX);
+    expect(ids('/blog/')).toContain('BlogPosts/index@');
+  });
+
+  it('matches a pattern whose literal suffix ends in a slash', () => {
+    setRootCtx({
+      rootConfig: {
+        base: '/',
+        i18n: {locales: ['en']},
+        server: {trailingSlash: false},
+      },
+      collections: {Docs: {url: '/docs/[slug]/overview/'}},
+    });
+    expect(ids('/docs/intro/overview')[0]).toBe('Docs/intro@');
+  });
+
+  // The default locale carries no prefix, so an empty locale has to be tried
+  // before the url format gets a chance to eat a real path segment.
+  it('handles a base path and a custom locale url format', () => {
+    setRootCtx({
+      rootConfig: {
+        base: '/foo/',
+        i18n: {
+          locales: ['en', 'de'],
+          urlFormat: '/intl/[locale]/[base]/[path]',
+        },
+        server: {trailingSlash: false},
+      },
+      collections: {Pages: {url: '/[...slug]'}},
+    });
+    expect(ids('/intl/de/foo/about')[0]).toBe('Pages/about@de');
+    expect(ids('/foo/about')[0]).toBe('Pages/about@');
+    expect(ids('/foo')).toContain('Pages/index@');
+  });
+
+  // Links rendered by the site are in serving space, but the pane's own src is
+  // in preview space, so both have to resolve.
+  it('matches both the preview url and the serving url', () => {
+    setRootCtx({
+      ...DOCS_CTX,
+      collections: {
+        Pages: {url: '/[...slug]', previewUrl: '/preview/[...slug]'},
+      },
+    });
+    expect(ids('/preview/about/')[0]).toBe('Pages/about@');
+    expect(ids('/about/')[0]).toBe('Pages/about@');
+  });
+
+  it('ignores collections that do not serve a url', () => {
+    setRootCtx({...DOCS_CTX, collections: {Data: {}}});
+    expect(ids('/about/')).toEqual([]);
+  });
+
+  it('returns nothing when the root context is unavailable', () => {
+    expect(getPreviewDocCandidates('/about/')).toEqual([]);
+  });
+});

--- a/packages/root-cms/ui/utils/preview-doc-match.ts
+++ b/packages/root-cms/ui/utils/preview-doc-match.ts
@@ -1,0 +1,300 @@
+/**
+ * Maps a preview pane url back to the CMS doc(s) that could be serving it.
+ *
+ * Used by the doc editor's "follow mode": when the user clicks a link inside
+ * the preview, the editor switches to the doc behind the page they landed on.
+ *
+ * The forward mapping in `doc-urls.ts` is lossy -- a slug's `--` separators
+ * become slashes, `/index` collapses to `/`, repeated slashes collapse -- so
+ * this can't be a true inverse. Instead, slugs are extracted loosely from the
+ * url and then confirmed by running the real forward functions and requiring
+ * an exact match, which keeps the matcher bug-compatible with the forward path
+ * by construction.
+ *
+ * The result is a ranked list rather than a single doc because a catch-all
+ * collection (`/[...slug]`) matches every url, so several collections can
+ * legitimately claim the same path. Callers must confirm that a candidate doc
+ * actually exists before using it.
+ *
+ * The url math lives here so it can be unit tested without a live iframe or a
+ * db connection.
+ */
+
+import {normalizeSlug} from '../../shared/slug.js';
+import {
+  formatUrlPath,
+  getDocPreviewPath,
+  getDocServingPath,
+  normalizeUrlPath,
+} from './doc-urls.js';
+
+/**
+ * Matches the slug placeholder in a collection's `url`/`previewUrl` pattern.
+ * Kept identical to the pattern used by `getDocServingPath()` and
+ * `getDocPreviewPath()` so the match lines up with what the forward path
+ * actually substituted.
+ */
+const SLUG_PLACEHOLDER = /\[.*slug\]/;
+
+/** Value substituted for `[path]` when deriving a url format's prefix. */
+const PATH_SENTINEL = '__rootpreviewpath__';
+
+/** A document whose url could produce a given preview path. */
+export interface PreviewDocCandidate {
+  collectionId: string;
+  slug: string;
+  /** The locale the url serves, or an empty string for the default locale. */
+  locale: string;
+  /** Literal path segments before the slug placeholder; higher is more specific. */
+  specificity: number;
+  /** Number of slug segments captured from the url; lower is more specific. */
+  segments: number;
+}
+
+/** A slug extracted from a url, before it has been verified. */
+interface SlugCandidate {
+  slug: string;
+  specificity: number;
+  segments: number;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Returns the literal url prefix that precedes `[path]` for a given locale
+ * (e.g. `/` for the default locale, or `/intl/de/foo/` for a project with a
+ * base path and a custom `i18n.urlFormat`), or `null` when the format has no
+ * `[path]` placeholder.
+ *
+ * The prefix is derived by calling the same formatter the forward path uses,
+ * with a sentinel standing in for the doc's path. This avoids re-implementing
+ * the placeholder substitution and works for formats that omit `[base]`.
+ */
+function getUrlFormatPrefix(locale: string): string | null {
+  const rootConfig = window.__ROOT_CTX.rootConfig;
+  let urlFormat = '/[base]/[path]';
+  if (locale) {
+    urlFormat = rootConfig.i18n?.urlFormat || '/[locale]/[base]/[path]';
+  }
+  let formatted: string;
+  try {
+    formatted = formatUrlPath(urlFormat, {
+      base: rootConfig.base || '/',
+      path: PATH_SENTINEL,
+      locale: locale,
+      slug: '',
+    });
+  } catch {
+    return null;
+  }
+  const index = formatted.indexOf(PATH_SENTINEL);
+  if (index < 0) {
+    return null;
+  }
+  return formatted.slice(0, index);
+}
+
+/**
+ * Returns `path` with the url format's `prefix` removed, or `null` when the
+ * path isn't under that prefix. The prefix always ends in a slash, so the
+ * prefix's own root (e.g. `/foo` for a base of `/foo/` on a site without
+ * trailing slashes) is matched separately.
+ */
+function getRelativePath(prefix: string, path: string): string | null {
+  if (path.startsWith(prefix)) {
+    return `/${path.slice(prefix.length)}`.replace(/\/+/g, '/');
+  }
+  if (prefix.endsWith('/') && path === prefix.slice(0, -1)) {
+    return '/';
+  }
+  return null;
+}
+
+/**
+ * Extracts the slugs a url path could have come from, given a collection's
+ * `url`/`previewUrl` pattern.
+ *
+ * The capture spans `/` because `[slug]` and `[...slug]` behave identically in
+ * the forward direction: the placeholder is substituted first and the slug's
+ * `--` separators are turned into slashes afterwards, so a `[slug]` collection
+ * can serve a multi-segment path too. Both a greedy and a lazy capture are
+ * tried, since a pattern with a literal suffix can match in more than one
+ * place.
+ */
+function getSlugCandidates(
+  pattern: string,
+  relativePath: string
+): SlugCandidate[] {
+  const match = pattern.match(SLUG_PLACEHOLDER);
+  if (!match || match.index === undefined) {
+    // The collection serves every doc from one fixed path, so the slug can't
+    // be recovered from the url.
+    return [];
+  }
+  const literalPrefix = pattern.slice(0, match.index).replaceAll('--', '/');
+  const literalSuffix = pattern
+    .slice(match.index + match[0].length)
+    .replaceAll('--', '/');
+  const specificity = literalPrefix.split('/').filter(Boolean).length;
+  // Repeated slashes collapse on the forward path, so any slash in the pattern
+  // matches one or more slashes in the url.
+  const prefixRe = escapeRegExp(literalPrefix).replaceAll('/', '/+');
+  const suffixRe = escapeRegExp(literalSuffix).replaceAll('/', '/+');
+  // A pattern's slash before the placeholder becomes `/+`, which needs a slash
+  // to consume. `normalizeUrlPath()` strips the trailing slash when the project
+  // doesn't use them, so match against a slash-terminated copy: without it a
+  // prefixed collection's root (e.g. `/blog` for `/blog/[slug]`) never matches
+  // its own `index` doc, and neither does a pattern whose literal suffix ends
+  // in a slash.
+  const probePath = relativePath.endsWith('/')
+    ? relativePath
+    : `${relativePath}/`;
+  const candidates: SlugCandidate[] = [];
+  const seen = new Set<string>();
+  const addSlug = (slug: string, segments: number) => {
+    if (!slug || seen.has(slug)) {
+      return;
+    }
+    seen.add(slug);
+    candidates.push({slug, specificity, segments});
+  };
+  for (const capture of ['(.*)', '(.*?)']) {
+    const captured = probePath.match(
+      new RegExp(`^${prefixRe}${capture}${suffixRe}/?$`)
+    );
+    if (!captured) {
+      continue;
+    }
+    const slug = normalizeSlug(captured[1]);
+    if (!slug) {
+      continue;
+    }
+    const segments = slug.split('--').length;
+    addSlug(slug, segments);
+    // A doc named `about--index` also serves `/about/`, so offer it too. It's
+    // ranked below the plain slug, which is the far more common shape.
+    addSlug(`${slug}--index`, segments + 1);
+  }
+  // The forward path renames `/index` to `/`, so the pattern's bare literal
+  // path is served by the slug `index`.
+  if (new RegExp(`^${prefixRe}${suffixRe}/?$`).test(probePath)) {
+    addSlug('index', 1);
+  }
+  return candidates;
+}
+
+/**
+ * Returns whether a doc's forward-mapped url matches `path`. Both the preview
+ * url and the serving url are accepted: the preview pane's own src is in
+ * preview space, but links rendered by the previewed site are in serving
+ * space.
+ */
+function testDocPathMatches(
+  collectionId: string,
+  slug: string,
+  locale: string,
+  path: string
+): boolean {
+  try {
+    const options = {collectionId, slug, locale};
+    return (
+      getDocPreviewPath(options) === path || getDocServingPath(options) === path
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns the documents whose preview or serving url could produce `pathname`,
+ * ranked most-specific first. Returns an empty array for paths that can't be a
+ * CMS doc (static assets, the CMS itself, urls outside the project's base
+ * path).
+ *
+ * Usage:
+ * ```
+ * const candidates = getPreviewDocCandidates('/blog/my-post/');
+ * // => [{collectionId: 'BlogPosts', slug: 'my-post', locale: '', ...}, ...]
+ * ```
+ */
+export function getPreviewDocCandidates(
+  pathname: string
+): PreviewDocCandidate[] {
+  const rootCtx = window.__ROOT_CTX;
+  const rootConfig = rootCtx?.rootConfig;
+  const collections = rootCtx?.collections;
+  if (!rootConfig || !collections || !pathname || !pathname.startsWith('/')) {
+    return [];
+  }
+  // Anything with a file extension is a static asset, never a doc. Mirrors the
+  // check the server uses to 404 asset-like slugs.
+  if (/\.[a-z0-9]+$/i.test(pathname)) {
+    return [];
+  }
+  const path = normalizeUrlPath(pathname, {
+    trailingSlash: rootConfig.server?.trailingSlash,
+  });
+  // The pane lands on the CMS itself when the preview session expires.
+  const cmsPath = normalizeUrlPath(`${rootConfig.base || '/'}/cms`, {
+    trailingSlash: false,
+  });
+  if (path === cmsPath || path.startsWith(`${cmsPath}/`)) {
+    return [];
+  }
+  // Sorted for a deterministic tiebreak between equally-specific collections.
+  const collectionIds = Object.keys(collections).sort();
+  // The default locale's urls carry no locale prefix, so try it first --
+  // otherwise a localized url format would happily eat a real path segment.
+  const locales = ['', ...(rootConfig.i18n?.locales || [])];
+  const candidates: PreviewDocCandidate[] = [];
+  const seen = new Set<string>();
+  for (const locale of locales) {
+    const prefix = getUrlFormatPrefix(locale);
+    if (prefix === null) {
+      continue;
+    }
+    const relativePath = getRelativePath(prefix, path);
+    if (relativePath === null) {
+      continue;
+    }
+    for (const collectionId of collectionIds) {
+      const collection = collections[collectionId];
+      // Collections without a `url` don't serve a page at all.
+      if (!collection?.url) {
+        continue;
+      }
+      const patterns = [
+        collection.previewUrl || collection.url,
+        collection.url,
+      ];
+      for (const pattern of patterns) {
+        for (const candidate of getSlugCandidates(pattern, relativePath)) {
+          const key = `${collectionId}/${candidate.slug}|${locale}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          if (!testDocPathMatches(collectionId, candidate.slug, locale, path)) {
+            continue;
+          }
+          candidates.push({
+            collectionId: collectionId,
+            slug: candidate.slug,
+            locale: locale,
+            specificity: candidate.specificity,
+            segments: candidate.segments,
+          });
+        }
+      }
+    }
+  }
+  candidates.sort(
+    (a, b) =>
+      b.specificity - a.specificity ||
+      a.segments - b.segments ||
+      a.collectionId.localeCompare(b.collectionId)
+  );
+  return candidates;
+}


### PR DESCRIPTION
Adds a "follow mode" toggle to the document editor header. When it's on, navigating within the preview pane switches the editor to the corresponding CMS document, so clicking a link in the preview brings the fields along with it.

> [!NOTE]
> Stacked on #1415, which fixes a pre-existing bug that follow mode would otherwise hit on every use. Review that one first; this PR targets its branch and should be rebased onto `main` once it lands.

## How a url is matched to a document

The forward mapping in `doc-urls.ts` is lossy — a slug's `--` separators become slashes, `/index` collapses to `/`, repeated slashes collapse — so this can't be a true inverse. `ui/utils/preview-doc-match.ts` instead extracts slugs loosely and then **verifies each candidate by running the real forward functions** (`getDocPreviewPath` / `getDocServingPath`) and requiring an exact match. That keeps the matcher bug-compatible with the forward path by construction, so `--`, `/index`, base paths, locale url formats and trailing-slash normalization need no special handling.

The result is a *ranked list*, not a single document, because a catch-all `/[...slug]` collection matches every url. In the repo's own `docs/` project, `/blog/sandbox/foo` legitimately matches three collections. Candidates are ranked by literal-prefix specificity, then captured-segment count, then collection id.

Ranking alone isn't enough, so `ui/utils/follow-mode.ts` confirms the document **actually exists** before routing: `DraftDocController` loads a missing doc as an empty editor rather than erroring, so following an unverified candidate would silently open a blank document. Candidates are probed in rank order, first hit wins, and misses are memoized for 60s (`getDocFromCacheOrFetch` only caches hits, so a page that isn't a document would otherwise re-read every candidate on every load).

## Timing

Both panes swap in the same frame:

- **On click**, the resolve and existence probe start immediately, in parallel with the page load. This also warms the db cache so the document is ready.
- **On the iframe's `load` event**, the resolved target is committed and the editor routes.

Resolving on the `load` event alone made the editor visibly lag the preview; committing as soon as the lookup finished made it arrive *before* the preview. Splitting resolution from the commit aligns them. Navigations with no click behind them — form posts, redirects, back/forward — resolve and commit together at `load`.

Switching follow mode on also reconciles: if you navigated with it off, the two panes are out of sync, so enabling it catches the editor up to whatever the preview is showing.

## Keeping the preview in draft mode

`preview=true` is what selects draft mode (`core/route.ts:610`), and a site's own links have no reason to carry a CMS-only param. Without handling, following a link would put the editor on a document's *draft* while the pane beside it rendered that document's *published* page.

A bubble-phase click listener on the preview document rewrites same-origin link navigations to keep `preview=true`. Rewriting the click (rather than re-navigating afterwards) is what keeps this to a single page load. Bubble phase so a previewed site that handles its own link clicks still wins; in-page hash links are skipped so a scroll doesn't become a page load. Form posts and JS redirects still land in published mode until the next reload.

## Safety

- **Unsaved changes.** Autosave runs on a 3s delay, so a click can land mid-window. The pending update is flushed before the route changes, and the controller flushes again when disposed.
- **Loops.** Following is skipped when any candidate is the document already being edited, and a sliding-window rate limit (5 follows in 5s) disarms the mode with a notification if a page bounces the preview between documents.
- **Staleness.** An in-flight follow is discarded if a newer navigation supersedes it, if follow mode is switched off, or if the preview unmounts.
- **History.** `route(url, replace)` — the iframe's own navigation already added a session history entry, so pushing another would make Back take two presses per followed link.
- Pages that aren't documents (list pages, 404s, external routes) are silently ignored; in follow mode they're common enough that notifying about each would be unusable.

## Testing

30 new unit tests covering the url matcher and the resolver (`427 passed` across the ui utils suite). Both new modules are pure enough to test without the Firestore emulator.

Manually exercised against a real site with live Firebase credentials, since the `docs/` project has no `.env`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
