### PR TITLE
feat: surface AI provider errors in Root AI chats and add a retry button

### DIFF
--- a/.changeset/ai-chat-retry-button.md
+++ b/.changeset/ai-chat-retry-button.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: surface AI provider errors in Root AI chats and add a retry button

--- a/packages/root-cms/shared/ai/errors.test.ts
+++ b/packages/root-cms/shared/ai/errors.test.ts
@@ -1,0 +1,98 @@
+import {APICallError, RetryError} from 'ai';
+import {describe, expect, test} from 'vitest';
+import {
+  formatAiErrorMessage,
+  isTransientAiError,
+  unwrapAiError,
+} from './errors.js';
+
+const HIGH_DEMAND =
+  'This model is currently experiencing high demand. Spikes in demand are usually temporary.';
+
+function apiError(statusCode: number, message: string) {
+  return new APICallError({
+    message,
+    url: 'https://example.com',
+    requestBodyValues: {},
+    statusCode,
+  });
+}
+
+describe('unwrapAiError', () => {
+  test('returns the last error from a RetryError', () => {
+    const inner = apiError(503, HIGH_DEMAND);
+    const retry = new RetryError({
+      message: `Failed after 3 attempts. Last error: ${HIGH_DEMAND}`,
+      reason: 'maxRetriesExceeded',
+      errors: [inner, inner, inner],
+    });
+    expect(unwrapAiError(retry)).toBe(inner);
+  });
+
+  test('passes other errors through', () => {
+    const err = new Error('boom');
+    expect(unwrapAiError(err)).toBe(err);
+  });
+});
+
+describe('isTransientAiError', () => {
+  test('treats 503 / 529 / 429 API errors as transient', () => {
+    expect(isTransientAiError(apiError(503, HIGH_DEMAND))).toBe(true);
+    expect(isTransientAiError(apiError(529, 'Overloaded'))).toBe(true);
+    expect(isTransientAiError(apiError(429, 'Rate limited'))).toBe(true);
+  });
+
+  test('treats auth and validation API errors as permanent', () => {
+    expect(isTransientAiError(apiError(401, 'Invalid API key'))).toBe(false);
+    expect(isTransientAiError(apiError(400, 'Bad request'))).toBe(false);
+  });
+
+  test('looks through RetryError wrappers', () => {
+    const retry = new RetryError({
+      message: 'Failed after 3 attempts.',
+      reason: 'maxRetriesExceeded',
+      errors: [apiError(503, HIGH_DEMAND)],
+    });
+    expect(isTransientAiError(retry)).toBe(true);
+  });
+
+  test('recognizes high-demand wording in plain errors', () => {
+    expect(isTransientAiError(new Error(HIGH_DEMAND))).toBe(true);
+    expect(isTransientAiError(new Error('schema mismatch'))).toBe(false);
+  });
+});
+
+describe('formatAiErrorMessage', () => {
+  test('surfaces the provider message for transient failures', () => {
+    const retry = new RetryError({
+      message: 'Failed after 3 attempts.',
+      reason: 'maxRetriesExceeded',
+      errors: [apiError(503, HIGH_DEMAND)],
+    });
+    expect(formatAiErrorMessage(retry)).toBe(
+      `The AI provider is temporarily unavailable (HTTP 503). ${HIGH_DEMAND} Please try again in a moment.`
+    );
+  });
+
+  test('falls back to a generic explanation when the provider gives none', () => {
+    expect(formatAiErrorMessage(apiError(529, ''))).toBe(
+      'The AI provider is temporarily unavailable (HTTP 529). The provider is temporarily unable to handle the request. Please try again in a moment.'
+    );
+  });
+
+  test('keeps the provider message for permanent failures', () => {
+    expect(formatAiErrorMessage(apiError(401, 'Invalid API key'))).toBe(
+      'Invalid API key (HTTP 401)'
+    );
+    expect(formatAiErrorMessage(new Error('schema mismatch'))).toBe(
+      'schema mismatch'
+    );
+  });
+
+  test('handles unknown error values', () => {
+    expect(formatAiErrorMessage(undefined)).toBe(
+      'An unexpected error occurred.'
+    );
+    expect(formatAiErrorMessage('plain string')).toBe('plain string');
+  });
+});

--- a/packages/root-cms/shared/ai/errors.ts
+++ b/packages/root-cms/shared/ai/errors.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser-safe helpers for turning errors thrown by the Vercel AI SDK (and the
+ * model providers behind it) into messages the CMS UI can show.
+ *
+ * `streamText` masks stream errors as "An error occurred." by default so that
+ * server-side details are not leaked to the client. The CMS streams directly
+ * from the browser, so there is nothing to hide: surfacing the provider's
+ * actual message (e.g. Gemini's "This model is currently experiencing high
+ * demand") lets the user know whether retrying is worthwhile.
+ *
+ * Keep this module free of Node-only imports.
+ */
+import {APICallError, RetryError} from 'ai';
+
+/**
+ * HTTP status codes that indicate a transient, load-related condition on the
+ * provider's side (rate limits, overload, gateway timeouts). 529 is Anthropic's
+ * "overloaded" status.
+ */
+const TRANSIENT_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 529]);
+
+/** Provider message fragments that indicate a transient condition. */
+const TRANSIENT_MESSAGE_RE =
+  /high demand|overloaded|rate limit|resource(?:_| )?exhausted|too many requests|try again later|temporarily unavailable/i;
+
+/**
+ * Unwraps the AI SDK's `RetryError` wrapper (thrown once the SDK's built-in
+ * retries are exhausted) to the underlying provider error.
+ */
+export function unwrapAiError(err: unknown): unknown {
+  if (RetryError.isInstance(err) && err.lastError) {
+    return err.lastError;
+  }
+  return err;
+}
+
+/** Returns the `message` of an unknown error value, or an empty string. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message.trim();
+  }
+  if (typeof err === 'string') {
+    return err.trim();
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    return String((err as any).message || '').trim();
+  }
+  return '';
+}
+
+/**
+ * Whether the error is a transient provider-side failure (high demand, rate
+ * limiting, etc.) that is likely to succeed if the request is retried.
+ */
+export function isTransientAiError(err: unknown): boolean {
+  const inner = unwrapAiError(err);
+  if (APICallError.isInstance(inner)) {
+    if (inner.statusCode !== undefined) {
+      return TRANSIENT_STATUS_CODES.has(inner.statusCode);
+    }
+    if (inner.isRetryable) {
+      return true;
+    }
+  }
+  return TRANSIENT_MESSAGE_RE.test(errorMessage(inner));
+}
+
+/**
+ * Formats an AI SDK error as a single user-facing message. Transient failures
+ * are labelled as such and include the provider's own explanation so the user
+ * knows the problem is on the provider's side and that a retry may help.
+ */
+export function formatAiErrorMessage(err: unknown): string {
+  const inner = unwrapAiError(err);
+  const detail = errorMessage(inner);
+  const status = APICallError.isInstance(inner) ? inner.statusCode : undefined;
+  const statusSuffix = status ? ` (HTTP ${status})` : '';
+  if (isTransientAiError(inner)) {
+    const explanation =
+      detail || 'The provider is temporarily unable to handle the request.';
+    return `The AI provider is temporarily unavailable${statusSuffix}. ${explanation} Please try again in a moment.`;
+  }
+  if (!detail) {
+    return `An unexpected error occurred${statusSuffix}.`;
+  }
+  return `${detail}${statusSuffix}`;
+}

--- a/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
+++ b/packages/root-cms/ui/components/AiEditModal/AiEditModal.css
@@ -148,12 +148,6 @@
 
 .AiEditModal__ChatPanel__error {
   margin: 8px 0;
-  padding: 8px 12px;
-  background: rgb(255, 245, 245);
-  border: 1px solid rgb(255, 201, 201);
-  border-radius: 4px;
-  color: rgb(201, 42, 42);
-  font-size: 0.875rem;
 }
 
 .AiEditModal__ChatPanel__message {

--- a/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
+++ b/packages/root-cms/ui/components/AiEditModal/ChatPanel.tsx
@@ -28,6 +28,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
+import {ChatErrorNotice} from '../ChatErrorNotice/ChatErrorNotice.js';
 import {IconRootAI} from '../IconRootAI/IconRootAI.js';
 import {Markdown} from '../Markdown/Markdown.js';
 // Tool-call, reasoning, and streaming-indicator UI is shared with the Root AI
@@ -209,7 +210,16 @@ function ChatPanelInner(props: {
   // don't re-fire onEditModeResponse on every streaming token.
   const lastEmittedRef = useRef<Map<string, string>>(new Map());
 
-  const {messages, sendMessage, status, error, stop, addToolOutput} = useChat({
+  const {
+    messages,
+    sendMessage,
+    regenerate,
+    clearError,
+    status,
+    error,
+    stop,
+    addToolOutput,
+  } = useChat({
     transport,
     // Auto-resubmit once all tool calls in the latest assistant message have
     // results, so the model can finish its turn after consulting tools.
@@ -271,9 +281,13 @@ function ChatPanelInner(props: {
         welcome={props.welcome}
       />
       {error && (
-        <div className="AiEditModal__ChatPanel__error">
-          <strong>Error:</strong> {error.message}
-        </div>
+        <ChatErrorNotice
+          className="AiEditModal__ChatPanel__error"
+          error={error}
+          busy={isStreaming}
+          onRetry={() => regenerate()}
+          onDismiss={clearError}
+        />
       )}
       <ChatComposer
         canAttach={props.model.capabilities.attachments}
@@ -507,7 +521,9 @@ function ToolPartView(props: {part: any}) {
         <span className="RootAIChat__tool__title">
           {prettyToolName(toolName, part.input)}
         </span>
-        <span className="RootAIChat__tool__state">{prettyToolState(state)}</span>
+        <span className="RootAIChat__tool__state">
+          {prettyToolState(state)}
+        </span>
       </button>
       {open && (
         <div className="RootAIChat__tool__body">

--- a/packages/root-cms/ui/components/ChatErrorNotice/ChatErrorNotice.css
+++ b/packages/root-cms/ui/components/ChatErrorNotice/ChatErrorNotice.css
@@ -1,0 +1,25 @@
+.ChatErrorNotice {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 16px;
+  padding: 12px 16px;
+  background: #fff5f5;
+  border: 1px solid #ffa8a8;
+  color: #c92a2a;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.ChatErrorNotice__message {
+  flex: 1 1 240px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.ChatErrorNotice__actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}

--- a/packages/root-cms/ui/components/ChatErrorNotice/ChatErrorNotice.tsx
+++ b/packages/root-cms/ui/components/ChatErrorNotice/ChatErrorNotice.tsx
@@ -1,0 +1,67 @@
+import './ChatErrorNotice.css';
+
+import {Button} from '@mantine/core';
+import {IconRefresh} from '@tabler/icons-preact';
+import {joinClassNames} from '../../utils/classes.js';
+
+/** Props for {@link ChatErrorNotice}. */
+export interface ChatErrorNoticeProps {
+  className?: string;
+  /** The error raised by the chat (`useChat().error`). */
+  error: Error;
+  /** Re-sends the failed turn. Omit to hide the retry button. */
+  onRetry?: () => void;
+  /** Clears the error without retrying. Omit to hide the dismiss button. */
+  onDismiss?: () => void;
+  /** Disables the actions while a retry is in flight. */
+  busy?: boolean;
+}
+
+/**
+ * Error banner shown below a chat transcript when a turn fails, e.g. when the
+ * model provider is overloaded. Offers a "Retry" button so the user can re-send
+ * the last message without retyping it.
+ */
+export function ChatErrorNotice(props: ChatErrorNoticeProps) {
+  return (
+    <div
+      className={joinClassNames('ChatErrorNotice', props.className)}
+      role="alert"
+    >
+      <div className="ChatErrorNotice__message">
+        <strong>Error:</strong> {props.error.message}
+      </div>
+      {(props.onRetry || props.onDismiss) && (
+        <div className="ChatErrorNotice__actions">
+          {props.onDismiss && (
+            <Button
+              variant="subtle"
+              color="red"
+              size="xs"
+              type="button"
+              className="ChatErrorNotice__button"
+              disabled={props.busy}
+              onClick={props.onDismiss}
+            >
+              Dismiss
+            </Button>
+          )}
+          {props.onRetry && (
+            <Button
+              variant="filled"
+              color="red"
+              size="xs"
+              type="button"
+              className="ChatErrorNotice__button"
+              leftIcon={<IconRefresh size={14} />}
+              disabled={props.busy}
+              onClick={props.onRetry}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.css
@@ -291,12 +291,6 @@
 .RootAIChat__error {
   max-width: 800px;
   margin: 0 auto 12px;
-  padding: 12px 16px;
-  background: #fff5f5;
-  border: 1px solid #ffa8a8;
-  color: #c92a2a;
-  border-radius: 8px;
-  font-size: 14px;
 }
 
 .RootAIChat__message {

--- a/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
+++ b/packages/root-cms/ui/components/RootAIChat/RootAIChat.tsx
@@ -53,6 +53,7 @@ import {joinClassNames} from '../../utils/classes.js';
 import {uploadFileToGCS} from '../../utils/gcs.js';
 import {stableJsonStringify} from '../../utils/objects.js';
 import {BouncingLoader} from '../BouncingLoader/BouncingLoader.js';
+import {ChatErrorNotice} from '../ChatErrorNotice/ChatErrorNotice.js';
 import {JsDiff} from '../JsDiff/JsDiff.js';
 import {Markdown} from '../Markdown/Markdown.js';
 import {
@@ -909,7 +910,16 @@ function ChatPane(props: {
     [persistChat]
   );
 
-  const {messages, sendMessage, status, error, stop, addToolOutput} = useChat({
+  const {
+    messages,
+    sendMessage,
+    regenerate,
+    clearError,
+    status,
+    error,
+    stop,
+    addToolOutput,
+  } = useChat({
     id: effectiveChatId,
     messages: props.initialMessages,
     transport,
@@ -944,9 +954,13 @@ function ChatPane(props: {
         }}
       />
       {error && (
-        <div className="RootAIChat__error">
-          <strong>Error:</strong> {error.message}
-        </div>
+        <ChatErrorNotice
+          className="RootAIChat__error"
+          error={error}
+          busy={isStreaming}
+          onRetry={() => regenerate()}
+          onDismiss={clearError}
+        />
       )}
       <ChatComposer
         disabled={!props.model}

--- a/packages/root-cms/ui/components/RootAIChat/clientChatTransport.ts
+++ b/packages/root-cms/ui/components/RootAIChat/clientChatTransport.ts
@@ -23,6 +23,7 @@ import {
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import {formatAiErrorMessage} from '../../../shared/ai/errors.js';
 import {
   resolveLanguageModel,
   withBrowserHeaders,
@@ -68,12 +69,15 @@ export function createClientChatTransport(
   options: ClientChatTransportOptions
 ): ChatTransport<UIMessage> {
   return {
-    async sendMessages({messages, abortSignal}): Promise<
-      ReadableStream<UIMessageChunk>
-    > {
+    async sendMessages({
+      messages,
+      abortSignal,
+    }): Promise<ReadableStream<UIMessageChunk>> {
       const turn = await options.loadTurnConfig();
       const tools = options.buildTools(turn.model);
-      const languageModel = resolveLanguageModel(withBrowserHeaders(turn.model));
+      const languageModel = resolveLanguageModel(
+        withBrowserHeaders(turn.model)
+      );
 
       // Heal any tool calls left unresolved by an abandoned turn (e.g. the
       // user closed the chat mid-approval) so every `tool_use` keeps a
@@ -93,6 +97,14 @@ export function createClientChatTransport(
       return result.toUIMessageStream({
         sendReasoning: turn.model.capabilities.reasoning,
         originalMessages: messages,
+        // The SDK masks stream errors as "An error occurred." by default to
+        // avoid leaking server details. Everything here already runs in the
+        // browser, so surface the provider's message (e.g. "high demand")
+        // instead and let the user decide whether to retry.
+        onError: (err) => {
+          console.error('Root AI request failed:', err);
+          return formatAiErrorMessage(err);
+        },
         onFinish: options.onFinish
           ? ({messages: finalMessages}) => {
               void options.onFinish!(finalMessages);


### PR DESCRIPTION
Fixes #1421

## Summary

When a model provider fails (e.g. Gemini's 503 `This model is currently experiencing high demand. Spikes in demand are usually temporary.`), the Root AI chat and the "Edit with AI" modal only showed **Error: An error occurred.** The AI SDK masks stream errors by default so server details don't leak to the client, but the CMS streams directly from the browser, so there is nothing to hide.

- **`shared/ai/errors.ts`** (new, isomorphic): unwraps the SDK's `RetryError` wrapper to the underlying `APICallError`, classifies transient failures (408/429/5xx/529 or "high demand"/"overloaded"/"rate limit" wording), and formats a user-facing message such as `The AI provider is temporarily unavailable (HTTP 503). This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again in a moment.`
- **`clientChatTransport.ts`**: passes that formatter as `toUIMessageStream({onError})` so the real provider message reaches `useChat().error` (the raw error is also logged to the console).
- **`ChatErrorNotice`** (new component): error banner with **Retry** and **Dismiss** buttons. Retry calls `useChat().regenerate()`, which drops any partial assistant message and re-sends the last user turn; Dismiss calls `clearError()`. Both buttons are disabled while a retry is streaming.
- Used by both `RootAIChat` and `AiEditModal/ChatPanel`, replacing their inline error `<div>`s (their CSS now only keeps layout/margins).

Auto-retry with a countdown was left out: `streamText` already retries transient errors twice with exponential backoff before the error surfaces, so a manual retry button seemed like the right next step.

## Testing

- Added `shared/ai/errors.test.ts` (10 tests) covering `RetryError` unwrapping, transient classification, and message formatting; passes with `vitest`.
- `eslint` passes on all touched files (this also picked up a few pre-existing prettier fixes in `clientChatTransport.ts` and `ChatPanel.tsx`).
- `pnpm build:ui:bundle` succeeds.
- Not exercised against a live provider outage; the formatted message was verified via the unit tests using real `APICallError`/`RetryError` instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ap5BbSve85mw6nBYu4j8x

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ap5BbSve85mw6nBYu4j8x)_