### PR TITLE
feat: let the preview pane switch the edited doc

### DIFF
--- a/.changeset/document-editor-reset.md
+++ b/.changeset/document-editor-reset.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: reset the document editor when navigating between documents

--- a/.changeset/preview-iframe-detection.md
+++ b/.changeset/preview-iframe-detection.md
@@ -1,5 +1,0 @@
----
-'@blinkk/root-cms': patch
----
-
-fix: detect the preview pane after an in-preview navigation

--- a/.changeset/preview-iframe-detection.md
+++ b/.changeset/preview-iframe-detection.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+fix: detect the preview pane after an in-preview navigation

--- a/.changeset/preview-navigate-channel.md
+++ b/.changeset/preview-navigate-channel.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: let the preview pane switch the edited doc

--- a/packages/root-cms/browser-client/browser-client.ts
+++ b/packages/root-cms/browser-client/browser-client.ts
@@ -330,10 +330,26 @@ export class RootCMSBrowserClient {
     return new PreviewConnection();
   }
 
-  /** Returns whether this page is rendered inside the in-CMS preview pane. */
+  /**
+   * Returns whether this page is rendered inside the in-CMS preview pane.
+   *
+   * The parent's location is the reliable signal: the preview iframe is
+   * same-origin, so the CMS path is readable. The referrer only names the CMS
+   * for the first page the pane loads -- once the user follows a link inside
+   * the preview it names the previous page of the site instead -- so it is
+   * kept as a fallback for the cases where the parent can't be read.
+   */
   static isInPreviewIframe(): boolean {
     if (window.parent === window) {
       return false;
+    }
+    try {
+      const parentPath = window.parent.location.pathname;
+      if (parentPath.startsWith('/cms')) {
+        return true;
+      }
+    } catch {
+      // Cross-origin parent: fall through to the referrer check.
     }
     return document.referrer.startsWith(`${window.location.origin}/cms`);
   }

--- a/packages/root-cms/browser-client/browser-client.ts
+++ b/packages/root-cms/browser-client/browser-client.ts
@@ -16,6 +16,7 @@
 
 import {
   isHighlightNodeMessage,
+  NavigateToDocMessage,
   ScrollToDeeplinkMessage,
 } from '../shared/embed-protocol.js';
 import {normalizeSlug} from '../shared/slug.js';
@@ -25,6 +26,7 @@ import {Emitter} from './emitter.js';
 export {SaveState} from '../shared/embed-protocol.js';
 export type {
   HighlightNodeMessage,
+  NavigateToDocMessage,
   RootEmbedMessage,
   ScrollToDeeplinkMessage,
 } from '../shared/embed-protocol.js';
@@ -197,6 +199,48 @@ export class PreviewConnection {
       return;
     }
     const message: ScrollToDeeplinkMessage = {scrollToDeeplink: {deepKey}};
+    window.parent.postMessage(message, window.location.origin);
+  }
+
+  /**
+   * Tells the doc editor to switch to a document, so the editor follows the
+   * preview as the user navigates the site.
+   *
+   * Call it with the page's own doc id when the page loads. `isEmbedded` is
+   * false outside the CMS preview pane, so the call is a no-op on the live
+   * site. The CMS only acts on it when the plugin's `preview.channel` enables
+   * messages from the preview.
+   *
+   * The editor asks the user before switching by default, since a doc changing
+   * on its own is disorienting for someone who doesn't know the page can do
+   * that. Pass `{confirm: false}` to switch straight away, for sites that have
+   * their own affordance for it (a toggle the user turned on, say).
+   *
+   * Usage:
+   * ```
+   * const preview = new PreviewConnection();
+   * if (preview.isEmbedded) {
+   *   preview.navigateToDoc(doc.id);
+   * }
+   * ```
+   */
+  navigateToDoc(docId: string, options?: {confirm?: boolean}) {
+    if (window.parent === window) {
+      return;
+    }
+    const [collection, ...slugParts] = docId.split('/');
+    const slug = normalizeSlug(slugParts.join('/'));
+    if (!collection || !slug) {
+      throw new Error(
+        `invalid docId: "${docId}" (expected "<collection>/<slug>")`
+      );
+    }
+    const message: NavigateToDocMessage = {
+      navigateToDoc: {
+        docId: `${collection}/${slug}`,
+        confirm: options?.confirm,
+      },
+    };
     window.parent.postMessage(message, window.location.origin);
   }
 

--- a/packages/root-cms/shared/embed-protocol.test.ts
+++ b/packages/root-cms/shared/embed-protocol.test.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect} from 'vitest';
 import {
   isHighlightNodeMessage,
+  isNavigateToDocMessage,
   isRootEmbedMessage,
   isRootToolLocationMessage,
   isScrollToDeeplinkMessage,
@@ -97,5 +98,48 @@ describe('isHighlightNodeMessage', () => {
     expect(isHighlightNodeMessage({highlightNode: null})).toBe(false);
     expect(isHighlightNodeMessage({highlightNode: {}})).toBe(false);
     expect(isHighlightNodeMessage({highlightNode: {deepKey: 1}})).toBe(false);
+  });
+});
+
+describe('isNavigateToDocMessage', () => {
+  it('accepts a doc id, with or without an explicit confirm flag', () => {
+    expect(
+      isNavigateToDocMessage({navigateToDoc: {docId: 'Pages/about'}})
+    ).toBe(true);
+    expect(
+      isNavigateToDocMessage({
+        navigateToDoc: {docId: 'Pages/about', confirm: false},
+      })
+    ).toBe(true);
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(isNavigateToDocMessage({navigateToDoc: {}})).toBe(false);
+    expect(isNavigateToDocMessage({navigateToDoc: {docId: 42}})).toBe(false);
+    expect(
+      isNavigateToDocMessage({
+        navigateToDoc: {docId: 'Pages/a', confirm: 'yes'},
+      })
+    ).toBe(false);
+    expect(isNavigateToDocMessage({navigateToDoc: null})).toBe(false);
+    expect(isNavigateToDocMessage({})).toBe(false);
+    expect(isNavigateToDocMessage(null)).toBe(false);
+    expect(isNavigateToDocMessage('navigateToDoc')).toBe(false);
+  });
+
+  // The un-namespaced messages share a channel, so they must stay distinct.
+  it('does not match the other message types', () => {
+    expect(
+      isNavigateToDocMessage({scrollToDeeplink: {deepKey: 'hero.title'}})
+    ).toBe(false);
+    expect(isNavigateToDocMessage({highlightNode: {deepKey: null}})).toBe(
+      false
+    );
+    expect(isScrollToDeeplinkMessage({navigateToDoc: {docId: 'Pages/a'}})).toBe(
+      false
+    );
+    expect(isHighlightNodeMessage({navigateToDoc: {docId: 'Pages/a'}})).toBe(
+      false
+    );
   });
 });

--- a/packages/root-cms/shared/embed-protocol.ts
+++ b/packages/root-cms/shared/embed-protocol.ts
@@ -9,6 +9,8 @@
  *   namespaced under `root` ({@link RootEmbedMessage}).
  * - Parent window -> doc editor: field focus requests
  *   ({@link ScrollToDeeplinkMessage}).
+ * - In-CMS preview iframe -> doc editor: requests to edit another doc
+ *   ({@link NavigateToDocMessage}).
  * - Doc editor -> in-CMS preview iframe: field highlight requests
  *   ({@link HighlightNodeMessage}).
  *
@@ -74,6 +76,32 @@ export interface ScrollToDeeplinkMessage {
 }
 
 /**
+ * Requests that the doc editor switch to another document.
+ *
+ * Posted by a page rendered inside the CMS preview pane to say which doc it is
+ * showing, so the editor can follow the preview as the user navigates the site.
+ * The page knows its own doc id, which is why the CMS doesn't try to derive one
+ * from the url.
+ *
+ * The doc id is untrusted input: the CMS checks the collection exists and the
+ * slug is well-formed before routing anywhere.
+ */
+export interface NavigateToDocMessage {
+  navigateToDoc: {
+    /** The doc to edit, e.g. "Pages/about". */
+    docId: string;
+    /**
+     * Whether to ask the user before switching docs. Defaults to `true`: the
+     * editor would otherwise jump to another doc unannounced, which is
+     * disorienting for an editor who doesn't know the page can do that. Set it
+     * to `false` only when the site has its own affordance, e.g. a toggle the
+     * user turned on.
+     */
+    confirm?: boolean;
+  };
+}
+
+/**
  * Requests that the preview page highlight the node associated with a field.
  * A `null` deepKey clears all highlights.
  */
@@ -119,6 +147,19 @@ export function isScrollToDeeplinkMessage(
   const req = (data as ScrollToDeeplinkMessage)?.scrollToDeeplink;
   return (
     typeof req === 'object' && req !== null && typeof req.deepKey === 'string'
+  );
+}
+
+/** Returns whether a postMessage payload is a {@link NavigateToDocMessage}. */
+export function isNavigateToDocMessage(
+  data: unknown
+): data is NavigateToDocMessage {
+  const req = (data as NavigateToDocMessage)?.navigateToDoc;
+  return (
+    typeof req === 'object' &&
+    req !== null &&
+    typeof req.docId === 'string' &&
+    (req.confirm === undefined || typeof req.confirm === 'boolean')
   );
 }
 

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.css
@@ -312,3 +312,7 @@
   overflow: hidden;
   background: white;
 }
+
+.DocumentPage__followConfirm__dontAsk {
+  margin-top: 16px;
+}

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -426,7 +426,7 @@ function DocumentPageLayout(props: DocumentPageProps & {canEdit: boolean}) {
                   'DocumentPage__side__editor--centered'
               )}
             >
-              <DocEditor docId={docId} />
+              <DocEditor key={docId} docId={docId} />
             </div>
           </SplitPanel.Item>
           <SplitPanel.Item
@@ -665,11 +665,6 @@ function getLocaleLabel(locale: string) {
 
 DocumentPage.Preview = (props: PreviewProps) => {
   const draft = useDraftDoc();
-  // TODO(stevenle): add a loader here instead.
-  if (draft.loading) {
-    return null;
-  }
-
   const [collectionId, slug] = props.docId.split('/');
   const collections = window.__ROOT_CTX.collections;
   const rootCollection = collections[collectionId];
@@ -857,7 +852,7 @@ DocumentPage.Preview = (props: PreviewProps) => {
     return () => {
       removeOnFlush?.();
     };
-  }, []);
+  }, [draft.controller]);
 
   // Navigate every visible iframe to the localized preview url. Runs on mount
   // (initial load) and whenever the selected locale changes.

--- a/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/root-cms/ui/pages/DocumentPage/DocumentPage.tsx
@@ -1,7 +1,8 @@
 import './DocumentPage.css';
 
-import {ActionIcon, Button, Tooltip} from '@mantine/core';
+import {ActionIcon, Button, Checkbox, Tooltip} from '@mantine/core';
 import {useHotkeys} from '@mantine/hooks';
+import {useModals} from '@mantine/modals';
 import {
   IconArrowLeft,
   IconArrowUpRight,
@@ -11,9 +12,12 @@ import {
   IconLayoutSidebarRightExpand,
 } from '@tabler/icons-preact';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
+import {useLocation} from 'preact-iso';
+import {isNavigateToDocMessage} from '../../../shared/embed-protocol.js';
 import {ChecksPanel} from '../../components/ChecksPanel/ChecksPanel.js';
 import {ConditionalTooltip} from '../../components/ConditionalTooltip/ConditionalTooltip.js';
 import {DocEditor} from '../../components/DocEditor/DocEditor.js';
+import {DocIdBadge} from '../../components/DocIdBadge/DocIdBadge.js';
 import {
   DocumentPagePreviewBar,
   type DeviceType,
@@ -22,8 +26,10 @@ import {useEditJsonModal} from '../../components/EditJsonModal/EditJsonModal.js'
 import {RootAIChat} from '../../components/RootAIChat/RootAIChat.js';
 import {SearchPanel} from '../../components/SearchPanel/SearchPanel.js';
 import {SplitPanel} from '../../components/SplitPanel/SplitPanel.js';
+import {Text} from '../../components/Text/Text.js';
 import {DraftDocProvider, useDraftDoc} from '../../hooks/useDraftDoc.js';
 import {useLocalStorage} from '../../hooks/useLocalStorage.js';
+import {useModalTheme} from '../../hooks/useModalTheme.js';
 import {usePageTitle} from '../../hooks/usePageTitle.js';
 import {useProjectRoles} from '../../hooks/useProjectRoles.js';
 import {useStringParam} from '../../hooks/useQueryParam.js';
@@ -31,6 +37,8 @@ import {Layout} from '../../layout/Layout.js';
 import {testAiEnabled} from '../../utils/ai.js';
 import {joinClassNames} from '../../utils/classes.js';
 import {getDocPreviewPath, getDocServingPath} from '../../utils/doc-urls.js';
+import {isAllowedOrigin} from '../../utils/embed-bridge.js';
+import {testEnableChannelFromPreview} from '../../utils/iframe-preview.js';
 import {testCanEdit} from '../../utils/permissions.js';
 import {
   getPreviewPathFromUrlKey,
@@ -622,6 +630,17 @@ interface PreviewProps {
   docId: string;
 }
 
+/**
+ * The answer to remember when the user ticks "don't ask again" in the
+ * confirmation below: `true` to keep following, `false` to stop following, and
+ * `null` to keep asking.
+ *
+ * Scoped to the page session rather than persisted: following is only useful
+ * for a stretch of browsing, and a decision made once shouldn't quietly
+ * outlive it. Reloading the CMS asks again.
+ */
+let rememberedFollowAnswer: boolean | null = null;
+
 const DeviceResolution = {
   mobile: [430, 932],
   tablet: [768, 1024],
@@ -713,6 +732,9 @@ DocumentPage.Preview = (props: PreviewProps) => {
   // The url the preview panes are expected to be showing. Used to detect when
   // the user navigates within a pane so the other panes can be brought along.
   const syncedUrlKey = useRef<string | null>(null);
+  const {route} = useLocation();
+  const modals = useModals();
+  const modalTheme = useModalTheme();
   const previewFrameRef = useRef<HTMLDivElement>(null);
   // Remembers the viewport selection from before 2-up was enabled so it can be
   // restored when 2-up is turned back off.
@@ -811,6 +833,108 @@ DocumentPage.Preview = (props: PreviewProps) => {
   }
 
   /**
+   * Returns whether a doc id from the preview names a real collection and a
+   * well-formed slug. Without this a previewed page could send the editor to
+   * an arbitrary route.
+   */
+  function testDocIdIsValid(docId: string): boolean {
+    const parts = docId.split('/');
+    if (parts.length !== 2) {
+      return false;
+    }
+    const [collection, slug] = parts;
+    // The slug isn't matched against the CMS slug pattern: docs created before
+    // it was enforced would stop being reachable. Rejecting dot segments and
+    // requiring a known collection is what keeps the route well-formed.
+    if (!collection || !slug || slug === '.' || slug === '..') {
+      return false;
+    }
+    return Boolean(window.__ROOT_CTX.collections[collection]);
+  }
+
+  /**
+   * Switches the editor to the doc a preview pane says it is showing.
+   *
+   * The doc id comes from the previewed page itself (see `navigateToDoc()` in
+   * the browser client), so there is nothing to derive from the url. It is
+   * still untrusted input -- any page the pane can reach could post it -- so
+   * the collection and slug are validated before routing anywhere.
+   */
+  function navigateToDoc(docId: string, options?: {confirm?: boolean}) {
+    if (docId === props.docId || !testDocIdIsValid(docId)) {
+      return;
+    }
+    // Confirm unless the site opted out. The editor switching docs on its own
+    // is disorienting for someone who doesn't know the page can ask for it.
+    if (options?.confirm === false || rememberedFollowAnswer === true) {
+      openDoc(docId);
+      return;
+    }
+    // The user asked not to be prompted again and said no last time.
+    if (rememberedFollowAnswer === false) {
+      return;
+    }
+    // Read on confirm rather than through state: the checkbox only has to be
+    // correct at the moment the user accepts, so there's nothing to re-render.
+    let dontAskAgain = false;
+    modals.openConfirmModal({
+      ...modalTheme,
+      title: 'The preview has changed',
+      children: (
+        <>
+          <Text size="body-sm" weight="semi-bold">
+            Do you want to load this page in the editor?
+          </Text>
+          <DocIdBadge docId={docId} />
+          <Checkbox
+            className="DocumentPage__followConfirm__dontAsk"
+            label="Don't ask again this session"
+            size="xs"
+            onChange={(e: Event) => {
+              dontAskAgain = (e.currentTarget as HTMLInputElement).checked;
+            }}
+          />
+        </>
+      ),
+      labels: {confirm: 'Yes', cancel: 'No'},
+      cancelProps: {size: 'xs'},
+      confirmProps: {size: 'xs'},
+      onConfirm: () => {
+        if (dontAskAgain) {
+          rememberedFollowAnswer = true;
+        }
+        openDoc(docId);
+      },
+      onCancel: () => {
+        if (dontAskAgain) {
+          rememberedFollowAnswer = false;
+        }
+      },
+    });
+  }
+
+  /** Routes the editor to a doc the preview asked for. */
+  function openDoc(docId: string) {
+    // Autosave runs on a delay, so a navigation can land mid-window. This
+    // isn't awaited: the update is handed to Firestore before the route
+    // changes, and the controller flushes again when it's disposed.
+    draft.controller?.flush();
+    const params = new URLSearchParams(window.location.search);
+    // Both of these point at a field in the doc being left behind.
+    params.delete('modal');
+    params.delete('deeplink');
+    const query = params.toString();
+    const [collection, slug] = docId.split('/');
+    const path = `/cms/content/${encodeURIComponent(
+      collection
+    )}/${encodeURIComponent(slug)}`;
+    // Push, so the doc the editor came from stays in the back stack. The
+    // iframe's own navigation doesn't add a top-level entry, so replacing here
+    // would discard the previous doc and leave the back button doing nothing.
+    route(`${path}${query ? `?${query}` : ''}`);
+  }
+
+  /**
    * Returns the url a newly-mounted pane should open at, which is whatever page
    * the other panes are showing (or the doc's preview url when there are none).
    */
@@ -843,6 +967,27 @@ DocumentPage.Preview = (props: PreviewProps) => {
   function reloadAllIframes() {
     iframeRefs.current.forEach((iframe) => reloadIframe(iframe));
   }
+
+  // Listen for a preview pane asking the editor to open another doc. Only
+  // messages from this page's own preview iframes are accepted, so an
+  // unrelated frame can't drive the editor.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (!testEnableChannelFromPreview() || !isAllowedOrigin(event.origin)) {
+        return;
+      }
+      const isOwnPane = Array.from(iframeRefs.current.values()).some(
+        (iframe) => iframe.contentWindow === event.source
+      );
+      if (!isOwnPane || !isNavigateToDocMessage(event.data)) {
+        return;
+      }
+      const req = event.data.navigateToDoc;
+      navigateToDoc(req.docId, {confirm: req.confirm});
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [props.docId]);
 
   // Reload every visible preview iframe whenever the draft is flushed.
   useEffect(() => {

--- a/packages/root-cms/ui/utils/iframe-preview.ts
+++ b/packages/root-cms/ui/utils/iframe-preview.ts
@@ -38,3 +38,9 @@ function testEnableChannelToPreview() {
   const previewOptions = window.__ROOT_CTX.preview || {};
   return [true, 'to-preview'].includes(previewOptions.channel);
 }
+
+/** Returns whether messages from the preview should be accepted. */
+export function testEnableChannelFromPreview() {
+  const previewOptions = window.__ROOT_CTX.preview || {};
+  return [true, 'from-preview'].includes(previewOptions.channel);
+}


### PR DESCRIPTION
Second attempt at #1416, rebuilt around your suggestion instead of the approach you declined. No url guessing, and nothing happens unless a project asks for it.

> [!NOTE]
> Stacked on #1415. Review that first; this targets its branch and I'll rebase onto `main` once it lands.

## What it adds

`PreviewConnection.navigateToDoc(docId)` on the preview channel. A page rendered in the preview pane says which doc it is, and the editor offers to switch to it:

```ts
const preview = new PreviewConnection();
if (preview.isEmbedded) {
  preview.navigateToDoc(doc.id);
}
```

The page already knows its own doc id, so nothing is derived from the url — no reverse-mapping, no ambiguity when two collections claim the same path, no existence probes. That was the weakest part of #1416 and this removes the need for it entirely.

## Confirmation, per your review

The editor asks before switching, since a doc changing on its own is disorienting for someone who doesn't know the page can do that:

> **The preview has changed**
> Do you want to load this page in the editor?
> `Pages/team`
> ☐ Don't ask again this session
> **No**  **Yes**

The checkbox remembers the **answer**, not just the prompt: tick + Yes follows silently for the rest of the session, tick + No stops asking and stops following, so the CMS behaves exactly as it did before this feature. It's scoped to the page session and never persisted — reloading asks again, so there's no stuck state and nothing to undo in settings.

`navigateToDoc(docId, {confirm: false})` skips the prompt, for a site that has its own affordance.

## Nothing happens by default

Two independent conditions, both pre-existing:

- The CMS only acts on the message when `preview.channel` enables the from-preview direction, which defaults to `false`.
- The site has to call `navigateToDoc()` itself.

I deliberately did **not** add a config flag — `preview.channel` already gates the direction and a second key would be redundant. The diff is additive, and `<DocumentPage.Preview>` keeps its `key={docId}`, so existing doc-to-doc navigation is unchanged.

## The doc id is untrusted

It arrives by `postMessage` from whatever page the pane navigated to, so:

- accepted only from this page's own preview iframes (`contentWindow === event.source`, not just an origin check) and from an allowed origin;
- the collection must exist in `__ROOT_CTX.collections`;
- dot segments rejected, route segments `encodeURIComponent`'d.

The slug is deliberately *not* matched against the CMS slug pattern — docs created before it was enforced would silently stop being reachable.

## The first commit is a separate bug fix

`isInPreviewIframe()` tested `document.referrer` against the CMS path, which only holds for the **first** page the pane loads. Follow a link inside the preview and the referrer names the previous page of the site, so it returned `false` for every page after that.

This is pre-existing and affects `focusField()` / click-to-edit today, not just this feature — but the feature can't work without it, which is why it's here rather than in its own PR. Kept as its own commit so it can be reviewed on its own, and happy to split it out if you'd prefer to land it separately. The pane is same-origin, so the parent's location is the reliable signal; the referrer check stays as a fallback.

## Testing

12 unit tests for the message guard, including that it stays distinct from the other un-namespaced messages sharing the channel. 824 pass across `ui`/`shared`/`browser-client`; lint clean.

Exercised against a real site with live Firebase credentials: the prompt and both answers, the session memory in both directions, consecutive follows, back-button behaviour, and the default-off path.

Two things that testing corrected, both worth flagging since I had them wrong in an earlier revision of this description:

- The route is a **push**, not a replace. I had assumed the iframe's own navigation already added a top-level history entry; it doesn't. Replacing discarded the previous doc's entry, so Back appeared to do nothing but flicker the tab title. With push, one Back returns the editor, url, and pane together.
- A follow adds two history entries — the route plus the remounted preview's load. Back still works in a single press, but the second entry is a consequence of keeping `key={docId}`.

## Known tradeoff

Following a link remounts the preview pane, so the page loads a second time. Keeping the pane alive across doc changes fixes that, but it means un-keying `<DocumentPage.Preview>`, which changes behaviour for *all* doc-to-doc navigation. That didn't belong in this PR — happy to propose it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
