### PR TITLE
feat: honor i18n.fallbacks in v1 translations and export resolveLocaleFallbacks

### DIFF
--- a/.changeset/i18n-fallbacks-v1-translations.md
+++ b/.changeset/i18n-fallbacks-v1-translations.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: honor i18n.fallbacks in v1 translations and export resolveLocaleFallbacks

--- a/docs/routes/blog.tsx
+++ b/docs/routes/blog.tsx
@@ -1,5 +1,9 @@
 import type {Handler, HandlerContext, Request, Response} from '@blinkk/root';
-import {RootCMSClient, translationsForLocale} from '@blinkk/root-cms/client';
+import {
+  RootCMSClient,
+  resolveLocaleFallbacks,
+  translationsForLocale,
+} from '@blinkk/root-cms/client';
 import {BlogPost} from '@/components/BlogPost/BlogPost.js';
 import {Container} from '@/components/Container/Container.js';
 import {Text} from '@/components/Text/Text.js';
@@ -65,7 +69,10 @@ export const handle: Handler = async (req: BlogRequest, res: Response) => {
   const locale = ctx.route.isDefaultLocale
     ? ctx.getPreferredLocale(['en'])
     : ctx.route.locale;
-  const translations = translationsForLocale(translationsMap, locale);
+  const translations = translationsForLocale(
+    translationsMap,
+    resolveLocaleFallbacks(cmsClient.rootConfig.i18n, locale)
+  );
 
   if (mode === 'published') {
     res.setHeader('cache-control', 'public, max-age=15, s-maxage=30');

--- a/docs/utils/cms-route.ts
+++ b/docs/utils/cms-route.ts
@@ -6,7 +6,11 @@ import {
   Response,
   RouteParams,
 } from '@blinkk/root';
-import {RootCMSClient, translationsForLocale} from '@blinkk/root-cms/client';
+import {
+  RootCMSClient,
+  resolveLocaleFallbacks,
+  translationsForLocale,
+} from '@blinkk/root-cms/client';
 
 export type CMSRequest = Request & {
   cmsClient: RootCMSClient;
@@ -126,7 +130,10 @@ export function cmsRoute(options: CMSRouteOptions) {
       return {notFound: true};
     }
 
-    const translations = translationsForLocale(translationsMap, locale);
+    const translations = translationsForLocale(
+      translationsMap,
+      resolveLocaleFallbacks(cmsClient.rootConfig.i18n, locale)
+    );
     let props: any = {...data, locale, mode, slug, doc};
     if (options.preRenderHook) {
       props = await options.preRenderHook(props, routeContext);
@@ -227,7 +234,10 @@ export function cmsRoute(options: CMSRouteOptions) {
         req.get('x-country-code') ||
         req.get('x-appengine-country') ||
         null;
-      const translations = translationsForLocale(translationsMap, locale);
+      const translations = translationsForLocale(
+        translationsMap,
+        resolveLocaleFallbacks(cmsClient.rootConfig.i18n, locale)
+      );
       let props: any = {...data, req, locale, mode, slug, doc, country};
       if (options.preRenderHook) {
         props = await options.preRenderHook(props, routeContext);

--- a/packages/root-cms/core/client.ts
+++ b/packages/root-cms/core/client.ts
@@ -14,6 +14,11 @@ import {
   unmarshalDataSourceData,
 } from '../shared/data-source.js';
 import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
+
+export {
+  resolveLocaleFallbacks,
+  type LocaleFallbacksI18nConfig,
+} from '../shared/locale-fallbacks.js';
 import {toDocEditOperations, type Proposal} from '../shared/proposal.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {hashStr} from '../shared/strings.js';
@@ -1879,6 +1884,11 @@ export class RootCMSClient {
   /**
    * Loads translations for a particular locale.
    *
+   * The locale is expanded through the fallback chain configured in
+   * `i18n.fallbacks` (ending with `i18n.defaultLocale`), so a string missing
+   * a translation for the locale falls through to its fallbacks before the
+   * source string is used.
+   *
    * Returns a map like:
    * ```
    * {
@@ -1891,7 +1901,11 @@ export class RootCMSClient {
     options?: LoadTranslationsOptions
   ): Promise<LocaleTranslations> {
     const translationsMap = await this.loadTranslations(options);
-    return translationsForLocale(translationsMap, locale);
+    const fallbackLocales = resolveLocaleFallbacks(
+      this.rootConfig.i18n,
+      locale
+    );
+    return translationsForLocale(translationsMap, fallbackLocales);
   }
 
   /**
@@ -3013,6 +3027,17 @@ function randString(len: number): string {
  * Converts a translations map from `loadTranslations()` to a map of source to
  * translated string for a particular locale.
  *
+ * The locale is either a single locale (e.g. `"fr"`), which falls back to
+ * `en` and then the source string, or an ordered fallback chain (e.g.
+ * `["en-CA", "en-GB", "en"]`) where the first locale with a translation wins
+ * before falling back to the source string. Use `resolveLocaleFallbacks()`
+ * to build the chain from the `i18n.fallbacks` config:
+ *
+ * ```ts
+ * const fallbackLocales = resolveLocaleFallbacks(rootConfig.i18n, 'en-CA');
+ * const translations = translationsForLocale(translationsMap, fallbackLocales);
+ * ```
+ *
  * Returns a map like:
  * ```
  * {
@@ -3022,12 +3047,19 @@ function randString(len: number): string {
  */
 export function translationsForLocale(
   translationsMap: TranslationsMap,
-  locale: string
-) {
+  locale: string | string[]
+): LocaleTranslations {
+  const fallbackLocales = Array.isArray(locale) ? locale : [locale, 'en'];
   const localeTranslations: LocaleTranslations = {};
   Object.values(translationsMap).forEach((string) => {
     const source = string.source;
-    const translation = string[locale] || string.en || string.source;
+    let translation = source;
+    for (const fallbackLocale of fallbackLocales) {
+      if (string[fallbackLocale]) {
+        translation = string[fallbackLocale];
+        break;
+      }
+    }
     localeTranslations[source] = translation;
   });
   return localeTranslations;

--- a/packages/root-cms/core/route.ts
+++ b/packages/root-cms/core/route.ts
@@ -251,22 +251,21 @@ export function createRoute(options: CreateRouteOptions): Route {
 
   /**
    * Flattens a loaded translations map to a source -> translation map for a
-   * locale, resolving the locale's fallback chain (`i18n.fallbacks`) when the
-   * v2 translations manager is enabled.
+   * locale, resolving the locale's fallback chain (`i18n.fallbacks`).
    */
   function translationsMapForLocale(
     cmsClient: RootCMSClient,
     translationsMap: Record<string, any>,
     locale: string
   ): Record<string, string> {
+    const fallbackLocales = resolveLocaleFallbacks(
+      cmsClient.rootConfig.i18n,
+      locale
+    );
     if (cmsClient.isV2TranslationsEnabled()) {
-      const fallbackLocales = resolveLocaleFallbacks(
-        cmsClient.rootConfig.i18n,
-        locale
-      );
       return translationsForLocaleV2(translationsMap, fallbackLocales);
     }
-    return translationsForLocale(translationsMap, locale);
+    return translationsForLocale(translationsMap, fallbackLocales);
   }
 
   async function generateProps(routeContext: RouteContext, locale: string) {

--- a/packages/root-cms/core/runtime.ts
+++ b/packages/root-cms/core/runtime.ts
@@ -2,6 +2,7 @@
 
 import {RootConfig} from '@blinkk/root';
 import {FieldValue, Query, Timestamp} from 'firebase-admin/firestore';
+import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
 import {normalizeSlug} from '../shared/slug.js';
 import {
   LoadTranslationsOptions,
@@ -266,5 +267,6 @@ export async function loadTranslationsForLocale(
   options?: LoadTranslationsOptions
 ): Promise<LocaleTranslations> {
   const translationsMap = await loadTranslations(rootConfig, options);
-  return translationsForLocale(translationsMap, locale);
+  const fallbackLocales = resolveLocaleFallbacks(rootConfig.i18n, locale);
+  return translationsForLocale(translationsMap, fallbackLocales);
 }

--- a/packages/root-cms/core/translations-for-locale.test.ts
+++ b/packages/root-cms/core/translations-for-locale.test.ts
@@ -1,0 +1,64 @@
+import {describe, expect, it} from 'vitest';
+import {resolveLocaleFallbacks} from '../shared/locale-fallbacks.js';
+import {TranslationsMap, translationsForLocale} from './client.js';
+
+const translationsMap: TranslationsMap = {
+  hash1: {source: 'Hello', en: 'Hello', 'en-GB': 'Hello (GB)', fr: 'Bonjour'},
+  hash2: {source: 'Colour', en: 'Color', 'en-GB': 'Colour'},
+  hash3: {source: 'Untranslated', en: ''},
+  hash4: {source: 'Only source'},
+};
+
+describe('translationsForLocale', () => {
+  it('resolves a single locale with en and source fallbacks', () => {
+    expect(translationsForLocale(translationsMap, 'fr')).toEqual({
+      Hello: 'Bonjour',
+      Colour: 'Color',
+      Untranslated: 'Untranslated',
+      'Only source': 'Only source',
+    });
+  });
+
+  it('uses the first locale in the fallback chain with a translation', () => {
+    expect(
+      translationsForLocale(translationsMap, ['en-CA', 'en-GB', 'en'])
+    ).toEqual({
+      Hello: 'Hello (GB)',
+      Colour: 'Colour',
+      Untranslated: 'Untranslated',
+      'Only source': 'Only source',
+    });
+  });
+
+  it('falls back to the source string when no locale in the chain matches', () => {
+    expect(translationsForLocale(translationsMap, ['de', 'es'])).toEqual({
+      Hello: 'Hello',
+      Colour: 'Colour',
+      Untranslated: 'Untranslated',
+      'Only source': 'Only source',
+    });
+  });
+
+  it('honors the i18n.fallbacks config via resolveLocaleFallbacks()', () => {
+    const i18n = {
+      locales: ['en', 'en-GB', 'en-CA', 'fr'],
+      fallbacks: {'en-CA': ['en-GB']},
+    };
+    expect(
+      translationsForLocale(
+        translationsMap,
+        resolveLocaleFallbacks(i18n, 'en-CA')
+      )
+    ).toEqual({
+      Hello: 'Hello (GB)',
+      Colour: 'Colour',
+      Untranslated: 'Untranslated',
+      'Only source': 'Only source',
+    });
+    // Without a configured fallback, the chain is just the locale and the
+    // default locale, matching the single-locale behavior.
+    expect(
+      translationsForLocale(translationsMap, resolveLocaleFallbacks(i18n, 'fr'))
+    ).toEqual(translationsForLocale(translationsMap, 'fr'));
+  });
+});


### PR DESCRIPTION
Fixes #1420.

## Problem

`i18n.fallbacks` only took effect when the `experiments.v2TranslationsManager` flag was on. On the default v1 path, `translationsForLocale()` resolved a single locale with a hardcoded `locale -> en -> source` chain, so configuring fallbacks type-checked and silently did nothing. `resolveLocaleFallbacks()` also lived in `shared/locale-fallbacks.ts` without being re-exported from any public entry point, so sites with custom route handlers had to reimplement it.

## Changes

- **`translationsForLocale(map, locale | locale[])`** now accepts an ordered fallback chain in addition to a single locale, mirroring `translationsForLocaleV2()`. The single-locale form is unchanged (`locale -> en -> source`); the array form tries each locale in order and then falls back to the source string.
- **v1 paths honor `i18n.fallbacks`**: `RootCMSClient.loadTranslationsForLocale()`, the deprecated runtime `loadTranslationsForLocale()`, and the built-in `cmsRoute` (`translationsMapForLocale` in `core/route.ts`) now resolve the locale through `resolveLocaleFallbacks()` regardless of the v2 experiment.
- **Public export**: `resolveLocaleFallbacks` and `LocaleFallbacksI18nConfig` are re-exported from `@blinkk/root-cms/client`, which also surfaces them from `@blinkk/root-cms` via `core/core.ts`.
- The docs playground routes (`docs/utils/cms-route.ts`, `docs/routes/blog.tsx`) use the public API as an example of the custom-route case from the issue.
- Added `core/translations-for-locale.test.ts` covering the single-locale form, an explicit chain, the source-string fallback, and the chain produced by `resolveLocaleFallbacks()` with an `i18n.fallbacks` config.
- Changeset (patch) included.

## Behavior note

When no fallbacks are configured, the resolved chain is `[locale, defaultLocale]`, so for the default `defaultLocale: 'en'` the built-in paths behave exactly as before. If a project sets a non-`en` `defaultLocale`, the v1 built-in paths now fall back to that locale instead of the hardcoded `en`, which matches the documented `i18n.fallbacks` semantics and the v2 path. Direct callers of `translationsForLocale(map, 'fr')` with a string still get the old `en` fallback.

## Verification

- `pnpm build` passes.
- `eslint` passes on all changed files (the repo-wide `pnpm lint` has pre-existing failures in unrelated `packages/root` files).
- `tsc` on `packages/root-cms/core` reports no errors in the changed files.
- `vitest run core/translations-for-locale.test.ts shared/locale-fallbacks.test.ts`: 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117bhyfy3KbLD181zqi4fhw

---
_Generated by [Claude Code](https://claude.ai/code/session_0117bhyfy3KbLD181zqi4fhw)_