### PR TITLE
fix: don't query firestore in useDocsList before a collection is selected

### DIFF
--- a/.changeset/doc-picker-empty-collection.md
+++ b/.changeset/doc-picker-empty-collection.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: don't query firestore in useDocsList before a collection is selected

--- a/packages/root-cms/ui/hooks/useDocsList.test.tsx
+++ b/packages/root-cms/ui/hooks/useDocsList.test.tsx
@@ -1,0 +1,78 @@
+import {render} from '@testing-library/preact';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  collection: vi.fn(),
+  getDocs: vi.fn(),
+  orderBy: vi.fn(),
+  query: vi.fn(),
+  documentId: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: mocks.collection,
+  getDocs: mocks.getDocs,
+  orderBy: mocks.orderBy,
+  query: mocks.query,
+  documentId: mocks.documentId,
+}));
+
+vi.mock('./useFirebase.js', () => ({
+  useFirebase: () => ({db: {type: 'mock-db'}}),
+}));
+
+import {useDocsList} from './useDocsList.js';
+
+/** Renders the hook and reports its results back to the caller. */
+function renderUseDocsList(collectionId: string) {
+  const result: {loading: boolean; docs: any[]} = {loading: true, docs: []};
+  function TestComponent() {
+    const [loading, , docs] = useDocsList(collectionId, {orderBy: 'slug'});
+    result.loading = loading;
+    result.docs = docs;
+    return null;
+  }
+  render(<TestComponent />);
+  return result;
+}
+
+describe('useDocsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.collection.mockImplementation((_db: unknown, ...path: string[]) => ({
+      path: path.join('/'),
+    }));
+    mocks.query.mockImplementation((colRef: any) => colRef);
+    mocks.getDocs.mockResolvedValue({docs: []});
+    (window as any).__ROOT_CTX = {
+      rootConfig: {projectId: 'test-project'},
+      collections: {Pages: {}},
+    };
+  });
+
+  it('queries the collection\u2019s Drafts subcollection', async () => {
+    const result = renderUseDocsList('Pages');
+    await vi.waitFor(() => expect(result.loading).toBe(false));
+
+    expect(mocks.collection).toHaveBeenCalledWith(
+      {type: 'mock-db'},
+      'Projects',
+      'test-project',
+      'Collections',
+      'Pages',
+      'Drafts'
+    );
+    expect(mocks.getDocs).toHaveBeenCalled();
+  });
+
+  it('skips the query when no collection is selected', async () => {
+    const result = renderUseDocsList('');
+    await vi.waitFor(() => expect(result.loading).toBe(false));
+
+    // An empty collection id collapses the path to
+    // `Projects/<id>/Collections/Drafts`, which firestore rejects.
+    expect(mocks.collection).not.toHaveBeenCalled();
+    expect(mocks.getDocs).not.toHaveBeenCalled();
+    expect(result.docs).toEqual([]);
+  });
+});

--- a/packages/root-cms/ui/hooks/useDocsList.ts
+++ b/packages/root-cms/ui/hooks/useDocsList.ts
@@ -32,6 +32,16 @@ export function useDocsList(collectionId: string, options: UseDocsListOptions) {
   const includeArchived = options.includeArchived ?? false;
 
   const listDocs = async () => {
+    // Callers may render before a collection is chosen (e.g. the doc picker's
+    // "Content Type" select starts blank when a field spans multiple
+    // collections). An empty segment collapses the firestore path to
+    // `Projects/<id>/Collections/Drafts`, which throws an "Invalid collection
+    // reference" error and surfaces as a "Something went wrong" notification.
+    if (!collectionId) {
+      setDocs([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     const dbCollection = collection(
       db,


### PR DESCRIPTION
## Problem

Opening a reference field's doc picker can throw a firestore error and pop a red
**"Something went wrong"** notification, before the editor has done anything:

```
invalid-argument: Invalid collection reference. Collection references must have
an odd number of segments, but Projects/<projectId>/Collections/Drafts has 4.
```

`useDocsList` builds its path from the collection id it is handed:

```ts
collection(db, 'Projects', projectId, 'Collections', collectionId, 'Drafts');
```

When `collectionId` is `''` the segment collapses and the path becomes
`Projects/<projectId>/Collections/Drafts` — four segments, which the firestore
web SDK rejects for a collection reference. Nothing catches the rejection, so
the global error handler surfaces it as a notification.

## How it's reached

`DocPickerModal` only auto-selects a collection when the field targets exactly
one:

```ts
return collections.length === 1 ? collections[0] : '';
```

A `schema.references`/`schema.reference` field spanning **multiple**
collections therefore opens with the "Content Type" select blank, and
`DocPickerModal.DocsList` is still rendered with `collection=""`. So the query
fires with an empty collection id and throws.

Repro: on a doc with a multi-collection reference field, clear
`DocPickerModal.lastSelectedCollection` from localStorage and open that field's
picker.

The failure is cosmetic — the picker itself works once a content type is
chosen, and any selection the editor makes saves normally — but it reads like
the edit failed, which is alarming and hard to self-diagnose.

## Fix

Return early from `listDocs()` when there is no collection id, leaving the list
empty so the existing `Select a content type to view documents` placeholder
renders as intended.

`DocSelectModal` already guards its render on `selectedCollectionId`, and
`CollectionPage` always passes a real id, so the hook-level guard is the one
place that covers every caller.

## Testing

- New `ui/hooks/useDocsList.test.tsx`: asserts the normal path still queries
  `.../Collections/<id>/Drafts`, and that an empty collection id issues no
  firestore call at all. Verified the second test fails without the fix
  (`collection()` is called with the empty segment).
- `vitest run ui/` in `packages/root-cms`: 56 files / 550 tests passing.
- `eslint` clean on the changed files.
