### PR TITLE
feat: add filter chips, deep links, and scrolling to the global search

### DIFF
--- a/.changeset/global-search-polish.md
+++ b/.changeset/global-search-polish.md
@@ -1,0 +1,5 @@
+---
+'@blinkk/root-cms': patch
+---
+
+feat: add filter chips, deep links, and scrolling to the global search

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.css
@@ -176,3 +176,130 @@
   border: 1px solid var(--mantine-color-gray-3, #dee2e6);
   border-bottom-width: 2px;
 }
+
+/*
+ * The spotlight paper has no max height of its own, so long result lists
+ * used to overflow the viewport with no way to scroll. Cap the paper to the
+ * viewport (minus the spotlight's 120px top offset and a bottom margin) and
+ * let the results area scroll instead.
+ */
+.GlobalSearch__spotlight {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 144px);
+}
+
+/* Keep the search input at its natural height; only the body flexes. */
+.GlobalSearch__spotlight > :not(.GlobalSearch__body) {
+  flex: 0 0 auto;
+}
+
+.GlobalSearch__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.GlobalSearch__results {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.GlobalSearch__resetFilter {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: var(--mantine-color-blue-6, #228be6);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.GlobalSearchFilters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--mantine-color-gray-2, #e9ecef);
+}
+
+.GlobalSearchFilters__chips {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.GlobalSearchFilters__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border: 1px solid var(--mantine-color-gray-3, #dee2e6);
+  border-radius: 999px;
+  background: var(--mantine-color-white, #fff);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--mantine-color-dark-7, #343a40);
+  cursor: pointer;
+}
+
+.GlobalSearchFilters__chip:hover {
+  background: var(--mantine-color-gray-0, #f8f9fa);
+}
+
+.GlobalSearchFilters__chip--empty {
+  color: var(--mantine-color-gray-6, #868e96);
+}
+
+.GlobalSearchFilters__chip--active,
+.GlobalSearchFilters__chip--active:hover {
+  border-color: var(--mantine-color-dark-7, #343a40);
+  background: var(--mantine-color-dark-7, #343a40);
+  color: var(--mantine-color-white, #fff);
+}
+
+.GlobalSearchFilters__count {
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--mantine-color-gray-2, #e9ecef);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--mantine-color-gray-7, #495057);
+}
+
+.GlobalSearchFilters__chip--active .GlobalSearchFilters__count {
+  background: rgba(255, 255, 255, 0.2);
+  color: inherit;
+}
+
+.GlobalSearchFilters__copy {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--mantine-color-gray-6, #868e96);
+  cursor: pointer;
+}
+
+.GlobalSearchFilters__copy:hover {
+  background: var(--mantine-color-gray-1, #f1f3f5);
+  color: var(--mantine-color-dark-7, #343a40);
+}
+
+.GlobalSearchFilters__copy--copied {
+  color: var(--mantine-color-green-7, #2f9e44);
+}

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.test.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.test.tsx
@@ -1,0 +1,255 @@
+import {act, cleanup, fireEvent, render, screen} from '@testing-library/preact';
+import {LocationProvider} from 'preact-iso';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {DocSlugHit, GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
+import {GlobalSearch, openGlobalSearch} from './GlobalSearch.js';
+
+const fieldHits: GlobalSearchHit[] = [];
+const docSlugHits: DocSlugHit[] = [];
+
+// Mantine components can't render under jsdom here (their hooks run outside
+// the test's Preact instance), so the inner Spotlight is replaced with a
+// minimal stand-in that honors the same props contract: a controlled input,
+// the actions wrapper, and the action component.
+vi.mock('@mantine/spotlight/esm/Spotlight/Spotlight.js', () => ({
+  Spotlight: (props: any) => {
+    if (!props.opened) {
+      return null;
+    }
+    const Wrapper = props.actionsWrapperComponent;
+    const Action = props.actionComponent;
+    const actions = props
+      .filter(props.query, props.actions)
+      .slice(0, props.limit);
+    return (
+      <div className={props.classNames?.spotlight}>
+        <input
+          placeholder={props.searchPlaceholder}
+          value={props.query}
+          onInput={(e: any) => props.onQueryChange(e.currentTarget.value)}
+          onKeyDown={(e: any) => {
+            if (e.code === 'Escape') {
+              props.onClose();
+            }
+          }}
+        />
+        <Wrapper>
+          {actions.length > 0 ? (
+            actions.map((action: any) => (
+              <Action
+                key={action.id}
+                action={action}
+                query={props.query}
+                hovered={false}
+                onTrigger={() => action.onTrigger(action)}
+              />
+            ))
+          ) : (
+            <div>{props.nothingFoundMessage}</div>
+          )}
+        </Wrapper>
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../hooks/useGlobalSearch.js', () => ({
+  useGlobalSearch: () => ({
+    hits: fieldHits,
+    loading: false,
+    error: null,
+    status: null,
+  }),
+  useDocSlugSearch: () => ({hits: docSlugHits, loading: false}),
+}));
+
+vi.mock('../../hooks/usePendingReleases.js', () => ({
+  usePendingReleases: () => ({releases: [], loading: false}),
+}));
+
+vi.mock('../../utils/data-source.js', () => ({
+  listDataSources: () => Promise.resolve([]),
+}));
+
+function renderSearch() {
+  return render(
+    <LocationProvider>
+      <GlobalSearch>
+        <div>app</div>
+      </GlobalSearch>
+    </LocationProvider>
+  );
+}
+
+function getInput(): HTMLInputElement {
+  return screen.getByPlaceholderText(
+    'Search docs, collections, releases…'
+  ) as HTMLInputElement;
+}
+
+/** Finds a filter chip by label, e.g. `getChip('Documents')`. */
+function getChip(label: string): HTMLButtonElement {
+  const chips = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('.GlobalSearchFilters__chip')
+  );
+  const chip = chips.find(
+    (el) => el.querySelector('span')?.textContent === label
+  );
+  if (!chip) {
+    throw new Error(`chip not found: ${label}`);
+  }
+  return chip;
+}
+
+/** Returns the count badge of a filter chip, or null when it has none. */
+function chipCount(label: string): string | null {
+  return (
+    getChip(label).querySelector('.GlobalSearchFilters__count')?.textContent ??
+    null
+  );
+}
+
+/** Returns true if a result group header (e.g. "Documents") is rendered. */
+function hasHeader(label: string): boolean {
+  return Array.from(
+    document.querySelectorAll('.GlobalSearchAction--header')
+  ).some((el) => el.textContent === label);
+}
+
+/** Flushes pending timers (URL sync debounce, close transition). */
+async function flush() {
+  await act(async () => {
+    await vi.runAllTimersAsync();
+  });
+}
+
+describe('GlobalSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+    (window as any).__ROOT_CTX = {
+      rootConfig: {projectId: 'test'},
+      collections: {
+        Pages: {name: 'Pages', description: 'Site pages'},
+        Posts: {name: 'Posts'},
+      },
+    };
+    fieldHits.length = 0;
+    docSlugHits.length = 0;
+    docSlugHits.push({collection: 'Pages', slug: 'home', docId: 'Pages/home'});
+    fieldHits.push({
+      id: 'Pages/home#fields.title',
+      docId: 'Pages/home',
+      collection: 'Pages',
+      slug: 'home',
+      deepKey: 'fields.title',
+      fieldLabel: 'Title',
+      fieldType: 'string',
+      text: 'Welcome to pages',
+      score: 1,
+      terms: ['pages'],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    window.history.replaceState({}, '', '/cms/');
+  });
+
+  it('stays closed when the URL has no search params', () => {
+    window.history.replaceState({}, '', '/cms/');
+    renderSearch();
+    expect(
+      screen.queryByPlaceholderText('Search docs, collections, releases…')
+    ).toBeNull();
+  });
+
+  it('opens from a deep link with the query and filter prefilled', () => {
+    window.history.replaceState({}, '', '/cms/?modal=search&q=pages&type=docs');
+    renderSearch();
+    expect(getInput().value).toBe('pages');
+    expect(getChip('Documents').getAttribute('aria-pressed')).toBe('true');
+    expect(getChip('All').getAttribute('aria-pressed')).toBe('false');
+    // Only the "Documents" group is shown.
+    expect(hasHeader('Documents')).toBe(true);
+    expect(hasHeader('Field matches')).toBe(false);
+    expect(hasHeader('Jump to')).toBe(false);
+  });
+
+  it('shows all result groups with counts when no filter is active', () => {
+    window.history.replaceState({}, '', '/cms/?modal=search&q=pages');
+    renderSearch();
+    // "Pages" matches the collection, the doc slug hit, and the field hit.
+    expect(getChip('All').getAttribute('aria-pressed')).toBe('true');
+    expect(chipCount('All')).toBe('3');
+    expect(chipCount('Documents')).toBe('1');
+    expect(chipCount('Field matches')).toBe('1');
+    expect(chipCount('Collections')).toBe('1');
+    expect(chipCount('Releases')).toBeNull();
+    expect(hasHeader('Jump to')).toBe(true);
+    expect(hasHeader('Documents')).toBe(true);
+    expect(hasHeader('Field matches')).toBe(true);
+  });
+
+  it('filters results and mirrors the filter into the URL', async () => {
+    window.history.replaceState({}, '', '/cms/?modal=search&q=pages');
+    renderSearch();
+    fireEvent.click(getChip('Collections'));
+    expect(hasHeader('Jump to')).toBe(true);
+    expect(hasHeader('Documents')).toBe(false);
+    await flush();
+    expect(window.location.search).toBe(
+      '?modal=search&q=pages&type=collections'
+    );
+  });
+
+  it('offers to reset the filter when it hides every result', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/cms/?modal=search&q=pages&type=releases'
+    );
+    renderSearch();
+    expect(screen.getByText('No releases match.')).toBeTruthy();
+    fireEvent.click(screen.getByText('Show all results'));
+    expect(hasHeader('Documents')).toBe(true);
+    expect(getChip('All').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('removes the search params from the URL on close', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/cms/?deeplink=fields.title&modal=search&q=pages'
+    );
+    renderSearch();
+    fireEvent.keyDown(getInput(), {code: 'Escape', key: 'Escape'});
+    expect(window.location.search).toBe('?deeplink=fields.title');
+    await flush();
+    expect(window.location.search).toBe('?deeplink=fields.title');
+    expect(
+      screen.queryByPlaceholderText('Search docs, collections, releases…')
+    ).toBeNull();
+  });
+
+  it('opens via openGlobalSearch() and syncs the query into the URL', async () => {
+    window.history.replaceState({}, '', '/cms/content/Pages');
+    renderSearch();
+    act(() => {
+      openGlobalSearch({query: 'hello'});
+    });
+    expect(getInput().value).toBe('hello');
+    fireEvent.input(getInput(), {target: {value: 'hello world'}});
+    await flush();
+    expect(window.location.pathname).toBe('/cms/content/Pages');
+    expect(window.location.search).toBe('?modal=search&q=hello+world');
+  });
+
+  it('hides the filter chips while the query is empty', () => {
+    window.history.replaceState({}, '', '/cms/?modal=search');
+    renderSearch();
+    expect(getInput().value).toBe('');
+    expect(screen.queryByRole('group', {name: 'Filter results'})).toBeNull();
+  });
+});

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearch.tsx
@@ -1,12 +1,16 @@
 import './GlobalSearch.css';
-import {
-  SpotlightProvider,
-  SpotlightAction,
-  openSpotlight,
-} from '@mantine/spotlight';
+import {SpotlightAction} from '@mantine/spotlight';
+import {Spotlight} from '@mantine/spotlight/esm/Spotlight/Spotlight.js';
 import {IconSearch} from '@tabler/icons-preact';
-import {ComponentChildren} from 'preact';
-import {useEffect, useMemo, useState} from 'preact/hooks';
+import {ComponentChildren, createContext} from 'preact';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
 import {useLocation} from 'preact-iso';
 import {
   DocSlugHit,
@@ -18,6 +22,7 @@ import {
 import {usePendingReleases} from '../../hooks/usePendingReleases.js';
 import {DataSource, listDataSources} from '../../utils/data-source.js';
 import {isEditableTarget} from '../../utils/keyboard.js';
+import {showErrorNotification} from '../../utils/notifications.js';
 import {
   RecentView,
   recentViewFromUrl,
@@ -28,6 +33,18 @@ import {
   GlobalSearchAction,
   GlobalSearchActionMeta,
 } from './GlobalSearchAction.js';
+import {
+  GlobalSearchCounts,
+  GlobalSearchFilters,
+} from './GlobalSearchFilters.js';
+import {
+  GlobalSearchFilter,
+  GlobalSearchUrlState,
+  buildGlobalSearchUrl,
+  getGlobalSearchFilterLabel,
+  readGlobalSearchUrlState,
+  writeGlobalSearchUrlState,
+} from './search-filters.js';
 
 function formatLastIndexed(status: GlobalSearchStatus | null): string | null {
   if (!status?.lastRun) {
@@ -240,12 +257,114 @@ function buildTipsRow(): SpotlightAction {
   };
 }
 
+/** Custom event used by `openGlobalSearch()` to reach the provider. */
+const OPEN_EVENT = 'rootcms:open-global-search';
+
+/** Duration of the spotlight open/close transition. */
+const TRANSITION_MS = 150;
+
+/**
+ * Debounce for mirroring the query into the URL. Safari throttles
+ * `history.replaceState()` (100 calls per 30s), so the URL must not be
+ * rewritten on every keystroke.
+ */
+const URL_SYNC_DEBOUNCE_MS = 300;
+
+export interface OpenGlobalSearchOptions {
+  /** Query to prefill the search input with. */
+  query?: string;
+  /** Result type filter to preselect. */
+  filter?: GlobalSearchFilter;
+}
+
+/**
+ * Opens the global search modal from anywhere in the CMS, optionally with a
+ * prefilled query. Requires a mounted `<GlobalSearch>`.
+ */
+export function openGlobalSearch(options: OpenGlobalSearchOptions = {}) {
+  window.dispatchEvent(new CustomEvent(OPEN_EVENT, {detail: options}));
+}
+
+/** Rewrites the URL's search string without adding a history entry. */
+function replaceUrlSearch(search: string) {
+  const url = new URL(window.location.href);
+  url.search = search;
+  try {
+    // Preserve the existing history state so the router isn't disrupted.
+    window.history.replaceState(window.history.state, '', url.toString());
+  } catch (err) {
+    console.error('failed to update the search url:', err);
+  }
+}
+
+/** Removes the `?modal=search` params from the URL, if present. */
+function clearSearchUrlState() {
+  const search = window.location.search;
+  const next = writeGlobalSearchUrlState(search, null);
+  if (next !== search) {
+    replaceUrlSearch(next);
+  }
+}
+
+interface FiltersContextValue {
+  /** Whether the chip bar should render (only when there's a query). */
+  visible: boolean;
+  filter: GlobalSearchFilter;
+  onFilterChange: (filter: GlobalSearchFilter) => void;
+  counts: GlobalSearchCounts;
+  onCopyLink: () => Promise<boolean>;
+}
+
+const FILTERS_CONTEXT = createContext<FiltersContextValue | null>(null);
+
+/**
+ * Wraps the spotlight's action list. Renders the filter chips above the
+ * results and makes the results scrollable so long lists no longer overflow
+ * the viewport. Passed to `Spotlight` as `actionsWrapperComponent`, which is
+ * why it reads its state from context rather than props.
+ */
+function GlobalSearchBody(props: {children?: ComponentChildren}) {
+  const ctx = useContext(FILTERS_CONTEXT);
+  return (
+    <div className="GlobalSearch__body">
+      {ctx?.visible && (
+        <GlobalSearchFilters
+          value={ctx.filter}
+          onChange={ctx.onFilterChange}
+          counts={ctx.counts}
+          onCopyLink={ctx.onCopyLink}
+        />
+      )}
+      <div className="GlobalSearch__results">{props.children}</div>
+    </div>
+  );
+}
+
+/**
+ * Copies a shareable deep link to the current search to the clipboard.
+ * Returns false (after notifying the user) when the copy failed.
+ */
+async function copySearchLink(state: GlobalSearchUrlState): Promise<boolean> {
+  const url = new URL(buildGlobalSearchUrl(state), window.location.origin);
+  try {
+    await navigator.clipboard.writeText(url.toString());
+    return true;
+  } catch (err) {
+    showErrorNotification(err, {title: 'Failed to copy link'});
+    return false;
+  }
+}
+
 function GlobalSearchInner(props: {
   children: ComponentChildren;
+  opened: boolean;
   query: string;
+  filter: GlobalSearchFilter;
   onQueryChange: (q: string) => void;
+  onFilterChange: (filter: GlobalSearchFilter) => void;
+  onClose: () => void;
 }) {
-  const {query, onQueryChange} = props;
+  const {opened, query, filter, onQueryChange, onFilterChange} = props;
   const location = useLocation();
   const trimmedQuery = query.trim();
   const {
@@ -278,32 +397,6 @@ function GlobalSearchInner(props: {
 
   const {releases: pendingReleases} = usePendingReleases();
 
-  // Custom Cmd/Ctrl+K handler. We can't use Mantine's built-in `shortcut`
-  // prop because its `useHotkeys` only ignores INPUT/TEXTAREA/SELECT — not
-  // `contenteditable` rich text fields. Lexical binds Cmd+K to "insert link",
-  // so opening the global search at the same time clobbers that. Skip the
-  // shortcut whenever focus is inside any editable field.
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      const isModK =
-        (event.metaKey || event.ctrlKey) &&
-        !event.altKey &&
-        !event.shiftKey &&
-        (event.key.toLowerCase() === 'k' || event.code === 'KeyK');
-      if (!isModK) {
-        return;
-      }
-      if (isEditableTarget(event.target)) {
-        return;
-      }
-      event.preventDefault();
-      openSpotlight();
-    };
-    document.documentElement.addEventListener('keydown', onKeyDown);
-    return () =>
-      document.documentElement.removeEventListener('keydown', onKeyDown);
-  }, []);
-
   // Static spotlight targets: collections (always present), data sources, and
   // active releases (pending = not published, not archived).
   const staticTargets = useMemo<StaticTarget[]>(() => {
@@ -325,8 +418,32 @@ function GlobalSearchInner(props: {
 
   const navigate = (url: string) => location.route(url);
 
+  // Static matches split by kind so the filter chips can count and select
+  // them individually.
+  const matchedStatic = useMemo(() => {
+    const matched = filterStaticTargets(staticTargets, trimmedQuery);
+    return {
+      collections: matched.filter((t) => t.kind === 'collection'),
+      dataSources: matched.filter((t) => t.kind === 'data-source'),
+      releases: matched.filter((t) => t.kind === 'release'),
+    };
+  }, [staticTargets, trimmedQuery]);
+
+  const counts = useMemo<GlobalSearchCounts>(
+    () => ({
+      docs: docSlugHits.length,
+      fields: fieldHits.length,
+      collections: matchedStatic.collections.length,
+      'data-sources': matchedStatic.dataSources.length,
+      releases: matchedStatic.releases.length,
+    }),
+    [docSlugHits, fieldHits, matchedStatic]
+  );
+  const totalCount = Object.values(counts).reduce((sum, n) => sum + n, 0);
+
   // When the query is empty, surface recent views; when populated, compose
-  // matches across static targets, doc slug lookups, and field text hits.
+  // matches across static targets, doc slug lookups, and field text hits,
+  // narrowed down to the active filter.
   const actions: SpotlightAction[] = useMemo(() => {
     if (!trimmedQuery) {
       if (recentViews.length === 0) {
@@ -340,16 +457,23 @@ function GlobalSearchInner(props: {
       ];
     }
 
+    const show = (kind: Exclude<GlobalSearchFilter, 'all'>) =>
+      filter === 'all' || filter === kind;
+
     const result: SpotlightAction[] = [];
-    const matchedStatic = filterStaticTargets(staticTargets, trimmedQuery);
-    if (matchedStatic.length > 0) {
+    const statics: StaticTarget[] = [
+      ...(show('collections') ? matchedStatic.collections : []),
+      ...(show('data-sources') ? matchedStatic.dataSources : []),
+      ...(show('releases') ? matchedStatic.releases : []),
+    ];
+    if (statics.length > 0) {
       result.push(buildHeader('static', 'Jump to'));
-      for (const target of matchedStatic) {
+      for (const target of statics) {
         result.push(buildStaticAction(target, () => navigate(target.url)));
       }
     }
 
-    if (docSlugHits.length > 0) {
+    if (show('docs') && docSlugHits.length > 0) {
       result.push(buildHeader('docs', 'Documents'));
       for (const hit of docSlugHits) {
         const url = `/cms/content/${hit.collection}/${encodeURIComponent(
@@ -359,7 +483,7 @@ function GlobalSearchInner(props: {
       }
     }
 
-    if (fieldHits.length > 0) {
+    if (show('fields') && fieldHits.length > 0) {
       result.push(buildHeader('fields', 'Field matches'));
       for (const hit of fieldHits) {
         const url = `/cms/content/${hit.collection}/${encodeURIComponent(
@@ -371,9 +495,10 @@ function GlobalSearchInner(props: {
     return result;
   }, [
     trimmedQuery,
+    filter,
     fieldHits,
     docSlugHits,
-    staticTargets,
+    matchedStatic,
     recentViews,
     location,
   ]);
@@ -405,8 +530,39 @@ function GlobalSearchInner(props: {
     if (!trimmedQuery) {
       return 'Type to search · "quotes" for exact match · -word to exclude';
     }
+    if (filter !== 'all' && totalCount > 0) {
+      return (
+        <span>
+          No {getGlobalSearchFilterLabel(filter).toLowerCase()} match.{' '}
+          <button
+            type="button"
+            className="GlobalSearch__resetFilter"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onFilterChange('all')}
+          >
+            Show all results
+          </button>
+        </span>
+      );
+    }
     return 'No results. Try fewer words, or "quotes" for an exact phrase.';
-  }, [loading, trimmedQuery]);
+  }, [loading, trimmedQuery, filter, totalCount, onFilterChange]);
+
+  const onCopyLink = useCallback(
+    () => copySearchLink({query: trimmedQuery, filter}),
+    [trimmedQuery, filter]
+  );
+
+  const filtersCtx = useMemo<FiltersContextValue>(
+    () => ({
+      visible: !!trimmedQuery,
+      filter,
+      onFilterChange,
+      counts,
+      onCopyLink,
+    }),
+    [trimmedQuery, filter, onFilterChange, counts, onCopyLink]
+  );
 
   // Pass-through filter: server already ranks/filters and our static-target
   // filter is computed above; we don't want Spotlight's built-in title/
@@ -414,21 +570,26 @@ function GlobalSearchInner(props: {
   const filterAll = (_q: string, list: SpotlightAction[]) => list;
 
   return (
-    <SpotlightProvider
-      actions={augmented}
-      shortcut={null}
-      onQueryChange={onQueryChange}
-      searchPlaceholder="Search docs, collections, releases…"
-      searchIcon={<IconSearch size={18} />}
-      nothingFoundMessage={nothingFoundMessage}
-      filter={filterAll}
-      actionComponent={GlobalSearchAction}
-      limit={50}
-      cleanQueryOnClose
-      withinPortal
-    >
+    <FILTERS_CONTEXT.Provider value={filtersCtx}>
+      <Spotlight
+        opened={opened}
+        onClose={props.onClose}
+        query={query}
+        onQueryChange={onQueryChange}
+        actions={augmented}
+        transitionDuration={TRANSITION_MS}
+        classNames={{spotlight: 'GlobalSearch__spotlight'}}
+        searchPlaceholder="Search docs, collections, releases…"
+        searchIcon={<IconSearch size={18} />}
+        nothingFoundMessage={nothingFoundMessage}
+        filter={filterAll}
+        actionComponent={GlobalSearchAction}
+        actionsWrapperComponent={GlobalSearchBody}
+        limit={50}
+        withinPortal
+      />
       {props.children}
-    </SpotlightProvider>
+    </FILTERS_CONTEXT.Provider>
   );
 }
 
@@ -438,11 +599,137 @@ function GlobalSearchInner(props: {
  *  - Collections, data sources, and active releases by name
  *  - Documents by slug or `<collection>/<slug>` id
  *  - Field text hits from the server-side MiniSearch index
+ *
+ * Results can be narrowed by type with the filter chips, and the open state,
+ * query, and filter are mirrored into the URL so a search can be deep linked
+ * and shared, e.g. `/cms/?modal=search&q=foo&type=docs`.
+ *
+ * The inner `Spotlight` component is rendered directly (rather than through
+ * `SpotlightProvider`) so the query state lives here and can be prefilled.
  */
 export function GlobalSearch(props: {children: ComponentChildren}) {
+  const [opened, setOpened] = useState(false);
   const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<GlobalSearchFilter>('all');
+  const openedRef = useRef(opened);
+  openedRef.current = opened;
+  const clearTimerRef = useRef(0);
+  const urlTimerRef = useRef(0);
+
+  const open = useCallback((options: OpenGlobalSearchOptions = {}) => {
+    window.clearTimeout(clearTimerRef.current);
+    setQuery(options.query ?? '');
+    setFilter(options.filter ?? 'all');
+    setOpened(true);
+  }, []);
+
+  const close = useCallback(() => {
+    window.clearTimeout(urlTimerRef.current);
+    setOpened(false);
+    clearSearchUrlState();
+    // Clear the query once the close transition has finished so the results
+    // don't visibly flash away while the modal is still fading out.
+    clearTimerRef.current = window.setTimeout(() => {
+      setQuery('');
+      setFilter('all');
+    }, TRANSITION_MS);
+  }, []);
+
+  // Open requests from `openGlobalSearch()` (e.g. the sidebar search bar).
+  useEffect(() => {
+    const onOpen = (event: Event) => {
+      const detail = (event as CustomEvent<OpenGlobalSearchOptions>).detail;
+      open(detail || {});
+    };
+    window.addEventListener(OPEN_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_EVENT, onOpen);
+  }, [open]);
+
+  // Custom Cmd/Ctrl+K handler. We can't use Mantine's built-in `shortcut`
+  // prop because its `useHotkeys` only ignores INPUT/TEXTAREA/SELECT — not
+  // `contenteditable` rich text fields. Lexical binds Cmd+K to "insert link",
+  // so opening the global search at the same time clobbers that. Skip the
+  // shortcut whenever focus is inside any editable field.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const isModK =
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        (event.key.toLowerCase() === 'k' || event.code === 'KeyK');
+      if (!isModK) {
+        return;
+      }
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      open();
+    };
+    document.documentElement.addEventListener('keydown', onKeyDown);
+    return () =>
+      document.documentElement.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  // Deep links: open the modal when the URL carries `?modal=search`, both on
+  // the initial page load and on client-side navigations (e.g. the browser
+  // back button returning to a URL that had the search open). NOTE:
+  // `useLocation()` is what makes this reactive to client-side URL changes.
+  const {url} = useLocation();
+  useEffect(() => {
+    const state = readGlobalSearchUrlState(window.location.search);
+    if (!state || openedRef.current) {
+      return;
+    }
+    open(state);
+  }, [url, open]);
+
+  // Mirror the open state, query, and filter into the URL so the current
+  // search can be shared straight from the address bar.
+  useEffect(() => {
+    if (!opened) {
+      return;
+    }
+    window.clearTimeout(urlTimerRef.current);
+    urlTimerRef.current = window.setTimeout(() => {
+      const search = window.location.search;
+      const next = writeGlobalSearchUrlState(search, {
+        query: query.trim(),
+        filter,
+      });
+      if (next !== search) {
+        replaceUrlSearch(next);
+      }
+    }, URL_SYNC_DEBOUNCE_MS);
+  }, [opened, query, filter]);
+
+  // Place the caret at the end of a prefilled query so it can be refined
+  // without first moving the cursor.
+  useEffect(() => {
+    if (!opened || !query) {
+      return;
+    }
+    const handle = window.requestAnimationFrame(() => {
+      const input = document.querySelector<HTMLInputElement>(
+        '.GlobalSearch__spotlight input'
+      );
+      if (input && document.activeElement === input) {
+        input.setSelectionRange(input.value.length, input.value.length);
+      }
+    });
+    return () => window.cancelAnimationFrame(handle);
+    // Only runs when the modal opens; edits move the caret themselves.
+  }, [opened]);
+
   return (
-    <GlobalSearchInner query={query} onQueryChange={setQuery}>
+    <GlobalSearchInner
+      opened={opened}
+      query={query}
+      filter={filter}
+      onQueryChange={setQuery}
+      onFilterChange={setFilter}
+      onClose={close}
+    >
       {props.children}
     </GlobalSearchInner>
   );

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearchAction.tsx
@@ -8,6 +8,7 @@ import {
   IconRocket,
 } from '@tabler/icons-preact';
 import {ComponentChild} from 'preact';
+import {useEffect, useRef} from 'preact/hooks';
 import type {DocSlugHit, GlobalSearchHit} from '../../hooks/useGlobalSearch.js';
 import type {RecentView, RecentViewKind} from '../../utils/recent-views.js';
 import {buildSnippet} from './snippet.js';
@@ -102,6 +103,15 @@ interface RowProps {
 }
 
 function Row(props: RowProps) {
+  const ref = useRef<HTMLButtonElement>(null);
+  // Keep the keyboard-selected row visible now that long result lists
+  // scroll. `nearest` makes this a no-op for rows already in view (e.g.
+  // ones hovered with the mouse).
+  useEffect(() => {
+    if (props.hovered) {
+      ref.current?.scrollIntoView?.({block: 'nearest'});
+    }
+  }, [props.hovered]);
   const className = [
     'GlobalSearchAction',
     props.className || '',
@@ -111,6 +121,7 @@ function Row(props: RowProps) {
     .join(' ');
   return (
     <button
+      ref={ref}
       type="button"
       className={className}
       onMouseDown={(e) => {

--- a/packages/root-cms/ui/components/GlobalSearch/GlobalSearchFilters.tsx
+++ b/packages/root-cms/ui/components/GlobalSearch/GlobalSearchFilters.tsx
@@ -1,0 +1,101 @@
+import {IconCheck, IconLink} from '@tabler/icons-preact';
+import {useEffect, useState} from 'preact/hooks';
+import {joinClassNames} from '../../utils/classes.js';
+import {GLOBAL_SEARCH_FILTERS, GlobalSearchFilter} from './search-filters.js';
+
+/** Number of results available for each filter chip. */
+export type GlobalSearchCounts = Partial<
+  Record<Exclude<GlobalSearchFilter, 'all'>, number>
+>;
+
+export interface GlobalSearchFiltersProps {
+  /** The active filter. */
+  value: GlobalSearchFilter;
+  onChange: (filter: GlobalSearchFilter) => void;
+  /** Result counts per type, used to annotate the chips. */
+  counts: GlobalSearchCounts;
+  /** Called when the user clicks "Copy link". Resolves to true on success. */
+  onCopyLink: () => Promise<boolean>;
+}
+
+/** How long the "Copied" confirmation stays visible on the copy button. */
+const COPIED_FEEDBACK_MS = 1500;
+
+/**
+ * Row of result-type chips rendered between the global search input and the
+ * results list, plus a "Copy link" button that copies a shareable deep link
+ * to the current search.
+ */
+export function GlobalSearchFilters(props: GlobalSearchFiltersProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const handle = window.setTimeout(
+      () => setCopied(false),
+      COPIED_FEEDBACK_MS
+    );
+    return () => window.clearTimeout(handle);
+  }, [copied]);
+
+  const total = Object.values(props.counts).reduce(
+    (sum, n) => sum + (n || 0),
+    0
+  );
+
+  return (
+    <div
+      className="GlobalSearchFilters"
+      role="group"
+      aria-label="Filter results"
+    >
+      <div className="GlobalSearchFilters__chips">
+        {GLOBAL_SEARCH_FILTERS.map((option) => {
+          const count =
+            option.id === 'all' ? total : props.counts[option.id] || 0;
+          const active = option.id === props.value;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              className={joinClassNames(
+                'GlobalSearchFilters__chip',
+                active && 'GlobalSearchFilters__chip--active',
+                count === 0 && 'GlobalSearchFilters__chip--empty'
+              )}
+              aria-pressed={active}
+              // Keep focus in the search input so typing continues to work
+              // after picking a filter.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => props.onChange(option.id)}
+            >
+              <span>{option.label}</span>
+              {count > 0 && (
+                <span className="GlobalSearchFilters__count">{count}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        className={joinClassNames(
+          'GlobalSearchFilters__copy',
+          copied && 'GlobalSearchFilters__copy--copied'
+        )}
+        title="Copy a link to this search"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={async () => {
+          if (await props.onCopyLink()) {
+            setCopied(true);
+          }
+        }}
+      >
+        {copied ? <IconCheck size={14} /> : <IconLink size={14} />}
+        <span>{copied ? 'Copied' : 'Copy link'}</span>
+      </button>
+    </div>
+  );
+}

--- a/packages/root-cms/ui/components/GlobalSearch/search-filters.test.ts
+++ b/packages/root-cms/ui/components/GlobalSearch/search-filters.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from 'vitest';
+import {
+  buildGlobalSearchUrl,
+  parseGlobalSearchFilter,
+  readGlobalSearchUrlState,
+  writeGlobalSearchUrlState,
+} from './search-filters.js';
+
+describe('parseGlobalSearchFilter', () => {
+  it('returns known filters as-is', () => {
+    expect(parseGlobalSearchFilter('docs')).toBe('docs');
+    expect(parseGlobalSearchFilter('data-sources')).toBe('data-sources');
+  });
+
+  it('falls back to "all" for unknown or empty values', () => {
+    expect(parseGlobalSearchFilter('bogus')).toBe('all');
+    expect(parseGlobalSearchFilter('')).toBe('all');
+    expect(parseGlobalSearchFilter(null)).toBe('all');
+    expect(parseGlobalSearchFilter(undefined)).toBe('all');
+  });
+});
+
+describe('readGlobalSearchUrlState', () => {
+  it('returns null when the modal param is missing or different', () => {
+    expect(readGlobalSearchUrlState('')).toBeNull();
+    expect(readGlobalSearchUrlState('?q=foo')).toBeNull();
+    expect(readGlobalSearchUrlState('?modal=localization&q=foo')).toBeNull();
+  });
+
+  it('reads the query and filter', () => {
+    expect(readGlobalSearchUrlState('?modal=search&q=hello+world')).toEqual({
+      query: 'hello world',
+      filter: 'all',
+    });
+    expect(
+      readGlobalSearchUrlState('?modal=search&q=foo&type=releases')
+    ).toEqual({query: 'foo', filter: 'releases'});
+  });
+
+  it('opens with an empty query when q is missing', () => {
+    expect(readGlobalSearchUrlState('?modal=search')).toEqual({
+      query: '',
+      filter: 'all',
+    });
+  });
+
+  it('ignores unknown filters', () => {
+    expect(readGlobalSearchUrlState('?modal=search&type=nope')).toEqual({
+      query: '',
+      filter: 'all',
+    });
+  });
+});
+
+describe('writeGlobalSearchUrlState', () => {
+  it('adds the search params while preserving unrelated params', () => {
+    expect(
+      writeGlobalSearchUrlState('?deeplink=fields.title', {
+        query: 'foo bar',
+        filter: 'docs',
+      })
+    ).toBe('?deeplink=fields.title&modal=search&q=foo+bar&type=docs');
+  });
+
+  it('omits q and type when they are at their defaults', () => {
+    expect(writeGlobalSearchUrlState('', {query: '', filter: 'all'})).toBe(
+      '?modal=search'
+    );
+  });
+
+  it('replaces existing search params', () => {
+    expect(
+      writeGlobalSearchUrlState('?modal=search&q=old&type=fields', {
+        query: 'new',
+        filter: 'all',
+      })
+    ).toBe('?modal=search&q=new');
+  });
+
+  it('removes the search params when state is null', () => {
+    expect(
+      writeGlobalSearchUrlState('?modal=search&q=foo&type=docs', null)
+    ).toBe('');
+    expect(
+      writeGlobalSearchUrlState('?deeplink=x&modal=search&q=foo', null)
+    ).toBe('?deeplink=x');
+  });
+
+  it('round trips with readGlobalSearchUrlState', () => {
+    const state = {query: 'a "quoted" -phrase', filter: 'fields' as const};
+    expect(
+      readGlobalSearchUrlState(writeGlobalSearchUrlState('', state))
+    ).toEqual(state);
+  });
+});
+
+describe('buildGlobalSearchUrl', () => {
+  it('builds a shareable CMS path', () => {
+    expect(buildGlobalSearchUrl({query: 'foo', filter: 'all'})).toBe(
+      '/cms/?modal=search&q=foo'
+    );
+    expect(buildGlobalSearchUrl({query: 'foo', filter: 'releases'})).toBe(
+      '/cms/?modal=search&q=foo&type=releases'
+    );
+  });
+});

--- a/packages/root-cms/ui/components/GlobalSearch/search-filters.ts
+++ b/packages/root-cms/ui/components/GlobalSearch/search-filters.ts
@@ -1,0 +1,111 @@
+/**
+ * Result types that the global search filter chips can narrow results down
+ * to. `all` shows every group.
+ */
+export type GlobalSearchFilter =
+  | 'all'
+  | 'docs'
+  | 'fields'
+  | 'collections'
+  | 'data-sources'
+  | 'releases';
+
+export interface GlobalSearchFilterOption {
+  id: GlobalSearchFilter;
+  /** Chip label. */
+  label: string;
+}
+
+/** Filter chips in display order. */
+export const GLOBAL_SEARCH_FILTERS: GlobalSearchFilterOption[] = [
+  {id: 'all', label: 'All'},
+  {id: 'docs', label: 'Documents'},
+  {id: 'fields', label: 'Field matches'},
+  {id: 'collections', label: 'Collections'},
+  {id: 'data-sources', label: 'Data sources'},
+  {id: 'releases', label: 'Releases'},
+];
+
+/** Returns the chip label for a filter. */
+export function getGlobalSearchFilterLabel(filter: GlobalSearchFilter): string {
+  const option = GLOBAL_SEARCH_FILTERS.find((f) => f.id === filter);
+  return option?.label || 'All';
+}
+
+/** Parses a filter id (e.g. from a URL param), falling back to `all`. */
+export function parseGlobalSearchFilter(
+  value: string | null | undefined
+): GlobalSearchFilter {
+  if (!value) {
+    return 'all';
+  }
+  const option = GLOBAL_SEARCH_FILTERS.find((f) => f.id === value);
+  return option ? option.id : 'all';
+}
+
+/** URL param that flags the open modal, e.g. `?modal=search`. */
+export const SEARCH_MODAL_PARAM = 'modal';
+/** Value of `SEARCH_MODAL_PARAM` that opens the global search. */
+export const SEARCH_MODAL_VALUE = 'search';
+/** URL param holding the search query. */
+export const SEARCH_QUERY_PARAM = 'q';
+/** URL param holding the active result type filter. */
+export const SEARCH_FILTER_PARAM = 'type';
+
+/** The global search state that is mirrored into the URL. */
+export interface GlobalSearchUrlState {
+  query: string;
+  filter: GlobalSearchFilter;
+}
+
+/**
+ * Reads the global search deep link state from a URL search string (e.g.
+ * `window.location.search`). Returns null when the URL does not target the
+ * search modal.
+ */
+export function readGlobalSearchUrlState(
+  search: string
+): GlobalSearchUrlState | null {
+  const params = new URLSearchParams(search);
+  if (params.get(SEARCH_MODAL_PARAM) !== SEARCH_MODAL_VALUE) {
+    return null;
+  }
+  return {
+    query: params.get(SEARCH_QUERY_PARAM) || '',
+    filter: parseGlobalSearchFilter(params.get(SEARCH_FILTER_PARAM)),
+  };
+}
+
+/**
+ * Returns a new URL search string (including the leading `?`, or an empty
+ * string when there are no params) with the global search params applied on
+ * top of the existing params. Passing `null` removes the search params.
+ */
+export function writeGlobalSearchUrlState(
+  search: string,
+  state: GlobalSearchUrlState | null
+): string {
+  const params = new URLSearchParams(search);
+  params.delete(SEARCH_MODAL_PARAM);
+  params.delete(SEARCH_QUERY_PARAM);
+  params.delete(SEARCH_FILTER_PARAM);
+  if (state) {
+    params.set(SEARCH_MODAL_PARAM, SEARCH_MODAL_VALUE);
+    if (state.query) {
+      params.set(SEARCH_QUERY_PARAM, state.query);
+    }
+    if (state.filter !== 'all') {
+      params.set(SEARCH_FILTER_PARAM, state.filter);
+    }
+  }
+  const str = params.toString();
+  return str ? `?${str}` : '';
+}
+
+/**
+ * Builds a shareable CMS path that opens the global search with the given
+ * query, e.g. `/cms/?modal=search&q=foo`.
+ */
+export function buildGlobalSearchUrl(state: GlobalSearchUrlState): string {
+  return `/cms/${writeGlobalSearchUrlState('', state)}`;
+}

--- a/packages/root-cms/ui/components/SearchBar/SearchBar.tsx
+++ b/packages/root-cms/ui/components/SearchBar/SearchBar.tsx
@@ -1,8 +1,8 @@
 import './SearchBar.css';
-import {openSpotlight} from '@mantine/spotlight';
 import {IconSearch} from '@tabler/icons-preact';
 import {useEffect, useState} from 'preact/hooks';
 import {joinClassNames} from '../../utils/classes.js';
+import {openGlobalSearch} from '../GlobalSearch/GlobalSearch.js';
 
 interface SearchBarProps {
   className?: string;
@@ -24,7 +24,7 @@ export function SearchBar(props: SearchBarProps) {
   }, []);
 
   const onClick = () => {
-    openSpotlight();
+    openGlobalSearch();
   };
 
   return (

--- a/packages/root-cms/ui/mantine-spotlight-internal.d.ts
+++ b/packages/root-cms/ui/mantine-spotlight-internal.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Type shim for the inner `Spotlight` component of `@mantine/spotlight`. The
+ * package only exports `SpotlightProvider`, which owns the query state and
+ * offers no way to set it from outside (needed for `?modal=search&q=` deep
+ * links). The global search renders the inner component directly instead,
+ * using the package's own `.d.ts` for the types.
+ */
+declare module '@mantine/spotlight/esm/Spotlight/Spotlight.js' {
+  export {Spotlight} from '@mantine/spotlight/lib/Spotlight/Spotlight.js';
+}


### PR DESCRIPTION
Implements the three requests in #1413.

## Changes

**1. Long result lists overflow the viewport**
The spotlight paper had no max height, so results below the fold were unreachable. The paper is now capped to the viewport (minus Mantine's 120px top offset) and the results area scrolls. The keyboard-selected row is kept in view with `scrollIntoView({block: 'nearest'})`.

**2. Deep linking**
The modal opens from `/cms/?modal=search&q=foo` (optionally `&type=docs`). While open, the query and filter are mirrored into the URL with a debounced `history.replaceState` (Safari throttles it to 100 calls/30s), so the address bar is always shareable. Closing removes the params. The browser back button returning to a URL with the search open re-opens it. A **Copy link** button in the chip bar copies a canonical `/cms/?modal=search&q=…` link.

**3. Filter chips**
A chip row above the results narrows them by type: All · Documents · Field matches · Collections · Data sources · Releases, with per-type counts. When a filter hides every result, the empty state offers a one-click "Show all results".

## Implementation notes

Mantine's `SpotlightProvider` owns the query state and exposes no way to set it, which deep linking needs. The inner `Spotlight` component is now rendered directly (deep import of `@mantine/spotlight/esm/Spotlight/Spotlight.js`, typed by a small shim in `ui/mantine-spotlight-internal.d.ts` that re-uses the package's own `.d.ts`). `GlobalSearch` now owns `opened`/`query`/`filter`. `openSpotlight()` is replaced by `openGlobalSearch({query?, filter?})`, and `SearchBar` is updated accordingly. Mantine is still pinned to 4.2.12, so the deep import path is stable.

## Tests

- `search-filters.test.ts`: URL param read/write/round-trip and filter parsing.
- `GlobalSearch.test.tsx`: opens from a deep link with query and filter prefilled, chip counts, filtering, URL sync on filter change and typing, param removal on close, `openGlobalSearch()`, and chips hidden for an empty query. The inner Spotlight is stubbed there because Mantine components don't render under the jsdom vitest setup (matching how other component tests in the repo avoid real Mantine).

`vitest run ui/components/GlobalSearch` passes (29 tests), `tsc -p ui/tsconfig.json --noEmit` is clean apart from a pre-existing error in `Layout.tsx`, and eslint is clean on the changed files. The root `pnpm lint` reports pre-existing errors in untouched packages only.

Not verified in a real browser in this environment (no Firebase project available), so a manual pass on scrolling and the chip layout in the dev CMS would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bp241NKTQ5446aGXjEs8Mi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp241NKTQ5446aGXjEs8Mi)_